### PR TITLE
Centralize agent review run contracts

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -13,7 +13,7 @@ const {
   splitCsv,
   writeGithubOutput,
 } = require('./lib/common.cjs');
-const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
+const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 const {
   runtimeAgentCiFirstNonEmptyArray,
   runtimeAgentCiFirstNonEmptyObject,
@@ -37,7 +37,7 @@ function buildConfig(env) {
   const targetRepo = required(env.TARGET_REPO, 'TARGET_REPO');
   const componentId = env.COMPONENT_ID || path.basename(workspace);
   const componentPath = env.COMPONENT_PATH || workspace;
-  const runtimeId = env.RUNTIME || env.RUNTIME_PROVIDER || env.BACKEND || DEFAULT_RUNTIME_ID;
+  const runtimeId = runtimeIdFromOptions({}, env);
   const runtimeProfile = required(env.PROFILE || env.RUNTIME_PROFILE, 'PROFILE or RUNTIME_PROFILE');
   const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
   const runtime = resolveRuntimeProvider(runtimeId, { workspace, env });

--- a/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
+++ b/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
@@ -4,7 +4,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { capture, normalizeProviderPlugin, parseJsonInput, requireRepo, run, splitCsv } = require('./lib/common.cjs');
-const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
+const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 
 function main() {
   const printPlan = process.argv.includes('--print-plan');
@@ -24,7 +24,7 @@ function main() {
 }
 
 function dependencyEntries(env) {
-  const runtimeId = env.RUNTIME || env.RUNTIME_PROVIDER || env.BACKEND || DEFAULT_RUNTIME_ID;
+  const runtimeId = runtimeIdFromOptions({}, env);
   const runtime = resolveRuntimeProvider(runtimeId, { env });
   const entries = runtime.checkout.repo ? [{ repo: runtime.checkout.repo, ref: runtime.checkout.ref, target: runtime.checkout.target }] : [];
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', true);

--- a/.github/scripts/runtime-agent-full-run/run-runtime-agent-task.cjs
+++ b/.github/scripts/runtime-agent-full-run/run-runtime-agent-task.cjs
@@ -12,7 +12,7 @@ const path = require('node:path');
 /**
  * Internal dependencies
  */
-const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
+const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 const {
   genericAgentLoopStdoutSummary,
   runGenericAgentLoop,
@@ -39,7 +39,7 @@ try {
   const configPath = readConfigPath();
   const config = readJson(configPath);
   const controllerLoopProofPolicy = resolveControllerLoopProofPolicy(config);
-  const runtime = resolveRuntimeProvider(config.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || DEFAULT_RUNTIME_ID, { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd(), executor: config.executor || {} });
+  const runtime = resolveRuntimeProvider(runtimeIdFromOptions({ runtime_id: config.runtime_id || config.runtime }, process.env), { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd(), executor: config.executor || {} });
   const result = runGenericAgentLoop({
     plan: config,
     runtime,

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -572,10 +572,13 @@ jobs:
           PROVIDER_SECRET_3: ${{ secrets.PROVIDER_SECRET_3 }}
           PROVIDER_SECRET_4: ${{ secrets.PROVIDER_SECRET_4 }}
           PROVIDER_SECRET_5: ${{ secrets.PROVIDER_SECRET_5 }}
-          HOMEBOY_RUNTIME_AGENT_RESULTS_FILE: ${{ runner.temp }}/run-results.json
-          HOMEBOY_AGENT_TASK_OUTCOME_FILE: ${{ runner.temp }}/agent-task-outcome.json
-          HOMEBOY_RUNTIME_AGENT_EVENTS_FILE: ${{ runner.temp }}/runtime-agent-events.json
-          HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE: ${{ runner.temp }}/runtime-agent-loop-result.json
+          HOMEBOY_RUNTIME_AGENT_RUN_DIR: ${{ runner.temp }}/runtime-agent-run
+          HOMEBOY_RUNTIME_AGENT_RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
+          HOMEBOY_AGENT_TASK_OUTCOME_FILE: ${{ runner.temp }}/runtime-agent-run/outcome.json
+          HOMEBOY_RUNTIME_AGENT_EVENTS_FILE: ${{ runner.temp }}/runtime-agent-run/events.json
+          HOMEBOY_RUNTIME_AGENT_STATUS_FILE: ${{ runner.temp }}/runtime-agent-run/status.json
+          HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE: ${{ runner.temp }}/runtime-agent-run/loop-result.json
+          HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE: ${{ runner.temp }}/runtime-agent-run/loop-policy.json
           HOMEBOY_RUNTIME_AGENT_REPLAY_BUNDLE_DIR: ${{ inputs.replay_bundle_artifact_name != '' && format('{0}/runtime-agent-replay-bundles', runner.temp) || '' }}
         run: node .ci/homeboy-extensions/runtime-agent-ci/scripts/run-headless-loop.cjs --spec "${{ steps.config.outputs.config_path }}" ${{ inputs.dry_run && '--dry-run' || '' }}
 
@@ -584,7 +587,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
-          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
           CONFIG_FILE: ${{ steps.config.outputs.config_path }}
         run: |
           set -euo pipefail
@@ -598,7 +601,7 @@ jobs:
         id: extract
         if: ${{ always() && inputs.run_agent && ! inputs.dry_run }}
         env:
-          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
         run: |
           set -euo pipefail
           bash .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/extract-engine-data.sh \
@@ -614,7 +617,7 @@ jobs:
         if: ${{ always() && inputs.run_agent && ! inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
-          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
           CONFIG_FILE: ${{ steps.config.outputs.config_path }}
         run: |
           set -euo pipefail
@@ -627,7 +630,7 @@ jobs:
         id: extract_dry_run
         if: ${{ always() && inputs.run_agent && inputs.dry_run }}
         env:
-          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
         run: |
           set -euo pipefail
           bash .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/extract-engine-data.sh \
@@ -644,7 +647,7 @@ jobs:
         id: engine-data
         if: ${{ inputs.run_agent }}
         env:
-          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
           ENGINE_DATA_OUTPUTS: ${{ inputs.engine_data_outputs }}
           RUNTIME_OUTPUT_PROJECTIONS: ${{ inputs.runtime_output_projections }}
           FLOW_SLUG: ${{ inputs.workload_id }}
@@ -660,7 +663,7 @@ jobs:
       - name: Assert success
         if: ${{ inputs.run_agent && ! inputs.dry_run }}
         env:
-          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
           FLOW_SLUG: ${{ inputs.workload_id }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
         run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/assert-success.cjs
@@ -669,7 +672,7 @@ jobs:
         id: transcript-artifact
         if: ${{ always() && inputs.run_agent && inputs.transcript_artifact_name != '' && (steps.extract.outputs.transcript_json != '' || steps.extract_dry_run.outputs.transcript_json != '') }}
         env:
-          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
           FLOW_SLUG: ${{ inputs.workload_id }}
           TRANSCRIPT_JSON: ${{ steps.extract.outputs.transcript_json || steps.extract_dry_run.outputs.transcript_json }}
           TRANSCRIPT_HOST_DIR: ${{ steps.config.outputs.transcript_host_dir }}
@@ -689,9 +692,12 @@ jobs:
         with:
           name: ${{ inputs.transcript_artifact_name }}-results
           path: |
-            ${{ runner.temp }}/run-results.json
-            ${{ runner.temp }}/runtime-agent-events.json
-            ${{ runner.temp }}/runtime-agent-loop-result.json
+            ${{ runner.temp }}/runtime-agent-run/status.json
+            ${{ runner.temp }}/runtime-agent-run/outcome.json
+            ${{ runner.temp }}/runtime-agent-run/results.json
+            ${{ runner.temp }}/runtime-agent-run/events.json
+            ${{ runner.temp }}/runtime-agent-run/loop-result.json
+            ${{ runner.temp }}/runtime-agent-run/loop-policy.json
           if-no-files-found: warn
 
       - name: Upload replay bundle artifact

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -18,3 +18,4 @@ Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));
 Object.assign(module.exports, require('./lib/gate-plan-evaluator'));
 Object.assign(module.exports, require('./lib/agent-task-to-review-runner'));
 Object.assign(module.exports, require('./lib/loop-lifecycle.cjs'));
+Object.assign(module.exports, require('./lib/runtime-status.cjs'));

--- a/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
+++ b/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { AGENT_TASK_OUTCOME_SCHEMA } = require('../../agent-task-contracts/agent-task-provider-contract');
+const { normalizeAgentTaskOutcomeStatus } = require('./runtime-status.cjs');
 
 const TERMINAL_FAILURE_STATUSES = ['failed', 'provider_error', 'timeout', 'unable_to_remediate'];
 const SUCCESS_STATUSES = ['succeeded', 'no_op', 'follow_up_issue'];
@@ -59,59 +60,14 @@ function normalizeAgentTaskStatus(result = {}, options = {}) {
   const explicitStatus = options.status;
   const resultStatus = result && typeof result === 'object' ? result.status : undefined;
 
-  if (TERMINAL_FAILURE_STATUSES.includes(resultStatus)) {
-    return resultStatus;
-  }
-  if (result?.provider_error) {
-    return 'provider_error';
-  }
-  if (result?.timeout) {
-    return 'timeout';
-  }
-  if (result?.unable_to_remediate) {
-    return 'unable_to_remediate';
-  }
-  if (result?.success === false || exitStatus !== 0) {
-    return 'failed';
-  }
   if (TERMINAL_FAILURE_STATUSES.includes(explicitStatus)) {
     return explicitStatus;
   }
-  if (explicitStatus) {
-    return explicitStatus;
-  }
-  return normalizeProviderStatus(result, exitStatus);
+  return normalizeAgentTaskOutcomeStatus({ ...result, status: explicitStatus || resultStatus }, { exitStatus });
 }
 
 function normalizeProviderStatus(result = {}, exitStatus = 0) {
-  if (TERMINAL_FAILURE_STATUSES.includes(result.status)) {
-    return result.status;
-  }
-  if (result.provider_error) {
-    return 'provider_error';
-  }
-  if (result.timeout) {
-    return 'timeout';
-  }
-  if (result.unable_to_remediate) {
-    return 'unable_to_remediate';
-  }
-  if (result.success === false || exitStatus !== 0) {
-    return 'failed';
-  }
-  if (result.status === 'completed') {
-    return 'succeeded';
-  }
-  if (result.status === 'succeeded' || result.status === 'no_op') {
-    return result.status;
-  }
-  if (result.outcome === 'no_op' || result.no_op) {
-    return 'no_op';
-  }
-  if (result.success === true) {
-    return 'succeeded';
-  }
-  return Object.keys(result || {}).length > 0 ? 'provider_error' : 'failed';
+  return normalizeAgentTaskOutcomeStatus(result, { exitStatus });
 }
 
 function providerFailureClassification(classification, status) {

--- a/runtime-agent-ci/lib/artifact-paths.cjs
+++ b/runtime-agent-ci/lib/artifact-paths.cjs
@@ -3,6 +3,15 @@
 const path = require('node:path');
 
 const ARTIFACT_PATHS_SCHEMA = 'homeboy/runtime-agent-artifact-paths/v1';
+const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
+  events: 'events.json',
+  status: 'status.json',
+  results: 'results.json',
+  outcome: 'outcome.json',
+  fanout_run: 'fanout-run.json',
+  loop_result: 'loop-result.json',
+  loop_policy: 'loop-policy.json',
+});
 
 function runtimeAgentArtifactPaths(options = {}) {
   const provided = options.artifact_paths && typeof options.artifact_paths === 'object' && !Array.isArray(options.artifact_paths) ? options.artifact_paths : {};
@@ -27,15 +36,19 @@ function runtimeAgentArtifactPaths(options = {}) {
   return stripUndefined({
     schema: ARTIFACT_PATHS_SCHEMA,
     run_dir: runDir,
-    events: firstString(provided.events, options.eventsFile, options.events_file, options.env?.HOMEBOY_RUNTIME_AGENT_EVENTS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_EVENTS_FILE, runDir ? path.join(runDir, 'events.json') : ''),
-    status: firstString(provided.status, options.statusFile, options.status_file, options.env?.HOMEBOY_RUNTIME_AGENT_STATUS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_STATUS_FILE, runDir ? path.join(runDir, 'status.json') : ''),
-    results: firstString(provided.results, options.resultsFile, options.results_file, options.env?.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE, runDir ? path.join(runDir, 'results.json') : ''),
-    outcome: firstString(provided.outcome, options.outcomeFile, options.outcome_file, options.env?.HOMEBOY_AGENT_TASK_OUTCOME_FILE, process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE, runDir ? path.join(runDir, 'outcome.json') : ''),
+    events: firstString(provided.events, options.eventsFile, options.events_file, options.env?.HOMEBOY_RUNTIME_AGENT_EVENTS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_EVENTS_FILE, runArtifactPath(runDir, 'events')),
+    status: firstString(provided.status, options.statusFile, options.status_file, options.env?.HOMEBOY_RUNTIME_AGENT_STATUS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_STATUS_FILE, runArtifactPath(runDir, 'status')),
+    results: firstString(provided.results, options.resultsFile, options.results_file, options.env?.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE, runArtifactPath(runDir, 'results')),
+    outcome: firstString(provided.outcome, options.outcomeFile, options.outcome_file, options.env?.HOMEBOY_AGENT_TASK_OUTCOME_FILE, process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE, runArtifactPath(runDir, 'outcome')),
     stderr: firstString(provided.stderr, options.stderrFile, options.stderr_file, options.env?.HOMEBOY_RUNTIME_AGENT_STDERR_FILE, process.env.HOMEBOY_RUNTIME_AGENT_STDERR_FILE),
-    fanout_run: firstString(provided.fanout_run, provided.fanoutRun, options.fanoutRunFile, options.fanout_run_file, options.runsOutputPath, options.runs_output_path, options.env?.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, process.env.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, runDir ? path.join(runDir, 'fanout-run.json') : ''),
-    loop_result: firstString(provided.loop_result, provided.loopResult, options.loopResultFile, options.loop_result_file, options.resultFile, options.result_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, runDir ? path.join(runDir, 'loop-result.json') : ''),
-    loop_policy: firstString(provided.loop_policy, provided.loopPolicy, options.loopPolicyFile, options.loop_policy_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, runDir ? path.join(runDir, 'loop-policy.json') : ''),
+    fanout_run: firstString(provided.fanout_run, provided.fanoutRun, options.fanoutRunFile, options.fanout_run_file, options.runsOutputPath, options.runs_output_path, options.env?.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, process.env.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, runArtifactPath(runDir, 'fanout_run')),
+    loop_result: firstString(provided.loop_result, provided.loopResult, options.loopResultFile, options.loop_result_file, options.resultFile, options.result_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, runArtifactPath(runDir, 'loop_result')),
+    loop_policy: firstString(provided.loop_policy, provided.loopPolicy, options.loopPolicyFile, options.loop_policy_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, runArtifactPath(runDir, 'loop_policy')),
   });
+}
+
+function runArtifactPath(runDir, key) {
+  return runDir && CANONICAL_RUN_ARTIFACT_FILES[key] ? path.join(runDir, CANONICAL_RUN_ARTIFACT_FILES[key]) : '';
 }
 
 function firstString(...values) {
@@ -53,5 +66,6 @@ function stripUndefined(value) {
 
 module.exports = {
   ARTIFACT_PATHS_SCHEMA,
+  CANONICAL_RUN_ARTIFACT_FILES,
   runtimeAgentArtifactPaths,
 };

--- a/runtime-agent-ci/lib/batch-production-loop-runner.js
+++ b/runtime-agent-ci/lib/batch-production-loop-runner.js
@@ -9,6 +9,7 @@ const {
   FANOUT_RECONCILE_RUN_STATUSES,
   executeFanoutReconcileRun,
 } = require('./fanout-reconcile-runner');
+const { normalizeHostRecordStatus, providerStatusSucceeded } = require('./runtime-status.cjs');
 const DEFAULT_MAX_ITERATIONS = 3;
 
 async function runBatchProductionLoop(options = {}) {
@@ -178,7 +179,7 @@ async function executeGroups(context) {
     plan: {
       schema: 'homeboy/batch-production-loop-wave-plan/v1',
       summary: { group_count: context.groups.length, task_count: context.groups.length },
-      task_requests: context.groups.map((group, index) => ({ group, group_index: index, group_key: groupKey(group, index) })),
+      task_requests: context.groups.map((group, index) => batchProductionTaskRequest(group, index)),
     },
     concurrency: context.concurrency,
     task_id: (task) => task.group_key,
@@ -204,7 +205,7 @@ async function executeGroups(context) {
         return failedGroupOutcome(task.group, task.group_index, error);
       }
     },
-    is_record_successful: (record) => record.success === true,
+    is_record_successful: (record) => normalizeHostRecordStatus(record) === 'completed',
     classify_outcome: (record) => record.outcome,
     include_reconciliation: false,
   });
@@ -214,6 +215,24 @@ async function executeGroups(context) {
 function resolveExecuteGroup(options) {
   const execution = optionalObject(options.execution || options.executor);
   return requiredFunction(options.executeGroup || options.execute_group || execution.executeGroup || execution.execute_group || execution.runGroup || execution.run_group, 'executeGroup');
+}
+
+function batchProductionGroup(input = {}, index = 0) {
+  const group = optionalObject(input);
+  return {
+    ...group,
+    key: groupKey(group, index),
+  };
+}
+
+function batchProductionTaskRequest(group = {}, index = 0) {
+  const normalizedGroup = batchProductionGroup(group, index);
+  return {
+    schema: 'homeboy/batch-production-loop-task-request/v1',
+    group: normalizedGroup,
+    group_index: index,
+    group_key: normalizedGroup.key,
+  };
 }
 
 async function applyFanoutPolicy(fanoutPolicy, context) {
@@ -245,7 +264,7 @@ function defaultReconcileWave({ groupOutcomes }) {
 
 function defaultClassifyGroupOutcome(outcome) {
   const status = outcome?.status || outcome?.state || '';
-  const success = outcome?.success === true || ['accepted', 'completed', 'passed', 'succeeded'].includes(status);
+  const success = outcome?.success === true || providerStatusSucceeded(status);
   return {
     success,
     status: status || (success ? 'completed' : 'failed'),
@@ -397,5 +416,7 @@ module.exports = {
   DEFAULT_CONCURRENCY,
   FANOUT_RECONCILE_RECORD_STATUSES,
   FANOUT_RECONCILE_RUN_STATUSES,
+  batchProductionGroup,
+  batchProductionTaskRequest,
   runBatchProductionLoop,
 };

--- a/runtime-agent-ci/lib/fanout-reconcile-runner.js
+++ b/runtime-agent-ci/lib/fanout-reconcile-runner.js
@@ -6,6 +6,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { runtimeAgentArtifactPaths } = require('./artifact-paths.cjs');
+const { normalizeHostRecordStatus, normalizeHostRunStatus } = require('./runtime-status.cjs');
 
 const PLAN_SCHEMA = 'homeboy/fanout-reconcile-plan/v1';
 const RUN_SCHEMA = 'homeboy/fanout-reconcile-run/v1';
@@ -109,7 +110,7 @@ async function executeFanoutReconcileRun(input) {
     writeRun({
       ...baseRun,
       records,
-      status: 'incomplete',
+      status: normalizeHostRunStatus('incomplete'),
       current_group: firstRunningGroup(running),
       current_groups: runningGroups(running),
     });
@@ -118,7 +119,7 @@ async function executeFanoutReconcileRun(input) {
   writeRun({
     ...baseRun,
     records,
-    status: 'incomplete',
+    status: normalizeHostRunStatus('incomplete'),
     current_group: null,
   });
 
@@ -175,7 +176,7 @@ async function executeFanoutReconcileRun(input) {
     records,
     outcomes,
     ...(input.include_reconciliation === false ? {} : { reconciliation }),
-    status: records.every(isRecordSuccessful) ? 'completed' : 'failed',
+    status: normalizeHostRunStatus({ success: records.every(isRecordSuccessful) }),
   };
 
   writeRun(run);
@@ -241,20 +242,7 @@ function normalizeFanoutRecord(record) {
 }
 
 function normalizeFanoutRecordStatus(record) {
-  const status = text(record.status);
-  if (FANOUT_RECONCILE_RECORD_STATUSES.includes(status)) {
-    return status;
-  }
-  if (record.success === true || FANOUT_RECONCILE_SUCCESS_STATUSES.includes(status)) {
-    return 'completed';
-  }
-
-  const outcomeStatus = text(record.outcome?.status || record.outcome_status || record.provider_status);
-  if (FANOUT_RECONCILE_SUCCESS_STATUSES.includes(outcomeStatus)) {
-    return 'completed';
-  }
-
-  return 'failed';
+  return normalizeHostRecordStatus(record);
 }
 
 function errorMessage(error) {

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -740,6 +740,14 @@ function writeGenericAgentLoopArtifacts(options = {}) {
   if (artifactPaths.results) {
     writeJsonFile(artifactPaths.results, options.results);
   }
+  if (artifactPaths.status) {
+    writeJsonFile(artifactPaths.status, {
+      schema: 'homeboy/runtime-agent-status/v1',
+      task_id: options.outcome?.task_id || options.request?.task_id || '',
+      status: options.outcome?.status || 'failed',
+      success: ['succeeded', 'no_op'].includes(options.outcome?.status),
+    });
+  }
 }
 
 function genericAgentLoopStdoutSummary(options = {}) {

--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -13,7 +13,7 @@ const {
   normalizeLoopPolicy: normalizeSharedLoopPolicy,
 } = require('./loop-policy');
 const { executeFanoutReconcileRun } = require('./fanout-reconcile-runner');
-const { resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
+const { resolveRuntimeProvider, runtimeIdFromOptions } = require('./runtime-provider-resolver.cjs');
 const { runtimeAgentArtifactPaths } = require('./artifact-paths.cjs');
 
 async function runHeadlessDeterministicLoop(options = {}) {
@@ -195,7 +195,7 @@ function writeHeadlessDeterministicLoopArtifacts(options = {}) {
   writeGenericAgentLoopArtifacts({
     outcome: options.result?.outcome,
     results: options.result?.results,
-    artifact_paths: artifactPaths,
+    artifact_paths: { ...artifactPaths, status: '' },
   });
 }
 
@@ -561,7 +561,7 @@ function resolveLoopRuntime(spec, options = {}) {
       workspace: spec.component_path || options.workspace || process.cwd(),
     });
   }
-  return resolveRuntimeProvider(spec.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND, {
+  return resolveRuntimeProvider(runtimeIdFromOptions({ runtime_id: spec.runtime_id || spec.runtime }, process.env), {
     ...options,
     workspace: spec.component_path || options.workspace || process.cwd(),
   });

--- a/runtime-agent-ci/lib/headless-production-loop-spec.js
+++ b/runtime-agent-ci/lib/headless-production-loop-spec.js
@@ -1,21 +1,5 @@
 'use strict';
 
-const PROVIDER_DEFAULT_SECRET_ENV = Object.freeze({
-  codex: [
-    'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
-    'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
-    'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
-    'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
-    'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
-  ],
-  openai: ['OPENAI_API_KEY'],
-  'claude-code': [
-    'AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN',
-    'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
-    'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
-  ],
-});
-
 function materializeHeadlessProductionLoopSpec(spec = {}, options = {}) {
   const base = requiredObject(spec, 'spec');
   const overrides = runtimeOverrides(options);
@@ -68,12 +52,19 @@ function runtimeOverrides(options = {}) {
 }
 
 function secretEnvOverrides(options = {}, provider = '') {
-  return arrayValue(options.secretEnv || options.secret_env) || providerDefaultSecretEnv(provider);
+  return arrayValue(options.secretEnv || options.secret_env) || providerDefaultSecretEnv(provider, options.runtime || options.runtime_manifest || options.runtimeManifest);
 }
 
-function providerDefaultSecretEnv(provider = '') {
-  const names = PROVIDER_DEFAULT_SECRET_ENV[String(provider || '').trim()];
-  return names ? [...names] : undefined;
+function providerDefaultSecretEnv(provider = '', runtime = {}) {
+  const defaults = runtime?.executor?.provider_defaults?.[provider] || runtime?.provider_defaults?.[provider];
+  if (!defaults || typeof defaults !== 'object' || Array.isArray(defaults)) {
+    return undefined;
+  }
+  return uniqueStrings([
+    ...(arrayValue(defaults.secret_env) || []),
+    ...(arrayValue(defaults.required_secret_env) || []),
+    ...(arrayValue(defaults.optional_secret_env) || []),
+  ]);
 }
 
 function loopTasks(spec) {
@@ -129,6 +120,10 @@ function objectValue(value) {
 
 function arrayValue(value) {
   return Array.isArray(value) && value.length > 0 ? value : undefined;
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
 }
 
 function optionalObject(value) {

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -12,7 +12,7 @@ const {
   genericAgentTaskRunnerSpec,
   normalizeRuntimeExecutionDescriptor,
 } = require('./generic-agent-task-plan');
-const { normalizeRuntimeId, resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
+const { normalizeRuntimeId, resolveRuntimeProvider, runtimeIdFromOptions } = require('./runtime-provider-resolver.cjs');
 const {
   expandAgentTaskCapabilityBundles,
   expandAgentTaskToolPresets,
@@ -67,7 +67,7 @@ function runtimeAgentCiAbilityTaskRequest(options = {}, context = {}) {
 function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
   const taskExecutorConfig = context.taskExecutorConfig || runtimeAgentCiTaskExecutorConfig;
   const config = taskExecutorConfig(options);
-  const runtime = options.runtime || options.runtimeId || options.runtime_id || options.runtimeProvider || options.runtime_provider;
+  const runtime = runtimeIdFromOptions(options, {});
   const normalizedRuntime = runtime ? normalizeRuntimeId(runtime) : runtime;
   return genericAgentTaskRunnerSpec({
     backend: options.backend || options.runtimeBackend || options.runtime_backend || runtimeBackendForRuntime(normalizedRuntime),
@@ -92,7 +92,7 @@ function runtimeBackendForRuntime(runtime) {
 
 function runtimeAgentCiTaskExecutorConfig(options = {}) {
   const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile(options);
-  const runtimeProvider = options.runtime || options.runtimeId || options.runtime_id || options.runtimeProvider || options.runtime_provider;
+  const runtimeId = runtimeIdFromOptions(options, {});
   const runtimeExecution = normalizeRuntimeExecutionDescriptor(options.runtimeExecution || options.runtime_execution, runtimeProfile);
   const runtimeTaskInput = runtimeExecution?.input || options.abilityInput || options.ability_input || {};
   const workload = nonEmptyObject(options.workload);
@@ -113,7 +113,7 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     ...(options.config || {}),
     provider: options.provider,
     model: options.model,
-    runtime_provider: runtimeProvider ? normalizeRuntimeId(runtimeProvider) : runtimeProvider,
+    runtime_id: runtimeId ? normalizeRuntimeId(runtimeId) : runtimeId,
     runtime_profile: runtimeProfile.id,
     runtime_profiles: runtimeProfilesForOptions(options, runtimeProfile),
     runtime_component_paths: options.runtimeComponentPaths || options.runtime_component_paths,
@@ -146,7 +146,6 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     runtime_config_mounts: options.runtimeConfigMounts || options.runtime_config_mounts,
     runtime_state_mounts: options.runtimeStateMounts || options.runtime_state_mounts,
     provider_runtime_invocation: nonEmptyObject(providerRuntimeInvocation),
-    runtime_id: options.runtimeId || options.runtime_id,
     runtime_bin: options.runtimeBin || options.runtime_bin,
   });
 }

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -89,6 +89,28 @@ function normalizeRuntimeId(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 	return runtimeAliasMap(options.registry || runtimeRegistry(options))[id]?.replacement || id;
 }
 
+function runtimeIdFromOptions(options = {}, env = process.env) {
+	return firstString(
+		options.runtimeId,
+		options.runtime_id,
+		options.runtime,
+		env.RUNTIME_ID,
+		env.RUNTIME,
+		legacyRuntimeIdFromOptions(options, env),
+		DEFAULT_RUNTIME_ID
+	);
+}
+
+function legacyRuntimeIdFromOptions(options = {}, env = process.env) {
+	return firstString(
+		options.runtimeProvider,
+		options.runtime_provider,
+		options.backend,
+		env.RUNTIME_PROVIDER,
+		env.BACKEND
+	);
+}
+
 function runtimeIdAliasDeprecation(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 	const id = runtimeId || DEFAULT_RUNTIME_ID;
 	return runtimeAliasMap(options.registry || runtimeRegistry(options))[id] || null;
@@ -448,6 +470,7 @@ module.exports = {
 	DEFAULT_RUNTIME_ID,
 	manifestRuntimeAliases,
 	normalizeRuntimeId,
+	runtimeIdFromOptions,
 	runtimeIdAliasDeprecation,
 	resolveRuntimeProvider,
 	runtimeManifestPath,

--- a/runtime-agent-ci/lib/runtime-status.cjs
+++ b/runtime-agent-ci/lib/runtime-status.cjs
@@ -1,0 +1,97 @@
+'use strict';
+
+const HOST_RECORD_SUCCESS_STATUSES = Object.freeze(['completed']);
+const HOST_RECORD_FAILURE_STATUSES = Object.freeze(['failed', 'missing_record']);
+const HOST_RUN_SUCCESS_STATUSES = Object.freeze(['completed']);
+const HOST_RUN_FAILURE_STATUSES = Object.freeze(['failed']);
+const HOST_RUN_PENDING_STATUSES = Object.freeze(['incomplete']);
+const PROVIDER_SUCCESS_STATUSES = Object.freeze(['accepted', 'completed', 'passed', 'success', 'succeeded', 'no_op']);
+const PROVIDER_FAILURE_STATUSES = Object.freeze(['cancelled', 'failed', 'provider_error', 'timeout', 'unable_to_remediate']);
+
+function normalizeHostRecordStatus(value = {}, options = {}) {
+  const record = plainObject(value) ? value : { status: value };
+  const status = text(record.status || record.state);
+  if (HOST_RECORD_SUCCESS_STATUSES.includes(status) || HOST_RECORD_FAILURE_STATUSES.includes(status)) {
+    return status;
+  }
+  if (record.success === true || providerStatusSucceeded(status) || providerStatusSucceeded(record.outcome?.status || record.outcome_status || record.provider_status)) {
+    return 'completed';
+  }
+  if (options.pending === true && ['pending', 'running', 'started', 'in_progress'].includes(status)) {
+    return 'missing_record';
+  }
+  return 'failed';
+}
+
+function normalizeHostRunStatus(value = {}, options = {}) {
+  const run = plainObject(value) ? value : { status: value };
+  const status = text(run.status || run.state);
+  if (HOST_RUN_SUCCESS_STATUSES.includes(status) || HOST_RUN_FAILURE_STATUSES.includes(status) || HOST_RUN_PENDING_STATUSES.includes(status)) {
+    return status;
+  }
+  if (run.incomplete === true || options.incomplete === true || ['pending', 'running', 'started', 'in_progress'].includes(status)) {
+    return 'incomplete';
+  }
+  if (run.success === true || run.accepted === true || providerStatusSucceeded(status)) {
+    return 'completed';
+  }
+  return 'failed';
+}
+
+function normalizeAgentTaskOutcomeStatus(result = {}, options = {}) {
+  const status = text(options.status || result.status || result.state);
+  const exitStatus = options.exitStatus ?? options.exit_status ?? 0;
+  if (['provider_error', 'timeout', 'unable_to_remediate', 'failed'].includes(status)) {
+    return status;
+  }
+  if (result.provider_error) {
+    return 'provider_error';
+  }
+  if (result.timeout) {
+    return 'timeout';
+  }
+  if (result.unable_to_remediate) {
+    return 'unable_to_remediate';
+  }
+  if (result.success === false || exitStatus !== 0) {
+    return 'failed';
+  }
+  if (status === 'no_op' || result.outcome === 'no_op' || result.no_op) {
+    return 'no_op';
+  }
+  if (providerStatusSucceeded(status) || result.success === true) {
+    return 'succeeded';
+  }
+  return Object.keys(result || {}).length > 0 ? 'provider_error' : 'failed';
+}
+
+function providerStatusSucceeded(status) {
+  return PROVIDER_SUCCESS_STATUSES.includes(text(status));
+}
+
+function providerStatusFailed(status) {
+  return PROVIDER_FAILURE_STATUSES.includes(text(status));
+}
+
+function text(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+module.exports = {
+  HOST_RECORD_FAILURE_STATUSES,
+  HOST_RECORD_SUCCESS_STATUSES,
+  HOST_RUN_FAILURE_STATUSES,
+  HOST_RUN_PENDING_STATUSES,
+  HOST_RUN_SUCCESS_STATUSES,
+  PROVIDER_FAILURE_STATUSES,
+  PROVIDER_SUCCESS_STATUSES,
+  normalizeAgentTaskOutcomeStatus,
+  normalizeHostRecordStatus,
+  normalizeHostRunStatus,
+  providerStatusFailed,
+  providerStatusSucceeded,
+};

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -19,6 +19,7 @@
     "./generic-fanout-reconcile-workflow": "./lib/generic-fanout-reconcile-workflow.js",
     "./agent-task-to-review-runner": "./lib/agent-task-to-review-runner.js",
     "./runtime-workflow-inputs": "./lib/runtime-workflow-inputs.cjs",
+    "./runtime-status": "./lib/runtime-status.cjs",
     "./artifact-paths": "./lib/artifact-paths.cjs",
     "./loop-lifecycle": "./lib/loop-lifecycle.cjs",
     "./workspace-publication-lifecycle": "./lib/workspace-publication-lifecycle.cjs"
@@ -27,7 +28,8 @@
     "homeboy-controller-loop-proof-validate": "./scripts/homeboy-controller-loop-proof-validate.cjs",
     "homeboy-generic-fanout-reconcile": "./scripts/homeboy-generic-fanout-reconcile.cjs",
     "homeboy-render-runtime-workflow-inputs": "./scripts/render-runtime-workflow-inputs.cjs",
-    "homeboy-run-headless-production-loop": "./scripts/run-headless-loop.cjs"
+    "homeboy-run-headless-production-loop": "./scripts/run-headless-loop.cjs",
+    "homeboy-run-agent-task-to-review": "./scripts/run-agent-task-to-review.cjs"
   },
   "scripts": {
     "test:controller-loop-proof-validator": "node ../tests/controller-loop-proof-validator.test.mjs",

--- a/runtime-agent-ci/scripts/run-agent-loop.cjs
+++ b/runtime-agent-ci/scripts/run-agent-loop.cjs
@@ -4,7 +4,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { runGenericAgentLoop, writeGenericAgentLoopArtifacts } = require('../lib/generic-agent-loop-runner');
-const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../lib/runtime-provider-resolver.cjs');
+const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../lib/runtime-provider-resolver.cjs');
 
 try {
   const configPath = process.argv[2] || process.env.HOMEBOY_RUNTIME_AGENT_CONFIG_PATH || '';
@@ -13,7 +13,7 @@ try {
   }
   const plan = JSON.parse(fs.readFileSync(configPath, 'utf8'));
   const repoRoot = path.resolve(__dirname, '..', '..');
-  const runtime = resolveRuntimeProvider(plan.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || DEFAULT_RUNTIME_ID, {
+  const runtime = resolveRuntimeProvider(runtimeIdFromOptions({ runtime_id: plan.runtime_id || plan.runtime }, process.env), {
     repoRoot,
     workspace: plan.component_path || process.cwd(),
     executor: plan.executor || {},

--- a/runtime-agent-ci/scripts/run-agent-task-to-review.cjs
+++ b/runtime-agent-ci/scripts/run-agent-task-to-review.cjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { runtimeAgentArtifactPaths } = require('../lib/artifact-paths.cjs');
+const { runAgentTaskToReview } = require('../lib/agent-task-to-review-runner');
+const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../lib/runtime-provider-resolver.cjs');
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const configPath = args.config || args.spec || process.env.HOMEBOY_RUNTIME_AGENT_CONFIG_PATH || '';
+  if (!configPath) {
+    throw new Error('Pass --config <path>, --spec <path>, or HOMEBOY_RUNTIME_AGENT_CONFIG_PATH.');
+  }
+  const plan = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const runtime = resolveRuntimeProvider(runtimeIdFromOptions({ runtime_id: args.runtime_id || plan.runtime_id || plan.runtime }, process.env), {
+    repoRoot,
+    workspace: plan.component_path || plan.workspace || process.cwd(),
+    executor: plan.executor || {},
+  });
+  const result = runAgentTaskToReview({
+    plan,
+    runtime,
+    configPath,
+    repoRoot,
+    extensionPath: repoRoot,
+    replayBundleDir: process.env.HOMEBOY_RUNTIME_AGENT_REPLAY_BUNDLE_DIR,
+    validationPolicy: {
+      scenario_id: plan.workload_id || plan.task_id,
+      success_requires_pr: plan.success_requires_pr,
+      success_completion_outcomes: plan.success_completion_outcomes,
+      controller_loop_proof: plan.controller_loop_proof || plan.validation_policy?.controller_loop_proof,
+    },
+  });
+  writeAgentTaskToReviewArtifacts({ result, ...args });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.exitCode = result.success ? 0 : 1;
+} catch (error) {
+  process.stderr.write(`${error && error.message ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}
+
+function writeAgentTaskToReviewArtifacts(options = {}) {
+  const artifactPaths = runtimeAgentArtifactPaths(options);
+  writeJsonIfPath(artifactPaths.outcome, options.result?.runtime_result?.outcome || options.result?.outcome || options.result);
+  writeJsonIfPath(artifactPaths.results, options.result?.results);
+  writeJsonIfPath(artifactPaths.loop_result, options.result);
+  writeJsonIfPath(artifactPaths.events, options.result?.runtime_result?.loop?.events || []);
+  writeJsonIfPath(artifactPaths.loop_policy, options.result?.runtime_result?.loop?.policy_status || null);
+  writeJsonIfPath(artifactPaths.status, {
+    schema: 'homeboy/runtime-agent-status/v1',
+    status: options.result?.status || 'failed',
+    success: options.result?.success === true,
+    task_id: options.result?.task_id || '',
+    terminal_status: options.result?.terminal_status || '',
+    error: options.result?.error || '',
+  });
+}
+
+function writeJsonIfPath(filePath, value) {
+  if (!filePath) {
+    return;
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    args[key] = argv[index + 1];
+    index += 1;
+  }
+  return args;
+}

--- a/runtime-agent-ci/tests/batch-production-loop-runner.test.js
+++ b/runtime-agent-ci/tests/batch-production-loop-runner.test.js
@@ -6,6 +6,8 @@ const {
   BATCH_PRODUCTION_LOOP_EVIDENCE_SCHEMA,
   BATCH_PRODUCTION_LOOP_RESULT_SCHEMA,
   BATCH_PRODUCTION_LOOP_WAVE_SCHEMA,
+  batchProductionGroup,
+  batchProductionTaskRequest,
   runBatchProductionLoop,
 } = require('../lib/batch-production-loop-runner');
 
@@ -13,6 +15,13 @@ const {
   assert.equal(BATCH_PRODUCTION_LOOP_RESULT_SCHEMA, 'homeboy/batch-production-loop-result/v1');
   assert.equal(BATCH_PRODUCTION_LOOP_WAVE_SCHEMA, 'homeboy/batch-production-loop-wave/v1');
   assert.equal(BATCH_PRODUCTION_LOOP_EVIDENCE_SCHEMA, 'homeboy/batch-production-loop-evidence/v1');
+  assert.deepEqual(batchProductionGroup({ key: 'wpsg:theme' }, 0), { key: 'wpsg:theme' });
+  assert.deepEqual(batchProductionTaskRequest({ key: 'wpsg:theme' }, 2), {
+    schema: 'homeboy/batch-production-loop-task-request/v1',
+    group: { key: 'wpsg:theme' },
+    group_index: 2,
+    group_key: 'wpsg:theme',
+  });
 
   const successful = await runBatchProductionLoop({
     loopId: 'successful-batch',

--- a/runtime-agent-ci/tests/headless-production-loop-spec.test.js
+++ b/runtime-agent-ci/tests/headless-production-loop-spec.test.js
@@ -60,7 +60,14 @@ const codeboxRequest = buildGenericAgentLoopRequest({
 assert.equal(codeboxRequest.executor.backend, 'codebox');
 assert.equal(codeboxRequest.executor.config.provider, 'codex');
 assert.equal(codeboxRequest.executor.config.model, 'gpt-5.5');
-assert.deepEqual(codeboxRequest.executor.secret_env, providerDefaultSecretEnv('codex'));
+assert.deepEqual(codeboxRequest.executor.secret_env, []);
+assert.deepEqual(providerDefaultSecretEnv('codex', {
+  executor: {
+    provider_defaults: {
+      codex: { secret_env: ['CODEX_TOKEN'] },
+    },
+  },
+}), ['CODEX_TOKEN']);
 
 const explicitSecretEnvSpec = materializeHeadlessProductionLoopSpec(baseSpec, {
   provider: 'codex',


### PR DESCRIPTION
## Summary
- expose agent task to review as a package CLI primitive
- centralize host/provider status mapping and runtime id selection
- standardize runtime-agent run artifacts under a canonical run directory
- move provider secret defaults to manifest/explicit inputs and add batch DTO helpers

## Tests
- npm run test:agent-task-to-review-runner
- node tests/batch-production-loop-runner.test.js
- node tests/headless-production-loop-spec.test.js
- node tests/headless-deterministic-loop-runner.test.js
- node tests/build-runner-config.test.js
- node tests/runtime-agent-full-run-control-plane.test.js
- npm run test:controller-loop-proof-validator
- npm run test:generic-fanout-reconcile-boundary
- npm run test:workspace-publication-lifecycle
- npm run test:agent-task-outcome-normalizer
- npm run test:gate-plan-evaluator
- npm run test:loop-lifecycle
- node tests/generic-fanout-reconcile-workflow.test.js
- node tests/generic-agent-loop-runner.test.js
- node tests/runtime-provider-boundary.test.js
- node --check runtime-agent-ci/scripts/run-agent-task-to-review.cjs
- node --check runtime-agent-ci/lib/runtime-status.cjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implementation, tests, and PR preparation