### PR TITLE
Add canonical fuzz result envelope

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -26,6 +26,7 @@ const { aggregateWordPressFuzzCoverage } = require('./wordpress-fuzz-coverage-ag
 
 const WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA = 'homeboy/wordpress-fuzz-runner-result/v1';
 const HOMEBOY_FUZZ_CAMPAIGN_SCHEMA = 'homeboy/fuzz-campaign/v1';
+const HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA = 'homeboy/fuzz-result-envelope/v1';
 const HOMEBOY_FUZZ_CONTRACT_VERSION = 1;
 
 function readWordPressFuzzRunnerEnv(env = process.env) {
@@ -119,7 +120,8 @@ function buildWordPressFuzzRunnerSummary({
 }) {
 	const coverage = aggregateCoverage(workload, codeboxResult);
 	const status = normalizeRunnerStatus(codeboxResult, coverage);
-	const homeboyFuzzCampaign = buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, status });
+	const homeboyFuzzResultEnvelope = buildHomeboyFuzzResultEnvelope({ runId, workloadId, seed, maxDuration, workload, plan, codeboxResult, status, runtimeTaskRequest, taskRequest });
+	const homeboyFuzzCampaign = buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, status, homeboyFuzzResultEnvelope });
 
 	return stripUndefined({
 		schema: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
@@ -143,6 +145,7 @@ function buildWordPressFuzzRunnerSummary({
 		observation_set: codeboxResult.observation_set,
 		hotspot_summary: codeboxResult.hotspot_summary || coverage?.hotspot_summary,
 		homeboy_fuzz_campaign: homeboyFuzzCampaign,
+		homeboy_fuzz_result_envelope: homeboyFuzzResultEnvelope,
 		metadata: objectOrUndefined(workload.metadata),
 	});
 }
@@ -389,7 +392,7 @@ function normalizeRunnerStatus(codeboxResult, coverage) {
 	return status;
 }
 
-function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, status }) {
+function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, status, homeboyFuzzResultEnvelope }) {
 	const diagnostics = normalizeArray(codeboxResult?.failures || codeboxResult?.metadata?.diagnostics || codeboxResult?.diagnostics);
 	return stripUndefined({
 		schema: HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
@@ -410,7 +413,114 @@ function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, stat
 			hotspot_summary: codeboxResult?.hotspot_summary,
 			observation: codeboxResult?.observation,
 			wordpress_fuzz_result: codeboxResult?.wordpress_fuzz_result,
+			fuzz_result_envelope: homeboyFuzzResultEnvelope,
 		}),
+	});
+}
+
+function buildHomeboyFuzzResultEnvelope({ runId, workloadId, seed, maxDuration, workload, plan, codeboxResult, status, runtimeTaskRequest, taskRequest }) {
+	const artifacts = normalizeArray(codeboxResult?.artifacts);
+	const requiredArtifacts = requiredFuzzArtifactStatuses({ artifacts, runtimeTaskRequest, taskRequest, workload });
+	const failures = normalizeArray(codeboxResult?.failures || codeboxResult?.metadata?.diagnostics || codeboxResult?.diagnostics);
+	return stripUndefined({
+		schema: HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA,
+		version: HOMEBOY_FUZZ_CONTRACT_VERSION,
+		id: codeboxResult?.request_id || runId,
+		status,
+		succeeded: codeboxResult?.succeeded,
+		campaign: stripUndefined({
+			id: runId,
+			workload_id: workloadId,
+			plan_id: plan?.id,
+			safety_class: deriveHomeboyFuzzSafetyClass(plan),
+			seed,
+			max_duration_seconds: maxDuration,
+			metadata: objectOrUndefined(workload?.metadata),
+		}),
+		result: stripUndefined({
+			provider: 'wp-codebox',
+			provider_result_schema: codeboxResult?.result_schema,
+			wordpress_fuzz_result: codeboxResult?.wordpress_fuzz_result,
+			observation: codeboxResult?.observation,
+			observation_set: codeboxResult?.observation_set,
+			hotspot_summary: codeboxResult?.hotspot_summary,
+		}),
+		artifacts,
+		gates: stripUndefined({
+			required_artifacts: requiredArtifacts.length > 0 ? requiredArtifacts : undefined,
+			failures: failures.length > 0 ? failures : undefined,
+		}),
+		dispatch: fuzzDispatchIdentity({ codeboxResult, runtimeTaskRequest, taskRequest }),
+	});
+}
+
+function requiredFuzzArtifactStatuses({ artifacts = [], runtimeTaskRequest = {}, taskRequest = {}, workload = {} } = {}) {
+	const declarations = dedupeRequiredArtifactDeclarations([
+		...normalizeArray(runtimeTaskRequest.artifact_declarations),
+		...normalizeArray(taskRequest.artifact_declarations),
+		...normalizeArray(workload?.artifacts?.expected),
+		...normalizeArray(workload?.artifacts?.required),
+		...normalizeArray(workload?.cases).flatMap((entry) => normalizeArray(entry?.artifacts).filter((artifact) => artifact?.required === true)),
+	]);
+	return declarations.map((declaration) => stripUndefined({
+		name: declaration.name,
+		role: declaration.role || declaration.kind,
+		semantic_key: declaration.semantic_key || declaration.semanticKey || declaration.metadata?.semantic_key,
+		schema: declaration.schema || declaration.metadata?.schema,
+		path: declaration.path,
+		required: declaration.required !== false,
+		status: artifacts.some((artifact) => fuzzArtifactMatchesDeclaration(artifact, declaration)) ? 'present' : 'missing',
+	}));
+}
+
+function dedupeRequiredArtifactDeclarations(declarations = []) {
+	const seen = new Set();
+	return declarations.filter((declaration) => {
+		if (!objectOrUndefined(declaration)) {
+			return false;
+		}
+		if (declaration.required === false) {
+			return false;
+		}
+		const key = [
+			declaration.name,
+			declaration.path,
+			declaration.semantic_key || declaration.semanticKey || declaration.metadata?.semantic_key,
+			declaration.schema || declaration.metadata?.schema,
+		].filter(Boolean).join(':');
+		if (!key || seen.has(key)) {
+			return false;
+		}
+		seen.add(key);
+		return true;
+	});
+}
+
+function fuzzArtifactMatchesDeclaration(artifact = {}, declaration = {}) {
+	const declarationSemanticKey = declaration.semantic_key || declaration.semanticKey || declaration.metadata?.semantic_key;
+	const artifactSemanticKey = artifact.semantic_key || artifact.semanticKey || artifact.metadata?.semantic_key;
+	const declarationSchema = declaration.schema || declaration.metadata?.schema;
+	const artifactSchema = artifact.schema || artifact.metadata?.schema;
+	return Boolean(
+		(declaration.name && artifact.name === declaration.name)
+		|| (declaration.path && artifact.path === declaration.path)
+		|| (declarationSemanticKey && artifactSemanticKey === declarationSemanticKey)
+		|| (declarationSchema && artifactSchema === declarationSchema)
+	);
+}
+
+function fuzzDispatchIdentity({ codeboxResult = {}, runtimeTaskRequest = {}, taskRequest = {} } = {}) {
+	const runtimeTaskResult = objectOrUndefined(codeboxResult.runtime_task_result) || {};
+	const provider = runtimeTaskResult.provider || runtimeTaskRequest.provider;
+	const taskId = runtimeTaskResult.task_id || runtimeTaskRequest.task_id || taskRequest.task_id || codeboxResult.request_id;
+	if (!taskId && !provider?.id && !taskRequest.executor?.runtime) {
+		return undefined;
+	}
+	return stripUndefined({
+		task_id: taskId,
+		provider: provider?.id || provider,
+		runtime: taskRequest.executor?.runtime || runtimeTaskRequest.provider_metadata?.wp_codebox?.runtime,
+		ability: taskRequest.executor?.config?.runtime_task?.ability || runtimeTaskRequest.provider_metadata?.wp_codebox?.ability,
 	});
 }
 
@@ -555,6 +665,7 @@ function stripUndefined(value) {
 
 module.exports = {
 	HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
+	HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA,
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
 	runWordPressFuzzRunnerResult,

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -28,6 +28,7 @@ Module._load = function loadWithoutRuntimeAgentCi(request, parent, isMain) {
 
 const {
 	HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
+	HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA,
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
 	runWordPressFuzzRunnerResult,
@@ -101,6 +102,18 @@ assert.equal(result.homeboy_fuzz_campaign.safety_class, 'read_only');
 assert.equal(result.homeboy_fuzz_campaign.metadata.status, 'unsupported');
 assert.equal(result.homeboy_fuzz_campaign.metadata.wp_codebox_result_schema, 'wp-codebox/fuzz-suite-result/v1');
 assert.equal(result.homeboy_fuzz_campaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
+assert.equal(result.homeboy_fuzz_result_envelope.schema, HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA);
+assert.equal(result.homeboy_fuzz_result_envelope.version, 1);
+assert.equal(result.homeboy_fuzz_result_envelope.id, 'run-from-env');
+assert.equal(result.homeboy_fuzz_result_envelope.campaign.id, 'run-from-env');
+assert.equal(result.homeboy_fuzz_result_envelope.campaign.workload_id, 'workload-from-env');
+assert.equal(result.homeboy_fuzz_result_envelope.campaign.plan_id, 'generic-wordpress-plan');
+assert.equal(result.homeboy_fuzz_result_envelope.campaign.seed, 'seed-123');
+assert.equal(result.homeboy_fuzz_result_envelope.campaign.max_duration_seconds, 30);
+assert.equal(result.homeboy_fuzz_result_envelope.gates.required_artifacts.some((artifact) => artifact.name === 'result-envelope' && artifact.status === 'present'), true);
+assert.equal(result.homeboy_fuzz_result_envelope.gates.required_artifacts.some((artifact) => artifact.name === 'wordpress-fuzz-coverage' && artifact.status === 'missing'), true);
+assert.equal(result.homeboy_fuzz_result_envelope.dispatch.task_id, 'run-from-env');
+assert.equal(result.homeboy_fuzz_campaign.metadata.fuzz_result_envelope.schema, HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA);
 assert.equal(result.observation.schema, 'homeboy/wordpress-fuzz-observation/v1');
 assert.equal(result.homeboy_fuzz_campaign.metadata.observation.schema, 'homeboy/wordpress-fuzz-observation/v1');
 assert(!JSON.stringify(result).includes('woocommerce'), 'WordPress fuzz runner must stay product-agnostic');
@@ -128,6 +141,8 @@ assert.equal(executedResult.status, 'succeeded');
 assert.equal(executedResult.succeeded, true);
 assert.equal(executedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'artifacts/replay.json');
 assert.equal(executedResult.homeboy_fuzz_campaign.artifacts.some((artifact) => artifact.id === 'result-envelope' && artifact.kind === 'result_envelope'), true);
+assert.equal(executedResult.homeboy_fuzz_result_envelope.artifacts[0].path, 'artifacts/replay.json');
+assert.equal(executedResult.homeboy_fuzz_result_envelope.gates.required_artifacts.find((artifact) => artifact.name === 'result-envelope').status, 'present');
 assert.equal(executedResult.observation.status, 'succeeded');
 
 const mutatingPlanResult = buildWordPressFuzzRunnerResult({
@@ -469,6 +484,8 @@ assert.equal(homeboyCampaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
 assert.equal(homeboyCampaign.version, 1);
 assert.equal(homeboyCampaign.id, 'cli-run');
 assert.equal(homeboyCampaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
+assert.equal(homeboyCampaign.metadata.fuzz_result_envelope.schema, HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA);
+assert.equal(homeboyCampaign.metadata.fuzz_result_envelope.campaign.workload_id, 'cli-workload');
 
 const fakeCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-wp-codebox.js');
 const emptyCodeboxInstallRoot = path.join(tempDir, 'empty-wp-codebox-install');


### PR DESCRIPTION
## Summary
- Add a `homeboy/fuzz-result-envelope/v1` result alongside the existing WordPress fuzz runner output.
- Include campaign metadata, artifact refs, required artifact status, failure gates, and dispatch identity when available.
- Preserve the existing `homeboy_fuzz_campaign`, WordPress-specific result fields, and persisted campaign file shape.

## Testing
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wordpress-fuzz-runner-codebox-contract`
- `npm run test:wp-codebox-fuzz-suite`
- `npm run lint:js -- lib/wordpress-fuzz-runner.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the canonical fuzz result envelope slice, updating tests, and running verification.
