### PR TITLE
Project canonical WP Codebox fanout adapter metadata

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -47,6 +47,7 @@ const {
 } = require('./codebox-runtime-profile');
 const {
   WP_CODEBOX_BACKEND,
+  WP_CODEBOX_AGENT_FANOUT_REQUEST_SCHEMA,
   WP_CODEBOX_PROVIDER_ID,
   WP_CODEBOX_PROVIDER_LABEL,
   WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES,
@@ -57,6 +58,7 @@ const {
   WP_CODEBOX_TASK_REQUEST_SCHEMA,
   WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
   WP_CODEBOX_WORKSPACE_MOUNT_KIND,
+  wpCodeboxAgentFanoutAdapterContract,
   wpCodeboxProviderRuntimeInvocationContract,
   wpCodeboxProviderRuntimeOperationEntry,
 } = require('./wp-codebox-adapter-contract');
@@ -192,6 +194,7 @@ function providerContract(options = {}) {
     provider_preflight: runtimeProviderPreflight(),
     provider_credential_boundary: providerCredentialBoundary(),
     provider_runtime_invocation: providerRuntimeInvocationContract(),
+    agent_fanout_adapter: wpCodeboxAgentFanoutAdapterContract(),
     role_aliases: WP_CODEBOX_ROLE_ALIASES,
     deprecated_compatibility_aliases: LEGACY_RUNTIME_PACKAGE_ABILITY_DEPRECATIONS,
     upstream_primitive_requirements: WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
@@ -362,6 +365,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const agent = firstValue(config.agent, runtimeOptions.agent, '');
   const abilityRequirements = runtimeAbilityRequirements(runtimeTask, request, config, inputs, runtimeOptions);
   const providerRuntimeInvocation = providerRuntimeInvocationFromConfig(config, inputs, runtimeOptions);
+  const codeboxFanoutRequest = codeboxFanoutRequestFromAgentTaskRequest(request, config, inputs, runtimeOptions);
   const explicitSecretEnv = [
     ...(plannedSecretEnv.length > 0 ? plannedSecretEnv : normalizeArray(request.executor?.secret_env)),
     ...normalizeArray(config.secret_env),
@@ -407,6 +411,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     ability_requirements: abilityRequirements,
     callback_data: firstDefined(inputs.callback_data, inputs.callbackData, config.callback_data, config.callbackData, runtimeOptions.callbackData),
     provider_runtime_invocation: providerRuntimeInvocation,
+    ...(codeboxFanoutRequest ? { fanout_request: codeboxFanoutRequest } : {}),
     ability_tools: firstDefined(inputs.ability_tools, inputs.abilityTools, config.ability_tools, config.abilityTools, runtimeOptions.abilityTools, []),
     structured_artifacts: structuredArtifacts,
     sandbox_session_id: config.sandbox_session_id || request.task_id,
@@ -463,6 +468,65 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundle: agentBundle,
     parent_request: request,
   };
+}
+
+function codeboxFanoutRequestFromAgentTaskRequest(request, config = {}, inputs = {}, runtimeOptions = {}) {
+  const source = firstObject(
+    inputs.codebox_fanout_request,
+    inputs.codeboxFanoutRequest,
+    inputs.fanout_request,
+    inputs.fanoutRequest,
+    config.codebox_fanout_request,
+    config.codeboxFanoutRequest,
+    config.fanout_request,
+    config.fanoutRequest,
+    runtimeOptions.codeboxFanoutRequest,
+    runtimeOptions.fanoutRequest
+  );
+  if (!source) {
+    return null;
+  }
+  const workers = normalizeArray(source.workers).map((worker, index) => {
+    const metadata = firstObject(worker.metadata) || {};
+    return withoutUndefinedValues({
+      ...worker,
+      id: firstValue(worker.id, worker.worker_id, `${request.task_id}-worker-${index + 1}`),
+      goal: firstValue(worker.goal, worker.task, request.instructions),
+      agent: firstValue(worker.agent, source.agent, config.agent, runtimeOptions.agent),
+      dependsOn: normalizeArray(firstValue(worker.dependsOn, worker.depends_on)),
+      artifactNamespace: firstValue(worker.artifactNamespace, worker.artifact_namespace, `${request.task_id}/${index + 1}`),
+      metadata: {
+        ...metadata,
+        homeboy_task_id: request.task_id,
+        parent_plan_id: request.parent_plan_id,
+        group_key: request.group_key,
+      },
+    });
+  });
+
+  return withoutUndefinedValues({
+    ...source,
+    schema: WP_CODEBOX_AGENT_FANOUT_REQUEST_SCHEMA,
+    workers,
+    agent: firstValue(source.agent, config.agent, runtimeOptions.agent),
+    orchestrator: {
+      ...(firstObject(source.orchestrator) || {}),
+      agent_task_id: request.task_id,
+      parent_plan_id: request.parent_plan_id,
+      group_key: request.group_key,
+      provider: firstValue(config.provider, runtimeOptions.provider),
+      model: firstValue(request.executor?.model, config.model, runtimeOptions.model),
+      secret_env_names: normalizeArray(request.executor?.secret_env),
+    },
+    metadata: {
+      ...(firstObject(source.metadata) || {}),
+      homeboy_agent_task: {
+        task_id: request.task_id,
+        parent_plan_id: request.parent_plan_id,
+        group_key: request.group_key,
+      },
+    },
+  });
 }
 
 function expectedArtifactsForCodeboxTask(request, artifactDeclarations = []) {
@@ -1929,6 +1993,10 @@ function firstValue(...candidates) {
   return candidates.find((candidate) => candidate !== undefined && candidate !== null && candidate !== '');
 }
 
+function withoutUndefinedValues(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
 function recipeConfigFromAgentTaskRequest(request, config, inputs, runtimeOptions = {}) {
   const explicit = firstObject(
     inputs.recipe,
@@ -3289,7 +3357,9 @@ module.exports = {
   AGENT_TASK_EVENT_SCHEMA,
   providerContract,
   providerRuntimeInvocationContract,
+  wpCodeboxAgentFanoutAdapterContract,
   codeboxTaskRequestFromAgentTaskRequest,
+  codeboxFanoutRequestFromAgentTaskRequest,
   reconcileRunSummaryWithPublicEnvelope,
   normalizeCodeboxAgentTaskEvents,
   agentTaskOutcomeFromCodeboxResult,

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -9,6 +9,7 @@ const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
 const RUNTIME_INVOCATION_CONTRACT = providerRuntimeInvocationContract();
 
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
+const WP_CODEBOX_AGENT_FANOUT_REQUEST_SCHEMA = 'wp-codebox/agent-fanout-request/v1';
 const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
 const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
 const WP_CODEBOX_BACKEND = 'codebox';
@@ -107,6 +108,13 @@ const WP_CODEBOX_ROLE_ALIASES = {
 
 const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
   {
+    id: 'agent-fanout-request',
+    schema: WP_CODEBOX_AGENT_FANOUT_REQUEST_SCHEMA,
+    owner: 'wp-codebox',
+    adapter_behavior: 'project_homeboy_agent_task_metadata_without_product_assumptions',
+    requirement: 'Accept lower-level sandbox-native fanout requests with typed worker, artifact, event, and aggregation contracts. Homeboy owns durable fanout plan/run state; Homeboy Extensions only adapts generic task metadata, workspace, provider/model, secret-env names, progress/evidence callbacks, and artifact declarations into this request shape.',
+  },
+  {
     id: 'run-agent-task',
     schema: 'wp-codebox/run-agent-task/v1',
     owner: 'wp-codebox',
@@ -198,6 +206,34 @@ function wpCodeboxProviderRuntimeOperationConfig(key, operation) {
   });
 }
 
+function wpCodeboxAgentFanoutAdapterContract() {
+  return {
+    schema: 'homeboy-extensions/wp-codebox-agent-fanout-adapter/v1',
+    canonical_path: 'homeboy-durable-scheduler-to-homeboy-extensions-codebox-executor-to-wp-codebox-sandbox-fanout',
+    ownership: {
+      substrate: 'agents-api',
+      durable_scheduler: 'homeboy',
+      executor_adapter: 'homeboy-extensions',
+      sandbox_worker_runtime: 'wp-codebox',
+    },
+    accepted_request_schema: WP_CODEBOX_AGENT_FANOUT_REQUEST_SCHEMA,
+    maps: [
+      'task_id',
+      'parent_plan_id',
+      'group_key',
+      'metadata',
+      'workspace',
+      'artifact_declarations',
+      'expected_artifacts',
+      'secret_env_names',
+      'provider',
+      'model',
+      'progress_callbacks',
+      'evidence_refs',
+    ],
+  };
+}
+
 function firstValue(...values) {
   return values.find((value) => value !== undefined && value !== null && value !== '');
 }
@@ -212,6 +248,7 @@ function withoutUndefinedValues(value) {
 
 module.exports = {
   WP_CODEBOX_BACKEND,
+  WP_CODEBOX_AGENT_FANOUT_REQUEST_SCHEMA,
   WP_CODEBOX_PROVIDER_ID,
   WP_CODEBOX_PROVIDER_LABEL,
   WP_CODEBOX_PROVIDER_CREDENTIAL_BOUNDARY_SCHEMA,
@@ -226,6 +263,7 @@ module.exports = {
   WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
   WP_CODEBOX_WORKSPACE_MOUNT_KIND,
   wpCodeboxProviderRuntimeInvocationContract,
+  wpCodeboxAgentFanoutAdapterContract,
   wpCodeboxProviderRuntimeOperationConfig,
   wpCodeboxProviderRuntimeOperationEntry,
 };

--- a/docs/generic-fanout-reconcile-workflow.md
+++ b/docs/generic-fanout-reconcile-workflow.md
@@ -4,6 +4,14 @@
 
 This helper is the planner/reconciler side of the audit fanout boundary, not a runtime provider. Runtime packages, provider names, credentials, WordPress setup, sandbox recipes, and provider task schemas stay behind the `audit-fanout-runtime-provider` interface. The current audit fanout implementation is the quarantined WP Codebox lane, which maps grouped audit findings to `wp-codebox/task-input/v1` requests and executes them through Codebox-owned task runner contracts.
 
+For Codebox-backed product workflows, the product-facing path is Homeboy's
+durable `agent-task` scheduler/fanout plan. Homeboy Extensions is only the
+adapter: it projects Homeboy task metadata, workspace, artifact declarations,
+provider/model, secret-env names, progress/evidence callbacks, and optional
+`wp-codebox/agent-fanout-request/v1` payloads into WP Codebox-owned sandbox
+contracts. It does not own queue state, retries, PR/review policy, or
+Studio-specific assumptions.
+
 ## Plan
 
 ```bash

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -10,6 +10,7 @@ process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(__dirname, '..', '..', 
 const {
   agentTaskOutcomeFromCodeboxResult,
   artifactResultEnvelopeFromCodeboxResult,
+  codeboxFanoutRequestFromAgentTaskRequest,
   codeboxTaskRequestFromAgentTaskRequest,
   codeboxRunAgentTaskInvocation,
   normalizeCodeboxAgentTaskEvents,
@@ -19,6 +20,7 @@ const {
   publicEnvelopeBoundaryDiagnostic,
   providerContract,
   providerRuntimeInvocationContract,
+  wpCodeboxAgentFanoutAdapterContract,
   reconcileRunSummaryWithPublicEnvelope,
   runtimeContractSchemas,
   typedArtifactsFromCodeboxResult,
@@ -67,7 +69,12 @@ assert.equal(provider.backend, 'codebox');
 assert.equal(provider.runtime_id, 'wp-codebox');
 assert.equal(provider.integration_contract, 'homeboy-wordpress-agent-task/v1');
 assert.equal(provider.provider_credential_boundary.schema, 'wp-codebox/provider-credential-boundary/v1');
+assert.deepEqual(provider.agent_fanout_adapter, wpCodeboxAgentFanoutAdapterContract());
+assert.equal(provider.agent_fanout_adapter.ownership.durable_scheduler, 'homeboy');
+assert.equal(provider.agent_fanout_adapter.ownership.executor_adapter, 'homeboy-extensions');
+assert.equal(provider.agent_fanout_adapter.ownership.sandbox_worker_runtime, 'wp-codebox');
 assert.equal(provider.upstream_primitive_requirements.some((requirement) => requirement.id === 'provider-credential-boundary'), true);
+assert.equal(provider.upstream_primitive_requirements.some((requirement) => requirement.id === 'agent-fanout-request' && requirement.schema === 'wp-codebox/agent-fanout-request/v1'), true);
 assert.deepEqual(provider.deprecated_compatibility_aliases, [
   legacyRuntimePackageAbilityAlias('agents/run-runtime-package'),
   legacyRuntimePackageAbilityAlias('runtime-package/run'),
@@ -330,6 +337,44 @@ assert.equal(
   taskInput.sandbox_tool_policy.tools.some((tool) => tool.id === 'wordpress.read-post'),
   true
 );
+const fanoutAgentTaskRequest = {
+  ...genericAgentTaskRequest,
+  task_id: 'generic-fanout-task-1',
+  parent_plan_id: 'homeboy-plan-1',
+  group_key: 'site-generation',
+  executor: {
+    backend: 'codebox',
+    model: 'gpt-5.5',
+    secret_env: ['AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN'],
+    config: {
+      provider: 'codex',
+      model: 'gpt-5.5',
+      fanout_request: {
+        concurrency: 2,
+        workers: [
+          { id: 'design', goal: 'Generate design artifact' },
+          { id: 'verify', goal: 'Verify design artifact', depends_on: ['design'] },
+        ],
+      },
+    },
+  },
+};
+const fanoutRequest = codeboxFanoutRequestFromAgentTaskRequest(
+  fanoutAgentTaskRequest,
+  fanoutAgentTaskRequest.executor.config,
+  fanoutAgentTaskRequest.inputs,
+  {}
+);
+assert.equal(fanoutRequest.schema, 'wp-codebox/agent-fanout-request/v1');
+assert.deepEqual(fanoutRequest.workers.map((worker) => worker.id), ['design', 'verify']);
+assert.deepEqual(fanoutRequest.workers[1].dependsOn, ['design']);
+assert.equal(fanoutRequest.orchestrator.agent_task_id, 'generic-fanout-task-1');
+assert.equal(fanoutRequest.orchestrator.parent_plan_id, 'homeboy-plan-1');
+assert.equal(fanoutRequest.orchestrator.provider, 'codex');
+assert.equal(fanoutRequest.orchestrator.model, 'gpt-5.5');
+assert.deepEqual(fanoutRequest.orchestrator.secret_env_names, ['AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN']);
+assert.equal(fanoutRequest.metadata.homeboy_agent_task.group_key, 'site-generation');
+assert.equal(codeboxTaskRequestFromAgentTaskRequest(fanoutAgentTaskRequest).fanout_request.schema, 'wp-codebox/agent-fanout-request/v1');
 const stableCodeboxInvocation = codeboxRunAgentTaskInvocation({ taskInput });
 assert.equal(stableCodeboxInvocation.contract, runtimeContractSchemas().agentTask.runRequest);
 assert.equal(stableCodeboxInvocation.input.schema, runtimeContractSchemas().agentTask.runRequest);


### PR DESCRIPTION
## Summary
- Add a generic Homeboy Extensions to WP Codebox fanout adapter contract.
- Project optional wp-codebox agent fanout requests from Homeboy agent-task metadata without Studio-specific assumptions.
- Preserve provider/model, secret env names, task metadata, workspace/artifact context, and ownership docs.

## Tests
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node runtime-agent-ci/tests/generic-fanout-reconcile-workflow.test.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the adapter contract/projection, docs, and targeted test coverage.