### PR TITLE
feat(wordpress): bind fuzz proof outputs

### DIFF
--- a/wordpress/lib/wordpress-fuzz-campaign.js
+++ b/wordpress/lib/wordpress-fuzz-campaign.js
@@ -17,10 +17,11 @@ const {
 	buildWordPressPerformanceObservation,
 } = require('./wordpress-performance-observation-aggregate');
 const {
-	DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
-	DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+	wordpressFuzzPostprocessArtifactDeclarations,
+	wordpressFuzzPostprocessBinding,
+	wordpressFuzzPostprocessExpectedArtifacts,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
 } = require('./wp-codebox-fuzz-run');
@@ -61,6 +62,7 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 			production_campaign: production || undefined,
 		},
 		artifacts: input.artifacts || options.artifacts,
+		postprocess_binding: input.postprocess_binding || input.postprocessBinding || options.postprocess_binding || options.postprocessBinding || (production ? wordpressFuzzPostprocessBinding() : undefined),
 		production,
 	});
 	const suiteInput = wpCodeboxFuzzSuiteInput({
@@ -77,6 +79,7 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 			aggregation_hooks: campaignAggregationHooks(),
 			production_campaign: production || undefined,
 			output_requirements: production ? productionOutputRequirements() : undefined,
+			postprocess_binding: production ? wordpressFuzzPostprocessBinding() : undefined,
 		},
 	});
 	const taskRequest = wpCodeboxFuzzSuiteTaskRequest({
@@ -126,10 +129,12 @@ function buildWordPressFuzzCampaignWorkload(input = {}) {
 			})),
 		},
 		artifacts: input.artifacts || defaultCampaignArtifacts({ production: input.production }),
+		postprocess_binding: objectOrUndefined(input.postprocess_binding || input.postprocessBinding),
 		metadata: {
 			...(objectOrUndefined(input.metadata) || {}),
 			coverage_manifest: input.coverageManifest || input.coverage_manifest,
 			aggregation_hooks: campaignAggregationHooks(),
+			postprocess_binding: objectOrUndefined(input.postprocess_binding || input.postprocessBinding),
 		},
 	};
 }
@@ -187,20 +192,34 @@ function defaultCampaignArtifacts(options = {}) {
 
 function defaultCampaignArtifactsWithOptions(options = {}) {
 	const hotspotRequired = Boolean(options.production);
+	const expected = [
+		{ name: 'wordpress_fuzz_result', role: 'normalized_fuzz_result', semantic_key: 'fuzz.result.normalized', required: true },
+		{ name: 'wordpress_fuzz_coverage', role: 'coverage', semantic_key: 'fuzz.coverage', required: true },
+		{ name: 'wordpress-hotspots', role: 'hotspot_summary', semantic_key: 'fuzz.hotspot.summary', schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA, required: hotspotRequired },
+		{ name: 'wordpress_performance_observation', role: 'fuzz_report', semantic_key: 'fuzz.performance', required: false },
+	];
+	if (options.production) {
+		expected.push(...wordpressFuzzPostprocessBinding().outputs);
+	}
 	return {
-		expected: [
-			{ name: 'wordpress_fuzz_result', role: 'normalized_fuzz_result', semantic_key: 'fuzz.result.normalized', required: true },
-			{ name: 'wordpress_fuzz_coverage', role: 'coverage', semantic_key: 'fuzz.coverage', required: true },
-			{ name: 'wordpress-hotspots', role: 'hotspot_summary', semantic_key: 'fuzz.hotspot.summary', schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA, required: hotspotRequired },
-			{ name: 'wordpress_performance_observation', role: 'fuzz_report', semantic_key: 'fuzz.performance', required: false },
-		],
+		expected: dedupeArtifactsBySemanticKey(expected),
 	};
+}
+
+function dedupeArtifactsBySemanticKey(artifacts = []) {
+	const byKey = new Map();
+	for (const artifact of artifacts) {
+		byKey.set(artifact.semantic_key || artifact.name, artifact);
+	}
+	return [...byKey.values()];
 }
 
 function productionOutputRequirements() {
 	return {
 		required_artifact_keys: ['fuzz.coverage', 'fuzz.hotspot.summary'],
+		required_postprocess_outputs: ['fuzz.coverage', 'fuzz.hotspot.summary', 'fuzz.coverage.gap_report', 'fuzz.hotspot.codebox'],
 		required_artifact_schemas: [WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA],
+		production_campaign: true,
 	};
 }
 
@@ -208,16 +227,14 @@ function productionExpectedArtifacts(production = false) {
 	if (!production) {
 		return undefined;
 	}
-	return [...new Set([...DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS, 'wordpress-hotspots'])];
+	return wordpressFuzzPostprocessExpectedArtifacts();
 }
 
 function productionArtifactDeclarations(production = false) {
 	if (!production) {
 		return undefined;
 	}
-	return DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS.map((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary'
-		? { ...artifact, required: true }
-		: artifact);
+	return wordpressFuzzPostprocessArtifactDeclarations();
 }
 
 function aggregateWordPressFuzzCampaignResult(input = {}) {

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -138,6 +138,22 @@ const DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS = [
 		required: false,
 	},
 ];
+const WORDPRESS_FUZZ_POSTPROCESS_BINDING_SCHEMA = 'homeboy/wordpress-fuzz-postprocess-binding/v1';
+const WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS = [
+	{ role: 'coverage_summary_gaps', name: 'wordpress-fuzz-coverage', semantic_key: 'fuzz.coverage', content_type: 'application/json', required: true, postprocess_output: true },
+	{ role: 'hotspot_summary', name: 'homeboy-hotspot-summary', semantic_key: 'fuzz.hotspot.summary', schema: 'homeboy/fuzz-hotspot-set/v1', content_type: 'application/json', required: true, postprocess_output: true },
+	{ role: 'coverage_gap_report', name: 'wordpress-fuzz-gap-report', semantic_key: 'fuzz.coverage.gap_report', schema: 'homeboy/wordpress-fuzz-coverage-gap-report/v1', content_type: 'application/json', required: true, postprocess_output: true },
+	{ role: 'codebox_hotspot_artifact', name: 'wordpress-hotspots', semantic_key: 'fuzz.hotspot.codebox', schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA, content_type: 'application/json', required: true, postprocess_output: true, consumed_artifact: true },
+];
+const WORDPRESS_FUZZ_POSTPROCESS_BINDING = {
+	schema: WORDPRESS_FUZZ_POSTPROCESS_BINDING_SCHEMA,
+	version: 1,
+	provider: 'wp-codebox',
+	input_artifacts: [{ role: 'codebox_hotspot_artifact', name: 'wordpress-hotspots', semantic_key: 'fuzz.hotspot.codebox', schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA, required: true }],
+	outputs: WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS,
+	artifact_outputs: WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS,
+	proof_outputs: WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS.map((artifact) => ({ name: artifact.name, role: artifact.role, semantic_key: artifact.semantic_key, schema: artifact.schema, required: artifact.required })),
+};
 const HOMEBOY_FUZZ_WORKLOAD_SCHEMA = 'homeboy/fuzz-workload/v1';
 
 const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
@@ -213,6 +229,7 @@ function wpCodeboxFuzzSuiteInput(options = {}) {
 	const source = normalizeHomeboyFuzzWorkloadSource(options);
 	const cases = normalizeWpCodeboxFuzzSuiteCases(source || options);
 	const artifacts = source?.artifacts || options.artifacts;
+	const postprocessBinding = options.postprocessBinding || options.postprocess_binding || source?.postprocess_binding || source?.postprocessBinding;
 	return stripUndefined({
 		schema: wpCodeboxFuzzSuiteSchema(options),
 		id: options.id || options.runId || options.run_id,
@@ -229,8 +246,32 @@ function wpCodeboxFuzzSuiteInput(options = {}) {
 			coverage: objectOrUndefined(options.coverage),
 			runtime_profile: objectOrUndefined(options.runtimeProfile || options.runtime_profile),
 			artifacts: objectOrUndefined(artifacts),
+			postprocess_binding: objectOrUndefined(postprocessBinding),
 		}),
 	});
+}
+
+function wordpressFuzzPostprocessBinding(options = {}) {
+	const required = options.required === false ? false : true;
+	return {
+		...WORDPRESS_FUZZ_POSTPROCESS_BINDING,
+		outputs: WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS.map((artifact) => ({ ...artifact, required })),
+		artifact_outputs: WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS.map((artifact) => ({ ...artifact, required })),
+		proof_outputs: WORDPRESS_FUZZ_POSTPROCESS_BINDING.proof_outputs.map((artifact) => ({ ...artifact, required })),
+	};
+}
+
+function wordpressFuzzPostprocessArtifactDeclarations(options = {}) {
+	const required = options.required === false ? false : true;
+	const bySemanticKey = new Map(DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS.map((artifact) => [artifact.semantic_key, artifact]));
+	for (const artifact of WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS) {
+		bySemanticKey.set(artifact.semantic_key, { ...(bySemanticKey.get(artifact.semantic_key) || {}), ...artifact, required });
+	}
+	return [...bySemanticKey.values()];
+}
+
+function wordpressFuzzPostprocessExpectedArtifacts() {
+	return [...new Set([...DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS, ...WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS.map((artifact) => artifact.name)])];
 }
 
 function normalizeHomeboyFuzzWorkloadSource(options = {}) {
@@ -1009,7 +1050,7 @@ function normalizeWpCodeboxFuzzSuiteResult(result = {}, context = {}) {
 	]);
 	const hotspotSummary = normalizeFuzzHotspotSummary(source?.hotspot_summary || source?.hotspotSummary || source?.hotspots || source?.performance_hotspots || source?.performanceHotspots || derivedArtifacts.hotspot_summary || fuzzHotspotSummaryFromObservationSet(observationSet, { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id }), { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id });
 	const normalizedResult = normalizeEmbeddedWordPressFuzzResult(source);
-	const contractFailures = wpCodeboxFuzzContractFailures({ source, result, context, artifacts, coverageSummary, normalizedResult, hotspotSummary });
+	const contractFailures = wpCodeboxFuzzContractFailures({ source, result, context, artifacts, coverageSummary, normalizedResult, hotspotSummary, derivedArtifacts });
 	if (contractFailures.length > 0 && ['succeeded', 'success', 'passed', 'ok'].includes(String(status).toLowerCase())) {
 		status = 'failed';
 	}
@@ -1101,7 +1142,7 @@ function objectMetricObservations(metrics, defaults = {}) {
 	return Object.entries(metrics).flatMap(([metric, value]) => Number.isFinite(Number(value)) ? [{ ...defaults, metric, value }] : []);
 }
 
-function wpCodeboxFuzzContractFailures({ source = {}, result = {}, context = {}, artifacts = [], coverageSummary, normalizedResult, hotspotSummary }) {
+function wpCodeboxFuzzContractFailures({ source = {}, result = {}, context = {}, artifacts = [], coverageSummary, normalizedResult, hotspotSummary, derivedArtifacts }) {
 	if (wpCodeboxFuzzAllowsEmpty(source, context)) {
 		return [];
 	}
@@ -1132,6 +1173,7 @@ function wpCodeboxFuzzContractFailures({ source = {}, result = {}, context = {},
 
 	const requiredOutputFailures = requiredFuzzOutputFailures({ source, context, artifacts, normalizedResult, hotspotSummary });
 	failures.push(...requiredOutputFailures);
+	failures.push(...validateWordPressFuzzPostprocessOutputs({ source, context, artifacts, derivedArtifacts, hotspotSummary, normalizedResult }));
 
 	return failures;
 }
@@ -1665,6 +1707,58 @@ function normalizeDerivedFuzzArtifacts(source = {}, artifacts = []) {
 	});
 }
 
+function validateWordPressFuzzPostprocessOutputs({ source = {}, context = {}, artifacts = [], derivedArtifacts = {}, hotspotSummary, normalizedResult } = {}) {
+	if (!isProductionPostprocessRequired(source, context)) {
+		return [];
+	}
+	const missing = requiredPostprocessOutputsMissing({ artifacts, derivedArtifacts, hotspotSummary, normalizedResult });
+	if (missing.length === 0) {
+		return [];
+	}
+	return [{
+		severity: 'error',
+		code: 'wp_codebox_fuzz_required_postprocess_outputs_missing',
+		message: `Required WordPress fuzz postprocess outputs are missing: ${missing.join(', ')}.`,
+		missing_outputs: missing,
+	}];
+}
+
+function isProductionPostprocessRequired(source = {}, context = {}) {
+	const metadata = objectOrUndefined(source.metadata) || {};
+	const requestInput = context.request?.inputs?.ability_input || context.request?.executor?.config?.runtime_task?.input || {};
+	const inputMetadata = objectOrUndefined(requestInput.metadata) || {};
+	return Boolean(
+		metadata.production_campaign
+		|| metadata.output_requirements?.production_campaign
+		|| inputMetadata.production_campaign
+		|| inputMetadata.output_requirements?.production_campaign
+		|| inputMetadata.postprocess_binding?.required
+		|| inputMetadata.postprocess_binding?.outputs?.some((artifact) => artifact.required)
+	);
+}
+
+function requiredPostprocessOutputsMissing({ artifacts = [], derivedArtifacts = {}, hotspotSummary, normalizedResult } = {}) {
+	const checks = [
+		['fuzz.coverage', hasArtifactSemanticKey(artifacts, 'fuzz.coverage')],
+		['fuzz.hotspot.summary', Boolean(hotspotSummary?.items?.length > 0) || hasArtifactSemanticKey(artifacts, 'fuzz.hotspot.summary') || hasArtifactSchema(artifacts, WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA)],
+		['fuzz.coverage.gap_report', hasArtifactSemanticKey(artifacts, 'fuzz.coverage.gap_report') || normalizeArray(derivedArtifacts.coverage_gap_reports).length > 0],
+		['fuzz.hotspot.codebox', hasArtifactSemanticKey(artifacts, 'fuzz.hotspot.codebox') || hasArtifactSchema(artifacts, WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA) || hasArtifactName(artifacts, 'wordpress-hotspots')],
+	];
+	return checks.filter(([, present]) => !present).map(([key]) => key);
+}
+
+function hasArtifactSemanticKey(artifacts = [], semanticKey) {
+	return normalizeArray(artifacts).some((artifact) => (artifact.semantic_key || artifact.semanticKey || artifact.metadata?.semantic_key || artifact.metadata?.semanticKey) === semanticKey);
+}
+
+function hasArtifactSchema(artifacts = [], schema) {
+	return normalizeArray(artifacts).some((artifact) => (artifact.schema || artifact.artifact_schema || artifact.artifactSchema || artifact.metadata?.schema) === schema);
+}
+
+function hasArtifactName(artifacts = [], name) {
+	return normalizeArray(artifacts).some((artifact) => artifact.name === name);
+}
+
 function derivedArtifactPayload(artifact = {}) {
 	return objectOrUndefined(artifact.payload) || objectOrUndefined(artifact.data) || objectOrUndefined(artifact.content) || objectOrUndefined(artifact.result);
 }
@@ -1920,6 +2014,8 @@ module.exports = {
 	DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
 	ARTIFACT_POSTPROCESS_COMMAND,
 	FUZZ_ARTIFACT_SEMANTIC_KEYS,
+	WORDPRESS_FUZZ_POSTPROCESS_BINDING_SCHEMA,
+	WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS,
 	WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA,
 	WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA,
 	WORDPRESS_FUZZ_OBSERVATION_SCHEMA,
@@ -1931,6 +2027,9 @@ module.exports = {
 	normalizeWpCodeboxFuzzArtifacts,
 	normalizeWpCodeboxFuzzSuiteResult,
 	normalizeWordPressFuzzRuntimeTaskResult,
+	wordpressFuzzPostprocessArtifactDeclarations,
+	wordpressFuzzPostprocessBinding,
+	wordpressFuzzPostprocessExpectedArtifacts,
 	detectWpCodeboxPublicFuzzCapabilities,
 	preflightWpCodeboxFuzzCapabilityContract,
 	runWpCodeboxFuzzSuite,

--- a/wordpress/tests/wordpress-fuzz-campaign-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-campaign-smoke.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 
 const {
+	WORDPRESS_FUZZ_POSTPROCESS_BINDING_SCHEMA,
 	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 } = require('../lib/wp-codebox-fuzz-run');
 
@@ -102,11 +103,25 @@ const productionCampaign = compileWordPressFuzzCampaign({
 assert.equal(productionCampaign.workload.metadata.production_campaign, true);
 assert.equal(productionCampaign.wp_codebox.input.metadata.production_campaign, true);
 assert.deepEqual(productionCampaign.wp_codebox.input.metadata.output_requirements.required_artifact_keys, ['fuzz.coverage', 'fuzz.hotspot.summary']);
+assert.deepEqual(productionCampaign.wp_codebox.input.metadata.output_requirements.required_postprocess_outputs, ['fuzz.coverage', 'fuzz.hotspot.summary', 'fuzz.coverage.gap_report', 'fuzz.hotspot.codebox']);
 assert.deepEqual(productionCampaign.wp_codebox.input.metadata.output_requirements.required_artifact_schemas, [WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA]);
-assert.equal(productionCampaign.workload.artifacts.expected.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').name, 'wordpress-hotspots');
+assert.equal(productionCampaign.wp_codebox.input.metadata.output_requirements.production_campaign, true);
+assert.equal(productionCampaign.wp_codebox.input.metadata.postprocess_binding.schema, WORDPRESS_FUZZ_POSTPROCESS_BINDING_SCHEMA);
+assert.equal(productionCampaign.workload.postprocess_binding.schema, WORDPRESS_FUZZ_POSTPROCESS_BINDING_SCHEMA);
+assert.equal(productionCampaign.workload.metadata.postprocess_binding.schema, WORDPRESS_FUZZ_POSTPROCESS_BINDING_SCHEMA);
+assert.deepEqual(
+	productionCampaign.wp_codebox.input.metadata.postprocess_binding.outputs.map((artifact) => artifact.semantic_key).sort(),
+	['fuzz.coverage', 'fuzz.coverage.gap_report', 'fuzz.hotspot.codebox', 'fuzz.hotspot.summary'].sort()
+);
+assert.equal(productionCampaign.workload.artifacts.expected.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').name, 'homeboy-hotspot-summary');
 assert.equal(productionCampaign.workload.artifacts.expected.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').required, true);
+assert.equal(productionCampaign.workload.artifacts.expected.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.codebox').name, 'wordpress-hotspots');
+assert.equal(productionCampaign.workload.artifacts.expected.find((artifact) => artifact.semantic_key === 'fuzz.coverage.gap_report').name, 'wordpress-fuzz-gap-report');
 assert.equal(productionCampaign.wp_codebox.task_request.expected_artifacts.includes('wordpress-hotspots'), true);
+assert.equal(productionCampaign.wp_codebox.task_request.expected_artifacts.includes('homeboy-hotspot-summary'), true);
+assert.equal(productionCampaign.wp_codebox.task_request.expected_artifacts.includes('wordpress-fuzz-gap-report'), true);
 assert.equal(productionCampaign.wp_codebox.task_request.artifact_declarations.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').required, true);
-assert.equal(productionCampaign.wp_codebox.task_request.artifact_declarations.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.summary').schema, WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA);
+assert.equal(productionCampaign.wp_codebox.task_request.artifact_declarations.find((artifact) => artifact.semantic_key === 'fuzz.hotspot.codebox').schema, WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA);
+assert.equal(productionCampaign.wp_codebox.task_request.artifact_declarations.find((artifact) => artifact.semantic_key === 'fuzz.coverage.gap_report').required, true);
 
 console.log('wordpress fuzz campaign smoke passed');

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -29,6 +29,7 @@ const {
 	preflightWpCodeboxFuzzCapabilityContract,
 	runWpCodeboxPublicFuzzOperation,
 	runWpCodeboxFuzzSuite,
+	wordpressFuzzPostprocessBinding,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
 } = require('../lib/wp-codebox-fuzz-run');
@@ -798,6 +799,58 @@ runWpCodeboxFuzzSuite({
 	assert(hotspotArtifactMissing.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_output_artifacts_missing'));
 	assert(hotspotArtifactMissing.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_output_artifact_schemas_missing'));
 	assert(hotspotArtifactMissing.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_hotspot_artifact_missing'));
+	const productionPostprocessRequest = wpCodeboxFuzzSuiteTaskRequest({
+		taskId: 'production-postprocess-suite-task',
+		artifactDeclarations: [],
+		input: wpCodeboxFuzzSuiteInput({
+			id: 'production-postprocess-suite',
+			metadata: {
+				production_campaign: true,
+				postprocess_binding: wordpressFuzzPostprocessBinding(),
+			},
+		}),
+	});
+	const productionPostprocessObserved = normalizeWpCodeboxFuzzSuiteResult({
+		json: {
+			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+			status: 'passed',
+			summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+			wordpress_fuzz_result: {
+				schema: 'wordpress-fuzz-result/v1',
+				status: 'passed',
+				cases: [{ id: 'production-postprocess-case', status: 'passed' }],
+			},
+			artifacts: {
+				coverage: { path: 'coverage.json', semantic_key: 'fuzz.coverage' },
+				gap_report: {
+					path: 'gap-report.json',
+					semantic_key: 'fuzz.coverage.gap_report',
+					payload: { schema: 'homeboy/wordpress-fuzz-coverage-gap-report/v1', gaps: [] },
+				},
+				hotspot_summary: {
+					path: 'wordpress-hotspots.json',
+					schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+					payload: { schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA, db: [{ table: 'wp_posts', operation: 'SELECT', metric: 'query_count', count: 1 }] },
+				},
+			},
+		},
+	}, { request: productionPostprocessRequest });
+	assert.equal(productionPostprocessObserved.succeeded, true);
+	assert.equal(productionPostprocessObserved.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_postprocess_outputs_missing'), false);
+	const productionPostprocessMissing = normalizeWpCodeboxFuzzSuiteResult({
+		json: {
+			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+			status: 'passed',
+			summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+			cases: [{ id: 'production-postprocess-case', status: 'passed' }],
+			artifacts: { coverage: { path: 'coverage.json', semantic_key: 'fuzz.coverage' } },
+		},
+	}, { request: productionPostprocessRequest });
+	assert.equal(productionPostprocessMissing.succeeded, false);
+	assert.deepEqual(
+		productionPostprocessMissing.failures.find((failure) => failure.code === 'wp_codebox_fuzz_required_postprocess_outputs_missing').missing_outputs,
+		['fuzz.hotspot.summary', 'fuzz.coverage.gap_report', 'fuzz.hotspot.codebox']
+	);
 	const requiredOutputMissing = normalizeWpCodeboxFuzzSuiteResult({
 		json: {
 			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,


### PR DESCRIPTION
## Summary
- Add WordPress fuzz postprocess/proof output bindings for production campaigns.
- Bind Homeboy coverage, hotspot summary, gap report, and consumed Codebox hotspot artifacts.
- Fail closed when production postprocess outputs are declared but missing.
- Add focused campaign and Codebox fuzz-run tests.

## Verification
- npm run test:wordpress-fuzz-campaign
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Auditing the WordPress fuzz proof binding gap, drafting postprocess output binding/enforcement, adding focused tests, and preparing the PR.