### PR TITLE
Stop advertising legacy runtime package aliases

### DIFF
--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -58,10 +58,12 @@ in this adapter so the follow-up swap can remove the fallback while preserving
 Homeboy caller contracts.
 
 Runtime-package ability aliases are quarantined compatibility only. New callers
-should invoke `wp-codebox/run-runtime-package`; legacy `agents/run-runtime-package`
-and `runtime-package/run` requests still normalize to that Codebox-owned ability
-and include `deprecated_compatibility_alias` metadata so controllers can warn and
-migrate without breaking active callers.
+should invoke `wp-codebox/run-runtime-package`; generic callers may use
+`homeboy/run-runtime-package`. The provider contract no longer advertises legacy
+`agents/run-runtime-package` or `runtime-package/run` aliases, but explicit legacy
+requests still normalize to the Codebox-owned ability and include
+`deprecated_compatibility_alias` metadata so controllers can warn and migrate
+without breaking active callers.
 
 Provider credentials stay outside adapter payloads. The adapter forwards
 `secret_env` names and a `provider_credential_boundary` descriptor, and rejects

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -87,13 +87,6 @@ const RUNTIME_PACKAGE_ABILITY_ALIASES = new Set([
   ...LEGACY_RUNTIME_PACKAGE_ABILITIES,
 ]);
 const LEGACY_RUNTIME_PACKAGE_ABILITY_QUARANTINE = 'legacy-runtime-package-ability-alias';
-const LEGACY_RUNTIME_PACKAGE_ABILITY_DEPRECATIONS = Array.from(LEGACY_RUNTIME_PACKAGE_ABILITIES).map((ability) => ({
-  schema: 'wp-codebox/deprecated-compatibility-alias/v1',
-  alias: ability,
-  replacement: WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY,
-  quarantine: LEGACY_RUNTIME_PACKAGE_ABILITY_QUARANTINE,
-  status: 'deprecated',
-}));
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
@@ -201,7 +194,6 @@ function providerContract(options = {}) {
     provider_runtime_invocation: providerRuntimeInvocationContract(),
     agent_fanout_adapter: wpCodeboxAgentFanoutAdapterContract(),
     role_aliases: WP_CODEBOX_ROLE_ALIASES,
-    deprecated_compatibility_aliases: LEGACY_RUNTIME_PACKAGE_ABILITY_DEPRECATIONS,
     upstream_primitive_requirements: WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
     status: 'active',
     integration_contract: 'homeboy-wordpress-agent-task/v1',

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -612,22 +612,6 @@
           "require_typed_artifacts": true
         }
       },
-      "deprecated_compatibility_aliases": [
-        {
-          "schema": "wp-codebox/deprecated-compatibility-alias/v1",
-          "alias": "agents/run-runtime-package",
-          "replacement": "wp-codebox/run-runtime-package",
-          "quarantine": "legacy-runtime-package-ability-alias",
-          "status": "deprecated"
-        },
-        {
-          "schema": "wp-codebox/deprecated-compatibility-alias/v1",
-          "alias": "runtime-package/run",
-          "replacement": "wp-codebox/run-runtime-package",
-          "quarantine": "legacy-runtime-package-ability-alias",
-          "status": "deprecated"
-        }
-      ],
       "upstream_primitive_requirements": [
         {
           "id": "run-agent-task",

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -75,10 +75,7 @@ assert.equal(provider.agent_fanout_adapter.ownership.executor_adapter, 'homeboy-
 assert.equal(provider.agent_fanout_adapter.ownership.sandbox_worker_runtime, 'wp-codebox');
 assert.equal(provider.upstream_primitive_requirements.some((requirement) => requirement.id === 'provider-credential-boundary'), true);
 assert.equal(provider.upstream_primitive_requirements.some((requirement) => requirement.id === 'agent-fanout-request' && requirement.schema === 'wp-codebox/agent-fanout-request/v1'), true);
-assert.deepEqual(provider.deprecated_compatibility_aliases, [
-  legacyRuntimePackageAbilityAlias('agents/run-runtime-package'),
-  legacyRuntimePackageAbilityAlias('runtime-package/run'),
-]);
+assert.equal(Object.hasOwn(provider, 'deprecated_compatibility_aliases'), false);
 assert.deepEqual(provider.provider_runtime_invocation, providerRuntimeInvocationContract());
 assert.equal(provider.provider_runtime_invocation.tasks.workspaceCommand, 'wp-codebox.runner-workspace.command');
 assert.equal(provider.provider_runtime_invocation.abilities.workspaceCommand, 'wp-codebox/runner-workspace-command');
@@ -233,6 +230,7 @@ assert.equal(runtime.agent_task_executors[0].id, provider.id);
 assert.equal(runtime.agent_task_executors[0].backend, provider.backend);
 assert.equal(runtime.agent_task_executors[0].runtime_id, provider.runtime_id);
 assert.equal(runtime.agent_task_executors[0].integration_contract, provider.integration_contract);
+assert.equal(Object.hasOwn(runtime.agent_task_executors[0], 'deprecated_compatibility_aliases'), false);
 assert.equal(runtime.agent_task_executors[0].upstream_primitive_requirements.some((requirement) => requirement.id === 'run-agent-task' && requirement.schema === 'wp-codebox/run-agent-task/v1'), true);
 assert.deepEqual(provider.provider_runtime_invocation, providerRuntimeInvocationContract());
 assert.deepEqual(provider.runner_readiness, [{


### PR DESCRIPTION
## Summary
- Remove deprecated runtime-package ability alias advertising from the WP Codebox provider contract and runtime manifest.
- Keep explicit legacy request normalization for active callers, including deprecated compatibility metadata on normalized tasks.
- Update boundary tests and WP Codebox runtime docs to reflect the canonical advertised ability path.

## Tests
- npm run test:codebox-agent-task-executor-boundary (agent-runtimes/wp-codebox)
- npm run test:wp-codebox-adapter-boundary (agent-runtimes/wp-codebox)
- npm run test:wp-codebox-adapter-contract (agent-runtimes/wp-codebox)
- npm run test:codebox-agent-task-executor-boundary (wordpress)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting alias usage, editing runtime provider/manifest/tests/docs, running verification, and drafting this PR description.