### PR TITLE
Fix fuzz runner WP Codebox binary override

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -251,7 +251,7 @@ function discoverWpCodeboxBin(env) {
 }
 
 function wpCodeboxCommand(env) {
-	return discoverWpCodeboxBin(env) || env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
+	return env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || discoverWpCodeboxBin(env) || 'wp-codebox';
 }
 
 function parseJsonObject(value) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -416,18 +416,18 @@ assert.equal(
 assert.equal(
 	wpCodeboxCommand({
 		HOMEBOY_WP_CODEBOX_INSTALL_DIR: codeboxInstallRoot,
-		HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/stale/wp-codebox',
+		HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/settings/wp-codebox',
 	}),
-	cachedCodeboxBin,
-	'Homeboy-managed WP Codebox cache should beat stale persisted settings'
+	'/settings/wp-codebox',
+	'Explicit WP Codebox settings should override the Homeboy-managed cache'
 );
 assert.equal(
 	wpCodeboxCommand({
 		HOMEBOY_WP_CODEBOX_BIN: '/explicit/wp-codebox',
 		HOMEBOY_WP_CODEBOX_INSTALL_DIR: codeboxInstallRoot,
 	}),
-	cachedCodeboxBin,
-	'Homeboy-managed WP Codebox cache should beat stale ambient runner env'
+	'/explicit/wp-codebox',
+	'Explicit WP Codebox env should override the Homeboy-managed cache'
 );
 
 const cli = spawnSync(runnerPath, [], {


### PR DESCRIPTION
## Summary
- Prefer explicit HOMEBOY_WP_CODEBOX_BIN / HOMEBOY_SETTINGS_WP_CODEBOX_BIN over the auto-discovered WP Codebox cache in the WordPress fuzz runner
- Update the fuzz runner smoke test to cover explicit override precedence

## Testing
- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the fuzz-runner binary selection bug, drafting the minimal code/test change, and running focused verification.