### PR TITLE
Stage Codebox artifact postprocess helpers

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -866,8 +866,8 @@ async function runWpCodeboxPublicFuzzOperation(options = {}) {
 }
 
 function wpCodeboxPublicCliInput(request = {}, options = {}) {
-	const input = wpCodeboxFuzzRequestInput(request, options);
 	const runtimeRequirements = objectOrUndefined(wpCodeboxFuzzRequestRuntimeRequirements(request));
+	const input = stageArtifactPostprocessHelpers(wpCodeboxFuzzRequestInput(request, options), runtimeRequirements);
 	return {
 		...input,
 		metadata: {
@@ -876,6 +876,56 @@ function wpCodeboxPublicCliInput(request = {}, options = {}) {
 			homeboy_wp_codebox_fuzz_execution: request,
 		},
 	};
+}
+
+function stageArtifactPostprocessHelpers(input = {}, runtimeRequirements = {}) {
+	const pluginSlug = wpCodeboxRuntimePluginSlug(runtimeRequirements);
+	if (!pluginSlug || !Array.isArray(input.cases)) {
+		return input;
+	}
+	let changed = false;
+	const cases = input.cases.map((fuzzCase) => {
+		const workload = objectOrUndefined(fuzzCase?.input);
+		if (!workload || workload.schema !== DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA) {
+			return fuzzCase;
+		}
+		const sourcePath = workload.metadata?.source_path || workload.metadata?.sourcePath;
+		const packageRoot = typeof sourcePath === 'string' ? packageRootFromWorkloadPath(sourcePath) : undefined;
+		const stagedFiles = [...normalizeArray(workload.staged_files || workload.stagedFiles)];
+		for (const phase of ['before', 'steps', 'after']) {
+			for (const step of normalizeArray(workload[phase])) {
+				const helperPath = typeof step?.helperPath === 'string' ? step.helperPath : undefined;
+				if (!helperPath || !packageRoot || path.isAbsolute(helperPath) || helperPath.split(/[\\/]+/).includes('..')) {
+					continue;
+				}
+				const source = path.join(packageRoot, helperPath);
+				if (!fs.existsSync(source)) {
+					continue;
+				}
+				const target = `/wordpress/wp-content/plugins/${pluginSlug}/${helperPath}`;
+				if (!stagedFiles.some((entry) => objectOrUndefined(entry)?.source === source && objectOrUndefined(entry)?.target === target)) {
+					stagedFiles.push({ source, target });
+					changed = true;
+				}
+			}
+		}
+		if (stagedFiles.length === normalizeArray(workload.staged_files || workload.stagedFiles).length) {
+			return fuzzCase;
+		}
+		changed = true;
+		return { ...fuzzCase, input: { ...workload, staged_files: stagedFiles, stagedFiles: undefined } };
+	});
+	return changed ? { ...input, cases } : input;
+}
+
+function wpCodeboxRuntimePluginSlug(runtimeRequirements = {}) {
+	for (const plugin of [...normalizeArray(runtimeRequirements.extra_plugins), ...normalizeArray(runtimeRequirements.component_contracts)]) {
+		const slug = objectOrUndefined(plugin)?.slug;
+		if (typeof slug === 'string' && slug.trim()) {
+			return slug.trim();
+		}
+	}
+	return undefined;
 }
 
 function detectWpCodeboxPublicFuzzCapabilities(options = {}) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -971,6 +971,41 @@ runWpCodeboxFuzzSuite({
 }).then((summary) => {
 	assert.equal(summary.succeeded, true);
 	assert.equal(summary.artifacts.some((artifact) => artifact.name === 'case-log'), true);
+	const stagedHelperDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-staged-helper-'));
+	fs.mkdirSync(path.join(stagedHelperDir, 'bench'));
+	fs.mkdirSync(path.join(stagedHelperDir, 'tools'));
+	const stagedWorkloadPath = path.join(stagedHelperDir, 'bench', 'coverage-gap-report.workload.json');
+	const stagedHelperPath = path.join(stagedHelperDir, 'tools', 'artifact-helper.mjs');
+	fs.writeFileSync(stagedHelperPath, 'export {};\n', 'utf8');
+	const stagedHelperInput = wpCodeboxFuzzSuiteInput({
+		id: 'staged-helper-suite',
+		cases: [{
+			id: 'staged-helper-case',
+			target: { kind: 'runtime', id: 'wordpress.run-workload', entrypoint: 'wordpress.run-workload' },
+			input: wpCodeboxWordPressWorkloadRunInput({
+				id: 'staged-helper-workload',
+				packageRoot: stagedHelperDir,
+				steps: [{ command: 'artifact-postprocess', args: { helper: stagedHelperPath, action: 'coverage-gap-report', input: { path: '${artifacts.root}' }, output: { path: 'coverage/gaps.json' } } }],
+				metadata: { source_path: stagedWorkloadPath },
+			}),
+		}],
+	});
+	return runWpCodeboxFuzzSuite({
+		taskId: 'public-cli-staged-helper-run',
+		input: stagedHelperInput,
+		wpCodeboxBin: '/custom/direct-wp-codebox',
+		runtimeRequirements: { extra_plugins: [{ slug: 'sample-plugin', source: stagedHelperDir, loadAs: 'plugin' }] },
+		runPublicCli: ({ args }) => {
+			if (args.includes('--help')) return { status: 0, stdout: 'usage' };
+			const publicCliInput = JSON.parse(fs.readFileSync(args[2], 'utf8'));
+			const stagedFiles = publicCliInput.cases[0].input.staged_files;
+			assert.equal(publicCliInput.cases[0].input.steps[0].helperPath, 'tools/artifact-helper.mjs');
+			assert.deepEqual(stagedFiles, [{ source: stagedHelperPath, target: '/wordpress/wp-content/plugins/sample-plugin/tools/artifact-helper.mjs' }]);
+			return { status: 0, stdout: JSON.stringify({ schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA, status: 'passed', summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 } }) };
+		},
+	}).finally(() => fs.rmSync(stagedHelperDir, { recursive: true, force: true }));
+}).then((summary) => {
+	assert.equal(summary.succeeded, true);
 	const largeCliDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-large-codebox-cli-'));
 	const largeCli = path.join(largeCliDir, 'wp-codebox-large-output.cjs');
 	fs.writeFileSync(largeCli, `


### PR DESCRIPTION
## Summary
- Stage artifact-postprocess helper files into the mounted WordPress plugin root before public WP Codebox fuzz dispatch.
- Preserve WP Codebox's helper sandbox rule while allowing rig-owned helper files to execute as workload postprocess steps.
- Add a regression covering the actual public CLI input builder path.

## Testing
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root cause analysis, implementation, and focused regression test updates.