### PR TITLE
fix(wordpress): expose campaign artifacts

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -391,6 +391,7 @@ function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, stat
 		id: runId,
 		title: `WordPress fuzz campaign ${runId}`,
 		safety_class: deriveHomeboyFuzzSafetyClass(plan),
+		artifacts: homeboyFuzzCampaignArtifacts(codeboxResult),
 		metadata: stripUndefined({
 			workload_id: workloadId,
 			plan_id: plan?.id,
@@ -403,6 +404,35 @@ function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, stat
 			hotspot_summary: codeboxResult?.hotspot_summary,
 			observation: codeboxResult?.observation,
 			wordpress_fuzz_result: codeboxResult?.wordpress_fuzz_result,
+		}),
+	});
+}
+
+function homeboyFuzzCampaignArtifacts(codeboxResult = {}) {
+	return normalizeArray(codeboxResult?.wordpress_fuzz_result?.artifacts || codeboxResult?.wordpressFuzzResult?.artifacts || codeboxResult?.artifacts)
+		.map(homeboyFuzzCampaignArtifact)
+		.filter(Boolean);
+}
+
+function homeboyFuzzCampaignArtifact(artifact = {}) {
+	if (!objectOrUndefined(artifact)) {
+		return null;
+	}
+	const id = artifact.id || artifact.name || artifact.role || artifact.kind;
+	const kind = artifact.kind || artifact.role || artifact.name || artifact.id;
+	if (!id || !kind) {
+		return null;
+	}
+	return stripUndefined({
+		schema: 'homeboy/fuzz-artifact/v1',
+		id: String(id),
+		kind: String(kind),
+		metadata: stripUndefined({
+			name: artifact.name,
+			role: artifact.role,
+			semantic_key: artifact.semantic_key || artifact.semanticKey,
+			content_type: artifact.content_type || artifact.contentType,
+			schema: artifact.schema || artifact.metadata?.schema,
 		}),
 	});
 }

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -116,7 +116,10 @@ const executedResult = buildWordPressFuzzRunnerResult({
 			schema: 'wp-codebox/fuzz-suite-result/v1',
 			suite: { id: 'generic-wordpress-plan' },
 			status: 'succeeded',
-			artifactRefs: [{ path: 'artifacts/replay.json', kind: 'replay' }],
+			artifactRefs: [
+				{ path: 'artifacts/replay.json', kind: 'replay' },
+				{ name: 'result-envelope', role: 'result_envelope', content: { status: 'succeeded' } },
+			],
 		},
 	},
 });
@@ -124,6 +127,7 @@ const executedResult = buildWordPressFuzzRunnerResult({
 assert.equal(executedResult.status, 'succeeded');
 assert.equal(executedResult.succeeded, true);
 assert.equal(executedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'artifacts/replay.json');
+assert.equal(executedResult.homeboy_fuzz_campaign.artifacts.some((artifact) => artifact.id === 'result-envelope' && artifact.kind === 'result_envelope'), true);
 assert.equal(executedResult.observation.status, 'succeeded');
 
 const mutatingPlanResult = buildWordPressFuzzRunnerResult({
@@ -357,7 +361,7 @@ const dispatchPromise = runWordPressFuzzRunnerResult({
 	assert.equal(dispatchedResult.succeeded, true);
 	assert.equal(dispatchedResult.wp_codebox_result.request_id, 'dispatch-run');
 	assert.equal(dispatchedResult.wp_codebox_result.coverage_summary.surface_count, 1);
-	assert.deepEqual(dispatchedResult.wp_codebox_result.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage']);
+	assert.deepEqual(dispatchedResult.wp_codebox_result.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'result_envelope']);
 	assert.equal(dispatchedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].semantic_key, 'fuzz.report');
 	assert.equal(dispatchedResult.homeboy_fuzz_campaign.metadata.artifact_refs[1].semantic_key, 'fuzz.coverage');
 });


### PR DESCRIPTION
## Summary
- promote normalized WordPress/WP Codebox fuzz artifacts into top-level Homeboy campaign artifacts
- emit Homeboy artifact `id`/`kind` fields so strict Homeboy fuzz gates can see required artifacts
- cover result-envelope promotion in the WordPress fuzz runner smoke test

## Why
Homeboy strict fuzz validation checks top-level campaign artifacts. The direct WP Codebox result contained `result-envelope` under nested WordPress metadata, but the Homeboy campaign had no top-level artifacts, so `--require-result-envelope` still failed.

## Testing
- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, code changes, and targeted test verification.