### PR TITLE
Mount Codebox postprocess artifact roots

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -867,7 +867,7 @@ async function runWpCodeboxPublicFuzzOperation(options = {}) {
 
 function wpCodeboxPublicCliInput(request = {}, options = {}) {
 	const runtimeRequirements = objectOrUndefined(wpCodeboxFuzzRequestRuntimeRequirements(request));
-	const input = stageArtifactPostprocessHelpers(wpCodeboxFuzzRequestInput(request, options), runtimeRequirements);
+	const input = stageArtifactPostprocessHelpers(wpCodeboxFuzzRequestInput(request, options), runtimeRequirements, options);
 	return {
 		...input,
 		metadata: {
@@ -878,8 +878,10 @@ function wpCodeboxPublicCliInput(request = {}, options = {}) {
 	};
 }
 
-function stageArtifactPostprocessHelpers(input = {}, runtimeRequirements = {}) {
+function stageArtifactPostprocessHelpers(input = {}, runtimeRequirements = {}, options = {}) {
 	const pluginSlug = wpCodeboxRuntimePluginSlug(runtimeRequirements);
+	const artifactRoot = wpCodeboxArtifactPostprocessRoot(options);
+	const runtimeArtifactRoot = '/tmp/wp-codebox-artifacts';
 	if (!pluginSlug || !Array.isArray(input.cases)) {
 		return input;
 	}
@@ -892,8 +894,16 @@ function stageArtifactPostprocessHelpers(input = {}, runtimeRequirements = {}) {
 		const sourcePath = workload.metadata?.source_path || workload.metadata?.sourcePath;
 		const packageRoot = typeof sourcePath === 'string' ? packageRootFromWorkloadPath(sourcePath) : undefined;
 		const stagedFiles = [...normalizeArray(workload.staged_files || workload.stagedFiles)];
+		const mounts = [...normalizeArray(workload.mounts)];
 		for (const phase of ['before', 'steps', 'after']) {
 			for (const step of normalizeArray(workload[phase])) {
+				if ((step?.inputArtifactRoot === '${artifacts.root}' || step?.inputArtifactRoot === '{{artifacts.root}}') && artifactRoot) {
+					step.inputArtifactRoot = runtimeArtifactRoot;
+					if (!mounts.some((entry) => objectOrUndefined(entry)?.source === artifactRoot && objectOrUndefined(entry)?.target === runtimeArtifactRoot)) {
+						mounts.push({ source: artifactRoot, target: runtimeArtifactRoot, mode: 'readwrite' });
+						changed = true;
+					}
+				}
 				const helperPath = typeof step?.helperPath === 'string' ? step.helperPath : undefined;
 				if (!helperPath || !packageRoot || path.isAbsolute(helperPath) || helperPath.split(/[\\/]+/).includes('..')) {
 					continue;
@@ -909,13 +919,34 @@ function stageArtifactPostprocessHelpers(input = {}, runtimeRequirements = {}) {
 				}
 			}
 		}
-		if (stagedFiles.length === normalizeArray(workload.staged_files || workload.stagedFiles).length) {
+		if (stagedFiles.length === normalizeArray(workload.staged_files || workload.stagedFiles).length && mounts.length === normalizeArray(workload.mounts).length) {
 			return fuzzCase;
 		}
 		changed = true;
-		return { ...fuzzCase, input: { ...workload, staged_files: stagedFiles, stagedFiles: undefined } };
+		return { ...fuzzCase, input: { ...workload, mounts, staged_files: stagedFiles, stagedFiles: undefined } };
 	});
 	return changed ? { ...input, cases } : input;
+}
+
+function wpCodeboxArtifactPostprocessRoot(options = {}) {
+	const env = { ...process.env, ...(options.env || {}) };
+	const candidates = [
+		options.artifactsRoot,
+		options.artifactRoot,
+		options.artifacts_root,
+		options.artifact_root,
+		env.HOMEBOY_ARTIFACT_ROOT,
+		env.HOMEBOY_ARTIFACT_DIR,
+		env.HOMEBOY_ARTIFACTS_DIR,
+		env.HOMEBOY_RUN_ARTIFACT_ROOT,
+		env.HOMEBOY_RUN_ARTIFACT_DIR,
+	];
+	for (const candidate of candidates) {
+		if (typeof candidate === 'string' && candidate.trim() && fs.existsSync(candidate)) {
+			return path.resolve(candidate);
+		}
+	}
+	return undefined;
 }
 
 function wpCodeboxRuntimePluginSlug(runtimeRequirements = {}) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -976,6 +976,8 @@ runWpCodeboxFuzzSuite({
 	fs.mkdirSync(path.join(stagedHelperDir, 'tools'));
 	const stagedWorkloadPath = path.join(stagedHelperDir, 'bench', 'coverage-gap-report.workload.json');
 	const stagedHelperPath = path.join(stagedHelperDir, 'tools', 'artifact-helper.mjs');
+	const stagedArtifactRoot = path.join(stagedHelperDir, 'artifacts');
+	fs.mkdirSync(stagedArtifactRoot);
 	fs.writeFileSync(stagedHelperPath, 'export {};\n', 'utf8');
 	const stagedHelperInput = wpCodeboxFuzzSuiteInput({
 		id: 'staged-helper-suite',
@@ -995,11 +997,15 @@ runWpCodeboxFuzzSuite({
 		input: stagedHelperInput,
 		wpCodeboxBin: '/custom/direct-wp-codebox',
 		runtimeRequirements: { extra_plugins: [{ slug: 'sample-plugin', source: stagedHelperDir, loadAs: 'plugin' }] },
+		env: { HOMEBOY_ARTIFACT_ROOT: stagedArtifactRoot },
 		runPublicCli: ({ args }) => {
 			if (args.includes('--help')) return { status: 0, stdout: 'usage' };
 			const publicCliInput = JSON.parse(fs.readFileSync(args[2], 'utf8'));
+			const workload = publicCliInput.cases[0].input;
 			const stagedFiles = publicCliInput.cases[0].input.staged_files;
-			assert.equal(publicCliInput.cases[0].input.steps[0].helperPath, 'tools/artifact-helper.mjs');
+			assert.equal(workload.steps[0].helperPath, 'tools/artifact-helper.mjs');
+			assert.equal(workload.steps[0].inputArtifactRoot, '/tmp/wp-codebox-artifacts');
+			assert.deepEqual(workload.mounts, [{ source: stagedArtifactRoot, target: '/tmp/wp-codebox-artifacts', mode: 'readwrite' }]);
 			assert.deepEqual(stagedFiles, [{ source: stagedHelperPath, target: '/wordpress/wp-content/plugins/sample-plugin/tools/artifact-helper.mjs' }]);
 			return { status: 0, stdout: JSON.stringify({ schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA, status: 'passed', summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 } }) };
 		},


### PR DESCRIPTION
## Summary
- Resolve Homeboy artifact-root inputs for WP Codebox artifact-postprocess workloads.
- Mount the artifact root into the Codebox runtime and rewrite `${artifacts.root}` to the mounted runtime path.
- Extend the public CLI adapter regression to cover helper staging plus artifact-root mounting.

## Testing
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root cause analysis, implementation, and focused regression test updates.
