### PR TITLE
Pass Codebox bench source roots for monorepo plugins

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -152,6 +152,26 @@ if [ -n "$WP_CODEBOX_SOURCE_ROOT" ]; then
     fi
 fi
 
+homeboy_wp_codebox_component_extra_plugin_json() {
+    local plugin_file="$1"
+
+    if [ -n "$WP_CODEBOX_SOURCE_ROOT" ]; then
+        jq -nc \
+            --arg source "$WP_CODEBOX_SOURCE_ROOT" \
+            --arg sourceSubpath "$WP_CODEBOX_SOURCE_SUBPATH" \
+            --arg slug "$PLUGIN_SLUG" \
+            --arg pluginFile "${PLUGIN_SLUG}/${plugin_file}" \
+            '[{source: $source, sourceRoot: $source, sourceSubpath: $sourceSubpath, slug: $slug, pluginFile: $pluginFile, activate: false}]'
+        return
+    fi
+
+    jq -nc \
+        --arg source "$WP_CODEBOX_PLUGIN_SOURCE_PATH" \
+        --arg slug "$PLUGIN_SLUG" \
+        --arg pluginFile "${PLUGIN_SLUG}/${plugin_file}" \
+        '[{source: $source, slug: $slug, pluginFile: $pluginFile, activate: false}]'
+}
+
 homeboy_wp_codebox_resolve_host_path() {
     local base_dir="$1"
     local path_value="$2"
@@ -979,7 +999,7 @@ homeboy_wp_codebox_require_bench_primitive "external-http-guardrail"
 MOUNTS_JSON="[]"
 COMPONENT_PLUGIN_FILE="$(homeboy_wp_codebox_find_plugin_file "$WP_CODEBOX_PLUGIN_SOURCE_PATH" || true)"
 if [ -n "$COMPONENT_PLUGIN_FILE" ]; then
-    EXTRA_PLUGINS_JSON=$(jq -nc --arg source "$WP_CODEBOX_PLUGIN_SOURCE_PATH" --arg slug "$PLUGIN_SLUG" --arg pluginFile "${PLUGIN_SLUG}/${COMPONENT_PLUGIN_FILE}" '[{source: $source, slug: $slug, pluginFile: $pluginFile, activate: false}]')
+    EXTRA_PLUGINS_JSON=$(homeboy_wp_codebox_component_extra_plugin_json "$COMPONENT_PLUGIN_FILE")
 else
     EXTRA_PLUGINS_JSON="[]"
     MOUNTS_JSON=$(jq -nc --arg source "$WP_CODEBOX_PLUGIN_SOURCE_PATH" --arg target "/wordpress/wp-content/plugins/${PLUGIN_SLUG}" '[{source: $source, target: $target, mode: "readonly"}]')

--- a/wordpress/tests/wp-codebox-bench-prepare-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-prepare-steps-smoke.js
@@ -33,11 +33,15 @@ if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
 const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
 const extraPlugins = recipe.inputs.extraPlugins || recipe.inputs.extra_plugins || [];
 const plugin = extraPlugins.find((entry) => entry.slug === 'prepare-steps-fixture');
-if (!plugin || !fs.existsSync(plugin.source + '/includes/react-admin/feature-config.php')) {
+if (!plugin || !plugin.sourceSubpath || !fs.existsSync(plugin.source + '/' + plugin.sourceSubpath + '/includes/react-admin/feature-config.php')) {
   process.stderr.write('generated feature config missing before wp-codebox launch\\n');
   process.exit(8);
 }
-if (!fs.existsSync(plugin.source + '/../../packages/php/monorepo-plugin/composer.json')) {
+if (plugin.source !== plugin.sourceRoot || plugin.sourceSubpath !== 'plugins/prepare-steps-fixture') {
+  process.stderr.write('monorepo source root/subpath missing from plugin recipe input\\n');
+  process.exit(10);
+}
+if (!fs.existsSync(plugin.source + '/packages/php/monorepo-plugin/composer.json')) {
   process.stderr.write('monorepo composer path repository missing from plugin source context\\n');
   process.exit(9);
 }


### PR DESCRIPTION
## Summary
- Emit WP Codebox bench component extra_plugins with sourceRoot/sourceSubpath when wp_codebox_source_root is configured.
- Keep plugin-only behavior unchanged when no source root is configured.
- Tighten the bench prepare smoke so it verifies monorepo root/subpath context reaches WP Codebox for Composer path repositories.

## Owner / dependency
- Homeboy Extensions owns emitting the recipe input from Lab settings.
- WP Codebox owns preserving sourceRoot/sourceSubpath in buildWordPressBenchRecipe: https://github.com/Automattic/wp-codebox/pull/1534
- This PR should merge after the WP Codebox PR and after Homeboy runs with a WP Codebox core module including that fix.

## Tests
- HOMEBOY_WP_CODEBOX_CORE_MODULE=/Users/chubes/Developer/wp-codebox@fix-issue-6472-bench-extra-plugin-source-root/packages/runtime-core/dist/recipe-builders.js node wordpress/tests/wp-codebox-bench-prepare-steps-smoke.js
- HOMEBOY_WP_CODEBOX_CORE_MODULE=/Users/chubes/Developer/wp-codebox@fix-issue-6472-bench-extra-plugin-source-root/packages/runtime-core/dist/recipe-builders.js bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the owner boundary, implementing the Homeboy Extensions recipe emission change, and drafting tests/PR text.

Fixes Extra-Chill/homeboy#6472