### PR TITLE
Declare WP Codebox result contract

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -482,6 +482,16 @@
           "provider_run_result": ["codebox_run_result"]
         }
       },
+      "result_contract": {
+        "typed_artifact_envelope": {
+          "schema": "wp-codebox/artifact-result-envelope/v1",
+          "output": "provider_run_result",
+          "provider_label": "WP Codebox",
+          "diagnostic_class_prefix": "codebox",
+          "private_shape_markers": ["agent_result", "metadata.agent_runtime"],
+          "require_typed_artifacts": true
+        }
+      },
       "deprecated_compatibility_aliases": [
         {
           "schema": "wp-codebox/deprecated-compatibility-alias/v1",


### PR DESCRIPTION
## Summary
- declare the WP Codebox typed-artifact result envelope contract in the runtime manifest
- keeps Homeboy core PR #6479 behavior active through provider data instead of core backend branching

## Tests
- `node -e 'JSON.parse(require("fs").readFileSync("agent-runtimes/wp-codebox/wp-codebox.json", "utf8"))'`

## Related
- Extra-Chill/homeboy#6479

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Manifest update, validation, and PR drafting.