### PR TITLE
fix(wordpress): expand workload template paths

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -518,6 +518,7 @@ function homeboyFuzzWorkloadRunInputFromFile(workloadPath, options = {}) {
 	} catch {
 		return undefined;
 	}
+	source = expandWorkloadTemplateTokens(source, { packageRoot: packageRootFromWorkloadPath(filePath), sourceFilePath: filePath });
 	const steps = normalizeWordPressWorkloadSteps(source.run || source.steps, { sourceFilePath: filePath });
 	if (steps.length === 0) {
 		return undefined;
@@ -533,6 +534,29 @@ function homeboyFuzzWorkloadRunInputFromFile(workloadPath, options = {}) {
 			source_entry: options.entry,
 		}),
 	});
+}
+
+function packageRootFromWorkloadPath(filePath) {
+	const parent = path.basename(path.dirname(filePath));
+	if (['bench', 'fuzz', 'manifests', 'tools'].includes(parent)) {
+		return path.dirname(path.dirname(filePath));
+	}
+	return path.dirname(filePath);
+}
+
+function expandWorkloadTemplateTokens(value, replacements = {}) {
+	if (typeof value === 'string') {
+		return value
+			.replaceAll('${package.root}', replacements.packageRoot || '')
+			.replaceAll('${source.file}', replacements.sourceFilePath || '');
+	}
+	if (Array.isArray(value)) {
+		return value.map((item) => expandWorkloadTemplateTokens(item, replacements));
+	}
+	if (objectOrUndefined(value)) {
+		return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, expandWorkloadTemplateTokens(item, replacements)]));
+	}
+	return value;
 }
 
 function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, artifacts = []) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -184,12 +184,14 @@ const preflightPassed = preflightWpCodeboxFuzzCapabilityContract({
 });
 assert.equal(preflightPassed.ok, true);
 
-const tempWorkloadDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-run-smoke-'));
+const tempPackageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-run-smoke-'));
+const tempWorkloadDir = path.join(tempPackageRoot, 'bench');
+fs.mkdirSync(tempWorkloadDir, { recursive: true });
 const jsonWorkloadPath = path.join(tempWorkloadDir, 'json-workload-smoke.workload.json');
 fs.writeFileSync(jsonWorkloadPath, `${JSON.stringify({
 	id: 'json-workload-smoke',
-	run: [{ type: 'php', code: 'return array("ok" => true);' }],
-	metadata: { fixture: 'json-workload-smoke' },
+	run: [{ command: 'wp-codebox/run-fuzz-suite', args: ['suite=${package.root}/manifests/codebox-fuzz-suite-smoke.json'] }],
+	metadata: { fixture: 'json-workload-smoke', package_root: '${package.root}' },
 })}\n`, 'utf8');
 
 const jsonWorkloadManifest = {
@@ -232,9 +234,9 @@ assert.deepEqual(jsonWorkloadInput.cases[0].input, {
 	secret_env: [],
 	staged_files: [],
 	before: [],
-	steps: [{ type: 'php', code: 'return array("ok" => true);' }],
+	steps: [{ command: 'wp-codebox/run-fuzz-suite', args: [`suite=${tempPackageRoot}/manifests/codebox-fuzz-suite-smoke.json`] }],
 	after: [],
-	metadata: { fixture: 'json-workload-smoke', source_path: jsonWorkloadPath, source_entry: 'wp-codebox/run-fuzz-suite' },
+	metadata: { fixture: 'json-workload-smoke', package_root: tempPackageRoot, source_path: jsonWorkloadPath, source_entry: 'wp-codebox/run-fuzz-suite' },
 });
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.plugin-state', args: ['plugin-state-json={"activate":[{"plugin":"sample-plugin/sample-plugin.php"}],"deactivate":[],"report":true}'] }]);
 assert.equal(JSON.stringify(jsonWorkloadInput).includes('wordpress.ensure-plugin-active'), false);


### PR DESCRIPTION
## Summary
- Recursively expand known template tokens in JSON WordPress workload files loaded for fuzz execution.
- Resolve `${package.root}` from package-shaped workload paths such as `<package>/bench/*.workload.json`.
- Add regression coverage proving nested Codebox fuzz-suite paths are concrete before dispatch.

## Evidence
Offloaded Woo fuzz run `wc-db-api-codebox-suite-20260626T0140Z` reached nested fuzz-suite execution and failed because Codebox received the literal path `${package.root}/manifests/codebox-fuzz-suite-smoke.json`.

## Verification
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Diagnosing the offloaded fuzz failure, drafting the template expansion fix, adding focused tests, and preparing the PR.
