### PR TITLE
Declare WP Codebox runner diagnostics

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -102,6 +102,91 @@
     },
     "required_paths": ["runtime_bin"]
   },
+  "materialization": {
+    "diagnostics": {
+      "tools": [
+        {
+          "tool": "wp-codebox",
+          "legacy_output": "wp_codebox",
+          "configured_binary_env": [
+            "HOMEBOY_WP_CODEBOX_BIN",
+            "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"
+          ],
+          "install_dir_env": "HOMEBOY_WP_CODEBOX_INSTALL_DIR",
+          "default_install_dir": "${HOME}/.cache/homeboy/wp-codebox",
+          "managed_cache_source": "${install_dir}/source",
+          "managed_cache_binary": "${managed_cache_source}/packages/cli/dist/index.js",
+          "effective_binary_rule": "managed cache binary wins when executable; otherwise configured binary, then PATH",
+          "diagnostic_script": "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; revision=$(git -C \"$managed_source\" rev-parse --short HEAD 2>/dev/null || true); printf 'configured_binary=%s\\nmanaged_cache_source=%s\\nmanaged_cache_binary=%s\\neffective_binary=%s\\neffective_source=%s\\nmanaged_cache_revision=%s\\n' \"${configured:-}\" \"$managed_source\" \"$managed_binary\" \"${effective:-}\" \"$source\" \"${revision:-}\""
+        }
+      ],
+      "runtimes": [
+        {
+          "tool": "wp-codebox",
+          "legacy_output": "wp_codebox_runtime",
+          "configured_binary_env": [
+            "HOMEBOY_WP_CODEBOX_BIN",
+            "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"
+          ],
+          "install_dir_env": "HOMEBOY_WP_CODEBOX_INSTALL_DIR",
+          "default_install_dir": "${HOME}/.cache/homeboy/wp-codebox",
+          "managed_cache_source": "${install_dir}/source",
+          "managed_cache_binary": "${managed_cache_source}/packages/cli/dist/index.js",
+          "effective_binary_rule": "managed cache binary wins when executable; otherwise configured binary, then PATH",
+          "packages": [
+            {
+              "field": "playground_package",
+              "package": "@automattic/wp-codebox-playground",
+              "expected_path": "${managed_cache_source}/packages/playground"
+            },
+            {
+              "field": "core_package",
+              "package": "@automattic/wp-codebox-core",
+              "expected_path": "${managed_cache_source}/packages/core",
+              "env_override": "HOMEBOY_WP_CODEBOX_CORE_MODULE"
+            }
+          ],
+          "probes": [
+            {
+              "field": "source_git_sha",
+              "source": "runtime_probe_command"
+            },
+            {
+              "field": "dist_build_freshness",
+              "source": "runtime_probe_command"
+            }
+          ],
+          "runtime_probe_script": "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; resolve_pkg() { node -e 'const path=require(\"path\"); try { const p=require.resolve(process.argv[2] + \"/package.json\", { paths: [process.argv[1]] }); process.stdout.write(path.dirname(p)); } catch (error) {}' \"$managed_source\" \"$1\" 2>/dev/null || true; }; playground=$(resolve_pkg @automattic/wp-codebox-playground); core=$(resolve_pkg @automattic/wp-codebox-core); if [ -z \"$core\" ] && [ -n \"${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}\" ]; then core=$HOMEBOY_WP_CODEBOX_CORE_MODULE; fi; revision=$(git -C \"$managed_source\" rev-parse HEAD 2>/dev/null || true); if [ ! -e \"$managed_binary\" ]; then dist_state=missing; elif find \"$managed_source/packages/cli/src\" -type f -newer \"$managed_binary\" 2>/dev/null | read newer; then dist_state=stale; else dist_state=fresh; fi; printf 'cli_binary=%s\\ncli_binary_source=%s\\nmanaged_cache_source=%s\\nmanaged_cache_binary=%s\\nplayground_path=%s\\ncore_path=%s\\nsource_git_sha=%s\\ndist_build_freshness=%s\\n' \"${effective:-}\" \"$source\" \"$managed_source\" \"$managed_binary\" \"${playground:-}\" \"${core:-}\" \"${revision:-}\" \"$dist_state\"",
+          "source_consistency": [
+            {
+              "id": "wp_codebox.mixed_cli_source",
+              "severity": "warning",
+              "path": "configured_binary",
+              "root": "${managed_cache_source}",
+              "message": "Configured WP Codebox CLI `${path}` is outside managed cache `${root}`; runner jobs may mix a stale CLI with managed package sources.",
+              "remediation": "Unset HOMEBOY_WP_CODEBOX_BIN/HOMEBOY_SETTINGS_WP_CODEBOX_BIN or point it at the managed cache binary reported here."
+            },
+            {
+              "id": "wp_codebox.mixed_core_source",
+              "severity": "warning",
+              "path": "HOMEBOY_WP_CODEBOX_CORE_MODULE",
+              "root": "${managed_cache_source}",
+              "message": "Resolved WP Codebox core path `${path}` is outside managed cache `${root}`; runner jobs may mix core and playground builds.",
+              "remediation": "Refresh the WordPress extension setup/runtime env so HOMEBOY_WP_CODEBOX_CORE_MODULE resolves from the same managed WP Codebox checkout used by the CLI."
+            }
+          ]
+        }
+      ],
+      "followups": [
+        {
+          "label": "wp_codebox_effective_binary",
+          "legacy_output": "managed_followups",
+          "command_script": "configured=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}; install_dir=${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}; managed_source=$install_dir/source; managed_binary=$managed_source/packages/cli/dist/index.js; if [ -x \"$managed_binary\" ]; then effective=$managed_binary; source=managed_cache; elif [ -n \"$configured\" ]; then effective=$configured; source=configured; else effective=$(command -v wp-codebox 2>/dev/null || true); source=path; fi; revision=$(git -C \"$managed_source\" rev-parse --short HEAD 2>/dev/null || true); printf 'configured_binary=%s\\nmanaged_cache_source=%s\\nmanaged_cache_binary=%s\\neffective_binary=%s\\neffective_source=%s\\nmanaged_cache_revision=%s\\n' \"${configured:-}\" \"$managed_source\" \"$managed_binary\" \"${effective:-}\" \"$source\" \"${revision:-}\"",
+          "purpose": "Print the configured WP Codebox binary, managed cache binary/source, effective binary/source, and managed cache revision used by runner workloads."
+        }
+      ]
+    }
+  },
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",


### PR DESCRIPTION
## Summary
- declare WP Codebox runner status/env diagnostics in the runtime manifest
- preserve the legacy runner status/env output slots via declared diagnostic metadata
- move the effective-binary followup command into runtime data

Depends on Homeboy core contract PR: https://github.com/Extra-Chill/homeboy/pull/6531

## Tests
- node -e "JSON.parse(require('fs').readFileSync('agent-runtimes/wp-codebox/wp-codebox.json','utf8'))"
- node tests/agent-runtime-package-surface-smoke.mjs
- npm run test:wp-codebox-adapter-boundary (agent-runtimes/wp-codebox)
- npm run test:wp-codebox-adapter-contract (agent-runtimes/wp-codebox)
- npm run test:wp-codebox-runtime-contract-source (agent-runtimes/wp-codebox)
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and verified runner diagnostic contract cleanup.
