### PR TITLE
Preflight WP Codebox runtime readiness

### DIFF
--- a/agent-runtimes/wp-codebox/index.js
+++ b/agent-runtimes/wp-codebox/index.js
@@ -13,4 +13,5 @@ module.exports = {
 	...require('./lib/provider-preflight-manifest'),
 	...require('./lib/provider-outcome-normalizer'),
 	...require('./lib/wp-codebox-runtime-contract-source'),
+	...require('./lib/wp-codebox-runtime-readiness'),
 };

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-readiness.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-readiness.js
@@ -1,0 +1,162 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  coreModuleCandidates,
+  loadCanonicalRuntimeContractSourceSync,
+} = require('./wp-codebox-runtime-contract-source');
+
+const RUNTIME_READINESS_FAILURE_CLASS = 'codebox.preflight.runtime_readiness';
+const RUNTIME_CONTRACT_FAILURE_CLASS = 'codebox.preflight.runtime_contract_unavailable';
+const RUNTIME_OVERLAY_FAILURE_CLASS = 'codebox.preflight.runtime_overlay_dependency_unprepared';
+const OWNER_SURFACE = 'wp-codebox-runtime-integration';
+
+class WpCodeboxRuntimeReadinessError extends Error {
+  constructor(diagnostics) {
+    super(diagnostics[0]?.message || 'WP Codebox runtime readiness preflight failed.');
+    this.name = 'WpCodeboxRuntimeReadinessError';
+    this.diagnostics = diagnostics;
+  }
+}
+
+function wpCodeboxRuntimeReadinessDiagnostics(taskInput = {}, options = {}) {
+  return [
+    ...runtimeContractReadinessDiagnostics(options),
+    ...runtimeOverlayReadinessDiagnostics(taskInput, options),
+  ];
+}
+
+function assertWpCodeboxRuntimeReady(taskInput = {}, options = {}) {
+  const diagnostics = wpCodeboxRuntimeReadinessDiagnostics(taskInput, options);
+  if (diagnostics.length > 0) {
+    throw new WpCodeboxRuntimeReadinessError(diagnostics);
+  }
+}
+
+function runtimeContractReadinessDiagnostics(options = {}) {
+  try {
+    loadCanonicalRuntimeContractSourceSync({ ...options, required: true });
+    return [];
+  } catch (error) {
+    return [runtimeContractDiagnostic(error, options)];
+  }
+}
+
+function runtimeContractDiagnostic(error, options = {}) {
+  const explicitModule = options.wpCodeboxCoreModule || options.coreModule || process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE || '';
+  const explicitPathMissing = explicitModule && isPathLike(explicitModule) && !fs.existsSync(resolvePath(explicitModule));
+  const message = explicitPathMissing
+    ? `WP Codebox canonical runtime contract manifest is unavailable. HOMEBOY_WP_CODEBOX_CORE_MODULE points to missing path: ${explicitModule}.`
+    : 'WP Codebox canonical runtime contract manifest is unavailable. Install @automattic/wp-codebox-core or configure HOMEBOY_WP_CODEBOX_CORE_MODULE.';
+
+  return {
+    class: RUNTIME_CONTRACT_FAILURE_CLASS,
+    message,
+    data: {
+      phase: 'codebox.preflight',
+      owner_surface: OWNER_SURFACE,
+      remediation: explicitPathMissing
+        ? `Set HOMEBOY_WP_CODEBOX_CORE_MODULE to a valid WP Codebox contracts module path or install @automattic/wp-codebox-core. Missing path: ${explicitModule}`
+        : 'Install @automattic/wp-codebox-core or set HOMEBOY_WP_CODEBOX_CORE_MODULE to the canonical WP Codebox contracts module path.',
+      env: 'HOMEBOY_WP_CODEBOX_CORE_MODULE',
+      configured_module: explicitModule,
+      checked_candidates: coreModuleCandidates(options),
+      errors: normalizeContractErrors(error?.wpCodeboxRuntimeContractErrors),
+    },
+  };
+}
+
+function runtimeOverlayReadinessDiagnostics(taskInput = {}, options = {}) {
+  const overlays = normalizeArray(options.runtimeOverlays || taskInput.runtime_overlays || taskInput.runtimeOverlays);
+  return overlays.flatMap((overlay, index) => runtimeOverlayDiagnostics(overlay, index));
+}
+
+function runtimeOverlayDiagnostics(overlay, index) {
+  if (!overlay || typeof overlay !== 'object' || Array.isArray(overlay)) {
+    return [];
+  }
+
+  const source = overlay.source || overlay.path || '';
+  const library = overlay.library || overlay.name || overlay.slug || '';
+  const requiresComposer = overlay.requires_composer === true
+    || overlay.requiresComposer === true
+    || library === 'php-ai-client'
+    || fs.existsSync(path.join(resolvePath(source), 'composer.json'));
+  if (!requiresComposer) {
+    return [];
+  }
+  if (!source) {
+    return [runtimeOverlayDiagnostic(index, overlay, 'Runtime overlay requires Composer dependencies but does not define a source path.', '')];
+  }
+
+  const resolvedSource = resolvePath(source);
+  if (!fs.existsSync(resolvedSource)) {
+    return [];
+  }
+  const composerJson = path.join(resolvedSource, 'composer.json');
+  if (!fs.existsSync(composerJson)) {
+    return [runtimeOverlayDiagnostic(index, overlay, `Runtime overlay source path is missing composer.json: ${source}.`, resolvedSource)];
+  }
+  if (!fs.existsSync(path.join(resolvedSource, 'vendor', 'autoload.php'))) {
+    return [runtimeOverlayDiagnostic(index, overlay, `Runtime overlay Composer dependencies are not installed: ${source}/vendor/autoload.php is missing.`, resolvedSource)];
+  }
+  return [];
+}
+
+function runtimeOverlayDiagnostic(index, overlay, message, resolvedSource) {
+  const source = overlay?.source || overlay?.path || '';
+  const setupCommand = source ? `composer install --working-dir=${source}` : '';
+  return {
+    class: RUNTIME_OVERLAY_FAILURE_CLASS,
+    message,
+    data: {
+      phase: 'codebox.preflight',
+      owner_surface: OWNER_SURFACE,
+      overlay_index: index,
+      overlay,
+      source,
+      resolved_source: resolvedSource,
+      expected: 'runtime overlay source with prepared Composer vendor/autoload.php',
+      setup_command: setupCommand,
+      remediation: setupCommand ? `Prepare the runtime overlay before dispatch: ${setupCommand}` : 'Provide a prepared runtime overlay source path before dispatch.',
+    },
+  };
+}
+
+function normalizeContractErrors(errors) {
+  return normalizeArray(errors).map((entry) => ({
+    specifier: entry?.specifier || '',
+    message: entry?.message || entry?.error?.message || '',
+  }));
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : (value === undefined || value === null || value === '' ? [] : [value]);
+}
+
+function resolvePath(value) {
+  const raw = String(value || '');
+  if (raw.startsWith('~/')) {
+    return path.join(process.env.HOME || '', raw.slice(2));
+  }
+  return raw ? path.resolve(raw) : '';
+}
+
+function isPathLike(value) {
+  const raw = String(value || '');
+  return raw.startsWith('.') || raw.startsWith('/') || raw.startsWith('~/') || raw.includes('\\');
+}
+
+module.exports = {
+  OWNER_SURFACE,
+  RUNTIME_CONTRACT_FAILURE_CLASS,
+  RUNTIME_OVERLAY_FAILURE_CLASS,
+  RUNTIME_READINESS_FAILURE_CLASS,
+  WpCodeboxRuntimeReadinessError,
+  assertWpCodeboxRuntimeReady,
+  runtimeContractReadinessDiagnostics,
+  runtimeOverlayReadinessDiagnostics,
+  wpCodeboxRuntimeReadinessDiagnostics,
+};

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -15,7 +15,8 @@
     "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js",
     "./wp-codebox-adapter-descriptor": "./lib/wp-codebox-adapter-descriptor.js",
     "./wp-codebox-adapter-contract": "./lib/wp-codebox-adapter-contract.js",
-    "./wp-codebox-runtime-contract-source": "./lib/wp-codebox-runtime-contract-source.js"
+    "./wp-codebox-runtime-contract-source": "./lib/wp-codebox-runtime-contract-source.js",
+    "./wp-codebox-runtime-readiness": "./lib/wp-codebox-runtime-readiness.js"
   },
   "bin": {
     "homeboy-codebox-agent-task-executor": "./scripts/agent/homeboy-codebox-agent-task-executor.cjs"

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -27,6 +27,9 @@ const {
   providerSecretEnv,
 } = require('../../lib/provider-preflight-manifest');
 const {
+  wpCodeboxRuntimeReadinessDiagnostics,
+} = require('../../lib/wp-codebox-runtime-readiness');
+const {
   loadWpCodeboxCore,
 } = requireWpCodeboxCoreLoader();
 
@@ -551,6 +554,25 @@ function runtimeOverlayConfigFailurePayload(error) {
   };
 }
 
+function runtimeReadinessFailurePayload(taskInput) {
+  const diagnostics = wpCodeboxRuntimeReadinessDiagnostics(taskInput);
+  if (diagnostics.length === 0) {
+    return null;
+  }
+  return {
+    success: false,
+    status: 'failed',
+    failure_classification: 'provider',
+    summary: diagnostics[0].message || 'WP Codebox runtime readiness preflight failed.',
+    diagnostics,
+    metadata: {
+      phase: 'codebox.preflight',
+      owner_surface: 'wp-codebox-runtime-integration',
+      runtime_readiness_failed: true,
+    },
+  };
+}
+
 async function runTaskRunner(request) {
   const coreNormalizers = await loadCodeboxCoreNormalizers();
   const runner = argValue('--task-runner') || DEFAULT_TASK_RUNNER;
@@ -564,6 +586,10 @@ async function runTaskRunner(request) {
       return agentTaskOutcomeFromCodeboxResult(request, validationPayload, { exitStatus: 1, ...coreNormalizers });
     }
     throw error;
+  }
+  const runtimeReadinessPayload = runtimeReadinessFailurePayload(taskInput);
+  if (runtimeReadinessPayload) {
+    return agentTaskOutcomeFromCodeboxResult(request, runtimeReadinessPayload, { exitStatus: 1, ...coreNormalizers });
   }
   const missingModelPayload = missingModelPreflightPayload(taskInput);
   if (missingModelPayload) {

--- a/tests/wp-codebox-adapter-boundary-smoke.mjs
+++ b/tests/wp-codebox-adapter-boundary-smoke.mjs
@@ -24,6 +24,7 @@ const stableConsumerExports = [
   './wp-codebox-adapter-contract',
   './wp-codebox-adapter-descriptor',
   './wp-codebox-runtime-contract-source',
+  './wp-codebox-runtime-readiness',
 ];
 const forbidden = /datamachine|data machine|wp-site-generator|wpsg|site generator/i;
 for (const exportName of stableConsumerExports) {

--- a/tests/wp-codebox-runtime-readiness-controller-smoke.mjs
+++ b/tests/wp-codebox-runtime-readiness-controller-smoke.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-readiness-controller-'));
+const executor = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs');
+const coreModule = path.join(rootDir, 'wordpress', 'tests', 'fixtures', 'wp-codebox-core-agent-task-normalizer.mjs');
+
+try {
+  const overlayRoot = path.join(tempRoot, 'php-ai-client');
+  fs.mkdirSync(overlayRoot, { recursive: true });
+  fs.writeFileSync(path.join(overlayRoot, 'composer.json'), '{"name":"fixture/php-ai-client"}\n');
+
+  const runner = path.join(tempRoot, 'runner.cjs');
+  const capture = path.join(tempRoot, 'runner-called.json');
+  fs.writeFileSync(runner, `#!/usr/bin/env node
+'use strict';
+require('node:fs').writeFileSync(${JSON.stringify(capture)}, 'called');
+process.stdout.write(JSON.stringify({ success: true, status: 'completed' }));
+`);
+  fs.chmodSync(runner, 0o755);
+
+  const request = {
+    schema: 'homeboy/agent-task-request/v1',
+    task_id: 'runtime-readiness-controller-smoke',
+    executor: {
+      backend: 'codebox',
+      model: 'gpt-5.5',
+      config: {
+        provider: 'openai',
+        provider_plugin_paths: ['/providers/openai'],
+        runtime_overlays: [{
+          kind: 'bundled-library',
+          library: 'php-ai-client',
+          source: overlayRoot,
+          target: '/wordpress/wp-includes/php-ai-client',
+        }],
+      },
+    },
+    instructions: 'Verify runtime readiness preflight.',
+    workspace: { mode: 'ephemeral' },
+    limits: { timeout_ms: 120000 },
+  };
+
+  const result = spawnSync(process.execPath, [executor, '--task-runner', runner], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: {
+      ...process.env,
+      HOMEBOY_WP_CODEBOX_CORE_MODULE: coreModule,
+    },
+  });
+
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const outcome = JSON.parse(result.stdout);
+  assert.equal(outcome.status, 'failed');
+  assert.equal(outcome.failure_classification, 'provider');
+  const diagnostic = outcome.diagnostics.find((entry) => entry.class === 'codebox.preflight.runtime_overlay_dependency_unprepared');
+  assert.ok(diagnostic, 'runtime overlay dependency diagnostic is emitted');
+  assert.match(diagnostic.message, /vendor\/autoload\.php is missing/);
+  assert.equal(diagnostic.data.setup_command, `composer install --working-dir=${overlayRoot}`);
+  assert.equal(diagnostic.data.owner_surface, 'wp-codebox-runtime-integration');
+  assert.equal(fs.existsSync(capture), false, 'task runner is not spawned when runtime readiness fails');
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+console.log('wp-codebox runtime readiness controller smoke passed');

--- a/tests/wp-codebox-runtime-readiness-smoke.mjs
+++ b/tests/wp-codebox-runtime-readiness-smoke.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
+
+const {
+  RUNTIME_CONTRACT_FAILURE_CLASS,
+  RUNTIME_OVERLAY_FAILURE_CLASS,
+  runtimeContractReadinessDiagnostics,
+  runtimeOverlayReadinessDiagnostics,
+  wpCodeboxRuntimeReadinessDiagnostics,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-readiness-'));
+try {
+  const missingContract = path.join(tempRoot, 'missing-contract.cjs');
+  const contractDiagnostics = runtimeContractReadinessDiagnostics({ wpCodeboxCoreModule: missingContract });
+  assert.equal(contractDiagnostics.length, 1);
+  assert.equal(contractDiagnostics[0].class, RUNTIME_CONTRACT_FAILURE_CLASS);
+  assert.match(contractDiagnostics[0].message, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);
+  assert.match(contractDiagnostics[0].message, /missing-contract\.cjs/);
+  assert.equal(contractDiagnostics[0].data.env, 'HOMEBOY_WP_CODEBOX_CORE_MODULE');
+  assert.equal(contractDiagnostics[0].data.owner_surface, 'wp-codebox-runtime-integration');
+
+  const overlayRoot = path.join(tempRoot, 'php-ai-client');
+  fs.mkdirSync(overlayRoot, { recursive: true });
+  fs.writeFileSync(path.join(overlayRoot, 'composer.json'), '{"name":"fixture/php-ai-client"}\n');
+  const overlayTaskInput = {
+    runtime_overlays: [{
+      kind: 'bundled-library',
+      library: 'php-ai-client',
+      source: overlayRoot,
+      target: '/wordpress/wp-includes/php-ai-client',
+    }],
+  };
+  const overlayDiagnostics = runtimeOverlayReadinessDiagnostics(overlayTaskInput);
+  assert.equal(overlayDiagnostics.length, 1);
+  assert.equal(overlayDiagnostics[0].class, RUNTIME_OVERLAY_FAILURE_CLASS);
+  assert.match(overlayDiagnostics[0].message, /vendor\/autoload\.php is missing/);
+  assert.equal(overlayDiagnostics[0].data.setup_command, `composer install --working-dir=${overlayRoot}`);
+  assert.equal(overlayDiagnostics[0].data.owner_surface, 'wp-codebox-runtime-integration');
+
+  fs.mkdirSync(path.join(overlayRoot, 'vendor'), { recursive: true });
+  fs.writeFileSync(path.join(overlayRoot, 'vendor', 'autoload.php'), "<?php\n");
+  assert.deepEqual(runtimeOverlayReadinessDiagnostics(overlayTaskInput), []);
+  assert.deepEqual(wpCodeboxRuntimeReadinessDiagnostics(overlayTaskInput), []);
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+console.log('wp-codebox runtime readiness smoke passed');


### PR DESCRIPTION
## Summary
- Add WP Codebox runtime readiness diagnostics for canonical runtime contract availability and Composer-prepared runtime overlays.
- Fail the WP Codebox controller preflight before spawning the task runner when runtime readiness blocks execution.
- Add focused smoke coverage for readiness diagnostics, controller pre-spawn failure, and runtime package export coverage.

Closes #1916.

## Tests
- `node tests/wp-codebox-runtime-readiness-smoke.mjs`
- `node tests/wp-codebox-runtime-readiness-controller-smoke.mjs`
- `node tests/wp-codebox-adapter-boundary-smoke.mjs`
- `git diff --check`

## Notes
- `node wordpress/tests/codebox-agent-task-executor-smoke.js` currently fails before this change's assertions on existing manifest/providerContract drift between `agent-runtimes/wp-codebox/wp-codebox.json` and `providerContract()`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the WP Codebox runtime readiness preflight, focused tests, verification, and PR preparation.
