### PR TITLE
Honor WP Codebox binary setting JSON in fuzz runner

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -251,7 +251,12 @@ function discoverWpCodeboxBin(env) {
 }
 
 function wpCodeboxCommand(env) {
-	return env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || discoverWpCodeboxBin(env) || 'wp-codebox';
+	const settings = parseJsonObject(env.HOMEBOY_SETTINGS_JSON);
+	return env.HOMEBOY_WP_CODEBOX_BIN
+		|| env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
+		|| settings?.wp_codebox_bin
+		|| discoverWpCodeboxBin(env)
+		|| 'wp-codebox';
 }
 
 function parseJsonObject(value) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -429,6 +429,14 @@ assert.equal(
 	'/explicit/wp-codebox',
 	'Explicit WP Codebox env should override the Homeboy-managed cache'
 );
+assert.equal(
+	wpCodeboxCommand({
+		HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: '/settings-json/wp-codebox' }),
+		HOMEBOY_WP_CODEBOX_INSTALL_DIR: codeboxInstallRoot,
+	}),
+	'/settings-json/wp-codebox',
+	'Explicit WP Codebox setting JSON should override the Homeboy-managed cache'
+);
 
 const cli = spawnSync(runnerPath, [], {
 	encoding: 'utf8',


### PR DESCRIPTION
## Summary
- Read `wp_codebox_bin` from `HOMEBOY_SETTINGS_JSON` when selecting the WP Codebox CLI for WordPress fuzz runs
- Keep explicit env values ahead of settings JSON, and settings JSON ahead of the auto-discovered cache
- Extend the fuzz runner smoke coverage for JSON setting precedence

## Testing
- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the setting propagation gap, drafting the minimal code/test change, and running focused verification.