### PR TITLE
Infer provider secret defaults for headless loops

### DIFF
--- a/runtime-agent-ci/lib/headless-production-loop-spec.js
+++ b/runtime-agent-ci/lib/headless-production-loop-spec.js
@@ -1,5 +1,21 @@
 'use strict';
 
+const PROVIDER_DEFAULT_SECRET_ENV = Object.freeze({
+  codex: [
+    'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+    'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+    'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+  ],
+  openai: ['OPENAI_API_KEY'],
+  'claude-code': [
+    'AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN',
+    'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
+    'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
+  ],
+});
+
 function materializeHeadlessProductionLoopSpec(spec = {}, options = {}) {
   const base = requiredObject(spec, 'spec');
   const overrides = runtimeOverrides(options);
@@ -35,19 +51,29 @@ function materializeLoopPolicy(policy = {}, revolutions = 0) {
 }
 
 function runtimeOverrides(options = {}) {
+  const provider = stringValue(options.provider);
   return cleanObject({
     runtime_id: stringValue(options.runtimeId || options.runtime_id || options.runtime),
     runtime_profile: stringValue(options.runtimeProfile || options.runtime_profile || options.profile),
     runtime_profiles: objectValue(options.runtimeProfiles || options.runtime_profiles),
-    provider: stringValue(options.provider),
+    provider,
     model: stringValue(options.model),
     provider_plugin_paths: arrayValue(options.providerPluginPaths || options.provider_plugin_paths),
     provider_plugins: arrayValue(options.providerPlugins || options.provider_plugins),
-    secret_env: arrayValue(options.secretEnv || options.secret_env),
+    secret_env: secretEnvOverrides(options, provider),
     runtime_env: objectValue(options.runtimeEnv || options.runtime_env),
     runtime_config_mounts: arrayValue(options.runtimeConfigMounts || options.runtime_config_mounts),
     runtime_state_mounts: arrayValue(options.runtimeStateMounts || options.runtime_state_mounts),
   });
+}
+
+function secretEnvOverrides(options = {}, provider = '') {
+  return arrayValue(options.secretEnv || options.secret_env) || providerDefaultSecretEnv(provider);
+}
+
+function providerDefaultSecretEnv(provider = '') {
+  const names = PROVIDER_DEFAULT_SECRET_ENV[String(provider || '').trim()];
+  return names ? [...names] : undefined;
 }
 
 function loopTasks(spec) {
@@ -135,4 +161,5 @@ module.exports = {
   materializeHeadlessProductionLoopSpec,
   parseJsonArray,
   parseJsonObject,
+  providerDefaultSecretEnv,
 };

--- a/runtime-agent-ci/tests/headless-production-loop-spec.test.js
+++ b/runtime-agent-ci/tests/headless-production-loop-spec.test.js
@@ -2,7 +2,10 @@
 
 const assert = require('node:assert/strict');
 const { buildGenericAgentLoopRequest } = require('../lib/generic-agent-loop-runner');
-const { materializeHeadlessProductionLoopSpec } = require('../lib/headless-production-loop-spec');
+const {
+  materializeHeadlessProductionLoopSpec,
+  providerDefaultSecretEnv,
+} = require('../lib/headless-production-loop-spec');
 
 const baseSpec = {
   loop_id: 'generic-production-loop',
@@ -44,7 +47,6 @@ const codeboxSpec = materializeHeadlessProductionLoopSpec(baseSpec, {
   runtime_profiles: codeboxProfile,
   provider: 'codex',
   model: 'gpt-5.5',
-  secret_env: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
 });
 
 assert.equal(codeboxSpec.tasks[0].loop_policy.max_iterations, 4);
@@ -58,7 +60,13 @@ const codeboxRequest = buildGenericAgentLoopRequest({
 assert.equal(codeboxRequest.executor.backend, 'codebox');
 assert.equal(codeboxRequest.executor.config.provider, 'codex');
 assert.equal(codeboxRequest.executor.config.model, 'gpt-5.5');
-assert.deepEqual(codeboxRequest.executor.secret_env, ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN']);
+assert.deepEqual(codeboxRequest.executor.secret_env, providerDefaultSecretEnv('codex'));
+
+const explicitSecretEnvSpec = materializeHeadlessProductionLoopSpec(baseSpec, {
+  provider: 'codex',
+  secret_env: ['CUSTOM_CODEX_SECRET'],
+});
+assert.deepEqual(explicitSecretEnvSpec.tasks[0].secret_env, ['CUSTOM_CODEX_SECRET']);
 
 const swappedSpec = materializeHeadlessProductionLoopSpec(baseSpec, {
   revolutions: 2,


### PR DESCRIPTION
## Summary
- infer provider default secret env names for headless production loop materialization
- keep explicit secret_env overrides authoritative
- avoid requiring operators to repeat Codex/Claude/OpenAI secret names when provider selection already implies them

## Verification
- node runtime-agent-ci/tests/headless-production-loop-spec.test.js
- node runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
- WPSG N=1 dry-run without HOMEBOY_AGENT_RUNTIME_SECRET_ENV materialized Codex secret names only, with no secret values printed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the headless loop secret-env papercut, implementing the materializer fix, and running focused verification.