### PR TITLE
Normalize neutral runtime package ability for Codebox

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -80,7 +80,12 @@ const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 const AGENT_TASK_EVENT_SCHEMA = 'homeboy/agent-task-event/v1';
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
 const WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY = 'wp-codebox/run-runtime-package';
+const NEUTRAL_RUNTIME_PACKAGE_ABILITIES = new Set(['homeboy/run-runtime-package']);
 const LEGACY_RUNTIME_PACKAGE_ABILITIES = new Set(['agents/run-runtime-package', 'runtime-package/run']);
+const RUNTIME_PACKAGE_ABILITY_ALIASES = new Set([
+  ...NEUTRAL_RUNTIME_PACKAGE_ABILITIES,
+  ...LEGACY_RUNTIME_PACKAGE_ABILITIES,
+]);
 const LEGACY_RUNTIME_PACKAGE_ABILITY_QUARANTINE = 'legacy-runtime-package-ability-alias';
 const LEGACY_RUNTIME_PACKAGE_ABILITY_DEPRECATIONS = Array.from(LEGACY_RUNTIME_PACKAGE_ABILITIES).map((ability) => ({
   schema: 'wp-codebox/deprecated-compatibility-alias/v1',
@@ -909,7 +914,7 @@ function genericAbilityRuntimeTask(request, config, inputs) {
   const input = runtimeTaskInputFromAgentTaskRequest(request, config, inputs, declared);
   const normalizedAbility = normalizeRuntimeTaskAbilityForCodebox(ability);
   const abilityNormalization = runtimeTaskAbilityNormalization({ requestedAbility: ability, normalizedAbility });
-  if (LEGACY_RUNTIME_PACKAGE_ABILITIES.has(ability) || normalizedAbility === WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY) {
+  if (RUNTIME_PACKAGE_ABILITY_ALIASES.has(ability) || normalizedAbility === WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY) {
     return {
       ability: normalizedAbility,
       ...(abilityNormalization ? { ability_normalization: abilityNormalization } : {}),
@@ -920,7 +925,7 @@ function genericAbilityRuntimeTask(request, config, inputs) {
 }
 
 function normalizeRuntimeTaskAbilityForCodebox(ability) {
-  return LEGACY_RUNTIME_PACKAGE_ABILITIES.has(ability) ? WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY : ability;
+  return RUNTIME_PACKAGE_ABILITY_ALIASES.has(ability) ? WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY : ability;
 }
 
 function runtimePackageTaskInputForCodebox(input) {

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1351,9 +1351,10 @@ function runtimeTaskAbilityNormalizationEvidence(runtimeTask = {}) {
 }
 
 function runtimeComponentPaths(config, options = {}) {
-  const runtimeComponents = config.runtime_components && typeof config.runtime_components === 'object'
-    ? config.runtime_components
-    : {};
+  const runtimeComponents = {
+    ...(config.runtime_components && typeof config.runtime_components === 'object' ? config.runtime_components : {}),
+    ...(process.env.HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT ? { runtime: process.env.HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT } : {}),
+  };
   const explicit = config.runtime_component_paths && typeof config.runtime_component_paths === 'object'
     ? config.runtime_component_paths
     : {};

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -355,7 +355,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const model = request.executor.model || config.model || runtimeOptions.model || defaults.model || '';
   const runtimeTask = runtimeTaskWithExecutionDefaults(
     inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || runtimeOptions.runtimeTask,
-    { provider, model, agentBundles }
+    { provider, model, agentBundles, runtimePackage: runtimePackageDefaultFromProfile(config, runtimeOptions) }
   );
   let componentContracts = componentContractsFromAgentTaskRequest(request, config, runtimeOptions);
   let components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
@@ -612,6 +612,11 @@ function runtimeProfileFromExecutorConfig(config = {}, options = {}) {
   const profiles = firstObject(config.runtime_profiles, config.runtimeProfiles, options.runtimeProfiles, options.runtime_profiles) || {};
   const namedProfile = profiles[runtimeProfile] || profiles[runtimeProfile.trim()];
   return firstObject(namedProfile) || {};
+}
+
+function runtimePackageDefaultFromProfile(config = {}, runtimeOptions = {}) {
+  const runtimeProfile = firstObject(runtimeOptions.runtimeProfile) || {};
+  return firstValue(runtimeProfile.runtime_package, runtimeProfile.runtimePackage, runtimeProfile.package, config.runtime_profile, config.runtimeProfile, runtimeProfile.id);
 }
 
 function artifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs = {}, options = {}) {
@@ -1283,6 +1288,7 @@ function runtimeTaskWithExecutionDefaults(runtimeTask, defaults = {}) {
     ? normalizedRuntimeTask.input
     : {};
   const defaultInput = Object.fromEntries(Object.entries({
+    runtime_package: defaults.runtimePackage,
     provider: defaults.provider,
     model: defaults.model,
   }).filter(([, value]) => value !== '' && value !== undefined));

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -89,16 +89,22 @@ function runGenericAgentLoop(options = {}) {
     stopPolicy: options.stopPolicy || options.stop_policy,
   });
   const outcome = loop.outcome || normalizeOutcome(null, request);
-  validateGenericAgentLoopOutcomeContract({
-    request,
-    outcome,
-    runtime,
-    plan: options.plan || {},
-    validationPolicy,
-  });
-  const results = materializeGenericAgentLoopResults(outcome, { ...options, runtime });
+  let contractValidation = null;
+  let contractOutcome = outcome;
+  try {
+    contractValidation = validateGenericAgentLoopOutcomeContract({
+      request,
+      outcome,
+      runtime,
+      plan: options.plan || {},
+      validationPolicy,
+    });
+  } catch (error) {
+    contractOutcome = outcomeWithContractValidationFailure(outcome, request, error);
+  }
+  const results = materializeGenericAgentLoopResults(contractOutcome, { ...options, runtime });
   const controllerProofRequested = options.controllerProof === true || options.controller_proof === true;
-  const productionProof = controllerProofRequested ? buildBoundedProductionProof({ request, outcome, plan: options.plan || {}, validationPolicy }) : null;
+  const productionProof = controllerProofRequested ? buildBoundedProductionProof({ request, outcome: contractOutcome, plan: options.plan || {}, validationPolicy }) : null;
   const controllerProofValidation = controllerProofRequested ? validateControllerLoopProof({
     spec: buildControllerLoopProofSpec({ request, plan: options.plan || {}, validationPolicy }),
     proof: productionProof,
@@ -111,7 +117,7 @@ function runGenericAgentLoop(options = {}) {
   if (options.validate !== false && controllerProofRequested && !controllerProofValidation.valid) {
     throw new Error(`controller loop proof validation failed: ${controllerProofValidation.failures.map((item) => item.message).join('; ')}`);
   }
-  return { request, outcome, results, assertion, loop, productionProof, controllerProofValidation };
+  return { request, outcome: contractOutcome, results, assertion, loop, productionProof, controllerProofValidation, contractValidation };
 }
 
 function runGenericDeterministicLoop(options = {}) {
@@ -900,6 +906,43 @@ function normalizeOutcome(value, request) {
     status: 'failed',
     summary: 'Runtime agent task executor produced an invalid outcome.',
   };
+}
+
+function outcomeWithContractValidationFailure(outcome, request, error) {
+  const normalized = normalizeOutcome(outcome, request);
+  return {
+    ...normalized,
+    schema: normalized.schema || 'homeboy/agent-task-outcome/v1',
+    task_id: normalized.task_id || request.task_id,
+    status: 'failed',
+    summary: errorMessage(error),
+    diagnostics: [
+      ...(Array.isArray(normalized.diagnostics) ? normalized.diagnostics : []),
+      {
+        class: 'homeboy.generic_agent_loop.contract_validation_failed',
+        message: errorMessage(error),
+        data: {
+          original_status: normalized.status || '',
+          original_summary: normalized.summary || '',
+        },
+      },
+    ],
+    metadata: {
+      ...(optionalObject(normalized.metadata)),
+      generic_agent_loop_contract_validation: {
+        schema: 'homeboy/generic-agent-loop-contract-validation/v1',
+        valid: false,
+        error: errorMessage(error),
+        invalid_candidate_outcome: normalized,
+      },
+    },
+  };
+}
+
+function errorMessage(error) {
+  return error && typeof error.message === 'string' && error.message.trim()
+    ? error.message
+    : String(error || 'generic agent loop contract validation failed');
 }
 
 function findScenario(results, scenarioId) {

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -129,6 +129,35 @@ assert.equal(result.loop.outcome.status, 'succeeded');
 assert.equal(result.productionProof, null);
 assert.equal(result.controllerProofValidation, null);
 
+const invalidCandidateResult = genericLoopRunner.runGenericAgentLoop({
+  runtime,
+  plan: {
+    ...plan,
+    workload_id: 'invalid-candidate-contract',
+    artifact_declarations: [{ name: 'required-packet', kind: 'fixture/Packet/v1', required: true }],
+  },
+  validate: false,
+  validationPolicy: { success_completion_outcomes: ['done'] },
+  execute: ({ request }) => ({
+    schema: 'homeboy/agent-task-outcome/v1',
+    task_id: request.task_id,
+    status: 'provider_error',
+    summary: 'Provider returned no artifact packet.',
+    diagnostics: [{ class: 'fixture.provider_error', message: 'provider failure detail' }],
+  }),
+});
+assert.equal(invalidCandidateResult.outcome.status, 'failed');
+assert.match(invalidCandidateResult.outcome.summary, /missing declared artifact required-packet/);
+assert.equal(invalidCandidateResult.outcome.diagnostics[0].class, 'fixture.provider_error');
+assert.equal(
+  invalidCandidateResult.outcome.metadata.generic_agent_loop_contract_validation.invalid_candidate_outcome.status,
+  'provider_error'
+);
+assert.equal(
+  invalidCandidateResult.outcome.metadata.generic_agent_loop_contract_validation.invalid_candidate_outcome.summary,
+  'Provider returned no artifact packet.'
+);
+
 const proofPolicy = { preview_required: true, publication_required: true };
 const validProofRun = genericLoopRunner.runGenericAgentLoop({
   runtime,

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -542,6 +542,21 @@ assert.deepEqual(customRuntimePolicyTaskInput.allowed_tools, [
 assert.equal(customRuntimePolicyTaskInput.runtime_component_paths.agent_runtime, '/components/example-runtime');
 assert.equal(customRuntimePolicyTaskInput.runtime_component_paths.agent_runtime_tools, '/components/example-tools');
 
+const previousRuntimeComponentEnv = process.env.HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT;
+process.env.HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT = '/components/wp-codebox-runtime-plugin';
+const envRuntimeComponentTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'env-runtime-component-task-1',
+  executor: { backend: 'codebox', config: { provider: 'codex' } },
+  instructions: 'Run with a runtime component supplied by the selected runner environment.',
+});
+if (previousRuntimeComponentEnv === undefined) {
+  delete process.env.HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT;
+} else {
+  process.env.HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT = previousRuntimeComponentEnv;
+}
+assert.equal(envRuntimeComponentTaskInput.runtime_component_paths.runtime, '/components/wp-codebox-runtime-plugin');
+
 const runtimeInvocationTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'generic-provider-runtime-invocation-task-1',

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -766,6 +766,25 @@ assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.model, 'gpt-5.5');
 assert.deepEqual(legacyRuntimePackageTaskInput.runtime_task.input.metadata.runtime_package_descriptor, { slug: 'example-agent', source: 'bundles/example-agent' });
 assert.equal(Object.hasOwn(legacyRuntimePackageTaskInput.runtime_task.input, 'package'), false);
 
+const neutralRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'neutral-runtime-package-task-1',
+  executor: { backend: 'codebox', model: 'gpt-5.5', config: { provider: 'codex' } },
+  instructions: 'Run a neutral runtime-package task through the selected runtime adapter.',
+  inputs: {
+    ability_request: {
+      name: 'homeboy/run-runtime-package',
+      input: { package: { slug: 'example-agent', source: 'bundles/example-agent' } },
+    },
+  },
+});
+assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability_normalization.requested_ability, 'homeboy/run-runtime-package');
+assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability_normalization.normalized_codebox_ability, 'wp-codebox/run-runtime-package');
+assert.equal(Object.hasOwn(neutralRuntimePackageTaskInput.runtime_task.ability_normalization, 'deprecated_compatibility_alias'), false);
+assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.runtime_package, 'example-agent');
+assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent');
+
 const explicitRuntimePackageComponentTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'runtime-package-substrate-task-1',

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -785,6 +785,33 @@ assert.equal(Object.hasOwn(neutralRuntimePackageTaskInput.runtime_task.ability_n
 assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.runtime_package, 'example-agent');
 assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent');
 
+const neutralProfileRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'neutral-profile-runtime-package-task-1',
+  executor: {
+    backend: 'codebox',
+    model: 'gpt-5.5',
+    config: {
+      provider: 'codex',
+      runtime_profile: 'example-agent-profile',
+      runtime_profiles: {
+        'example-agent-profile': {
+          schema: 'homeboy/runtime-profile/v1',
+          id: 'example-agent-profile',
+          runtime_task_ability: 'homeboy/run-runtime-package',
+        },
+      },
+      runtime_task: { ability: 'homeboy/run-runtime-package', input: {} },
+    },
+  },
+  instructions: 'Run a neutral runtime-package task through the selected runtime profile.',
+});
+assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.runtime_package, 'example-agent-profile');
+assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent-profile');
+assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.provider, 'codex');
+assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.model, 'gpt-5.5');
+
 const explicitRuntimePackageComponentTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'runtime-package-substrate-task-1',


### PR DESCRIPTION
## Summary
- map neutral homeboy/run-runtime-package to wp-codebox/run-runtime-package in the WP Codebox adapter
- keep legacy aliases separate from neutral aliases so the neutral route is not marked deprecated
- cover the WPSG-style neutral runtime profile path

## Verification
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node runtime-agent-ci/tests/headless-production-loop-spec.test.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the live WPSG loop empty runtime result, implementing the adapter normalization, and focused verification.