### PR TITLE
Neutralize runner and preview examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Local path installs are linked installs. The active extension code is whatever t
 To repair a runner that was accidentally left linked to a stale or dirty checkout, use the standard bootstrap script with `--replace-existing`. For linked installs, Homeboy removes only the installed symlink, preserves the linked checkout, and installs a managed extracted copy from the configured repository URL:
 
 ```bash
-scripts/bootstrap-standard-extensions.sh --target homeboy-lab --extensions "wordpress" --replace-existing
+scripts/bootstrap-standard-extensions.sh --target example-runner --extensions "wordpress" --replace-existing
 ```
 
 Inspect the current state before debugging extension behavior:

--- a/docs/remote-runner-bootstrap.md
+++ b/docs/remote-runner-bootstrap.md
@@ -24,13 +24,13 @@ advertise or receive workloads for extension IDs that are present on that host.
 From a checkout of this repository, run:
 
 ```bash
-scripts/bootstrap-standard-extensions.sh --target homeboy-lab
+scripts/bootstrap-standard-extensions.sh --target example-runner
 ```
 
 Use any SSH target accepted by `ssh`:
 
 ```bash
-scripts/bootstrap-standard-extensions.sh --target chubes@homeboy-lab
+scripts/bootstrap-standard-extensions.sh --target operator@example-runner
 ```
 
 The script runs this idempotent install-and-verify loop on the target:
@@ -54,7 +54,7 @@ scripts/bootstrap-standard-extensions.sh
 Preview the exact target script without changing anything:
 
 ```bash
-scripts/bootstrap-standard-extensions.sh --target homeboy-lab --dry-run
+scripts/bootstrap-standard-extensions.sh --target example-runner --dry-run
 ```
 
 ## Repair Existing Installs
@@ -65,7 +65,7 @@ dirty checkout, repair it explicitly with `--replace-existing`:
 
 ```bash
 scripts/bootstrap-standard-extensions.sh \
-    --target homeboy-lab \
+    --target example-runner \
     --extensions "wordpress" \
     --replace-existing
 ```
@@ -82,7 +82,7 @@ refresh pass.
 Use `--extensions` for narrow runners or repair passes:
 
 ```bash
-scripts/bootstrap-standard-extensions.sh --target homeboy-lab --extensions "nodejs rust wordpress"
+scripts/bootstrap-standard-extensions.sh --target example-runner --extensions "nodejs rust wordpress"
 ```
 
 ## GitHub Installs Vs Local Path Installs
@@ -109,8 +109,8 @@ the symlink target points at, so they are easy to leave attached to stale or
 temporary worktrees. Before debugging remote-runner behavior, inspect the target:
 
 ```bash
-ssh homeboy-lab 'homeboy extension list && homeboy extension show rust'
-ssh homeboy-lab 'readlink ~/.config/homeboy/extensions/rust || true'
+ssh example-runner 'homeboy extension list && homeboy extension show rust'
+ssh example-runner 'readlink ~/.config/homeboy/extensions/rust || true'
 ```
 
 If a linked install is stale, reinstall from the GitHub monorepo URL with the
@@ -118,7 +118,7 @@ matching `--id` and `--replace`, or use the bootstrap repair mode:
 
 ```bash
 scripts/bootstrap-standard-extensions.sh \
-    --target homeboy-lab \
+    --target example-runner \
     --extensions "rust" \
     --replace-existing
 ```
@@ -129,8 +129,8 @@ If the target exposes Homeboy under a different command path, pass `--homeboy`:
 
 ```bash
 scripts/bootstrap-standard-extensions.sh \
-    --target homeboy-lab \
-    --homeboy /home/chubes/.local/bin/homeboy
+    --target example-runner \
+    --homeboy /home/operator/.local/bin/homeboy
 ```
 
 To test an extension branch on a runner, pass a repository path or URL with
@@ -139,8 +139,8 @@ should use the canonical GitHub URL.
 
 ```bash
 scripts/bootstrap-standard-extensions.sh \
-    --target homeboy-lab \
-    --repo /home/chubes/src/homeboy-extensions \
+    --target example-runner \
+    --repo /home/operator/src/homeboy-extensions \
     --extensions "rust"
 ```
 
@@ -149,12 +149,12 @@ scripts/bootstrap-standard-extensions.sh \
 After bootstrap, verify the runner from the dispatching machine:
 
 ```bash
-ssh homeboy-lab 'homeboy extension list'
-ssh homeboy-lab 'homeboy extension show nodejs'
-ssh homeboy-lab 'homeboy extension show rust'
-ssh homeboy-lab 'homeboy extension show wordpress'
-ssh homeboy-lab 'homeboy extension show go'
-ssh homeboy-lab 'homeboy extension show swift'
+ssh example-runner 'homeboy extension list'
+ssh example-runner 'homeboy extension show nodejs'
+ssh example-runner 'homeboy extension show rust'
+ssh example-runner 'homeboy extension show wordpress'
+ssh example-runner 'homeboy extension show go'
+ssh example-runner 'homeboy extension show swift'
 ```
 
 For a real offload check, run a Homeboy command for a component that requires one
@@ -173,7 +173,7 @@ Refresh that cache before collecting lab evidence that must point at a known WP
 Codebox revision:
 
 ```bash
-wordpress/scripts/build/update-wp-codebox-cache.sh --runner homeboy-lab --ref main
+wordpress/scripts/build/update-wp-codebox-cache.sh --runner example-runner --ref main
 ```
 
 The helper runs this sequence on the runner:

--- a/managed-preview/README.md
+++ b/managed-preview/README.md
@@ -82,14 +82,14 @@ Homeboy injects `HOMEBOY_SERVICE_LOCAL_URL` and `HOMEBOY_TUNNEL_PUBLIC_URL` into
 
 The broker response must prove `capabilities.hostname_preserving_browser_origin === true` and return browser-origin evidence matching the requested effective origin. A plain port tunnel that changes `window.location.origin` is rejected.
 
-Use `--target-id`, `--target-url`, and repeated `--route name=url` values to carry workload-owned proof targets into broker evidence without teaching this extension product semantics. For WPCOM, the rig can keep the exact `wordpress.com/ai` landing-page proof separate from Calypso `/start` and `/setup/ai-site-builder` proof:
+Use `--target-id`, `--target-url`, and repeated `--route name=url` values to carry workload-owned proof targets into broker evidence without teaching this extension product semantics. For example, a rig can keep an external landing-page proof separate from local application routes:
 
 ```sh
 node scripts/public-preview-backend.mjs \
-  --target-id wpcom-ai-landing \
-  --target-url https://wordpress.com/ai/ \
-  --route landing=https://wordpress.com/ai/ \
-  --route builder_handoff=https://wordpress.com/setup/ai-site-builder \
+  --target-id example-app-landing \
+  --target-url https://example.com/app/ \
+  --route landing=https://example.com/app/ \
+  --route builder_handoff=https://example.com/app/setup \
   --local-url http://127.0.0.1:7331 \
   --public-url https://preview-broker.example/runs/run-123 \
   --broker-url https://preview-broker.example/api/managed-previews \
@@ -98,23 +98,23 @@ node scripts/public-preview-backend.mjs \
 
 ## Hostname-Sensitive Proofs
 
-Some consumers need the browser-effective origin to remain the local development origin. The WPCOM Calypso `/start` proof is one of these: it expects `http://calypso.localhost:3000`, not a tunnel origin.
+Some consumers need the browser-effective origin to remain the local development origin. A hostname-sensitive application proof may expect `http://app.localhost:3000`, not a tunnel origin.
 
 For those consumers, pass `--expected-effective-origin` and `--require-host-preservation`. The helper fails before registering a backend that cannot prove it preserves the browser origin, returning structured blocker JSON on stderr. This keeps reviewer-clickable preview support from being mistaken for exact hostname-preserving proof.
 
 ```sh
 node scripts/public-preview-backend.mjs \
-  --target-id calypso-start \
-  --target-url http://calypso.localhost:3000/start \
-  --route start=http://calypso.localhost:3000/start \
-  --route builder_handoff=http://calypso.localhost:3000/setup/ai-site-builder \
-  --local-url http://calypso.localhost:3000 \
+  --target-id example-app-start \
+  --target-url http://app.localhost:3000/start \
+  --route start=http://app.localhost:3000/start \
+  --route setup=http://app.localhost:3000/setup \
+  --local-url http://app.localhost:3000 \
   --public-url https://preview-broker.example/runs/run-123 \
   --broker-url https://preview-broker.example/api/managed-previews \
-  --expected-effective-origin http://calypso.localhost:3000 \
-  --expected-config-hostname calypso.localhost \
+  --expected-effective-origin http://app.localhost:3000 \
+  --expected-config-hostname app.localhost \
   --require-host-preservation \
   --dry-run
 ```
 
-Until a broker endpoint exists and returns hostname-preserving evidence for `calypso.localhost:3000`, the Calypso `/start` proof should remain blocked rather than downgraded to a different-host tunnel proof.
+Until a broker endpoint exists and returns hostname-preserving evidence for `app.localhost:3000`, the hostname-sensitive proof should remain blocked rather than downgraded to a different-host tunnel proof.

--- a/scripts/bootstrap-standard-extensions.sh
+++ b/scripts/bootstrap-standard-extensions.sh
@@ -19,7 +19,7 @@ Install the standard Homeboy extension set on the local machine or an SSH
 reachable remote runner.
 
 Options:
-  --target <runner-id>        Runner ID such as homeboy-lab. Omit for local bootstrap.
+  --target <runner-id>        Runner ID such as example-runner. Omit for local bootstrap.
   --extensions "<ids>"       Space-separated extension IDs to install.
                              Default: nodejs rust wordpress go swift.
   --repo <url-or-path>        Extension monorepo URL or path.
@@ -33,8 +33,8 @@ Options:
   -h, --help                 Show this help.
 
 Examples:
-  scripts/bootstrap-standard-extensions.sh --target homeboy-lab
-  scripts/bootstrap-standard-extensions.sh --target chubes@homeboy-lab --extensions "nodejs rust wordpress"
+  scripts/bootstrap-standard-extensions.sh --target example-runner
+  scripts/bootstrap-standard-extensions.sh --target operator@example-runner --extensions "nodejs rust wordpress"
   scripts/bootstrap-standard-extensions.sh --repo /path/to/homeboy-extensions --extensions "rust" --dry-run
 USAGE
 }

--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -92,7 +92,7 @@ case "$OUTPUT" in
         ;;
 esac
 
-DRY_RUN_OUTPUT="$("$SCRIPT" --runner homeboy-lab --source "$REMOTE_REPO" --ref fixture-ref --dry-run)"
+DRY_RUN_OUTPUT="$("$SCRIPT" --runner example-runner --source "$REMOTE_REPO" --ref fixture-ref --dry-run)"
 case "$DRY_RUN_OUTPUT" in
     *"Fetching WP Codebox ref"*) ;;
     *)

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -13,10 +13,10 @@ usage() {
     cat <<'USAGE'
 Usage: scripts/update-wp-codebox-cache.sh [options]
 
-Update the WP Codebox source cache used by Homeboy lab runners.
+Update the WP Codebox source cache used by remote Homeboy runners.
 
 Options:
-  --target <runner-id>      Runner ID such as homeboy-lab. Omit to run locally.
+  --target <runner-id>      Runner ID such as example-runner. Omit to run locally.
   --runner <runner-id>      Alias for --target.
   --source <git-url>        WP Codebox repository URL.
                            Default: https://github.com/Automattic/wp-codebox.git
@@ -29,8 +29,8 @@ Options:
   -h, --help                Show this help.
 
 Examples:
-  scripts/update-wp-codebox-cache.sh --target homeboy-lab
-  scripts/update-wp-codebox-cache.sh --runner homeboy-lab --ref main
+  scripts/update-wp-codebox-cache.sh --target example-runner
+  scripts/update-wp-codebox-cache.sh --runner example-runner --ref main
   scripts/update-wp-codebox-cache.sh --source git@github.com:Automattic/wp-codebox.git --ref afe6890
 USAGE
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded personal runner examples with neutral runner placeholders in bootstrap docs and help text.
- Replace WPCOM/Calypso managed-preview proof examples with generic app proof targets.
- Keep changes limited to docs/help/example surfaces and a smoke fixture argument.

## Tests
- `bash -n scripts/bootstrap-standard-extensions.sh wordpress/scripts/build/update-wp-codebox-cache.sh wordpress/scripts/build/update-wp-codebox-cache-smoke.sh`
- `bash wordpress/scripts/build/update-wp-codebox-cache-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying docs/example-only cleanup changes.