### PR TITLE
fix(wordpress): use public plugin activation command

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -278,10 +278,10 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 			path: source,
 			pluginFile: activation,
 			loadAs: 'plugin',
-			activate: Boolean(activation),
 			metadata: stripUndefined({
 				component: componentId,
 				rig_id: context.rig_id,
+				activation: activation ? 'fuzz-suite-setup-step' : undefined,
 			}),
 		}),
 		componentContract: stripUndefined({

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -30,6 +30,7 @@ const {
 const {
 	homeboySettings,
 	wpCodeboxCommand,
+	wpCodeboxPluginStateStep,
 } = require('./wp-codebox-recipe-helper');
 const {
 	WP_CODEBOX_FUZZ_PUBLIC_ABILITIES,
@@ -545,7 +546,7 @@ function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, a
 }
 
 function wpCodeboxPluginActivationStep(plugin) {
-	return { command: 'wordpress.wp-cli', args: [`command=plugin activate ${plugin}`] };
+	return wpCodeboxPluginStateStep({ activate: [plugin] });
 }
 
 function homeboyFuzzWorkloadCaseAction({ genericCommand, workloadPath, workloadDefinition, execute = {} } = {}) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -208,7 +208,8 @@ const jsonWorkloadResult = buildWordPressFuzzRunnerResult({
 
 assert.equal(jsonWorkloadResult.wp_codebox_input.cases.length, 1);
 assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].id, 'json-workload:default');
-assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.setup, [{ command: 'wordpress.plugin-state', args: ['plugin-state-json={"activate":[{"plugin":"sample-plugin/sample-plugin.php"}],"deactivate":[],"report":true}'] }]);
+assert.equal(JSON.stringify(jsonWorkloadResult.wp_codebox_input).includes('wordpress.ensure-plugin-active'), false);
 assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/json-workload.workload.json'] }]);
 assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
 assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].artifacts[0].required, true);
@@ -221,9 +222,9 @@ assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.extra_plugin
 	path: '/runner/components/sample-plugin/plugins/sample-plugin',
 	pluginFile: 'sample-plugin/sample-plugin.php',
 	loadAs: 'plugin',
-	activate: true,
-	metadata: { component: 'sample-plugin', rig_id: 'sample-rig' },
+	metadata: { component: 'sample-plugin', rig_id: 'sample-rig', activation: 'fuzz-suite-setup-step' },
 }]);
+assert.equal(jsonWorkloadResult.wp_codebox_runtime_requirements.extra_plugins[0].activate, undefined);
 assert.equal(
 	jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0].source,
 	'/runner/components/sample-plugin/plugins/sample-plugin'

--- a/wordpress/tests/wordpress-rest-db-query-profile-preset-smoke.js
+++ b/wordpress/tests/wordpress-rest-db-query-profile-preset-smoke.js
@@ -54,7 +54,8 @@ assert.equal(suiteInput.cases[0].target.entrypoint, 'wordpress.run-workload');
 assert.equal(suiteInput.cases[0].input.schema, 'wp-codebox/wordpress-workload-run/v1');
 assert.equal(suiteInput.cases[0].input.steps[0].type, 'php');
 assert.equal(suiteInput.cases[0].input.metadata.source, 'inline');
-assert.deepEqual(suiteInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate example-plugin/example-plugin.php'] }]);
+assert.deepEqual(suiteInput.cases[0].phases.setup, [{ command: 'wordpress.plugin-state', args: ['plugin-state-json={"activate":[{"plugin":"example-plugin/example-plugin.php"}],"deactivate":[],"report":true}'] }]);
+assert.equal(JSON.stringify(suiteInput).includes('wordpress.ensure-plugin-active'), false);
 assert.deepEqual(suiteInput.cases[0].phases.action, [{ command: 'wordpress.run-workload' }]);
 
 const explicitOnly = buildWordPressRestDbQueryProfileWorkload({

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -236,7 +236,8 @@ assert.deepEqual(jsonWorkloadInput.cases[0].input, {
 	after: [],
 	metadata: { fixture: 'json-workload-smoke', source_path: jsonWorkloadPath, source_entry: 'wp-codebox/run-fuzz-suite' },
 });
-assert.deepEqual(jsonWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(jsonWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.plugin-state', args: ['plugin-state-json={"activate":[{"plugin":"sample-plugin/sample-plugin.php"}],"deactivate":[],"report":true}'] }]);
+assert.equal(JSON.stringify(jsonWorkloadInput).includes('wordpress.ensure-plugin-active'), false);
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: [`path=${jsonWorkloadPath}`] }]);
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].required, true);
@@ -328,7 +329,7 @@ const genericPrimitiveManifest = {
 };
 const genericPrimitiveInput = wpCodeboxFuzzSuiteInput({ id: 'generic-primitive-run', homeboyFuzzWorkload: genericPrimitiveManifest });
 assert.equal(genericPrimitiveInput.cases[0].target.entrypoint, 'wordpress.fuzz-admin-pages');
-assert.deepEqual(genericPrimitiveInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(genericPrimitiveInput.cases[0].phases.setup, [{ command: 'wordpress.plugin-state', args: ['plugin-state-json={"activate":[{"plugin":"sample-plugin/sample-plugin.php"}],"deactivate":[],"report":true}'] }]);
 assert.deepEqual(genericPrimitiveInput.cases[0].phases.action, [{ command: 'wordpress.fuzz-admin-pages', args: ['safe_methods=GET', 'max_pages=80', 'enumerate_menus=true'] }]);
 assert.deepEqual(genericPrimitiveInput.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=admin_page_coverage'] }]);
 
@@ -378,7 +379,7 @@ assert.equal(planWorkloadInput.cases.length, 1);
 assert.equal(planWorkloadInput.cases[0].id, 'plan-workload-smoke:default');
 assert.equal(planWorkloadInput.cases[0].target.entrypoint, 'wordpress.inventory-rest-routes');
 assert.deepEqual(planWorkloadInput.cases[0].input, { args: ['plugin=sample-plugin/sample-plugin.php', 'namespaces=sample/v1,sample/v2', 'artifact=route_inventory'] });
-assert.deepEqual(planWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(planWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.plugin-state', args: ['plugin-state-json={"activate":[{"plugin":"sample-plugin/sample-plugin.php"}],"deactivate":[],"report":true}'] }]);
 assert.deepEqual(planWorkloadInput.cases[0].phases.action, [{
 	command: 'wordpress.inventory-rest-routes',
 	args: ['plugin=sample-plugin/sample-plugin.php', 'namespaces=sample/v1,sample/v2', 'artifact=route_inventory'],


### PR DESCRIPTION
## Summary
- Generate public `wordpress.plugin-state` activation steps for WordPress fuzz workloads.
- Stop marking extra plugin runtime requirements with `activate=true` in the fuzz runner path.
- Keep activation handling product-neutral.
- Update fuzz runner smoke tests.

## Evidence
Offloaded Woo fuzz run `wc-db-api-codebox-suite-20260626T0100Z` exposed a brittle activation command boundary in generated fuzz workloads.

## Verification
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wordpress-rest-db-query-profile-preset`
- `npm run test:wp-codebox-recipe-helper`
- `npm run test:wp-codebox-fuzz-plan-recipe-builder`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Diagnosing the offloaded fuzz failure, drafting the fuzz adapter activation fix, updating tests, and preparing the PR.
