### PR TITLE
fix(wordpress): emit fuzz result envelope artifact

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -1611,7 +1611,31 @@ function normalizeWpCodeboxFuzzArtifacts(source = {}, result = {}) {
 	if (artifacts.length === 0) {
 		appendStructuredFuzzArtifacts(artifacts, source);
 	}
+	appendInlineResultEnvelopeArtifact(artifacts, source);
 	return dedupeArtifacts(artifacts.map(normalizeFuzzArtifact).filter(Boolean));
+}
+
+function appendInlineResultEnvelopeArtifact(artifacts, source = {}) {
+	if (!objectOrUndefined(source) || !source.schema || hasFuzzArtifactRole(artifacts, 'result_envelope')) {
+		return;
+	}
+	artifacts.push({
+		name: 'result-envelope',
+		role: 'result_envelope',
+		semantic_key: 'fuzz.result.envelope',
+		content: source,
+		metadata: { schema: source.schema },
+	});
+}
+
+function hasFuzzArtifactRole(artifacts = [], role) {
+	return normalizeArray(artifacts).some((artifact) => {
+		if (!objectOrUndefined(artifact)) {
+			return false;
+		}
+		const identity = fuzzArtifactIdentity(artifact);
+		return identity.role === role;
+	});
 }
 
 function appendStructuredFuzzArtifacts(artifacts, source = {}) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -316,6 +316,7 @@ assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name 
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'case-log'), true);
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'replay-data'), true);
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'coverage-summary'), true);
+assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'result-envelope' && artifact.role === 'result_envelope'), true);
 
 const genericPrimitiveManifest = {
 	schema: 'homeboy/fuzz-workload/v1',
@@ -556,7 +557,7 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.observation_set.observations.some((observation) => observation.case_id === 'case-000' && observation.metric === 'query_count'), true);
 	assert.equal(summary.runtime_task_result.observation_set.observations[0].fingerprint, 'select-posts');
 	assert.equal(summary.derived_artifacts.artifacts.some((artifact) => artifact.role === 'hotspot_summary'), true);
-	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'normalized_fuzz_result', 'coverage_gap_report', 'hotspot_summary', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case', 'repro_case']);
+	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'normalized_fuzz_result', 'coverage_gap_report', 'hotspot_summary', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case', 'repro_case', 'result_envelope']);
 	assert.equal(summary.artifacts[0].semantic_key, 'fuzz.report');
 	assert.equal(summary.artifacts[9].semantic_key, 'fuzz.case.repro');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').semantic_key, 'fuzz.coverage');
@@ -568,6 +569,7 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'failing_case').semantic_key, 'fuzz.case.failing');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'case_artifact').semantic_key, 'fuzz.case.artifact');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'repro_case').semantic_key, 'fuzz.case.repro');
+	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'result_envelope').semantic_key, 'fuzz.result.envelope');
 	assert.equal(summary.artifacts.some((artifact) => artifact.name === 'placeholder-only'), false);
 	assert.equal(summary.observation.schema, WORDPRESS_FUZZ_OBSERVATION_SCHEMA);
 	assert.equal(summary.observation.status, 'succeeded');
@@ -641,6 +643,7 @@ runWpCodeboxFuzzSuite({
 		['case_log', 'fuzz.case.log'],
 		['replay_data', 'fuzz.replay.data'],
 		['coverage_summary', 'fuzz.coverage.summary'],
+		['result_envelope', 'fuzz.result.envelope'],
 	]);
 
 	const normalized = normalizeWpCodeboxFuzzSuiteResult({ status: 'failed', failures: [{ message: 'boom' }] });
@@ -733,7 +736,6 @@ runWpCodeboxFuzzSuite({
 	assert.equal(emptyRequired.succeeded, false);
 	assert.deepEqual(emptyRequired.failures.map((failure) => failure.code), [
 		'wp_codebox_fuzz_empty_cases_for_declared_contract',
-		'wp_codebox_fuzz_required_artifacts_missing',
 	]);
 	const declaredOnlyEmpty = normalizeWpCodeboxFuzzSuiteResult({
 		json: {


### PR DESCRIPTION
## Summary
- add an inline `result-envelope` artifact when normalizing WP Codebox fuzz results that do not already provide one
- keep the artifact product-neutral and keyed with `fuzz.result.envelope`
- update the fuzz-run smoke coverage for strict result-envelope consumers

## Why
Homeboy strict fuzz runs with `--require-result-envelope` were marking a passed WP Codebox fuzz campaign as failed because the normalized campaign had case/replay/coverage artifacts but no concrete `result-envelope` artifact.

## Testing
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`
- Replayed saved Woo artifact through patched normalizer and confirmed it emits `result_envelope`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, code changes, and targeted test verification.