### PR TITLE
Refactor runtime full-run control-plane helpers

### DIFF
--- a/.github/scripts/runtime-agent-full-run/actions-artifact-downloads.cjs
+++ b/.github/scripts/runtime-agent-full-run/actions-artifact-downloads.cjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const { run, parseJsonInput } = require('./lib/common.cjs');
+
+function main() {
+  downloadArtifactsFromEnv(process.env);
+}
+
+function downloadArtifactsFromEnv(env) {
+  const downloads = normalizeArtifactDownloads(env.ACTIONS_ARTIFACT_DOWNLOADS || '[]', env.GITHUB_REPOSITORY || '');
+  for (const download of downloads) {
+    fs.mkdirSync(download.dir, { recursive: true });
+    run('gh', ['run', 'download', download.run_id, '--repo', download.repo, '--name', download.name, '--dir', download.dir]);
+  }
+  return downloads;
+}
+
+function normalizeArtifactDownloads(input, defaultRepo) {
+  return parseJsonInput('actions_artifact_downloads', input, 'array', []).map((entry, index) => normalizeArtifactDownload(entry, index, defaultRepo));
+}
+
+function normalizeArtifactDownload(entry, index, defaultRepo) {
+  if (!entry || Array.isArray(entry) || typeof entry !== 'object') {
+    throw new Error(`actions_artifact_downloads[${index}] must be an object`);
+  }
+  const repo = stringValue(entry.repo) || defaultRepo;
+  const runId = stringValue(entry.run_id ?? entry.runId);
+  const name = stringValue(entry.name ?? entry.artifact_name ?? entry.artifactName);
+  const dir = stringValue(entry.dir ?? entry.destination) || `.ci/actions-artifacts/${name}`;
+  if (!repo) {
+    throw new Error(`actions_artifact_downloads[${index}].repo is required`);
+  }
+  if (!runId) {
+    throw new Error(`actions_artifact_downloads[${index}].run_id is required`);
+  }
+  if (!name) {
+    throw new Error(`actions_artifact_downloads[${index}].name is required`);
+  }
+  return { repo, run_id: runId, name, dir };
+}
+
+function stringValue(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
+}
+
+module.exports = { downloadArtifactsFromEnv, normalizeArtifactDownloads };

--- a/.github/scripts/runtime-agent-full-run/project-callback-data.cjs
+++ b/.github/scripts/runtime-agent-full-run/project-callback-data.cjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+'use strict';
+
+const { parseJsonInput, writeGithubOutput } = require('./lib/common.cjs');
+
+function main() {
+  writeGithubOutput(projectCallbackData(process.env));
+}
+
+function projectCallbackData(env) {
+  const parsed = parseJsonInput('callback_data', env.CALLBACK_DATA || '{}', '', {});
+  const callbackData = parsed === null || parsed === false ? {} : parsed;
+  if (!callbackData || Array.isArray(callbackData) || typeof callbackData !== 'object') {
+    throw new Error('Invalid callback_data: expected JSON object.');
+  }
+  return { callback_data_json: JSON.stringify(callbackData) };
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
+}
+
+module.exports = { projectCallbackData };

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -461,22 +461,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ACTIONS_ARTIFACT_DOWNLOADS: ${{ inputs.actions_artifact_downloads }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          printf '%s' "$ACTIONS_ARTIFACT_DOWNLOADS" | jq -e 'type == "array"' >/dev/null
-          while IFS= read -r item; do
-            [ -n "$item" ] || continue
-            repo="$(jq -r '.repo // env.GITHUB_REPOSITORY' <<< "$item")"
-            run_id="$(jq -r '.run_id // .runId // ""' <<< "$item")"
-            name="$(jq -r '.name // .artifact_name // .artifactName // ""' <<< "$item")"
-            dir="$(jq -r '.dir // .destination // (".ci/actions-artifacts/" + $name)' --arg name "$(jq -r '.name // .artifact_name // .artifactName // ""' <<< "$item")" <<< "$item")"
-            [ -n "$repo" ] || { echo "Artifact download repo is required" >&2; exit 1; }
-            [ -n "$run_id" ] || { echo "Artifact download run_id is required" >&2; exit 1; }
-            [ -n "$name" ] || { echo "Artifact download name is required" >&2; exit 1; }
-            mkdir -p "$dir"
-            gh run download "$run_id" --repo "$repo" --name "$name" --dir "$dir"
-          done < <(printf '%s' "$ACTIONS_ARTIFACT_DOWNLOADS" | jq -c '.[]')
+        run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/actions-artifact-downloads.cjs
 
       - name: Prepare runtime payload
         if: ${{ inputs.run_agent && inputs.prepare_payload_command != '' }}
@@ -677,10 +662,7 @@ jobs:
         if: ${{ inputs.run_agent }}
         env:
           CALLBACK_DATA: ${{ inputs.callback_data }}
-        run: |
-          set -euo pipefail
-          json="$(printf '%s' "$CALLBACK_DATA" | jq -c '. // {}')"
-          printf 'callback_data_json=%s\n' "$json" >> "$GITHUB_OUTPUT"
+        run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/project-callback-data.cjs
 
       - name: Assert success
         if: ${{ inputs.run_agent && ! inputs.dry_run }}

--- a/runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js
+++ b/runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  normalizeArtifactDownloads,
+} = require('../../.github/scripts/runtime-agent-full-run/actions-artifact-downloads.cjs');
+const {
+  projectCallbackData,
+} = require('../../.github/scripts/runtime-agent-full-run/project-callback-data.cjs');
+
+assert.deepEqual(normalizeArtifactDownloads(JSON.stringify([
+  { runId: '123', artifactName: 'payload' },
+  { repo: 'Extra-Chill/other', run_id: '456', name: 'report', destination: 'artifacts/report' },
+]), 'Extra-Chill/example'), [
+  { repo: 'Extra-Chill/example', run_id: '123', name: 'payload', dir: '.ci/actions-artifacts/payload' },
+  { repo: 'Extra-Chill/other', run_id: '456', name: 'report', dir: 'artifacts/report' },
+]);
+
+assert.throws(
+  () => normalizeArtifactDownloads(JSON.stringify([{ name: 'payload' }]), 'Extra-Chill/example'),
+  /actions_artifact_downloads\[0\]\.run_id is required/
+);
+
+assert.deepEqual(projectCallbackData({ CALLBACK_DATA: '{"source":"workflow","attempt":2}' }), {
+  callback_data_json: '{"source":"workflow","attempt":2}',
+});
+
+assert.deepEqual(projectCallbackData({ CALLBACK_DATA: 'null' }), {
+  callback_data_json: '{}',
+});
+
+assert.deepEqual(projectCallbackData({ CALLBACK_DATA: 'false' }), {
+  callback_data_json: '{}',
+});
+
+assert.throws(
+  () => projectCallbackData({ CALLBACK_DATA: '[]' }),
+  /Invalid callback_data: expected JSON object/
+);
+
+process.stdout.write('Runtime agent full-run control-plane projection checks passed\n');


### PR DESCRIPTION
## Summary
- Move runtime full-run artifact-download input handling into a reusable JS script.
- Move callback data output projection into a reusable JS script.
- Add focused control-plane projection tests for request/config/output behavior.

## Tests
- `node runtime-agent-ci/tests/build-runner-config.test.js`
- `node runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js`
- `node tests/runtime-agent-full-run-local-shell-smoke.mjs`
- `HOMEBOY_WP_CODEBOX_CORE_MODULE="$PWD/tests/fixtures/wp-codebox-core-runtime-contract.cjs" node tests/runtime-agent-full-run-projection-boundary-smoke.mjs`
- `HOMEBOY_WP_CODEBOX_CORE_MODULE="$PWD/tests/fixtures/wp-codebox-core-runtime-contract.cjs" node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs`
- `node tests/runtime-agent-full-run-provider-neutral-smoke.mjs`
- `node runtime-agent-ci/tests/agent-task-outcome-normalizer.test.js`
- `node runtime-agent-ci/tests/generic-agent-loop-runner.test.js`
- `node --check .github/scripts/runtime-agent-full-run/actions-artifact-downloads.cjs`
- `node --check .github/scripts/runtime-agent-full-run/project-callback-data.cjs`
- `node --check runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the refactor, adding tests, and drafting this PR description.