### PR TITLE
Add generic headless production loop materializer

### DIFF
--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -8,6 +8,7 @@ Object.assign(module.exports, require('./lib/fanout-reconcile-runner'));
 Object.assign(module.exports, require('./lib/generic-fanout-reconcile-workflow'));
 Object.assign(module.exports, require('./lib/runtime-workflow-inputs.cjs'));
 Object.assign(module.exports, require('./lib/headless-deterministic-loop-runner'));
+Object.assign(module.exports, require('./lib/headless-production-loop-spec'));
 Object.assign(module.exports, require('./lib/preview-materialization'));
 Object.assign(module.exports, require('./lib/controller-loop-proof-validator'));
 Object.assign(module.exports, require('./lib/bounded-production-loop-runner'));

--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -50,7 +50,7 @@ async function runHeadlessDeterministicLoop(options = {}) {
       startedAt,
       events,
     }),
-    is_record_successful: (record) => record.status === 'succeeded',
+    is_record_successful: (record) => ['succeeded', 'no_op'].includes(record.status),
     classify_outcome: (record) => record.outcome,
     include_reconciliation: false,
   });
@@ -169,7 +169,7 @@ function executeHeadlessTask(options = {}) {
   return {
     id: request.task_id,
     task_index: task.task_index,
-    status: finalOutcome?.status === 'succeeded' ? 'succeeded' : 'failed',
+    status: ['succeeded', 'no_op'].includes(finalOutcome?.status) ? finalOutcome.status : 'failed',
     outcome: finalOutcome,
     task_result: taskResult,
   };

--- a/runtime-agent-ci/lib/headless-production-loop-spec.js
+++ b/runtime-agent-ci/lib/headless-production-loop-spec.js
@@ -1,0 +1,138 @@
+'use strict';
+
+function materializeHeadlessProductionLoopSpec(spec = {}, options = {}) {
+  const base = requiredObject(spec, 'spec');
+  const overrides = runtimeOverrides(options);
+  const revolutions = positiveInteger(options.revolutions || options.maxRevolutions || options.max_revolutions || options.iterations || options.maxIterations || options.max_iterations);
+  const tasks = loopTasks(base).map((task) => materializeTask(task, { overrides, revolutions }));
+  return cleanObject({
+    ...base,
+    ...overrides,
+    ...(revolutions ? { loop_policy: materializeLoopPolicy(base.loop_policy, revolutions) } : {}),
+    tasks,
+  });
+}
+
+function materializeTask(task, { overrides = {}, revolutions = 0 } = {}) {
+  return cleanObject({
+    ...task,
+    ...overrides,
+    ...(revolutions ? { loop_policy: materializeLoopPolicy(task.loop_policy, revolutions) } : {}),
+  });
+}
+
+function materializeLoopPolicy(policy = {}, revolutions = 0) {
+  const normalized = optionalObject(policy);
+  if (!revolutions) {
+    return normalized;
+  }
+  return {
+    ...normalized,
+    mode: normalized.mode || 'count',
+    max_iterations: revolutions,
+    max_revolutions: revolutions,
+  };
+}
+
+function runtimeOverrides(options = {}) {
+  return cleanObject({
+    runtime_id: stringValue(options.runtimeId || options.runtime_id || options.runtime),
+    runtime_profile: stringValue(options.runtimeProfile || options.runtime_profile || options.profile),
+    runtime_profiles: objectValue(options.runtimeProfiles || options.runtime_profiles),
+    provider: stringValue(options.provider),
+    model: stringValue(options.model),
+    provider_plugin_paths: arrayValue(options.providerPluginPaths || options.provider_plugin_paths),
+    provider_plugins: arrayValue(options.providerPlugins || options.provider_plugins),
+    secret_env: arrayValue(options.secretEnv || options.secret_env),
+    runtime_env: objectValue(options.runtimeEnv || options.runtime_env),
+    runtime_config_mounts: arrayValue(options.runtimeConfigMounts || options.runtime_config_mounts),
+    runtime_state_mounts: arrayValue(options.runtimeStateMounts || options.runtime_state_mounts),
+  });
+}
+
+function loopTasks(spec) {
+  const tasks = Array.isArray(spec.tasks) && spec.tasks.length > 0 ? spec.tasks : [spec];
+  return tasks.map((task, index) => {
+    const normalized = requiredObject(task, `tasks[${index}]`);
+    return {
+      ...normalized,
+      task_id: normalized.task_id || normalized.workload_id || `${loopId(spec)}-${index + 1}`,
+      workload_id: normalized.workload_id || normalized.task_id || `${loopId(spec)}-${index + 1}`,
+    };
+  });
+}
+
+function loopId(spec) {
+  return spec.loop_id || spec.plan_id || spec.workload_id || 'headless-production-loop';
+}
+
+function parseJsonObject(value, name) {
+  if (!value) {
+    return null;
+  }
+  const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${name} must be a JSON object.`);
+  }
+  return parsed;
+}
+
+function parseJsonArray(value, name) {
+  if (!value) {
+    return [];
+  }
+  const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${name} must be a JSON array.`);
+  }
+  return parsed;
+}
+
+function positiveInteger(value) {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function stringValue(value) {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
+}
+
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : undefined;
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) && value.length > 0 ? value : undefined;
+}
+
+function optionalObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function requiredObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name} must be an object.`);
+  }
+  return value;
+}
+
+function cleanObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => {
+    if (entry === undefined || entry === null || entry === '') {
+      return false;
+    }
+    if (Array.isArray(entry)) {
+      return entry.length > 0;
+    }
+    if (entry && typeof entry === 'object') {
+      return Object.keys(entry).length > 0;
+    }
+    return true;
+  }));
+}
+
+module.exports = {
+  materializeHeadlessProductionLoopSpec,
+  parseJsonArray,
+  parseJsonObject,
+};

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -14,6 +14,7 @@
     "./gate-plan-evaluator": "./lib/gate-plan-evaluator.js",
     "./generic-agent-loop-runner": "./lib/generic-agent-loop-runner.js",
     "./headless-deterministic-loop-runner": "./lib/headless-deterministic-loop-runner.js",
+    "./headless-production-loop-spec": "./lib/headless-production-loop-spec.js",
     "./loop-policy": "./lib/loop-policy.js",
     "./generic-fanout-reconcile-workflow": "./lib/generic-fanout-reconcile-workflow.js",
     "./agent-task-to-review-runner": "./lib/agent-task-to-review-runner.js",
@@ -24,7 +25,8 @@
   "bin": {
     "homeboy-controller-loop-proof-validate": "./scripts/homeboy-controller-loop-proof-validate.cjs",
     "homeboy-generic-fanout-reconcile": "./scripts/homeboy-generic-fanout-reconcile.cjs",
-    "homeboy-render-runtime-workflow-inputs": "./scripts/render-runtime-workflow-inputs.cjs"
+    "homeboy-render-runtime-workflow-inputs": "./scripts/render-runtime-workflow-inputs.cjs",
+    "homeboy-run-headless-production-loop": "./scripts/run-headless-loop.cjs"
   },
   "scripts": {
     "test:controller-loop-proof-validator": "node ../tests/controller-loop-proof-validator.test.mjs",

--- a/runtime-agent-ci/scripts/run-headless-loop.cjs
+++ b/runtime-agent-ci/scripts/run-headless-loop.cjs
@@ -7,6 +7,11 @@ const {
   runHeadlessDeterministicLoop,
   writeHeadlessDeterministicLoopArtifacts,
 } = require('../lib/headless-deterministic-loop-runner');
+const {
+  materializeHeadlessProductionLoopSpec,
+  parseJsonArray,
+  parseJsonObject,
+} = require('../lib/headless-production-loop-spec');
 
 (async () => {
 try {
@@ -16,7 +21,20 @@ try {
     throw new Error('Pass --spec <path>, --config <path>, or HOMEBOY_RUNTIME_AGENT_CONFIG_PATH.');
   }
   const repoRoot = path.resolve(__dirname, '..', '..');
-  const spec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
+  const spec = materializeHeadlessProductionLoopSpec(JSON.parse(fs.readFileSync(specPath, 'utf8')), {
+    revolutions: args.revolutions || args.max_revolutions || process.env.HOMEBOY_HEADLESS_LOOP_REVOLUTIONS,
+    runtime_id: args.runtime_id || process.env.HOMEBOY_AGENT_RUNTIME,
+    runtime_profile: args.runtime_profile || process.env.HOMEBOY_AGENT_RUNTIME_PROFILE,
+    runtime_profiles: parseJsonObject(args.runtime_profiles || process.env.HOMEBOY_AGENT_RUNTIME_PROFILES, 'runtime_profiles'),
+    provider: args.provider || process.env.HOMEBOY_AGENT_RUNTIME_PROVIDER,
+    model: args.model || process.env.HOMEBOY_AGENT_RUNTIME_MODEL,
+    provider_plugin_paths: listArg(args.provider_plugin_paths || process.env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS),
+    provider_plugins: parseJsonArray(args.provider_plugins || process.env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGINS, 'provider_plugins'),
+    secret_env: listArg(args.secret_env || process.env.HOMEBOY_AGENT_RUNTIME_SECRET_ENV),
+    runtime_env: parseJsonObject(args.runtime_env || process.env.HOMEBOY_AGENT_RUNTIME_ENV, 'runtime_env'),
+    runtime_config_mounts: parseJsonArray(args.runtime_config_mounts || process.env.HOMEBOY_AGENT_RUNTIME_CONFIG_MOUNTS, 'runtime_config_mounts'),
+    runtime_state_mounts: parseJsonArray(args.runtime_state_mounts || process.env.HOMEBOY_AGENT_RUNTIME_STATE_MOUNTS, 'runtime_state_mounts'),
+  });
   const result = await runHeadlessDeterministicLoop({
     spec,
     configPath: specPath,
@@ -61,4 +79,8 @@ function parseArgs(argv) {
     index += 1;
   }
   return args;
+}
+
+function listArg(value) {
+  return String(value || '').split(',').map((item) => item.trim()).filter(Boolean);
 }

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -205,6 +205,16 @@ assert.deepEqual(multiTask.tasks.map((task) => task.task_id), ['task-b', 'task-a
 assert.deepEqual(multiTask.fanout.records.map((record) => record.id), ['task-b', 'task-a']);
 assert.equal(multiTask.outcome.task_id, 'task-a');
 
+const dryRun = await runHeadlessDeterministicLoop({
+  spec: baseSpec,
+  runtime,
+  dryRun: true,
+});
+assert.equal(dryRun.status, 'succeeded');
+assert.equal(dryRun.tasks[0].outcome.status, 'no_op');
+assert.equal(dryRun.fanout.status, 'completed');
+assert.equal(dryRun.fanout.records[0].status, 'no_op');
+
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-headless-loop-policy-'));
 try {
   const loopPolicyFile = path.join(tmpRoot, 'loop-policy.json');

--- a/runtime-agent-ci/tests/headless-production-loop-spec.test.js
+++ b/runtime-agent-ci/tests/headless-production-loop-spec.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { buildGenericAgentLoopRequest } = require('../lib/generic-agent-loop-runner');
+const { materializeHeadlessProductionLoopSpec } = require('../lib/headless-production-loop-spec');
+
+const baseSpec = {
+  loop_id: 'generic-production-loop',
+  task_id: 'domain-workload',
+  workload_id: 'domain-workload',
+  target_repo: 'example/domain-workload',
+  component_path: '/workspace/domain-workload',
+  runtime_profile: 'domain-runtime-profile',
+  runtime_profiles: {
+    'domain-runtime-profile': {
+      id: 'domain-runtime-profile',
+      runtime_task_ability: 'runtime/run-task',
+    },
+  },
+  loop_policy: {
+    accepted_statuses: ['succeeded'],
+  },
+};
+
+const codeboxProfile = {
+  'codebox-codex': {
+    id: 'codebox-codex',
+    runtime_task_ability: 'wp-codebox/run-runtime-package',
+    runtime_bundle_ability: 'wp-codebox/run-runtime-package',
+  },
+};
+
+const codexProfile = {
+  'standalone-codex': {
+    id: 'standalone-codex',
+    runtime_task_ability: 'codex/run-task',
+  },
+};
+
+const codeboxSpec = materializeHeadlessProductionLoopSpec(baseSpec, {
+  revolutions: 4,
+  runtime_id: 'wp-codebox',
+  runtime_profile: 'codebox-codex',
+  runtime_profiles: codeboxProfile,
+  provider: 'codex',
+  model: 'gpt-5.5',
+  secret_env: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
+});
+
+assert.equal(codeboxSpec.tasks[0].loop_policy.max_iterations, 4);
+assert.equal(codeboxSpec.tasks[0].runtime_id, 'wp-codebox');
+assert.equal(codeboxSpec.tasks[0].runtime_profile, 'codebox-codex');
+
+const codeboxRequest = buildGenericAgentLoopRequest({
+  plan: codeboxSpec.tasks[0],
+  runtime: { id: 'wp-codebox', executor: { backend: 'codebox' } },
+});
+assert.equal(codeboxRequest.executor.backend, 'codebox');
+assert.equal(codeboxRequest.executor.config.provider, 'codex');
+assert.equal(codeboxRequest.executor.config.model, 'gpt-5.5');
+assert.deepEqual(codeboxRequest.executor.secret_env, ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN']);
+
+const swappedSpec = materializeHeadlessProductionLoopSpec(baseSpec, {
+  revolutions: 2,
+  runtime_id: 'codex',
+  runtime_profile: 'standalone-codex',
+  runtime_profiles: codexProfile,
+  provider: 'codex',
+});
+const swappedRequest = buildGenericAgentLoopRequest({
+  plan: swappedSpec.tasks[0],
+  runtime: { id: 'codex', executor: { backend: 'codex' } },
+});
+assert.equal(swappedRequest.executor.backend, 'codex');
+assert.equal(swappedRequest.executor.config.runtime_profile, 'standalone-codex');
+assert.equal(swappedRequest.executor.config.runtime_profiles['standalone-codex'].runtime_task_ability, 'codex/run-task');
+
+process.stdout.write('Headless production loop spec profile swap checks passed\n');


### PR DESCRIPTION
## Summary
- Add a generic headless production-loop spec materializer for runtime/provider/profile overrides and N-revolution limits.
- Expose the materializer through the runtime-agent-ci package and existing headless loop CLI.
- Treat dry-run `no_op` outcomes as successful fanout records so evidence stays clean.

## Verification
- `node runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js`
- `node runtime-agent-ci/tests/headless-production-loop-spec.test.js`
- `node runtime-agent-ci/tests/runtime-provider-boundary.test.js`
- Dry-run materialization from WPSG spec with `HOMEBOY_AGENT_RUNTIME=wp-codebox`, `HOMEBOY_AGENT_RUNTIME_PROVIDER=codex`, and `HOMEBOY_HEADLESS_LOOP_REVOLUTIONS=2`.

## Live-loop status
A full provider-backed loop was not launched locally. It requires Codex subscription secret env values and runtime/lab capacity; this PR verifies the generic request materialization path without running benchmarks or provider work locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the generic materializer, CLI wiring, tests, and documentation text.