### PR TITLE
fix(runtime-agent): serialize secret env names only

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -49,7 +49,7 @@ function buildConfig(env) {
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', true);
   const validationDependencies = validationPaths(workspace, providerPlugin, env.PROVIDER || '');
   const providerSecretEnvMapping = providerPlugin.provider_secret_env || {};
-  const providerBenchEnv = providerBenchEnvFromManifest(runtime, env.PROVIDER || '', env);
+  const providerBenchEnvNames = providerBenchEnvFromManifest(runtime, env.PROVIDER || '', env);
   for (const providerEnvName of Object.values(providerSecretEnvMapping)) {
     if (typeof providerEnvName !== 'string' || providerEnvName.length === 0) {
       continue;
@@ -57,9 +57,7 @@ function buildConfig(env) {
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(providerEnvName)) {
       throw new Error(`Invalid provider credential env name: ${providerEnvName}`);
     }
-    if (env[providerEnvName]) {
-      providerBenchEnv[providerEnvName] = env[providerEnvName];
-    }
+    providerBenchEnvNames.add(providerEnvName);
   }
 
   const runtimeTask = runtimeTaskFromEnv(env);
@@ -160,6 +158,12 @@ function buildConfig(env) {
     runtime_requirements: effectiveRuntimeProfile,
     github_token_env: 'HOMEBOY_GITHUB_APP_TOKEN',
     github_repository_token_env: 'GITHUB_TOKEN',
+    secret_env: uniqueStrings([
+      ...normalizeStringArray(runtimeConfig.secret_env),
+      'GITHUB_TOKEN',
+      'HOMEBOY_GITHUB_APP_TOKEN',
+      ...Array.from(providerBenchEnvNames),
+    ]),
     github_profile_id: env.GITHUB_PROFILE_ID || `${workloadId}-ci`,
     target_repo: targetRepo,
     context_repositories: normalizeContextRepositories(env.CONTEXT_REPOSITORIES || '[]'),
@@ -211,11 +215,8 @@ function buildConfig(env) {
     transcript_dir: runtimeProjection.transcript_dir,
     transcript_host_dir: runtimeProjection.transcript_host_dir,
     bench_env: {
-      GITHUB_TOKEN: env.GITHUB_REPOSITORY_TOKEN_VALUE || '',
-      HOMEBOY_GITHUB_APP_TOKEN: env.GITHUB_APP_TOKEN_VALUE || '',
       GITHUB_RUN_ID: env.GITHUB_RUN_ID_VALUE || '',
       GITHUB_RUN_ATTEMPT: env.GITHUB_RUN_ATTEMPT_VALUE || '',
-      ...providerBenchEnv,
     },
   };
 }
@@ -259,9 +260,7 @@ function providerBenchEnvFromManifest(runtime, provider, env) {
       }
     }
   }
-  return Object.fromEntries(Array.from(envNames)
-    .filter((name) => env[name])
-    .map((name) => [name, env[name]]));
+  return envNames;
 }
 
 function secretRequirementMatchesProvider(requirement, provider) {
@@ -277,6 +276,10 @@ function normalizeStringArray(value) {
     return [value];
   }
   return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string' && entry.length > 0) : [];
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
 }
 
 function runtimeWorkloadFromEnv(env, fallbackId) {

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -557,16 +557,9 @@ jobs:
           TOOL_RECORDERS: ${{ inputs.tool_recorders }}
           RUNNER_WORKSPACE_CONFIG: ${{ inputs.runner_workspace }}
           IGNORED_WORKSPACE_PATHS: ${{ inputs.ignored_workspace_paths }}
-          GITHUB_APP_TOKEN_VALUE: ${{ steps.app-token.outputs.token }}
-          GITHUB_REPOSITORY_TOKEN_VALUE: ${{ github.token }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
-          PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}
-          PROVIDER_SECRET_2: ${{ secrets.PROVIDER_SECRET_2 }}
-          PROVIDER_SECRET_3: ${{ secrets.PROVIDER_SECRET_3 }}
-          PROVIDER_SECRET_4: ${{ secrets.PROVIDER_SECRET_4 }}
-          PROVIDER_SECRET_5: ${{ secrets.PROVIDER_SECRET_5 }}
         run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
 
       - name: Run runtime agent

--- a/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
+++ b/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
@@ -51,10 +51,8 @@ const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutral-b
 const runtime = resolveRuntimeProvider('wp-codebox', { workspace });
 assert.deepEqual(providerBenchEnvFromManifest(runtime, 'openai', {
   OPENAI_API_KEY: 'manifest-secret-value',
-}), {
-  OPENAI_API_KEY: 'manifest-secret-value',
-});
-assert.deepEqual(providerBenchEnvFromManifest(runtime, 'openai', {}), {});
+}), new Set(['OPENAI_API_KEY']));
+assert.deepEqual(providerBenchEnvFromManifest(runtime, 'openai', {}), new Set(['OPENAI_API_KEY']));
 
 const config = buildConfig({
   GITHUB_WORKSPACE: workspace,
@@ -78,7 +76,17 @@ const config = buildConfig({
 assert.deepEqual(config.provider_secret_env_mapping, {
   connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
 });
-assert.equal(config.bench_env.PROVIDER_SECRET_1, 'secret-value');
+assert.deepEqual(config.secret_env, [
+  'GITHUB_TOKEN',
+  'HOMEBOY_GITHUB_APP_TOKEN',
+  'PROVIDER_SECRET_1',
+]);
+assert.equal('PROVIDER_SECRET_1' in config.bench_env, false);
+assert.equal('OPENAI_API_KEY' in config.bench_env, false);
+assert.equal('GITHUB_TOKEN' in config.bench_env, false);
+assert.equal('HOMEBOY_GITHUB_APP_TOKEN' in config.bench_env, false);
+assert.equal(JSON.stringify(config).includes('secret-value'), false);
+assert.equal(JSON.stringify(config).includes('manifest-secret-value'), false);
 
 const neutralConfig = buildConfig({
   GITHUB_WORKSPACE: workspace,
@@ -99,5 +107,6 @@ const neutralConfig = buildConfig({
 
 assert.deepEqual(neutralConfig.provider_secret_env_mapping, {});
 assert.equal('OPENAI_API_KEY' in neutralConfig.bench_env, false);
+assert.deepEqual(neutralConfig.secret_env, ['GITHUB_TOKEN', 'HOMEBOY_GITHUB_APP_TOKEN']);
 
 console.log('runtime agent full-run provider-neutral smoke passed');


### PR DESCRIPTION
## Summary
- Stop serializing GitHub/provider secret values into runtime-agent full-run config JSON.
- Keep secret resolution behavior through the existing `secret_env` env-name contract.
- Remove secret values from the config-generation workflow step.

## Tests
- `node tests/runtime-agent-full-run-provider-neutral-smoke.mjs`
- `node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs`
- `HOMEBOY_WP_CODEBOX_CORE_MODULE="$PWD/tests/fixtures/wp-codebox-core-runtime-contract.cjs" node tests/runtime-agent-full-run-projection-boundary-smoke.mjs`
- `npm --prefix runtime-agent-ci run test:controller-loop-proof-validator`
- `npm --prefix runtime-agent-ci run test:generic-fanout-reconcile-boundary`

## Notes
- `node tests/runtime-agent-full-run-local-shell-smoke.mjs` currently fails locally on missing `controller_loop_proof_validation` metadata before the changed config-builder assertions run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing runtime-agent full-run secret serialization, implementing the config/workflow change, and updating focused tests.