### PR TITLE
fix(wordpress): mark unsupported fuzz as non-proof

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -124,7 +124,7 @@ function buildWordPressFuzzRunnerSummary({
 	return stripUndefined({
 		schema: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 		status,
-		succeeded: !['failed', 'errored'].includes(String(status).toLowerCase()),
+		succeeded: !['failed', 'errored', 'error', 'skipped', 'unsupported', 'not_executed'].includes(String(status).toLowerCase()),
 		run_id: runId,
 		workload_id: workloadId,
 		seed,
@@ -342,7 +342,7 @@ function normalizeCodeboxResult(workload, context = {}) {
 	return normalizeWpCodeboxFuzzSuiteResult({
 		schema: 'wp-codebox/fuzz-suite-result/v1',
 		request_id: context.runId,
-		status: 'skipped',
+		status: 'unsupported',
 		diagnostics: [
 			{
 				severity: 'warning',
@@ -378,10 +378,15 @@ function hasCoverageFailures(coverage) {
 }
 
 function normalizeRunnerStatus(codeboxResult, coverage) {
-	if (codeboxResult.succeeded === false || hasCoverageFailures(coverage)) {
+	const status = codeboxResult.status || 'succeeded';
+	const normalized = String(status).toLowerCase();
+	if (['skipped', 'unsupported', 'not_executed'].includes(normalized)) {
+		return normalized;
+	}
+	if (hasCoverageFailures(coverage) || codeboxResult.succeeded === false) {
 		return 'failed';
 	}
-	return codeboxResult.status || 'succeeded';
+	return status;
 }
 
 function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, status }) {

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -37,6 +37,9 @@ async function main() {
 	const result = await buildRunnerResult(env);
 	writeHomeboyFuzzResultsFile(env.resultsFile, result.homeboy_fuzz_campaign);
 	process.stdout.write(`${JSON.stringify(fuzzRunnerStdoutSummary(result), null, 2)}\n`);
+	if (!result.succeeded) {
+		process.exitCode = 1;
+	}
 }
 
 function fuzzRunnerStdoutSummary(result = {}) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -77,7 +77,7 @@ const result = buildWordPressFuzzRunnerResult({
 });
 
 assert.equal(result.schema, WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA);
-assert.equal(result.status, 'failed');
+assert.equal(result.status, 'unsupported');
 assert.equal(result.succeeded, false);
 assert.equal(result.run_id, 'run-from-env');
 assert.equal(result.workload_id, 'workload-from-env');
@@ -98,7 +98,7 @@ assert.equal(result.homeboy_fuzz_campaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
 assert.equal(result.homeboy_fuzz_campaign.version, 1);
 assert.equal(result.homeboy_fuzz_campaign.id, 'run-from-env');
 assert.equal(result.homeboy_fuzz_campaign.safety_class, 'read_only');
-assert.equal(result.homeboy_fuzz_campaign.metadata.status, 'failed');
+assert.equal(result.homeboy_fuzz_campaign.metadata.status, 'unsupported');
 assert.equal(result.homeboy_fuzz_campaign.metadata.wp_codebox_result_schema, 'wp-codebox/fuzz-suite-result/v1');
 assert.equal(result.homeboy_fuzz_campaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
 assert.equal(result.observation.schema, 'homeboy/wordpress-fuzz-observation/v1');
@@ -457,9 +457,10 @@ const cli = spawnSync(runnerPath, [], {
 	},
 });
 
-assert.equal(cli.status, 0, cli.stderr);
+assert.equal(cli.status, 1, cli.stderr);
 const cliResult = JSON.parse(cli.stdout);
 assert.equal(cliResult.schema, WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA);
+assert.equal(cliResult.status, 'unsupported');
 assert.equal(cliResult.run_id, 'cli-run');
 assert.equal(cliResult.succeeded, false);
 assert.equal(cliResult.wp_codebox_input.metadata.limits.max_duration_seconds, 15);


### PR DESCRIPTION
## Summary
- Return unsupported WP Codebox fuzz execution as `unsupported` with `succeeded: false`.
- Preserve result/campaign evidence while making the CLI exit nonzero for non-proof fallback execution.
- Keep executable Codebox fuzz contract behavior covered by the existing canary.

## Tests
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wordpress-fuzz-runner-codebox-contract`
- `npm run lint:js -- lib/wordpress-fuzz-runner.js scripts/fuzz/fuzz-runner.cjs tests/wordpress-fuzz-runner-smoke.js` (passes with existing ignored-test-file warning)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, focused test updates, test command execution, and PR description drafting.