### PR TITLE
Fix direct WP Codebox fuzz execution

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -42,6 +42,7 @@ const WP_CODEBOX_FUZZ_SUITE_SCHEMA = 'wp-codebox/fuzz-suite/v1';
 const WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA = 'wp-codebox/fuzz-suite-result/v1';
 const WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA = 'wp-codebox/wordpress-hotspots/v1';
 const WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA = 'homeboy/wordpress-codebox-fuzz-suite-consumer/v1';
+const WP_CODEBOX_FUZZ_EXECUTION_SCHEMA = 'homeboy/wp-codebox-fuzz-execution/v1';
 const WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA = 'homeboy/wp-codebox-fuzz-preflight/v1';
 const WORDPRESS_FUZZ_OBSERVATION_SCHEMA = 'homeboy/wordpress-fuzz-observation/v1';
 const DEFAULT_FUZZ_SUITE_ABILITY = 'wp-codebox/run-fuzz-suite';
@@ -628,6 +629,29 @@ function wpCodeboxFuzzRuntimeTaskRequest(options = {}) {
 	});
 }
 
+function wpCodeboxFuzzExecutionRequest(options = {}) {
+	const input = wpCodeboxFuzzSuiteInput(options.input || options.abilityInput || options.ability_input || options);
+	const taskId = requiredString(options.taskId || options.task_id || input.id, 'taskId');
+	const ability = options.ability || wpCodeboxFuzzSuiteAbility(options);
+	const runtimeRequirements = options.runtimeRequirements || options.runtime_requirements;
+	return stripUndefined({
+		schema: WP_CODEBOX_FUZZ_EXECUTION_SCHEMA,
+		task_id: taskId,
+		ability,
+		command: wpCodeboxCommandFromFuzzAbility(ability, options),
+		input,
+		runtime_requirements: objectOrUndefined(runtimeRequirements),
+		artifact_declarations: options.artifactDeclarations || options.artifact_declarations || DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
+		expected_artifacts: options.expectedArtifacts || options.expected_artifacts || DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
+		instructions: options.instructions || 'Delegate WordPress fuzz execution to WP Codebox and return the declared fuzz artifacts.',
+		metadata: stripUndefined({
+			...(objectOrUndefined(options.metadata) || {}),
+			executor: 'wp-codebox-direct-fuzz',
+			runtime: options.runtime || options.runtimeId || options.runtime_id || 'wp-codebox',
+		}),
+	});
+}
+
 function wpCodeboxWordPressWorkloadRunInput(options = {}) {
 	return stripUndefined({
 		schema: wpCodeboxWordPressWorkloadRunSchema(options),
@@ -739,7 +763,7 @@ function isArtifactPostprocessCommand(value) {
 
 async function runWpCodeboxFuzzSuite(options = {}) {
 	const runtimeRequest = wpCodeboxFuzzRuntimeTaskRequest(options);
-	const request = runtimeRequest.provider_request;
+	const request = wpCodeboxFuzzExecutionRequest(options);
 	const runner = options.runFuzzSuite || options.runRuntimeTask || options.runTask;
 	if (typeof runner === 'function') {
 		const result = await runner(request, options);
@@ -751,7 +775,7 @@ async function runWpCodeboxFuzzSuite(options = {}) {
 }
 
 async function runWpCodeboxPublicFuzzOperation(options = {}) {
-	const request = options.request || wpCodeboxFuzzSuiteTaskRequest(options);
+	const request = options.request || wpCodeboxFuzzExecutionRequest(options);
 	const preflight = preflightWpCodeboxFuzzCapabilityContract({ ...options, request });
 	const capabilities = preflight.capabilities;
 	if (!preflight.ok) {
@@ -782,14 +806,14 @@ async function runWpCodeboxPublicFuzzOperation(options = {}) {
 }
 
 function wpCodeboxPublicCliInput(request = {}, options = {}) {
-	const input = request.executor?.config?.runtime_task?.input || options.input || {};
-	const runtimeRequirements = objectOrUndefined(request.executor?.config?.runtime_requirements || request.runtime_requirements);
+	const input = wpCodeboxFuzzRequestInput(request, options);
+	const runtimeRequirements = objectOrUndefined(wpCodeboxFuzzRequestRuntimeRequirements(request));
 	return {
 		...input,
 		metadata: {
 			...(objectOrUndefined(input.metadata) || {}),
 			runtime_requirements: runtimeRequirements,
-			homeboy_agent_task_request: request,
+			homeboy_wp_codebox_fuzz_execution: request,
 		},
 	};
 }
@@ -816,7 +840,7 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 	const manifest = wpCodeboxRuntimeContractManifest(options);
 	const wordpressRuntimeAbilities = objectOrUndefined(manifest.abilities?.wordpressRuntime) || {};
 	const commandManifest = buildWordPressFuzzCommandManifest();
-	const suiteInput = request?.executor?.config?.runtime_task?.input || request?.input || {};
+	const suiteInput = wpCodeboxFuzzRequestInput(request, options);
 	const plan = suiteInput.homeboy_fuzz_workload?.plan || suiteInput.homeboyFuzzWorkload?.plan || suiteInput.metadata?.workload?.plan || request?.input?.plan || options.plan || {};
 	const requiredPlanContracts = requiredWpCodeboxContractsForFuzzPlan(plan);
 	const requiredAbilities = { ...WP_CODEBOX_FUZZ_PUBLIC_ABILITIES };
@@ -871,12 +895,12 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 }
 
 function requiredPublicCommandsForRequest(request = {}, requiredPlanContracts = {}) {
-	const ability = request.executor?.config?.runtime_task?.ability || request.ability;
-	const input = request.executor?.config?.runtime_task?.input || request.input || {};
+	const ability = wpCodeboxFuzzRequestAbility(request);
 	if (ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY) {
 		return ['run-wordpress-workload'];
 	}
 	if (ability === DEFAULT_FUZZ_SUITE_ABILITY) {
+		const input = wpCodeboxFuzzRequestInput(request);
 		return unique([
 			'run-fuzz-suite',
 			...normalizeArray(requiredPlanContracts.commands),
@@ -909,7 +933,10 @@ function normalizeWpCodeboxPublicFuzzCapabilities(input = {}) {
 }
 
 function publicFuzzCliCommandForRequest(request = {}, capabilities = {}) {
-	const ability = request.executor?.config?.runtime_task?.ability || request.ability;
+	if (request.command && capabilities.commands?.[request.command]) {
+		return request.command;
+	}
+	const ability = wpCodeboxFuzzRequestAbility(request);
 	if (ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY && capabilities.commands?.['run-wordpress-workload']) {
 		return 'run-wordpress-workload';
 	}
@@ -920,6 +947,18 @@ function publicFuzzCliCommandForRequest(request = {}, capabilities = {}) {
 		return 'run-wordpress-workload';
 	}
 	return undefined;
+}
+
+function wpCodeboxFuzzRequestAbility(request = {}) {
+	return request.ability || request.executor?.config?.runtime_task?.ability;
+}
+
+function wpCodeboxFuzzRequestInput(request = {}, options = {}) {
+	return request.input || request.executor?.config?.runtime_task?.input || options.input || {};
+}
+
+function wpCodeboxFuzzRequestRuntimeRequirements(request = {}) {
+	return request.runtime_requirements || request.executor?.config?.runtime_requirements || request.executor?.config?.runtimeRequirements;
 }
 
 function unsupportedWpCodeboxPublicFuzzResult({ request = {}, capabilities = {}, preflight } = {}) {
@@ -970,6 +1009,13 @@ function runWpCodeboxPublicCliCommand(args, options = {}) {
 		maxBuffer: options.maxBuffer || 1024 * 1024 * 10,
 	});
 	return normalizeCliResult(result);
+}
+
+function wpCodeboxCommandFromFuzzAbility(ability, options = {}) {
+	if (ability === wpCodeboxWordPressWorkloadRunAbility(options) || ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY) {
+		return 'run-wordpress-workload';
+	}
+	return 'run-fuzz-suite';
 }
 
 function wpCodeboxPublicCliBin(options = {}) {
@@ -2021,6 +2067,7 @@ module.exports = {
 	WORDPRESS_FUZZ_OBSERVATION_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
+	WP_CODEBOX_FUZZ_EXECUTION_SCHEMA,
 	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 	buildWordPressFuzzCommandManifest,
 	buildWordPressFuzzObservation,
@@ -2034,6 +2081,7 @@ module.exports = {
 	preflightWpCodeboxFuzzCapabilityContract,
 	runWpCodeboxFuzzSuite,
 	runWpCodeboxPublicFuzzOperation,
+	wpCodeboxFuzzExecutionRequest,
 	wpCodeboxFuzzSuiteAbility,
 	wpCodeboxFuzzSuiteResultSchema,
 	wpCodeboxFuzzSuiteSchema,

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -1771,7 +1771,7 @@ function validateWordPressFuzzPostprocessOutputs({ source = {}, context = {}, ar
 
 function isProductionPostprocessRequired(source = {}, context = {}) {
 	const metadata = objectOrUndefined(source.metadata) || {};
-	const requestInput = context.request?.inputs?.ability_input || context.request?.executor?.config?.runtime_task?.input || {};
+	const requestInput = context.request?.input || context.request?.inputs?.ability_input || context.request?.executor?.config?.runtime_task?.input || {};
 	const inputMetadata = objectOrUndefined(requestInput.metadata) || {};
 	return Boolean(
 		metadata.production_campaign
@@ -1783,7 +1783,7 @@ function isProductionPostprocessRequired(source = {}, context = {}) {
 	);
 }
 
-function requiredPostprocessOutputsMissing({ artifacts = [], derivedArtifacts = {}, hotspotSummary, normalizedResult } = {}) {
+function requiredPostprocessOutputsMissing({ artifacts = [], derivedArtifacts = {}, hotspotSummary } = {}) {
 	const checks = [
 		['fuzz.coverage', hasArtifactSemanticKey(artifacts, 'fuzz.coverage')],
 		['fuzz.hotspot.summary', Boolean(hotspotSummary?.items?.length > 0) || hasArtifactSemanticKey(artifacts, 'fuzz.hotspot.summary') || hasArtifactSchema(artifacts, WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA)],

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -23,6 +23,8 @@ const {
 	wpCodeboxFuzzSuiteAbility,
 	wpCodeboxRuntimeContractManifest,
 } = require('../../lib/wp-codebox-fuzz-run');
+
+const WP_CODEBOX_FUZZ_EXECUTION_SCHEMA = 'homeboy/wp-codebox-fuzz-execution/v1';
 if (require.main === module) {
 	main().catch((error) => {
 		process.stderr.write(`${error.message}\n`);
@@ -95,7 +97,9 @@ function wpCodeboxPublicRuntimeInvocation(request, options = {}) {
 	if (requiresCodeboxTaskAdapter(request)) {
 		return null;
 	}
-	const runtimeTask = request.executor?.config?.runtime_task || {};
+	const runtimeTask = request.schema === WP_CODEBOX_FUZZ_EXECUTION_SCHEMA
+		? { ability: request.ability, input: request.input }
+		: request.executor?.config?.runtime_task || {};
 	const ability = runtimeTask.ability || wpCodeboxFuzzSuiteAbility(options);
 	const command = wpCodeboxCommandFromPublicAbility(ability, options);
 	if (!command) {
@@ -108,13 +112,17 @@ function wpCodeboxPublicRuntimeInvocation(request, options = {}) {
 			...(runtimeTask.input || {}),
 			metadata: {
 				...(runtimeTask.input?.metadata || {}),
-				homeboy_agent_task_request: request,
+				runtime_requirements: request.runtime_requirements,
+				homeboy_wp_codebox_fuzz_execution: request,
 			},
 		},
 	};
 }
 
 function requiresCodeboxTaskAdapter(request) {
+	if (request.schema === WP_CODEBOX_FUZZ_EXECUTION_SCHEMA) {
+		return false;
+	}
 	const config = request.executor?.config || {};
 	const runtimeRequirements = config.runtime_requirements || config.runtimeRequirements || {};
 	return [

--- a/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
+++ b/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
@@ -79,12 +79,16 @@ if (request.id !== 'contract-run' || request.cases?.[0]?.target_id !== 'rest-pos
   process.stderr.write('fuzz suite request was not built from the Homeboy workload');
   process.exit(1);
 }
-if (request.metadata?.homeboy_agent_task_request?.executor?.config?.runtime_task?.ability !== 'wp-codebox/run-fuzz-suite') {
-  process.stderr.write('missing Homeboy agent task request metadata for the public fuzz-suite call');
+if (request.metadata?.homeboy_wp_codebox_fuzz_execution?.schema !== 'homeboy/wp-codebox-fuzz-execution/v1') {
+  process.stderr.write('missing Homeboy direct fuzz execution metadata for the public fuzz-suite call');
   process.exit(1);
 }
-if (request.metadata?.homeboy_agent_task_request?.executor?.config?.runtime_task?.input?.schema !== 'wp-codebox/fuzz-suite/v1') {
-  process.stderr.write('Homeboy task request did not carry a fuzz-suite input');
+if (request.metadata?.homeboy_wp_codebox_fuzz_execution?.input?.schema !== 'wp-codebox/fuzz-suite/v1') {
+  process.stderr.write('Homeboy direct execution request did not carry a fuzz-suite input');
+  process.exit(1);
+}
+if (request.metadata?.homeboy_agent_task_request) {
+  process.stderr.write('fuzz execution must not route through Homeboy agent-task metadata');
   process.exit(1);
 }
 
@@ -149,12 +153,14 @@ assert.deepEqual(
 
 const observedRequest = JSON.parse(fs.readFileSync(observedRequestPath, 'utf8'));
 assert.equal(observedRequest.schema, 'wp-codebox/fuzz-suite/v1');
-assert.equal(observedRequest.metadata.homeboy_agent_task_request.task_id, 'contract-run');
-assert.equal(observedRequest.metadata.homeboy_agent_task_request.expected_artifacts[0], 'wp-codebox-fuzz-suite-result');
-assert.equal(observedRequest.metadata.homeboy_agent_task_request.artifact_declarations[0].semantic_key, 'fuzz.result.normalized');
-assert.equal(observedRequest.metadata.homeboy_agent_task_request.expected_artifacts.includes('case-log'), true);
-assert.equal(observedRequest.metadata.homeboy_agent_task_request.expected_artifacts.includes('replay-data'), true);
-assert.equal(observedRequest.metadata.homeboy_agent_task_request.expected_artifacts.includes('coverage-summary'), true);
+assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.schema, 'homeboy/wp-codebox-fuzz-execution/v1');
+assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.task_id, 'contract-run');
+assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.expected_artifacts[0], 'wp-codebox-fuzz-suite-result');
+assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.artifact_declarations[0].semantic_key, 'fuzz.result.normalized');
+assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.expected_artifacts.includes('case-log'), true);
+assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.expected_artifacts.includes('replay-data'), true);
+assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.expected_artifacts.includes('coverage-summary'), true);
+assert.equal(observedRequest.metadata.homeboy_agent_task_request, undefined);
 
 const campaign = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
 assert.equal(campaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -18,8 +18,6 @@ process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(
 	'wp-codebox-core-runtime-contract.cjs'
 );
 
-const { runtimeContractSchemas } = require('../../agent-runtimes/wp-codebox');
-
 const originalLoad = Module._load;
 Module._load = function loadWithoutRuntimeAgentCi(request, parent, isMain) {
 	if (request.includes('runtime-agent-ci')) {
@@ -330,13 +328,13 @@ const dispatchPromise = runWordPressFuzzRunnerResult({
 	workload,
 	runRuntimeTask: async (request) => {
 		dispatchedRequest = request;
+		assert.equal(request.schema, 'homeboy/wp-codebox-fuzz-execution/v1');
 		assert.equal(request.task_id, 'dispatch-run');
-		assert.equal(request.goal, 'Run WordPress fuzz suite generic-wordpress-workload and return the declared fuzz artifacts.');
-		assert.equal(request.executor.backend, 'codebox');
-		assert.equal(request.executor.config.runtime_task.ability, 'wp-codebox/run-fuzz-suite');
-		assert.equal(request.executor.config.runtime_task.input.schema, 'wp-codebox/fuzz-suite/v1');
-		assert.equal(request.executor.config.runtime_task.input.goal, 'Run WordPress fuzz suite generic-wordpress-workload and return the declared fuzz artifacts.');
-		assert.equal(request.executor.config.runtime_task.input.cases[0].target_id, 'rest-posts');
+		assert.equal(request.ability, 'wp-codebox/run-fuzz-suite');
+		assert.equal(request.input.schema, 'wp-codebox/fuzz-suite/v1');
+		assert.equal(request.input.goal, 'Run WordPress fuzz suite generic-wordpress-workload and return the declared fuzz artifacts.');
+		assert.equal(request.input.cases[0].target_id, 'rest-posts');
+		assert.equal(request.executor, undefined);
 		return {
 			json: {
 				schema: 'wp-codebox/fuzz-suite-result/v1',
@@ -480,7 +478,7 @@ if (subcommand !== 'run-fuzz-suite' || inputFileIndex === -1 || process.argv.inc
   process.stderr.write('expected public wp-codebox run-fuzz-suite command');
   process.exit(1);
 }
-if (request.schema !== 'wp-codebox/fuzz-suite/v1' || request.metadata?.homeboy_agent_task_request?.task_id !== 'dispatch-cli-run') {
+if (request.schema !== 'wp-codebox/fuzz-suite/v1' || request.metadata?.homeboy_wp_codebox_fuzz_execution?.task_id !== 'dispatch-cli-run' || request.metadata?.homeboy_agent_task_request) {
   process.stderr.write('invalid public fuzz-suite input');
   process.exit(1);
 }
@@ -525,62 +523,56 @@ const taskAdapterCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-task-ad
 fs.writeFileSync(taskAdapterCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const command = process.argv[2];
-if (command === 'run-fuzz-suite') {
-  process.stderr.write('runtime requirements must use the task adapter');
-  process.exit(1);
+if (command === 'run-fuzz-suite' && process.argv.includes('--help')) {
+  process.stdout.write('usage: wp-codebox run-fuzz-suite');
+  process.exit(0);
+}
+if (command === 'run-wordpress-workload' && process.argv.includes('--help')) {
+  process.stdout.write('usage: wp-codebox run-wordpress-workload');
+  process.exit(0);
 }
 const inputFile = process.argv[process.argv.indexOf('--input-file') + 1];
 const request = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
-if (command !== 'run-agent-task' || request.schema !== '${runtimeContractSchemas().agentTask.runRequest}' || request.task_id !== 'task-adapter-dispatch-cli-run') {
-  process.stderr.write('invalid run-agent-task adapter input');
+if (command !== 'run-fuzz-suite' || request.schema !== 'wp-codebox/fuzz-suite/v1' || request.metadata?.homeboy_wp_codebox_fuzz_execution?.task_id !== 'task-adapter-dispatch-cli-run') {
+  process.stderr.write('invalid direct fuzz suite input');
   process.exit(1);
 }
-if (request.runtime_task || request.artifact_declarations || request.sandbox_tool_policy || request.extra_plugins) {
-  process.stderr.write('adapter rebuilt the Codebox task payload instead of delegating to the adapter');
+if (request.metadata?.homeboy_agent_task_request) {
+  process.stderr.write('direct fuzz execution must not include agent-task metadata');
   process.exit(1);
 }
-if (request.task_input?.schema !== 'wp-codebox/task-input/v1') {
-  process.stderr.write('missing delegated task input');
+if (request.metadata?.homeboy_wp_codebox_fuzz_execution?.schema !== 'homeboy/wp-codebox-fuzz-execution/v1') {
+  process.stderr.write('missing direct fuzz execution envelope');
   process.exit(1);
 }
-if (request.task_input?.goal !== 'Run WordPress fuzz suite Runtime requirement workload and return the declared fuzz artifacts.') {
-  process.stderr.write('missing delegated task goal');
+if (request.metadata?.homeboy_wp_codebox_fuzz_execution?.input?.schema !== 'wp-codebox/fuzz-suite/v1') {
+  process.stderr.write('missing delegated fuzz input');
   process.exit(1);
 }
-if (request.task_input?.runtime_task?.ability !== 'wp-codebox/run-fuzz-suite' || request.task_input?.runtime_task?.input?.schema !== 'wp-codebox/fuzz-suite/v1') {
-  process.stderr.write('missing fuzz runtime task');
-  process.exit(1);
-}
-if (request.task_input?.artifact_declarations?.[0]?.name !== 'wp-codebox-fuzz-suite-result' || !request.task_input?.expected_artifacts?.includes('wordpress-fuzz-coverage')) {
+if (request.metadata?.homeboy_wp_codebox_fuzz_execution?.artifact_declarations?.[0]?.name !== 'wp-codebox-fuzz-suite-result' || !request.metadata?.homeboy_wp_codebox_fuzz_execution?.expected_artifacts?.includes('wordpress-fuzz-coverage')) {
   process.stderr.write('missing delegated artifact contract');
   process.exit(1);
 }
-if (request.task_input?.runtime_requirements?.extra_plugins?.[0]?.source !== '/runner/components/sample-plugin') {
+if (request.metadata?.runtime_requirements?.extra_plugins?.[0]?.source !== '/runner/components/sample-plugin') {
   process.stderr.write('missing delegated runtime extra plugin');
   process.exit(1);
 }
-if (request.task_input?.runtime_requirements?.runtime_env?.WP_CODEBOX_FUZZ_WORKLOAD_ROOT !== '${workloadRoot}') {
+if (request.metadata?.runtime_requirements?.runtime_env?.WP_CODEBOX_FUZZ_WORKLOAD_ROOT !== '${workloadRoot}') {
   process.stderr.write('missing delegated fuzz workload root env');
   process.exit(1);
 }
-if (request.task_input?.parent_request?.task_id !== 'task-adapter-dispatch-cli-run') {
-  process.stderr.write('missing parent request metadata');
+if (request.metadata?.homeboy_wp_codebox_fuzz_execution?.runtime_requirements?.runtime_env?.WP_CODEBOX_FUZZ_WORKLOAD_ROOT !== '${workloadRoot}') {
+  process.stderr.write('missing direct execution runtime requirements');
   process.exit(1);
 }
 process.stdout.write(JSON.stringify({
-  success: true,
-  agent_task_run_result: {
-    schema: '${runtimeContractSchemas().agentTask.runResult}',
-    result: {
-      schema: 'wp-codebox/fuzz-suite-result/v1',
-      request_id: request.task_id,
-      status: 'succeeded',
-      summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
-      cases: [{ id: 'get-posts', status: 'passed', success: true, diagnostics: [] }],
-      artifactRefs: [{ path: 'task-adapter/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
-      coverage_summary: { surface_count: 1, exercised_count: 1 }
-    }
-  }
+  schema: 'wp-codebox/fuzz-suite-result/v1',
+  request_id: request.id,
+  status: 'succeeded',
+  summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+  cases: [{ id: 'get-posts', status: 'passed', success: true, diagnostics: [] }],
+  artifactRefs: [{ path: 'task-adapter/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
+  coverage_summary: { surface_count: 1, exercised_count: 1 }
 }));
 `);
 fs.chmodSync(taskAdapterCodeboxBin, 0o755);

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -15,6 +15,7 @@ const {
 	WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA,
 	WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA,
 	WORDPRESS_FUZZ_OBSERVATION_SCHEMA,
+	WP_CODEBOX_FUZZ_EXECUTION_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
@@ -30,6 +31,7 @@ const {
 	runWpCodeboxPublicFuzzOperation,
 	runWpCodeboxFuzzSuite,
 	wordpressFuzzPostprocessBinding,
+	wpCodeboxFuzzExecutionRequest,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
 } = require('../lib/wp-codebox-fuzz-run');
@@ -142,6 +144,14 @@ assert.deepEqual(
 );
 assert(!JSON.stringify(taskRequest).includes('woocommerce'), 'fuzz suite helper must stay product-agnostic');
 assert.equal(wpCodeboxFuzzSuiteTaskRequest({ taskId: 'suite-task' }).executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+
+const executionRequest = wpCodeboxFuzzExecutionRequest({ taskId: 'direct-suite-task', input, wpCodeboxBin: '/custom/wp-codebox' });
+assert.equal(executionRequest.schema, WP_CODEBOX_FUZZ_EXECUTION_SCHEMA);
+assert.equal(executionRequest.task_id, 'direct-suite-task');
+assert.equal(executionRequest.command, 'run-fuzz-suite');
+assert.equal(executionRequest.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+assert.equal(executionRequest.metadata.executor, 'wp-codebox-direct-fuzz');
+assert.equal(executionRequest.executor, undefined);
 
 const preflightMissingCommand = preflightWpCodeboxFuzzCapabilityContract({
 	request: taskRequest,
@@ -426,7 +436,9 @@ runWpCodeboxFuzzSuite({
 	input,
 	runFuzzSuite: async (request) => {
 		invoked = true;
-		assert.equal(request.executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+		assert.equal(request.schema, WP_CODEBOX_FUZZ_EXECUTION_SCHEMA);
+		assert.equal(request.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+		assert.equal(request.executor, undefined);
 		return {
 			json: {
 				schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
@@ -875,11 +887,13 @@ runWpCodeboxFuzzSuite({
 	return runWpCodeboxFuzzSuite({
 		taskId: 'public-cli-suite-run',
 		input,
+		wpCodeboxBin: '/custom/direct-wp-codebox',
 		runtimeRequirements: {
 			extra_plugins: [{ slug: 'sample-plugin', source: '/runner/components/sample-plugin', loadAs: 'plugin' }],
 			runtime_env: { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: '/runner/workloads' },
 		},
-		runPublicCli: ({ args, stdin }) => {
+		runPublicCli: ({ command, args, stdin }) => {
+			assert.equal(command, '/custom/direct-wp-codebox');
 			if (args.join(' ') === 'run-fuzz-suite --help') {
 				return { status: 0, stdout: 'usage' };
 			}
@@ -894,6 +908,9 @@ runWpCodeboxFuzzSuite({
 			assert.equal(publicCliInput.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 			assert.equal(publicCliInput.metadata.runtime_requirements.extra_plugins[0].source, '/runner/components/sample-plugin');
 			assert.equal(publicCliInput.metadata.runtime_requirements.runtime_env.WP_CODEBOX_FUZZ_WORKLOAD_ROOT, '/runner/workloads');
+			assert.equal(publicCliInput.metadata.homeboy_wp_codebox_fuzz_execution.schema, WP_CODEBOX_FUZZ_EXECUTION_SCHEMA);
+			assert.equal(publicCliInput.metadata.homeboy_wp_codebox_fuzz_execution.expected_artifacts.includes('case-log'), true);
+			assert.equal(publicCliInput.metadata.homeboy_agent_task_request, undefined);
 			return {
 				status: 0,
 				stdout: JSON.stringify({


### PR DESCRIPTION
## Summary
- Add a first-class Homeboy WP Codebox fuzz execution envelope for deterministic fuzz runs.
- Dispatch WordPress fuzz suites directly through WP Codebox public CLI input instead of agent-task executor metadata.
- Keep legacy task/result envelopes available for Homeboy campaign/result artifacts while preserving the agent-task Codebox runtime for actual agent tasks.
- Update focused fuzz tests to assert direct executor selection and explicit WP Codebox binary forwarding.

## Verification
- `npm ci` in `wordpress/`
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wordpress-fuzz-runner-codebox-contract`
- `npm run test:wordpress-fuzz-runtime-task`
- `./node_modules/.bin/eslint lib/wp-codebox-fuzz-run.js lib/wordpress-fuzz-runner.js scripts/fuzz/fuzz-runner.cjs`
- `npm run lint:js` still fails on existing unrelated baseline lint issues outside the touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the direct Codebox fuzz execution path, updating focused tests, and running verification.