### PR TITLE
Pass controller execution run mode flags

### DIFF
--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -243,6 +243,10 @@ function normalizeControllerExecution(value) {
     policy_result: stringValue(value.policy_result || value.policyResult || value.policy_result_path || value.policyResultPath),
     output: stringValue(value.output || value.output_path || value.outputPath),
     max_actions: positiveInteger(value.max_actions || value.maxActions) || 100,
+    reconcile_stale: booleanValue(value.reconcile_stale ?? value.reconcileStale),
+    replace: booleanValue(value.replace),
+    fork: booleanValue(value.fork),
+    resume_existing: booleanValue(value.resume_existing ?? value.resumeExisting),
     prepare: normalizeArray(value.prepare || value.prepare_commands || value.prepareCommands),
     env: optionalObject(value.env),
     metadata: optionalObject(value.metadata),
@@ -308,6 +312,7 @@ function defaultExecuteControllerExecution(options = {}) {
   if (controllerExecution.output) {
     args.push('--output', controllerExecution.output);
   }
+  args.push(...controllerExecutionRunModeArgs(controllerExecution));
   const run = spawnSync(homeboyBin, args, { cwd, env, encoding: 'utf8' });
   if (run.status !== 0) {
     return {
@@ -327,6 +332,19 @@ function defaultExecuteControllerExecution(options = {}) {
     stderr: run.stderr || '',
     result: parsed,
   };
+}
+
+function controllerExecutionRunModeArgs(controllerExecution) {
+  const modes = [
+    ['reconcile_stale', '--reconcile-stale'],
+    ['replace', '--replace'],
+    ['fork', '--fork'],
+    ['resume_existing', '--resume-existing'],
+  ].filter(([key]) => controllerExecution[key] === true);
+  if (modes.length > 1) {
+    throw new Error(`controller_execution run mode flags are mutually exclusive: ${modes.map(([, flag]) => flag).join(', ')}`);
+  }
+  return modes.map(([, flag]) => flag);
 }
 
 function resolveControllerCwd(plan = {}, options = {}) {
@@ -1048,6 +1066,10 @@ function loopStatus(taskResults) {
 function positiveInteger(value) {
   const parsed = Number.parseInt(value || '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function booleanValue(value) {
+  return value === true || value === 'true';
 }
 
 function optionalObject(value) {

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -306,6 +306,44 @@ assert.equal(controllerBacked.tasks[0].outcome.metadata.controller_execution.max
 assert.equal(controllerBacked.tasks[0].outcome.metadata.controller_result.loop_id, 'controller-backed-loop');
 assert.equal(controllerRequest.controller_execution.spec, '.github/homeboy/controllers/static-site-generation-loop.controller.json');
 
+const controllerTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-controller-execution-'));
+try {
+  const argvFile = path.join(controllerTmpRoot, 'argv.json');
+  const fakeHomeboy = path.join(controllerTmpRoot, 'homeboy.js');
+  fs.writeFileSync(fakeHomeboy, `#!/usr/bin/env node
+const fs = require('node:fs');
+const argv = process.argv.slice(2);
+fs.writeFileSync(process.env.HOMEBOY_ARGV_FILE, JSON.stringify(argv));
+const outputIndex = argv.indexOf('--output');
+if (outputIndex !== -1) {
+  fs.writeFileSync(argv[outputIndex + 1], JSON.stringify({ schema: 'fixture/controller-result', loop_id: 'controller-reconcile-loop' }));
+}
+`);
+  fs.chmodSync(fakeHomeboy, 0o755);
+  const defaultController = await runHeadlessDeterministicLoop({
+    spec: {
+      ...baseSpec,
+      task_id: 'controller-reconcile-loop',
+      workload_id: 'controller-reconcile-loop',
+      component_path: controllerTmpRoot,
+      controller_execution: {
+        spec: 'controller.json',
+        output: path.join(controllerTmpRoot, 'controller-result.json'),
+        reconcile_stale: true,
+        env: { HOMEBOY_ARGV_FILE: argvFile },
+      },
+    },
+    runtime,
+    validate: false,
+    homeboyBin: fakeHomeboy,
+  });
+  assert.equal(defaultController.status, 'succeeded');
+  assert.ok(JSON.parse(fs.readFileSync(argvFile, 'utf8')).includes('--reconcile-stale'));
+  assert.equal(defaultController.tasks[0].outcome.metadata.controller_execution.reconcile_stale, true);
+} finally {
+  fs.rmSync(controllerTmpRoot, { recursive: true, force: true });
+}
+
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-headless-loop-policy-'));
 try {
   const loopPolicyFile = path.join(tmpRoot, 'loop-policy.json');


### PR DESCRIPTION
## Summary
- allow controller_execution specs to request Homeboy run mode flags
- pass reconcile_stale, replace, fork, or resume_existing through to controller run-from-spec
- cover reconcile_stale in the headless deterministic loop test

## Tests
- node runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing and testing the controller execution flag plumbing.