### PR TITLE
Pass fuzz artifact roots to Codebox

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -36,6 +36,7 @@ function readWordPressFuzzRunnerEnv(env = process.env) {
 		seed: env.HOMEBOY_FUZZ_SEED,
 		maxDuration: env.HOMEBOY_FUZZ_MAX_DURATION,
 		resultsFile: env.HOMEBOY_FUZZ_RESULTS_FILE,
+		artifactRoot: env.HOMEBOY_ARTIFACT_ROOT || env.HOMEBOY_ARTIFACT_DIR || env.HOMEBOY_ARTIFACTS_DIR || env.HOMEBOY_RUN_ARTIFACT_ROOT || env.HOMEBOY_RUN_ARTIFACT_DIR,
 		wpCodeboxFuzzWorkloadRoot: env.WP_CODEBOX_FUZZ_WORKLOAD_ROOT,
 		wpCodeboxBin: env.HOMEBOY_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN,
 		wpCliBin: env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN,

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -930,6 +930,7 @@ function stageArtifactPostprocessHelpers(input = {}, runtimeRequirements = {}, o
 
 function wpCodeboxArtifactPostprocessRoot(options = {}) {
 	const env = { ...process.env, ...(options.env || {}) };
+	const resultsFile = options.resultsFile || options.results_file || env.resultsFile || env.HOMEBOY_FUZZ_RESULTS_FILE;
 	const candidates = [
 		options.artifactsRoot,
 		options.artifactRoot,
@@ -940,6 +941,7 @@ function wpCodeboxArtifactPostprocessRoot(options = {}) {
 		env.HOMEBOY_ARTIFACTS_DIR,
 		env.HOMEBOY_RUN_ARTIFACT_ROOT,
 		env.HOMEBOY_RUN_ARTIFACT_DIR,
+		typeof resultsFile === 'string' && resultsFile.trim() ? path.dirname(resultsFile) : undefined,
 	];
 	for (const candidate of candidates) {
 		if (typeof candidate === 'string' && candidate.trim() && fs.existsSync(candidate)) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -997,7 +997,7 @@ runWpCodeboxFuzzSuite({
 		input: stagedHelperInput,
 		wpCodeboxBin: '/custom/direct-wp-codebox',
 		runtimeRequirements: { extra_plugins: [{ slug: 'sample-plugin', source: stagedHelperDir, loadAs: 'plugin' }] },
-		env: { HOMEBOY_ARTIFACT_ROOT: stagedArtifactRoot },
+		env: { resultsFile: path.join(stagedArtifactRoot, 'fuzz-results.json') },
 		runPublicCli: ({ args }) => {
 			if (args.includes('--help')) return { status: 0, stdout: 'usage' };
 			const publicCliInput = JSON.parse(fs.readFileSync(args[2], 'utf8'));


### PR DESCRIPTION
## Summary
- Preserve Homeboy fuzz artifact-root environment fields for WP Codebox fuzz execution.
- Fall back to the directory containing `HOMEBOY_FUZZ_RESULTS_FILE` when explicit artifact-root env fields are absent.
- Cover the results-file fallback in the public CLI adapter regression.

## Testing
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root cause analysis, implementation, and focused regression test updates.
