### PR TITLE
Defer Codex refresh to Codebox provider runtime

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -169,10 +169,8 @@ async function codexAuthPreflightEnv(request) {
     }
   }
 
-  if (manifest.refresh_hook === 'codex-oauth-refresh') {
-    throw new Error(`Codex provider auth preflight failed: token refresh requires a Codebox/provider-owned public credential refresh primitive; Homeboy passes secret_env names only. ${codexAuthGuidance()}`);
-  }
-
+  // HBE validates that the credential contract is present. Refresh belongs to
+  // WP Codebox/provider plugins, where provider-specific auth state lives.
   return {};
 }
 

--- a/wordpress/tests/codebox-codex-auth-preflight-smoke.js
+++ b/wordpress/tests/codebox-codex-auth-preflight-smoke.js
@@ -81,12 +81,10 @@ try {
   assert.equal(result.status, 1, result.stderr || result.stdout);
   const outcome = JSON.parse(result.stdout);
   assert.equal(outcome.status, 'failed');
-  assert.equal(outcome.failure_classification, 'provider');
-  assert.equal(outcome.diagnostics[0].class, 'codebox.preflight.codex_auth');
-  assert.match(outcome.diagnostics[0].data.stderr, /Codebox\/provider-owned public credential refresh primitive/);
-  assert.match(outcome.diagnostics[0].data.stderr, /Refresh Codex OAuth credentials/);
+  assert.notEqual(outcome.failure_classification, 'provider');
   assert(!JSON.stringify(outcome).includes('stale-access-token-value'));
   assert(!JSON.stringify(outcome).includes('stale-refresh-token-value'));
+  assert(!JSON.stringify(outcome).includes('credential refresh primitive'));
 
   const validAccessResult = spawnSync(process.execPath, [wpCodeboxTaskRunner], {
     encoding: 'utf8',
@@ -161,8 +159,8 @@ try {
       HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH: authPath,
     },
   });
-  assert.equal(refreshResult.status, 1, refreshResult.stderr || refreshResult.stdout);
-  assert.match(refreshResult.stderr, /Codebox\/provider-owned public credential refresh primitive/);
+  assert.notEqual(refreshResult.status, 0, 'fake WP Codebox command should fail after auth preflight');
+  assert(!`${refreshResult.stdout}${refreshResult.stderr}`.includes('credential refresh primitive'));
   const persisted = JSON.parse(fs.readFileSync(authPath, 'utf8'));
   assert.equal(persisted.preserved, true);
   assert.equal(persisted.tokens.access_token, 'stale-access-token-value');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -730,11 +730,10 @@ try {
       AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
     },
   });
-  assert.equal(codexResult.status, 1, codexResult.stderr || codexResult.stdout);
-  assert.match(codexResult.stderr, /Codebox\/provider-owned public credential refresh primitive/);
+  assert.equal(codexResult.status, 0, codexResult.stderr || codexResult.stdout);
   assert(!codexResult.stderr.includes('access-token-value'));
   assert(!codexResult.stderr.includes('refresh-token-value'));
-  assert(!fs.existsSync(codexCapturePath));
+  assert(fs.existsSync(codexCapturePath));
 
   const expiredCodexCapturePath = path.join(root, 'capture-expired-codex.json');
   const expiredCodexResult = spawnSync(process.execPath, [
@@ -790,13 +789,10 @@ try {
       AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
     },
   });
-  assert.equal(staleCodexResult.status, 1, staleCodexResult.stderr || staleCodexResult.stdout);
-  assert.match(staleCodexResult.stderr, /Codex provider auth preflight failed/);
-  assert.match(staleCodexResult.stderr, /Codebox\/provider-owned public credential refresh primitive/);
-  assert.match(staleCodexResult.stderr, /Refresh Codex OAuth credentials/);
+  assert.equal(staleCodexResult.status, 0, staleCodexResult.stderr || staleCodexResult.stdout);
   assert(!staleCodexResult.stderr.includes('stale-access-token-value'));
   assert(!staleCodexResult.stderr.includes('stale-refresh-token-value'));
-  assert(!fs.existsSync(staleCodexCapturePath));
+  assert(fs.existsSync(staleCodexCapturePath));
 
   const implicitRuntimeRequest = { ...request };
   delete implicitRuntimeRequest.runtime_component_paths;


### PR DESCRIPTION
## Summary
- stop failing WP Codebox runner preflight for expired-but-refreshable Codex tokens
- keep validation that required secret env names/values exist
- let WP Codebox/provider plugins own provider-specific refresh behavior

## Verification
- node wordpress/tests/codebox-codex-auth-preflight-smoke.js
- node wordpress/tests/wp-codebox-task-runner-smoke.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the live WPSG loop auth handoff failure, implementing the boundary fix, and focused verification.