### PR TITLE
Normalize fanout record statuses

### DIFF
--- a/runtime-agent-ci/lib/fanout-reconcile-runner.js
+++ b/runtime-agent-ci/lib/fanout-reconcile-runner.js
@@ -11,6 +11,7 @@ const PLAN_SCHEMA = 'homeboy/fanout-reconcile-plan/v1';
 const RUN_SCHEMA = 'homeboy/fanout-reconcile-run/v1';
 const FANOUT_RECONCILE_RECORD_STATUSES = ['completed', 'failed', 'missing_record'];
 const FANOUT_RECONCILE_RUN_STATUSES = ['incomplete', 'completed', 'failed'];
+const FANOUT_RECONCILE_SUCCESS_STATUSES = ['completed', 'succeeded', 'no_op', 'success', 'passed', 'accepted'];
 const DEFAULT_CONCURRENCY = 3;
 
 function writeJson(filePath, value) {
@@ -138,6 +139,7 @@ async function executeFanoutReconcileRun(input) {
       .then(() => executeTaskRequest(taskRequest, input))
       .catch((error) => failedTaskRecord(taskRequest, id, error))
       .then((record) => {
+        record = normalizeFanoutRecord(record);
         records.push(record);
         records.sort((left, right) => taskOrder(left) - taskOrder(right));
         onProgress(progressEvent(record.status || (isRecordSuccessful(record) ? 'completed' : 'failed'), taskRequest, plan, record));
@@ -230,6 +232,31 @@ function failedTaskRecord(taskRequest, id, error) {
   };
 }
 
+function normalizeFanoutRecord(record) {
+  const normalized = record && typeof record === 'object' ? record : {};
+  return {
+    ...normalized,
+    status: normalizeFanoutRecordStatus(normalized),
+  };
+}
+
+function normalizeFanoutRecordStatus(record) {
+  const status = text(record.status);
+  if (FANOUT_RECONCILE_RECORD_STATUSES.includes(status)) {
+    return status;
+  }
+  if (record.success === true || FANOUT_RECONCILE_SUCCESS_STATUSES.includes(status)) {
+    return 'completed';
+  }
+
+  const outcomeStatus = text(record.outcome?.status || record.outcome_status || record.provider_status);
+  if (FANOUT_RECONCILE_SUCCESS_STATUSES.includes(outcomeStatus)) {
+    return 'completed';
+  }
+
+  return 'failed';
+}
+
 function errorMessage(error) {
   if (error && typeof error.message === 'string' && error.message.trim()) {
     return error.message;
@@ -280,11 +307,19 @@ function defaultProgressEvent(status, taskRequest, plan, record = null) {
   };
 }
 
+function text(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
 module.exports = {
   PLAN_SCHEMA,
   RUN_SCHEMA,
   FANOUT_RECONCILE_PLAN_SCHEMA: PLAN_SCHEMA,
   FANOUT_RECONCILE_RECORD_STATUSES,
+  FANOUT_RECONCILE_SUCCESS_STATUSES,
   FANOUT_RECONCILE_RUN_SCHEMA: RUN_SCHEMA,
   FANOUT_RECONCILE_RUN_STATUSES,
   DEFAULT_CONCURRENCY,

--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -52,7 +52,7 @@ async function runHeadlessDeterministicLoop(options = {}) {
       startedAt,
       events,
     }),
-    is_record_successful: (record) => ['succeeded', 'no_op'].includes(record.status),
+    is_record_successful: (record) => record.status === 'completed',
     classify_outcome: (record) => record.outcome,
     include_reconciliation: false,
   });
@@ -172,7 +172,7 @@ function executeHeadlessTask(options = {}) {
   return {
     id: request.task_id,
     task_index: task.task_index,
-    status: ['succeeded', 'no_op'].includes(finalOutcome?.status) ? finalOutcome.status : 'failed',
+    status: ['succeeded', 'no_op'].includes(finalOutcome?.status) ? 'completed' : 'failed',
     outcome: finalOutcome,
     task_result: taskResult,
   };

--- a/runtime-agent-ci/tests/generic-fanout-reconcile-workflow.test.js
+++ b/runtime-agent-ci/tests/generic-fanout-reconcile-workflow.test.js
@@ -70,6 +70,29 @@ async function observedConcurrency(options = {}) {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   }
 
+  const providerStatusRun = await executeFanoutReconcileRun({
+    plan: {
+      schema: 'homeboy/fanout-reconcile-plan/v1',
+      task_requests: [
+        { task_id: 'provider-succeeded' },
+        { task_id: 'provider-no-op' },
+      ],
+    },
+    execute_task_request: (request) => ({
+      id: request.task_id,
+      status: request.task_id === 'provider-no-op' ? 'no_op' : 'succeeded',
+      outcome: {
+        schema: 'homeboy/agent-task-outcome/v1',
+        task_id: request.task_id,
+        status: request.task_id === 'provider-no-op' ? 'no_op' : 'succeeded',
+      },
+    }),
+  });
+
+  assert.equal(providerStatusRun.status, 'completed');
+  assert.deepEqual(providerStatusRun.records.map((record) => record.status), ['completed', 'completed']);
+  assert.deepEqual(providerStatusRun.records.map((record) => record.outcome.status), ['succeeded', 'no_op']);
+
   console.log('Generic fanout reconcile workflow test passed');
 })().catch((error) => {
   console.error(error);

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -74,6 +74,8 @@ assert.equal(twoRevolution.tasks[0].loop_policy.iterations[1].candidate_task_id,
 assert.equal(twoRevolution.tasks[0].loop_policy.iterations[1].accepted, true);
 assert.equal(twoRevolution.tasks[0].outcome.metadata.headless_loop_policy_status.iteration_count, 2);
 assert.equal(twoRevolution.tasks[0].results.scenarios[0].metadata.completion_outcome_satisfied, true);
+assert.equal(twoRevolution.fanout.records[0].status, 'completed');
+assert.equal(twoRevolution.fanout.records[0].outcome_status, 'succeeded');
 
 let boundedCalls = 0;
 const boundedFailure = await runHeadlessDeterministicLoop({
@@ -184,7 +186,8 @@ const dryRun = await runHeadlessDeterministicLoop({
 assert.equal(dryRun.status, 'succeeded');
 assert.equal(dryRun.tasks[0].outcome.status, 'no_op');
 assert.equal(dryRun.fanout.status, 'completed');
-assert.equal(dryRun.fanout.records[0].status, 'no_op');
+assert.equal(dryRun.fanout.records[0].status, 'completed');
+assert.equal(dryRun.fanout.records[0].outcome_status, 'no_op');
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-headless-loop-policy-'));
 try {


### PR DESCRIPTION
## Summary
- Normalize fanout record statuses to canonical host orchestration values.
- Preserve provider terminal statuses such as `succeeded` and `no_op` under `outcome.status`/summary outcome fields.
- Add regression coverage for `succeeded` and `no_op` fanout mapping.

## Tests
- `node tests/generic-fanout-reconcile-workflow.test.js`
- `node tests/headless-deterministic-loop-runner.test.js`
- `for test_file in tests/*.js; do node "" || exit 1; done` from `runtime-agent-ci`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implementing the fanout status normalization, updating regression tests, running verification, and drafting this PR description.