### PR TITLE
feat(wordpress): consume Codebox hotspot artifacts

### DIFF
--- a/wordpress/lib/wordpress-fuzz-campaign.js
+++ b/wordpress/lib/wordpress-fuzz-campaign.js
@@ -18,7 +18,9 @@ const {
 } = require('./wordpress-performance-observation-aggregate');
 const {
 	DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
+	DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
+	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
 } = require('./wp-codebox-fuzz-run');
@@ -83,6 +85,7 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 		taskId: input.task_id || input.taskId || options.taskId || options.task_id || `${plan.id}-wp-codebox-fuzz-suite`,
 		input: suiteInput,
 		artifactDeclarations: productionArtifactDeclarations(production),
+		expectedArtifacts: productionExpectedArtifacts(production),
 	});
 
 	return {
@@ -188,7 +191,7 @@ function defaultCampaignArtifactsWithOptions(options = {}) {
 		expected: [
 			{ name: 'wordpress_fuzz_result', role: 'normalized_fuzz_result', semantic_key: 'fuzz.result.normalized', required: true },
 			{ name: 'wordpress_fuzz_coverage', role: 'coverage', semantic_key: 'fuzz.coverage', required: true },
-			{ name: 'wordpress_fuzz_hotspots', role: 'hotspot_summary', semantic_key: 'fuzz.hotspot.summary', required: hotspotRequired },
+			{ name: 'wordpress-hotspots', role: 'hotspot_summary', semantic_key: 'fuzz.hotspot.summary', schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA, required: hotspotRequired },
 			{ name: 'wordpress_performance_observation', role: 'fuzz_report', semantic_key: 'fuzz.performance', required: false },
 		],
 	};
@@ -197,7 +200,15 @@ function defaultCampaignArtifactsWithOptions(options = {}) {
 function productionOutputRequirements() {
 	return {
 		required_artifact_keys: ['fuzz.coverage', 'fuzz.hotspot.summary'],
+		required_artifact_schemas: [WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA],
 	};
+}
+
+function productionExpectedArtifacts(production = false) {
+	if (!production) {
+		return undefined;
+	}
+	return [...new Set([...DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS, 'wordpress-hotspots'])];
 }
 
 function productionArtifactDeclarations(production = false) {

--- a/wordpress/lib/wordpress-fuzz-coverage-aggregate.js
+++ b/wordpress/lib/wordpress-fuzz-coverage-aggregate.js
@@ -308,19 +308,24 @@ function aggregateWordPressFuzzCoverage(input = {}) {
 }
 
 function aggregateFuzzHotspotSummary(input = {}) {
+	const artifactHotspotCandidates = normalizeArray(input.artifacts || input.results || input.coverage || []).flatMap((artifact) => [
+		artifact,
+		artifact?.hotspot_summary,
+		artifact?.hotspotSummary,
+		artifact?.hotspots,
+		artifact?.performance_hotspots,
+		artifact?.performanceHotspots,
+		artifact?.payload,
+		artifact?.data,
+		artifact?.content,
+	]);
 	const candidates = [
 		input.hotspot_summary,
 		input.hotspotSummary,
 		input.hotspots,
 		input.performance_hotspots,
 		input.performanceHotspots,
-		...normalizeArray(input.artifacts || input.results || input.coverage || []).flatMap((artifact) => [
-			artifact?.hotspot_summary,
-			artifact?.hotspotSummary,
-			artifact?.hotspots,
-			artifact?.performance_hotspots,
-			artifact?.performanceHotspots,
-		]),
+		...artifactHotspotCandidates,
 	];
 	const summaries = candidates.map((candidate) => normalizeFuzzHotspotSummary(candidate)).filter(Boolean);
 	if (summaries.length === 0) {

--- a/wordpress/lib/wordpress-fuzz-runtime-task.js
+++ b/wordpress/lib/wordpress-fuzz-runtime-task.js
@@ -5,6 +5,7 @@ const WORDPRESS_FUZZ_RUNTIME_TASK_RESULT_SCHEMA = 'homeboy/fuzz-runtime-task-res
 const WORDPRESS_FUZZ_HOTSPOT_SET_SCHEMA = 'homeboy/fuzz-hotspot-set/v1';
 const WORDPRESS_FUZZ_HOTSPOT_SUMMARY_SCHEMA = WORDPRESS_FUZZ_HOTSPOT_SET_SCHEMA;
 const WORDPRESS_FUZZ_OBSERVATION_SET_SCHEMA = 'homeboy/fuzz-observation-set/v1';
+const WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA = 'wp-codebox/wordpress-hotspots/v1';
 
 function buildWordPressFuzzRuntimeTaskRequest(options = {}) {
 	const provider = normalizeProvider(options.provider || options.runtimeId || options.runtime_id || 'wp-codebox');
@@ -192,7 +193,7 @@ function fuzzHotspotSummaryFromObservationSet(input, defaults = {}) {
 
 function normalizeFuzzHotspotSummary(input, defaults = {}) {
 	const source = objectOrUndefined(input) ? input : { items: input };
-	const rawItems = source.hotspots || source.items || source.entries || source.summary || [];
+	const rawItems = codeboxWordPressHotspotItems(source);
 	const summaryDefaults = {
 		...defaults,
 		dimension: nonEmptyString(source.dimension || source.kind || defaults.dimension),
@@ -217,13 +218,37 @@ function normalizeFuzzHotspotSummary(input, defaults = {}) {
 	});
 }
 
+function codeboxWordPressHotspotItems(source = {}) {
+	const direct = source.hotspots || source.items || source.entries || source.summary;
+	if (direct !== undefined) {
+		return direct;
+	}
+	if (source.schema !== WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA) {
+		return [];
+	}
+	return [
+		...typedHotspotItems(source.database || source.db || source.queries || source.query_hotspots || source.queryHotspots, 'database'),
+		...typedHotspotItems(source.api || source.rest || source.routes || source.rest_routes || source.restRoutes, 'api'),
+		...typedHotspotItems(source.performance || source.timing || source.timings, 'performance'),
+	];
+}
+
+function typedHotspotItems(value, dimension) {
+	return normalizeArray(value).flatMap((entry) => {
+		if (Array.isArray(entry)) {
+			return typedHotspotItems(entry, dimension);
+		}
+		return objectOrUndefined(entry) ? [{ dimension, ...entry }] : [];
+	});
+}
+
 function normalizeFuzzHotspotItem(entry = {}, defaults = {}) {
 	if (!objectOrUndefined(entry)) {
 		return undefined;
 	}
 	const metadata = objectOrUndefined(entry.metadata) || {};
-	const surfaceKey = nonEmptyString(entry.surface_key || entry.surfaceKey || entry.surface || entry.surface_id || entry.surfaceId || metadata.surface_key || metadata.surfaceKey || entry.key || entry.id);
-	const operationKey = nonEmptyString(entry.operation_key || entry.operationKey || entry.operation || entry.operation_id || entry.operationId || metadata.operation_key || metadata.operationKey || surfaceKey);
+	const surfaceKey = nonEmptyString(entry.surface_key || entry.surfaceKey || entry.surface || entry.surface_id || entry.surfaceId || entry.route || entry.endpoint || entry.path || entry.table || entry.query || metadata.surface_key || metadata.surfaceKey || entry.key || entry.id);
+	const operationKey = nonEmptyString(entry.operation_key || entry.operationKey || entry.operation || entry.operation_id || entry.operationId || entry.method || entry.verb || entry.action || metadata.operation_key || metadata.operationKey || surfaceKey);
 	const metric = nonEmptyString(entry.metric || entry.metric_name || entry.metricName || defaults.metric || inferMetric(entry));
 	const value = numericValue(entry.value ?? entry.metric_value ?? entry.metricValue ?? entry.count ?? entry.total ?? entry.duration_ms ?? entry.durationMs);
 	if (!surfaceKey || !operationKey || !metric || value === undefined) {
@@ -347,6 +372,7 @@ module.exports = {
 	WORDPRESS_FUZZ_RUNTIME_TASK_RESULT_SCHEMA,
 	WORDPRESS_FUZZ_HOTSPOT_SET_SCHEMA,
 	WORDPRESS_FUZZ_OBSERVATION_SET_SCHEMA,
+	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 	buildWordPressFuzzRuntimeTaskRequest,
 	fuzzHotspotSummaryFromObservationSet,
 	normalizeFuzzObservationSet,

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -40,6 +40,7 @@ const {
 
 const WP_CODEBOX_FUZZ_SUITE_SCHEMA = 'wp-codebox/fuzz-suite/v1';
 const WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA = 'wp-codebox/fuzz-suite-result/v1';
+const WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA = 'wp-codebox/wordpress-hotspots/v1';
 const WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA = 'homeboy/wordpress-codebox-fuzz-suite-consumer/v1';
 const WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA = 'homeboy/wp-codebox-fuzz-preflight/v1';
 const WORDPRESS_FUZZ_OBSERVATION_SCHEMA = 'homeboy/wordpress-fuzz-observation/v1';
@@ -130,8 +131,9 @@ const DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS = [
 	},
 	{
 		role: 'hotspot_summary',
-		name: 'hotspot-summary',
+		name: 'wordpress-hotspots',
 		semantic_key: 'fuzz.hotspot.summary',
+		schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 		content_type: 'application/json',
 		required: false,
 	},
@@ -1007,7 +1009,7 @@ function normalizeWpCodeboxFuzzSuiteResult(result = {}, context = {}) {
 	]);
 	const hotspotSummary = normalizeFuzzHotspotSummary(source?.hotspot_summary || source?.hotspotSummary || source?.hotspots || source?.performance_hotspots || source?.performanceHotspots || derivedArtifacts.hotspot_summary || fuzzHotspotSummaryFromObservationSet(observationSet, { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id }), { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id });
 	const normalizedResult = normalizeEmbeddedWordPressFuzzResult(source);
-	const contractFailures = wpCodeboxFuzzContractFailures({ source, result, context, artifacts, coverageSummary, normalizedResult });
+	const contractFailures = wpCodeboxFuzzContractFailures({ source, result, context, artifacts, coverageSummary, normalizedResult, hotspotSummary });
 	if (contractFailures.length > 0 && ['succeeded', 'success', 'passed', 'ok'].includes(String(status).toLowerCase())) {
 		status = 'failed';
 	}
@@ -1099,7 +1101,7 @@ function objectMetricObservations(metrics, defaults = {}) {
 	return Object.entries(metrics).flatMap(([metric, value]) => Number.isFinite(Number(value)) ? [{ ...defaults, metric, value }] : []);
 }
 
-function wpCodeboxFuzzContractFailures({ source = {}, result = {}, context = {}, artifacts = [], coverageSummary, normalizedResult }) {
+function wpCodeboxFuzzContractFailures({ source = {}, result = {}, context = {}, artifacts = [], coverageSummary, normalizedResult, hotspotSummary }) {
 	if (wpCodeboxFuzzAllowsEmpty(source, context)) {
 		return [];
 	}
@@ -1128,7 +1130,7 @@ function wpCodeboxFuzzContractFailures({ source = {}, result = {}, context = {},
 		});
 	}
 
-	const requiredOutputFailures = requiredFuzzOutputFailures({ source, context, artifacts, normalizedResult });
+	const requiredOutputFailures = requiredFuzzOutputFailures({ source, context, artifacts, normalizedResult, hotspotSummary });
 	failures.push(...requiredOutputFailures);
 
 	return failures;
@@ -1189,7 +1191,7 @@ function normalizeObservationMetrics({ coverageSummary, hotspotSummary, normaliz
 	});
 }
 
-function requiredFuzzOutputFailures({ source = {}, context = {}, artifacts = [], normalizedResult } = {}) {
+function requiredFuzzOutputFailures({ source = {}, context = {}, artifacts = [], normalizedResult, hotspotSummary } = {}) {
 	const requirements = fuzzOutputRequirements(source, context);
 	const failures = [];
 	const missingMetricPaths = requirements.normalizedMetricPaths.filter((metricPath) => !hasNumericPath(normalizedResult, metricPath));
@@ -1209,6 +1211,24 @@ function requiredFuzzOutputFailures({ source = {}, context = {}, artifacts = [],
 			code: 'wp_codebox_fuzz_required_output_artifacts_missing',
 			message: 'WP Codebox fuzz result is missing declared output artifact keys.',
 			missing_artifact_keys: missingArtifactKeys,
+		});
+	}
+
+	const missingArtifactSchemas = requirements.artifactSchemas.filter((schema) => !artifacts.some((artifact) => fuzzArtifactMatchesSchema(artifact, schema)));
+	if (missingArtifactSchemas.length > 0) {
+		failures.push({
+			severity: 'error',
+			code: 'wp_codebox_fuzz_required_output_artifact_schemas_missing',
+			message: 'WP Codebox fuzz result is missing declared output artifact schemas.',
+			missing_artifact_schemas: missingArtifactSchemas,
+		});
+	}
+
+	if (requirements.hotspotArtifactRequired && !hotspotSummary) {
+		failures.push({
+			severity: 'error',
+			code: 'wp_codebox_fuzz_required_hotspot_artifact_missing',
+			message: 'WP Codebox fuzz result is missing declared hotspot artifact payloads.',
 		});
 	}
 
@@ -1245,13 +1265,35 @@ function fuzzOutputRequirements(source = {}, context = {}) {
 			|| outputRequirements.required_artifact_keys
 			|| outputRequirements.requiredArtifactKeys
 		),
+		artifactSchemas: normalizeStringList(
+			metadata.required_artifact_schemas
+			|| metadata.requiredArtifactSchemas
+			|| outputRequirements.required_artifact_schemas
+			|| outputRequirements.requiredArtifactSchemas
+		),
 		evidenceStatuses: normalizeEvidenceStatusRequirements(
 			metadata.required_evidence_statuses
 			|| metadata.requiredEvidenceStatuses
 			|| outputRequirements.required_evidence_statuses
 			|| outputRequirements.requiredEvidenceStatuses
 		),
+		hotspotArtifactRequired: outputRequiresHotspotArtifact(metadata, outputRequirements),
 	};
+}
+
+function outputRequiresHotspotArtifact(metadata = {}, outputRequirements = {}) {
+	return normalizeStringList(
+		metadata.required_artifact_keys
+		|| metadata.requiredArtifactKeys
+		|| outputRequirements.required_artifact_keys
+		|| outputRequirements.requiredArtifactKeys
+	).includes('fuzz.hotspot.summary')
+		|| normalizeStringList(
+			metadata.required_artifact_schemas
+			|| metadata.requiredArtifactSchemas
+			|| outputRequirements.required_artifact_schemas
+			|| outputRequirements.requiredArtifactSchemas
+		).includes(WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA);
 }
 
 function normalizeStringList(value) {
@@ -1353,10 +1395,17 @@ function wpCodeboxFuzzRequiredArtifactDeclarations(request = {}) {
 }
 
 function fuzzArtifactMatchesKey(artifact = {}, key) {
-	return [artifact.name, artifact.role, artifact.semantic_key || artifact.semanticKey, artifact.path, artifact.metadata?.semantic_key || artifact.metadata?.semanticKey]
+	return [artifact.name, artifact.role, artifact.semantic_key || artifact.semanticKey, artifact.path, artifact.metadata?.semantic_key || artifact.metadata?.semanticKey, artifact.schema || artifact.metadata?.schema]
 		.filter(Boolean)
 		.map(String)
 		.includes(String(key));
+}
+
+function fuzzArtifactMatchesSchema(artifact = {}, schema) {
+	return [artifact.schema, artifact.artifact_schema, artifact.artifactSchema, artifact.metadata?.schema, artifact.payload?.schema, artifact.data?.schema, artifact.content?.schema]
+		.filter(Boolean)
+		.map(String)
+		.includes(String(schema));
 }
 function wpCodeboxFuzzCaseCount(source = {}, normalizedResult) {
 	const cases = source?.cases || source?.fuzz_cases || source?.fuzzCases || normalizedResult?.cases;
@@ -1636,6 +1685,7 @@ function isHotspotSummaryArtifact({ semanticKey = '', schema = '', payload } = {
 	return key === 'fuzz.hotspot.summary'
 		|| key === 'fuzz.hotspots'
 		|| key === 'performance.hotspots'
+		|| schemaName === WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA
 		|| schemaName.includes('hotspot')
 		|| (objectOrUndefined(payload) && (Array.isArray(payload.hotspots) || Array.isArray(payload.items)) && (payload.metric !== undefined || payload.ranking !== undefined));
 }
@@ -1875,6 +1925,7 @@ module.exports = {
 	WORDPRESS_FUZZ_OBSERVATION_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
+	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 	buildWordPressFuzzCommandManifest,
 	buildWordPressFuzzObservation,
 	normalizeWpCodeboxFuzzArtifacts,

--- a/wordpress/tests/wordpress-fuzz-campaign-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-campaign-smoke.js
@@ -3,6 +3,10 @@
 const assert = require('node:assert/strict');
 
 const {
+	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+} = require('../lib/wp-codebox-fuzz-run');
+
+const {
 	WORDPRESS_FUZZ_CAMPAIGN_SCHEMA,
 	WORDPRESS_FUZZ_PLAN_RESULT_GAP_REPORT_SCHEMA,
 	aggregateWordPressFuzzCampaignResult,
@@ -98,7 +102,11 @@ const productionCampaign = compileWordPressFuzzCampaign({
 assert.equal(productionCampaign.workload.metadata.production_campaign, true);
 assert.equal(productionCampaign.wp_codebox.input.metadata.production_campaign, true);
 assert.deepEqual(productionCampaign.wp_codebox.input.metadata.output_requirements.required_artifact_keys, ['fuzz.coverage', 'fuzz.hotspot.summary']);
+assert.deepEqual(productionCampaign.wp_codebox.input.metadata.output_requirements.required_artifact_schemas, [WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA]);
+assert.equal(productionCampaign.workload.artifacts.expected.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').name, 'wordpress-hotspots');
 assert.equal(productionCampaign.workload.artifacts.expected.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').required, true);
+assert.equal(productionCampaign.wp_codebox.task_request.expected_artifacts.includes('wordpress-hotspots'), true);
 assert.equal(productionCampaign.wp_codebox.task_request.artifact_declarations.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').required, true);
+assert.equal(productionCampaign.wp_codebox.task_request.artifact_declarations.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').schema, WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA);
 
 console.log('wordpress fuzz campaign smoke passed');

--- a/wordpress/tests/wordpress-fuzz-runtime-task.test.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-task.test.js
@@ -10,6 +10,7 @@ const {
 	fuzzHotspotSummaryFromObservationSet,
 	normalizeFuzzObservationSet,
 	normalizeFuzzHotspotSummary,
+	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 } = require('../lib/wordpress-fuzz-runtime-task');
 const {
 	WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA,
@@ -69,6 +70,17 @@ const observationHotspots = fuzzHotspotSummaryFromObservationSet(codeboxObservat
 assert.equal(observationHotspots.schema, WORDPRESS_FUZZ_HOTSPOT_SUMMARY_SCHEMA);
 assert.equal(observationHotspots.items[0].metadata.observation_id, codeboxObservations.observations[0].id);
 
+const codeboxWordPressHotspots = normalizeFuzzHotspotSummary({
+	schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+	db: [{ table: 'wp_posts', operation: 'SELECT', metric: 'query_count', count: 11 }],
+	api: [{ route: '/wp-json/wp/v2/posts', method: 'GET', metric: 'duration_ms', duration_ms: 84 }],
+});
+assert.equal(codeboxWordPressHotspots.schema, WORDPRESS_FUZZ_HOTSPOT_SUMMARY_SCHEMA);
+assert.equal(codeboxWordPressHotspots.items[0].dimension, 'database');
+assert.equal(codeboxWordPressHotspots.items[0].metadata.surface_key, 'wp_posts');
+assert.equal(codeboxWordPressHotspots.items[1].dimension, 'api');
+assert.equal(codeboxWordPressHotspots.items[1].metadata.operation_key, 'GET');
+
 const derivedAggregate = aggregateWordPressFuzzCoverage({
 	artifacts: [
 		{
@@ -82,10 +94,18 @@ const derivedAggregate = aggregateWordPressFuzzCoverage({
 			semantic_key: 'fuzz.hotspot.summary',
 			hotspots: [{ surface: 'route:/wp/v2/posts', operation: 'GET /wp/v2/posts', metric: 'duration_ms', value: 77 }],
 		},
+		{
+			name: 'wordpress-hotspots',
+			payload: {
+				schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+				db: [{ table: 'wp_options', operation: 'SELECT', metric: 'query_count', count: 5 }],
+			},
+		},
 	],
 });
 assert.equal(derivedAggregate.coverage_gaps[0].id, 'route:/wp/v2/comments');
 assert.equal(derivedAggregate.hotspot_summary.items[0].value, 77);
+assert.equal(derivedAggregate.hotspot_summary.items.some((item) => item.metadata.surface_key === 'wp_options'), true);
 
 Promise.all([
 	runWpCodeboxFuzzSuite({

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -17,6 +17,7 @@ const {
 	WORDPRESS_FUZZ_OBSERVATION_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
+	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 	buildWordPressFuzzCommandManifest,
 	wpCodeboxFuzzSuiteAbility,
 	wpCodeboxFuzzSuiteSchema,
@@ -131,6 +132,7 @@ assert.deepEqual(
 	]
 );
 assert.equal(taskRequest.artifact_declarations.find((artifact) => artifact.name === 'fuzz-observation-set').role, 'observation_set');
+assert.equal(taskRequest.artifact_declarations.find((artifact) => artifact.name === 'wordpress-hotspots').schema, WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA);
 assert.equal(taskRequest.artifact_declarations.find((artifact) => artifact.name === 'wp-codebox-fuzz-suite-result').role, 'codebox_result');
 assert.equal(taskRequest.artifact_declarations.find((artifact) => artifact.name === 'case-log').role, 'case_log');
 assert.deepEqual(
@@ -475,7 +477,7 @@ runWpCodeboxFuzzSuite({
 					coverage: { path: 'reports/coverage.json', content_type: 'application/json', size_bytes: 123, payload: { schema: 'wp-codebox/coverage-report/v1', covered: 1 } },
 					normalized_fuzz_result: { path: 'reports/wordpress-fuzz-result.json', content_type: 'application/json' },
 					coverage_gap_report: { path: 'reports/coverage-gaps.json', content_type: 'application/json', schema: 'homeboy/wordpress-coverage-gap-report/v1', semantic_key: 'fuzz.coverage.gap_report', payload: { schema: 'homeboy/wordpress-coverage-gap-report/v1', expected: 2, covered: 1, gaps: [{ id: 'route:/wp/v2/comments', type: 'rest_route', status: 'skipped' }] } },
-					hotspot_summary: { path: 'reports/hotspots.json', content_type: 'application/json', semantic_key: 'fuzz.hotspot.summary', payload: { schema: 'homeboy/fuzz-hotspot-summary/v1', metric: 'duration_ms', unit: 'ms', items: [{ surface: 'route:/wp/v2/posts', operation: 'GET /wp/v2/posts', value: 99, rank: 1 }] } },
+					hotspot_summary: { name: 'wordpress-hotspots', path: 'reports/hotspots.json', content_type: 'application/json', schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA, payload: { schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA, db: [{ table: 'wp_posts', operation: 'SELECT', metric: 'query_count', count: 4 }], api: [{ route: '/wp-json/wp/v2/posts', method: 'GET', metric: 'duration_ms', duration_ms: 99 }] } },
 					fuzz_case: { path: 'cases/case-000.json', case_id: 'case-000' },
 					placeholder_case: { name: 'placeholder-only' },
 					failing_case: { path: 'cases/failing-case.json', case_id: 'case-002' },
@@ -513,7 +515,8 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.coverage_gaps[0].status, 'skipped');
 	assert.equal(summary.coverage_gaps.some((gap) => gap.id === 'route:/wp/v2/comments'), true);
 	assert.equal(summary.derived_artifacts.coverage_gap_reports[0].coverage_gaps[0].id, 'route:/wp/v2/comments');
-	assert.equal(summary.hotspot_summary.items[0].value, 99);
+	assert.equal(summary.hotspot_summary.items.some((item) => item.dimension === 'api' && item.value === 99), true);
+	assert.equal(summary.hotspot_summary.items.some((item) => item.dimension === 'database' && item.metadata.surface_key === 'wp_posts'), true);
 	assert.equal(summary.observation_set.schema, 'homeboy/fuzz-observation-set/v1');
 	assert.equal(summary.observation_set.observations[0].family, 'query');
 	assert.equal(summary.observation_set.observations[1].metric, 'duration_ms');
@@ -540,7 +543,7 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.observation.summary.coverage.surface_count, 3);
 	assert.equal(summary.observation.metrics.coverage.exercised_count, 1);
 	assert.equal(summary.observation.metrics.db_query.query_count, 1);
-	assert.equal(summary.observation.metrics.hotspots.count, 1);
+	assert.equal(summary.observation.metrics.hotspots.count, 2);
 	assert.equal(summary.observation.artifacts.find((artifact) => artifact.role === 'normalized_fuzz_result').semantic_key, 'fuzz.result.normalized');
 	assert.equal(summary.observation.normalized_result.schema, 'wordpress-fuzz-result/v1');
 
@@ -746,6 +749,55 @@ runWpCodeboxFuzzSuite({
 	}, { request: requiredOutputRequest });
 	assert.equal(requiredOutputObserved.succeeded, true);
 	assert.equal(requiredOutputObserved.failures.length, 0);
+	const hotspotArtifactRequest = wpCodeboxFuzzSuiteTaskRequest({
+		taskId: 'required-hotspot-artifact-suite-task',
+		artifactDeclarations: [],
+		input: wpCodeboxFuzzSuiteInput({
+			id: 'required-hotspot-artifact-suite',
+			metadata: {
+				output_requirements: {
+					required_artifact_keys: ['fuzz.hotspot.summary'],
+					required_artifact_schemas: [WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA],
+				},
+			},
+		}),
+	});
+	const hotspotArtifactObserved = normalizeWpCodeboxFuzzSuiteResult({
+		json: {
+			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+			status: 'passed',
+			summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+			cases: [{ id: 'required-hotspot-case', status: 'passed' }],
+			artifacts: {
+				hotspot_summary: {
+					name: 'wordpress-hotspots',
+					path: 'reports/wordpress-hotspots.json',
+					schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+					payload: {
+						schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+						db: [{ table: 'wp_posts', operation: 'SELECT', metric: 'query_count', count: 7 }],
+						api: [{ route: '/wp-json/wp/v2/posts', method: 'GET', metric: 'duration_ms', duration_ms: 33 }],
+					},
+				},
+			},
+		},
+	}, { request: hotspotArtifactRequest });
+	assert.equal(hotspotArtifactObserved.succeeded, true);
+	assert.equal(hotspotArtifactObserved.hotspot_summary.items.some((item) => item.dimension === 'database' && item.value === 7), true);
+	assert.equal(hotspotArtifactObserved.hotspot_summary.items.some((item) => item.dimension === 'api' && item.value === 33), true);
+	const hotspotArtifactMissing = normalizeWpCodeboxFuzzSuiteResult({
+		json: {
+			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+			status: 'passed',
+			summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+			cases: [{ id: 'missing-hotspot-case', status: 'passed' }],
+			artifacts: { coverage: { path: 'coverage.json', semantic_key: 'fuzz.coverage' } },
+		},
+	}, { request: hotspotArtifactRequest });
+	assert.equal(hotspotArtifactMissing.succeeded, false);
+	assert(hotspotArtifactMissing.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_output_artifacts_missing'));
+	assert(hotspotArtifactMissing.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_output_artifact_schemas_missing'));
+	assert(hotspotArtifactMissing.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_hotspot_artifact_missing'));
 	const requiredOutputMissing = normalizeWpCodeboxFuzzSuiteResult({
 		json: {
 			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,


### PR DESCRIPTION
## Summary
- Normalize wp-codebox/wordpress-hotspots/v1 payloads into Homeboy WordPress fuzz hotspot summaries.
- Aggregate nested Codebox hotspot artifacts into coverage output.
- Enforce Codebox hotspot artifact presence for production campaigns.
- Add missing-artifact and DB/API hotspot normalization coverage.

## Verification
- npm run test:wordpress-fuzz-runtime-task
- npm run test:wp-codebox-fuzz-run
- npm run test:wordpress-fuzz-campaign
- npm run test:wordpress-fuzz-coverage-aggregate

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Auditing the WordPress orchestration consumption gap, drafting Codebox hotspot normalization/enforcement, adding focused tests, and preparing the PR.