### PR TITLE
Normalize WP Codebox fanout runtime task abilities

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -493,6 +493,8 @@ function codeboxFanoutRequestFromAgentTaskRequest(request, config = {}, inputs =
   }
   const workers = normalizeArray(source.workers).map((worker, index) => {
     const metadata = firstObject(worker.metadata) || {};
+    const runtimeTask = fanoutWorkerRuntimeTask(worker, request, config, runtimeOptions);
+    const runtimeTaskAbilityNormalization = runtimeTaskAbilityNormalizationEvidence(runtimeTask);
     return withoutUndefinedValues({
       ...worker,
       id: firstValue(worker.id, worker.worker_id, `${request.task_id}-worker-${index + 1}`),
@@ -500,6 +502,9 @@ function codeboxFanoutRequestFromAgentTaskRequest(request, config = {}, inputs =
       agent: firstValue(worker.agent, source.agent, config.agent, runtimeOptions.agent),
       dependsOn: normalizeArray(firstValue(worker.dependsOn, worker.depends_on)),
       artifactNamespace: firstValue(worker.artifactNamespace, worker.artifact_namespace, `${request.task_id}/${index + 1}`),
+      ...(runtimeTask ? { runtime_task: runtimeTask } : {}),
+      ...(runtimeTaskAbilityNormalization ? { runtime_task_ability_normalization: runtimeTaskAbilityNormalization } : {}),
+      ability_requirements: runtimeTask?.ability ? uniqueStrings([runtimeTask.ability, ...normalizeArray(worker.ability_requirements), ...normalizeArray(worker.abilityRequirements)]) : firstDefined(worker.ability_requirements, worker.abilityRequirements),
       metadata: {
         ...metadata,
         homeboy_task_id: request.task_id,
@@ -532,6 +537,40 @@ function codeboxFanoutRequestFromAgentTaskRequest(request, config = {}, inputs =
       },
     },
   });
+}
+
+function fanoutWorkerRuntimeTask(worker = {}, request = {}, config = {}, runtimeOptions = {}) {
+  const runtimeTask = firstObject(worker.runtime_task, worker.runtimeTask);
+  if (runtimeTask) {
+    return runtimeTaskWithExecutionDefaults(runtimeTask, fanoutWorkerRuntimeTaskDefaults(worker, request, config, runtimeOptions));
+  }
+
+  const abilityRequest = firstObject(worker.ability_request, worker.abilityRequest);
+  const ability = firstValue(
+    abilityRequest?.id,
+    abilityRequest?.name,
+    abilityRequest?.ability,
+    typeof worker.ability === 'string' ? worker.ability : '',
+    worker.ability_name,
+    worker.abilityName
+  );
+  if (!ability || typeof ability !== 'string') {
+    return null;
+  }
+
+  return runtimeTaskWithExecutionDefaults({
+    ability,
+    input: firstObject(abilityRequest?.input, abilityRequest?.args, worker.ability_input, worker.abilityInput, worker.input) || {},
+  }, fanoutWorkerRuntimeTaskDefaults(worker, request, config, runtimeOptions));
+}
+
+function fanoutWorkerRuntimeTaskDefaults(worker = {}, request = {}, config = {}, runtimeOptions = {}) {
+  return {
+    provider: firstValue(worker.provider, config.provider, runtimeOptions.provider),
+    model: firstValue(worker.model, request.executor?.model, config.model, runtimeOptions.model),
+    agentBundles: firstDefined(worker.agent_bundles, worker.agentBundles, runtimeOptions.agentBundles, []),
+    runtimePackage: firstValue(worker.runtime_package, worker.runtimePackage, runtimePackageDefaultFromProfile(config, runtimeOptions)),
+  };
 }
 
 function expectedArtifactsForCodeboxTask(request, artifactDeclarations = []) {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -375,6 +375,87 @@ assert.equal(fanoutRequest.orchestrator.model, 'gpt-5.5');
 assert.deepEqual(fanoutRequest.orchestrator.secret_env_names, ['AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN']);
 assert.equal(fanoutRequest.metadata.homeboy_agent_task.group_key, 'site-generation');
 assert.equal(codeboxTaskRequestFromAgentTaskRequest(fanoutAgentTaskRequest).fanout_request.schema, 'wp-codebox/agent-fanout-request/v1');
+
+const controllerRuntimeTaskFanoutRequest = codeboxFanoutRequestFromAgentTaskRequest({
+  ...fanoutAgentTaskRequest,
+  task_id: 'controller-runtime-task-fanout-1',
+  executor: {
+    ...fanoutAgentTaskRequest.executor,
+    config: {
+      ...fanoutAgentTaskRequest.executor.config,
+      fanout_request: {
+        workers: [{
+          id: 'concept',
+          goal: 'Generate concept packet',
+          runtime_task: {
+            ability: 'runtime-package/run',
+            input: { package: { slug: 'website-idea-agent', source: 'bundles/website-idea-agent' } },
+          },
+        }],
+      },
+    },
+  },
+}, {
+  ...fanoutAgentTaskRequest.executor.config,
+  fanout_request: {
+    workers: [{
+      id: 'concept',
+      goal: 'Generate concept packet',
+      runtime_task: {
+        ability: 'runtime-package/run',
+        input: { package: { slug: 'website-idea-agent', source: 'bundles/website-idea-agent' } },
+      },
+    }],
+  },
+}, fanoutAgentTaskRequest.inputs, {});
+assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.deepEqual(
+  controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.ability_normalization.deprecated_compatibility_alias,
+  legacyRuntimePackageAbilityAlias('runtime-package/run')
+);
+assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.runtime_package, 'website-idea-agent');
+assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.agent, 'website-idea-agent');
+assert.deepEqual(controllerRuntimeTaskFanoutRequest.workers[0].ability_requirements, ['wp-codebox/run-runtime-package']);
+
+const controllerAbilityRequestFanoutRequest = codeboxFanoutRequestFromAgentTaskRequest({
+  ...fanoutAgentTaskRequest,
+  task_id: 'controller-ability-request-fanout-1',
+  executor: {
+    ...fanoutAgentTaskRequest.executor,
+    config: {
+      ...fanoutAgentTaskRequest.executor.config,
+      fanout_request: {
+        workers: [{
+          id: 'design',
+          goal: 'Generate design packet',
+          ability_request: {
+            name: 'homeboy/run-runtime-package',
+            input: { package: { slug: 'design-agent', source: 'bundles/design-agent' } },
+          },
+          ability_requirements: ['wordpress/site-health'],
+        }],
+      },
+    },
+  },
+}, {
+  ...fanoutAgentTaskRequest.executor.config,
+  fanout_request: {
+    workers: [{
+      id: 'design',
+      goal: 'Generate design packet',
+      ability_request: {
+        name: 'homeboy/run-runtime-package',
+        input: { package: { slug: 'design-agent', source: 'bundles/design-agent' } },
+      },
+      ability_requirements: ['wordpress/site-health'],
+    }],
+  },
+}, fanoutAgentTaskRequest.inputs, {});
+assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability_normalization.requested_ability, 'homeboy/run-runtime-package');
+assert.equal(Object.hasOwn(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability_normalization, 'deprecated_compatibility_alias'), false);
+assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.input.runtime_package, 'design-agent');
+assert.deepEqual(controllerAbilityRequestFanoutRequest.workers[0].ability_requirements, ['wp-codebox/run-runtime-package', 'wordpress/site-health']);
 const stableCodeboxInvocation = codeboxRunAgentTaskInvocation({ taskInput });
 assert.equal(stableCodeboxInvocation.contract, runtimeContractSchemas().agentTask.runRequest);
 assert.equal(stableCodeboxInvocation.input.schema, runtimeContractSchemas().agentTask.runRequest);


### PR DESCRIPTION
## Summary
- Normalize controller/fanout worker runtime task abilities through the same WP Codebox runtime-package alias path used by direct task requests.
- Preserve runtime task ability normalization evidence on worker payloads.
- Add normalized runtime task abilities to worker ability requirements so sandbox preflight sees the canonical ability before execution.

Fixes #1915.

## Testing
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor (fails on existing provider-contract fixture mismatch unrelated to this change: agent_fanout_adapter/result_contract/upstream primitive ordering)
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected runtime task normalization paths, implemented fanout worker normalization, added focused boundary tests, and ran verification.