### PR TITLE
fix(wordpress): allow large codebox fuzz output

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -49,6 +49,7 @@ const WORDPRESS_FUZZ_OBSERVATION_SCHEMA = 'homeboy/wordpress-fuzz-observation/v1
 const DEFAULT_FUZZ_SUITE_ABILITY = 'wp-codebox/run-fuzz-suite';
 const DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY = 'wp-codebox/run-wordpress-workload';
 const DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA = 'wp-codebox/wordpress-workload-run/v1';
+const DEFAULT_PUBLIC_CLI_MAX_BUFFER_BYTES = 1024 * 1024 * 128;
 const DEFAULT_WP_CODEBOX_PUBLIC_CLI_BIN = 'wp';
 const WP_CODEBOX_PUBLIC_CLI_COMMANDS = WP_CODEBOX_FUZZ_PUBLIC_COMMANDS;
 const ARTIFACT_POSTPROCESS_COMMAND = 'homeboy.artifact-postprocess';
@@ -1042,7 +1043,7 @@ function runWpCodeboxPublicCliCommand(args, options = {}) {
 		encoding: 'utf8',
 		env: { ...process.env, ...(options.env || {}) },
 		cwd: options.cwd,
-		maxBuffer: options.maxBuffer || 1024 * 1024 * 10,
+		maxBuffer: options.maxBuffer || options.max_buffer || DEFAULT_PUBLIC_CLI_MAX_BUFFER_BYTES,
 	});
 	return normalizeCliResult(result);
 }

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -955,6 +955,30 @@ runWpCodeboxFuzzSuite({
 }).then((summary) => {
 	assert.equal(summary.succeeded, true);
 	assert.equal(summary.artifacts.some((artifact) => artifact.name === 'case-log'), true);
+	const largeCliDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-large-codebox-cli-'));
+	const largeCli = path.join(largeCliDir, 'wp-codebox-large-output.cjs');
+	fs.writeFileSync(largeCli, `
+const args = process.argv.slice(2);
+if (args.includes('--help')) {
+  process.stdout.write('usage');
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  schema: ${JSON.stringify(WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA)},
+  status: 'passed',
+  summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+  cases: [{ id: 'large-output-case', status: 'passed' }],
+  metadata: { large: 'x'.repeat(11 * 1024 * 1024) }
+}));
+`, 'utf8');
+	return runWpCodeboxFuzzSuite({
+		taskId: 'public-cli-large-output-run',
+		input,
+		wpCodeboxBin: largeCli,
+	}).finally(() => fs.rmSync(largeCliDir, { recursive: true, force: true }));
+}).then((summary) => {
+	assert.equal(summary.succeeded, true);
+	assert.equal(summary.result_schema, WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA);
 	assert.deepEqual(detectWpCodeboxPublicFuzzCapabilities({ publicCliCapabilities: { commands: { 'run-wordpress-workload': true } } }).commands, {
 		'run-fuzz-suite': false,
 		'run-wordpress-workload': true,


### PR DESCRIPTION
## Summary
- raise the WP Codebox public fuzz CLI buffer from 10 MB to 128 MB
- allow callers to override the buffer with either `maxBuffer` or `max_buffer`
- add smoke coverage for an 11 MB public CLI fuzz result

## Why
Woo fuzz proof runs can produce large WP Codebox JSON result envelopes. The previous 10 MB child-process buffer failed before Homeboy could persist or validate the fuzz result.

## Testing
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause investigation, code changes, and targeted test verification.