### PR TITLE
Build PHP fuzz workloads as workload-run input

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -464,6 +464,17 @@ function homeboyFuzzWorkloadRuntimeCommandInput(entry = {}, manifest = {}, execu
 	}
 	const workloadPath = execute.path || manifest.workload?.path;
 	if (typeof workloadPath === 'string' && workloadPath.trim() !== '') {
+		if (String(execute.type || manifest.workload?.type || '').toLowerCase() === 'php') {
+			return wpCodeboxWordPressWorkloadRunInput({
+				id: execute.entry || manifest.workload?.entry,
+				steps: [{ command: 'wordpress.run-workload', args: [`path=${workloadPath}`, 'type=php'] }],
+				metadata: stripUndefined({
+					source_path: workloadPath,
+					source_entry: execute.entry || manifest.workload?.entry,
+					source_type: 'php',
+				}),
+			});
+		}
 		const workloadInput = homeboyFuzzWorkloadRunInputFromFile(workloadPath, { entry: execute.entry || manifest.workload?.entry });
 		if (workloadInput) {
 			return workloadInput;

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -243,6 +243,23 @@ assert.equal(jsonWorkloadInput.cases[0].artifacts[0].required, true);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].metadata.semantic_key, 'fuzz.suite_result');
 assert.equal(jsonWorkloadInput.metadata.artifacts.expected[0].required, true);
 
+const phpWorkloadPath = path.join(tempWorkloadDir, 'bench', 'rest-product-batch-import.php');
+fs.mkdirSync(path.dirname(phpWorkloadPath), { recursive: true });
+fs.writeFileSync(phpWorkloadPath, '<?php return function (): array { return array("status" => "passed"); };\n', 'utf8');
+const phpWorkloadInput = wpCodeboxFuzzSuiteInput({
+	id: 'php-workload-run',
+	homeboyFuzzWorkload: {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: 'php-workload',
+		workload: { path: phpWorkloadPath, type: 'php', entry: 'rest-product-batch-import' },
+		cases: [{ id: 'php-workload:default', intent: { execute: { path: phpWorkloadPath, type: 'php', entry: 'rest-product-batch-import' } } }],
+	},
+});
+assert.equal(phpWorkloadInput.cases[0].input.schema, DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA);
+assert.deepEqual(phpWorkloadInput.cases[0].input.steps, [
+	{ command: 'wordpress.run-workload', args: [`path=${phpWorkloadPath}`, 'type=php'] },
+]);
+
 const wooDbApiWorkloadPath = path.join(tempWorkloadDir, 'rest-db-query-profile.workload.json');
 fs.mkdirSync(path.join(tempWorkloadDir, 'bench'), { recursive: true });
 fs.writeFileSync(path.join(tempWorkloadDir, 'bench', 'generated-rest-request-cases.php'), `<?php


### PR DESCRIPTION
## Summary
- Convert Homeboy PHP fuzz workload file references into `wp-codebox/wordpress-workload-run/v1` input with a `wordpress.run-workload` PHP step
- Keep JSON workload handling unchanged
- Add focused smoke coverage for PHP workload file conversion

## Testing
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Homeboy/WP Codebox workload input contract mismatch, drafting the minimal conversion fix, and running focused verification.