### PR TITLE
feat(wordpress): adapt fuzz plan cases to Codebox workloads

### DIFF
--- a/wordpress/lib/wordpress-fuzz-campaign.js
+++ b/wordpress/lib/wordpress-fuzz-campaign.js
@@ -17,6 +17,7 @@ const {
 	buildWordPressPerformanceObservation,
 } = require('./wordpress-performance-observation-aggregate');
 const {
+	DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
@@ -27,6 +28,7 @@ const HOMEBOY_FUZZ_WORKLOAD_SCHEMA = 'homeboy/fuzz-workload/v1';
 const WORDPRESS_FUZZ_PLAN_RESULT_GAP_REPORT_SCHEMA = 'homeboy/wordpress-fuzz-plan-result-gap-report/v1';
 
 function compileWordPressFuzzCampaign(input = {}, options = {}) {
+	const production = Boolean(input.production || options.production || input.production_campaign || options.production_campaign);
 	const discovery = normalizeWordPressRuntimeSurfaceDiscovery(
 		input.discovery || input.surfaceDiscovery || input.surface_discovery || input,
 		{
@@ -54,8 +56,10 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 			...(objectOrUndefined(input.metadata) || {}),
 			...(objectOrUndefined(options.metadata) || {}),
 			campaign_schema: WORDPRESS_FUZZ_CAMPAIGN_SCHEMA,
+			production_campaign: production || undefined,
 		},
 		artifacts: input.artifacts || options.artifacts,
+		production,
 	});
 	const suiteInput = wpCodeboxFuzzSuiteInput({
 		...(objectOrUndefined(options.suiteInput) || objectOrUndefined(options.suite_input) || {}),
@@ -69,6 +73,8 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 			...(objectOrUndefined(input.suite_input?.metadata) || objectOrUndefined(input.suiteInput?.metadata) || {}),
 			coverage_manifest: coverageManifest,
 			aggregation_hooks: campaignAggregationHooks(),
+			production_campaign: production || undefined,
+			output_requirements: production ? productionOutputRequirements() : undefined,
 		},
 	});
 	const taskRequest = wpCodeboxFuzzSuiteTaskRequest({
@@ -76,6 +82,7 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 		...(objectOrUndefined(input.task_request || input.taskRequest) || {}),
 		taskId: input.task_id || input.taskId || options.taskId || options.task_id || `${plan.id}-wp-codebox-fuzz-suite`,
 		input: suiteInput,
+		artifactDeclarations: productionArtifactDeclarations(production),
 	});
 
 	return {
@@ -115,7 +122,7 @@ function buildWordPressFuzzCampaignWorkload(input = {}) {
 				cases: arrayOf(target.cases).map((testCase) => wordpressFuzzPlanCaseToRuntimeCase(testCase, target)),
 			})),
 		},
-		artifacts: input.artifacts || defaultCampaignArtifacts(),
+		artifacts: input.artifacts || defaultCampaignArtifacts({ production: input.production }),
 		metadata: {
 			...(objectOrUndefined(input.metadata) || {}),
 			coverage_manifest: input.coverageManifest || input.coverage_manifest,
@@ -171,14 +178,35 @@ function campaignAggregationHooks() {
 	};
 }
 
-function defaultCampaignArtifacts() {
+function defaultCampaignArtifacts(options = {}) {
+	return defaultCampaignArtifactsWithOptions(options);
+}
+
+function defaultCampaignArtifactsWithOptions(options = {}) {
+	const hotspotRequired = Boolean(options.production);
 	return {
 		expected: [
 			{ name: 'wordpress_fuzz_result', role: 'normalized_fuzz_result', semantic_key: 'fuzz.result.normalized', required: true },
 			{ name: 'wordpress_fuzz_coverage', role: 'coverage', semantic_key: 'fuzz.coverage', required: true },
+			{ name: 'wordpress_fuzz_hotspots', role: 'hotspot_summary', semantic_key: 'fuzz.hotspot.summary', required: hotspotRequired },
 			{ name: 'wordpress_performance_observation', role: 'fuzz_report', semantic_key: 'fuzz.performance', required: false },
 		],
 	};
+}
+
+function productionOutputRequirements() {
+	return {
+		required_artifact_keys: ['fuzz.coverage', 'fuzz.hotspot.summary'],
+	};
+}
+
+function productionArtifactDeclarations(production = false) {
+	if (!production) {
+		return undefined;
+	}
+	return DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS.map((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary'
+		? { ...artifact, required: true }
+		: artifact);
 }
 
 function aggregateWordPressFuzzCampaignResult(input = {}) {

--- a/wordpress/lib/wordpress-runtime-surface-discovery.js
+++ b/wordpress/lib/wordpress-runtime-surface-discovery.js
@@ -154,6 +154,7 @@ function appendArtifactSurfaces(surfaces, artifact) {
 	appendArraySurfaces(surfaces, artifact.media || artifact.attachments, 'media', 'media');
 	appendArraySurfaces(surfaces, artifact.postTypes || artifact.post_types, 'post_type', 'post-types');
 	appendArraySurfaces(surfaces, artifact.taxonomies, 'taxonomy', 'taxonomies');
+	appendArraySurfaces(surfaces, artifact.wpCli || artifact.wp_cli || artifact.wpCliCommands || artifact.wp_cli_commands || artifact.commands, 'wp_cli_command', 'wp-cli');
 }
 
 function appendFuzzSurfaceArtifact(surfaces, artifact) {
@@ -256,6 +257,7 @@ function runtimeSurfaceValue(surface, type, index) {
 		|| surface.media
 		|| surface.query
 		|| surface.table
+		|| surface.command
 		|| surface.name
 		|| surface.block
 		|| surface.block_name

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -271,8 +271,8 @@ function homeboyFuzzWorkloadPlanCases(manifest = {}) {
 function homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry = {}, manifest = {}, index = 0) {
 	const caseId = entry.case_id || entry.caseId || entry.id || `${manifest.id || 'fuzz-workload'}:${index}`;
 	const artifacts = normalizeHomeboyFuzzCaseArtifacts(entry, manifest);
-	const command = entry.command || entry.target?.entrypoint || entry.target?.id;
-	const input = homeboyFuzzRuntimeCommandInput(entry.input);
+	const command = homeboyFuzzPlanCaseRuntimeCommand(entry);
+	const input = homeboyFuzzPlanCaseRuntimeInput(entry, manifest, caseId);
 	return stripUndefined({
 		id: caseId,
 		case_id: caseId,
@@ -302,15 +302,46 @@ function homeboyFuzzWorkloadPlanCasePhases(entry = {}, manifest = {}, artifacts 
 	const setup = typeof activation === 'string' && activation.trim() !== ''
 		? [wpCodeboxPluginActivationStep(activation)]
 		: undefined;
-	const command = entry.command || entry.target?.entrypoint || entry.target?.id;
+	const command = homeboyFuzzPlanCaseRuntimeCommand(entry);
+	const runtimeInput = homeboyFuzzPlanCaseRuntimeInput(entry, manifest, entry.case_id || entry.caseId || entry.id);
 	const action = typeof command === 'string' && command.trim() !== ''
-		? [{ command, args: homeboyFuzzCommandArgs(entry.input) }]
+		? [{ command, args: homeboyFuzzRuntimeCommandArgs(runtimeInput) }]
 		: [];
 	const assert = artifacts
 		.map((artifact) => artifact.name)
 		.filter(Boolean)
 		.map((artifact) => ({ command: 'wordpress.collect-workload-result', args: [`artifact=${artifact}`] }));
 	return stripUndefined({ setup, action, assert: assert.length > 0 ? assert : undefined });
+}
+
+function homeboyFuzzRuntimeCommandArgs(input) {
+	return Array.isArray(input?.args) ? input.args : homeboyFuzzCommandArgs(input);
+}
+
+function homeboyFuzzPlanCaseRuntimeCommand(entry = {}) {
+	return entry.command || entry.target?.entrypoint || entry.target?.id || 'wordpress.run-fuzz-case';
+}
+
+function homeboyFuzzPlanCaseRuntimeInput(entry = {}, manifest = {}, caseId) {
+	if (objectOrUndefined(entry.input)) {
+		return homeboyFuzzRuntimeCommandInput(entry.input);
+	}
+	return stripUndefined({
+		case_id: caseId,
+		target_id: entry.target_id,
+		surface_id: entry.surface_id,
+		intent: entry.intent,
+		operation_id: entry.operation_id || entry.operationId,
+		operation: objectOrUndefined(entry.operation),
+		seed: entry.seed || manifest.seed,
+		skip_reasons: nonEmptyArray(entry.skip_reasons || entry.skipReasons),
+		destructive_reasons: nonEmptyArray(entry.destructive_reasons || entry.destructiveReasons),
+	});
+}
+
+function nonEmptyArray(value) {
+	const normalized = normalizeArray(value);
+	return normalized.length > 0 ? normalized : undefined;
 }
 
 function homeboyFuzzCommandArgs(input) {
@@ -798,13 +829,32 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 
 function requiredPublicCommandsForRequest(request = {}, requiredPlanContracts = {}) {
 	const ability = request.executor?.config?.runtime_task?.ability || request.ability;
+	const input = request.executor?.config?.runtime_task?.input || request.input || {};
 	if (ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY) {
 		return ['run-wordpress-workload'];
 	}
 	if (ability === DEFAULT_FUZZ_SUITE_ABILITY) {
-		return ['run-fuzz-suite'];
+		return unique([
+			'run-fuzz-suite',
+			...normalizeArray(requiredPlanContracts.commands),
+			...(suiteInputRequiresWorkloadCommand(input) ? ['run-wordpress-workload'] : []),
+		]);
 	}
-	return requiredPlanContracts.commands?.length > 0 ? requiredPlanContracts.commands : [...WP_CODEBOX_PUBLIC_CLI_COMMANDS];
+	return requiredPlanContracts.commands?.length > 0 ? unique(requiredPlanContracts.commands) : [...WP_CODEBOX_PUBLIC_CLI_COMMANDS];
+}
+
+function suiteInputRequiresWorkloadCommand(input = {}) {
+	return normalizeArray(input.cases).some((testCase) => {
+		const commands = normalizeArray(testCase.phases?.action).map((step) => step?.command).filter(Boolean);
+		return testCase.metadata?.source_plan_case === true
+			|| testCase.target?.entrypoint === 'wordpress.run-fuzz-case'
+			|| commands.includes('wordpress.run-fuzz-case')
+			|| commands.includes('wordpress.run-workload');
+	});
+}
+
+function unique(values) {
+	return [...new Set(normalizeArray(values).filter(Boolean))].sort();
 }
 
 function normalizeWpCodeboxPublicFuzzCapabilities(input = {}) {
@@ -1020,11 +1070,33 @@ function normalizeCodeboxFuzzObservationSet(source = {}, context = {}) {
 			...normalizeArray(source?.resources || source?.resource_measurements || source?.resourceMeasurements).map((entry) => objectOrUndefined(entry) ? { family: 'resource', ...entry } : entry),
 			...normalizeArray(source?.timings || source?.timing_measurements || source?.timingMeasurements).map((entry) => objectOrUndefined(entry) ? { family: 'timing', ...entry } : entry),
 			...normalizeArray(source?.counters || source?.counter_measurements || source?.counterMeasurements).map((entry) => objectOrUndefined(entry) ? { family: 'counter', ...entry } : entry),
+			...wordpressFuzzResultCaseObservations(source?.wordpress_fuzz_result || source?.wordpressFuzzResult || source?.normalized_result || source?.normalizedResult),
 		],
 		metadata: stripUndefined({
 			wp_codebox_result_schema: source?.schema,
 		}),
 	}, { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id });
+}
+
+function wordpressFuzzResultCaseObservations(result = {}) {
+	return normalizeArray(result?.cases).flatMap((testCase) => {
+		const common = {
+			case_id: testCase.id || testCase.case_id || testCase.caseId,
+			target_id: testCase.target_id || testCase.targetId || testCase.surface_id || testCase.surfaceId,
+			operation_id: testCase.operation_id || testCase.operationId,
+		};
+		return [
+			...objectMetricObservations(testCase.db_query || testCase.dbQuery, { ...common, family: 'query', subject: 'db_query' }),
+			...objectMetricObservations(testCase.performance_metrics || testCase.performanceMetrics, { ...common, family: 'timing', subject: 'performance' }),
+		];
+	});
+}
+
+function objectMetricObservations(metrics, defaults = {}) {
+	if (!objectOrUndefined(metrics)) {
+		return [];
+	}
+	return Object.entries(metrics).flatMap(([metric, value]) => Number.isFinite(Number(value)) ? [{ ...defaults, metric, value }] : []);
 }
 
 function wpCodeboxFuzzContractFailures({ source = {}, result = {}, context = {}, artifacts = [], coverageSummary, normalizedResult }) {

--- a/wordpress/tests/wordpress-fuzz-campaign-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-campaign-smoke.js
@@ -88,4 +88,17 @@ const readOnlyCampaign = compileWordPressFuzzCampaign({
 });
 assert.equal(readOnlyCampaign.plan.metadata.mutation_mode, 'read_only');
 
+const productionCampaign = compileWordPressFuzzCampaign({
+	id: 'production-campaign',
+	production: true,
+	surfaces: [
+		{ id: 'rest:production', type: 'rest_route', route: '/wp/v2/posts', method: 'GET' },
+	],
+});
+assert.equal(productionCampaign.workload.metadata.production_campaign, true);
+assert.equal(productionCampaign.wp_codebox.input.metadata.production_campaign, true);
+assert.deepEqual(productionCampaign.wp_codebox.input.metadata.output_requirements.required_artifact_keys, ['fuzz.coverage', 'fuzz.hotspot.summary']);
+assert.equal(productionCampaign.workload.artifacts.expected.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').required, true);
+assert.equal(productionCampaign.wp_codebox.task_request.artifact_declarations.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').required, true);
+
 console.log('wordpress fuzz campaign smoke passed');

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -119,15 +119,20 @@ const runtimeDiscovery = normalizeWordPressRuntimeSurfaceDiscovery({
 		{ type: 'role', role: 'editor' },
 		{ type: 'media', name: 'attachment' },
 		{ type: 'db_query', query: 'SELECT ID FROM wp_posts' },
+		{ type: 'wp_cli_command', command: 'wp option list' },
 	],
 });
 assert.deepEqual(runtimeDiscovery.surfaces.map((surface) => surface.type), ['admin_page', 'ajax_action', 'db_table', 'rest_route']);
-assert.deepEqual(runtimeDiscovery.unsupported_surfaces.map((surface) => surface.type), ['cron_event', 'db_query', 'hook', 'media', 'option', 'role']);
+assert.deepEqual(runtimeDiscovery.unsupported_surfaces.map((surface) => surface.type), ['cron_event', 'db_query', 'hook', 'media', 'option', 'role', 'wp_cli_command']);
 assert.equal(runtimeDiscovery.unsupported_surfaces.every((surface) => surface.executable === false && surface.coverage_counted === false), true);
 assert.equal(runtimeDiscovery.diagnostics.every((diagnostic) => diagnostic.code === 'wordpress_surface_discovered_without_executable_runtime_collector'), true);
 const runtimePlan = buildWordPressFuzzPlanFromSurfaces(runtimeDiscovery);
 assert.deepEqual(runtimePlan.targets.map((target) => target.type), ['admin-page', 'ajax-action', 'database-table', 'rest-route']);
 assert.equal(runtimePlan.targets.find((target) => target.type === 'ajax-action').cases[0].intent, 'exercise-ajax-action');
+
+const wpCliRuntimeDiscovery = normalizeWordPressRuntimeSurfaceDiscovery({ wp_cli_commands: [{ command: 'wp cron event list' }] });
+assert.equal(wpCliRuntimeDiscovery.unsupported_surfaces[0].id, 'wp-cli:wp cron event list');
+assert.equal(wpCliRuntimeDiscovery.diagnostics[0].surface.type, 'wp_cli_command');
 
 const nestedPlan = buildWordPressFuzzPlanFromSurfaces({
 	hooks: {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -375,6 +375,48 @@ assert.equal(planWorkloadInput.cases[0].metadata.source_plan_case, true);
 assert.equal(planWorkloadInput.cases[0].metadata.target_id, 'sample-rest-routes');
 assert.deepEqual(planWorkloadInput.cases[0].inputs.budget_keys, ['max_rest_p95_duration_ms']);
 
+const genericPlanWorkloadInput = wpCodeboxFuzzSuiteInput({
+	id: 'generic-plan-workload-run',
+	homeboyFuzzWorkload: {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: 'generic-plan-workload',
+		plan: {
+			schema: 'wordpress-fuzz-plan/v1',
+			id: 'generic-plan',
+			targets: [{
+				id: 'hook:init',
+				surface_id: 'hook:init',
+				cases: [{ id: 'hook:init-generic-fuzz', intent: 'exercise-hook', operation: { hook: 'init' } }],
+			}],
+		},
+	},
+});
+assert.equal(genericPlanWorkloadInput.cases[0].target.entrypoint, 'wordpress.run-fuzz-case');
+assert.deepEqual(genericPlanWorkloadInput.cases[0].input, {
+	case_id: 'hook:init-generic-fuzz',
+	target_id: 'hook:init',
+	surface_id: 'hook:init',
+	intent: 'exercise-hook',
+	operation: { hook: 'init' },
+});
+assert.equal(genericPlanWorkloadInput.cases[0].phases.action[0].command, 'wordpress.run-fuzz-case');
+assert.deepEqual(genericPlanWorkloadInput.cases[0].phases.action[0].args, [
+	'case_id=hook:init-generic-fuzz',
+	'target_id=hook:init',
+	'surface_id=hook:init',
+	'intent=exercise-hook',
+	'operation={"hook":"init"}',
+]);
+
+const genericPlanTaskRequest = wpCodeboxFuzzSuiteTaskRequest({ taskId: 'generic-plan-task', input: genericPlanWorkloadInput });
+const genericPlanPreflight = preflightWpCodeboxFuzzCapabilityContract({
+	request: genericPlanTaskRequest,
+	runtimeContractManifest: manifest,
+	publicCliCapabilities: { commands: { 'run-fuzz-suite': true } },
+});
+assert.equal(genericPlanPreflight.ok, false);
+assert.equal(genericPlanPreflight.missing_contracts.some((contract) => contract.command === 'run-wordpress-workload'), true);
+
 let invoked = false;
 runWpCodeboxFuzzSuite({
 	taskId: 'wp-codebox-fuzz-suite-delegation-smoke',
@@ -475,6 +517,7 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.observation_set.schema, 'homeboy/fuzz-observation-set/v1');
 	assert.equal(summary.observation_set.observations[0].family, 'query');
 	assert.equal(summary.observation_set.observations[1].metric, 'duration_ms');
+	assert.equal(summary.observation_set.observations.some((observation) => observation.case_id === 'case-000' && observation.metric === 'query_count'), true);
 	assert.equal(summary.runtime_task_result.observation_set.observations[0].fingerprint, 'select-posts');
 	assert.equal(summary.derived_artifacts.artifacts.some((artifact) => artifact.role === 'hotspot_summary'), true);
 	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'normalized_fuzz_result', 'coverage_gap_report', 'hotspot_summary', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case', 'repro_case']);


### PR DESCRIPTION
## Summary
- Adapt wordpress-fuzz-plan/v1 cases to wordpress.run-fuzz-case workload commands when explicit Codebox commands are absent.
- Fail closed when public Codebox workload capability is required but unavailable.
- Enforce production campaign artifact requirements for coverage and hotspot summaries.
- Extend observation attribution from DB query and performance metrics.
- Normalize WP-CLI discovery as unsupported diagnostic surfaces.

## Verification
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
- node wordpress/tests/wordpress-fuzz-campaign-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node wordpress/tests/wordpress-fuzz-coverage-aggregate-smoke.js
- npm --prefix wordpress run test:wp-codebox-fuzz-run
- npm --prefix wordpress run test:wordpress-fuzz-campaign
- npm --prefix wordpress run test:wordpress-fuzz-plan-from-surfaces
- npm --prefix wordpress run test:wordpress-fuzz-runner
- npm --prefix wordpress run test:wordpress-runtime-surface-discovery

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Auditing WordPress fuzz orchestration gaps, drafting the Codebox workload adapter and artifact gates, adding focused tests, and preparing the PR.