### PR TITLE
Echo dispatch identity in runtime outputs

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -3274,6 +3274,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   assertAgentTaskRequest(request);
   const publicResultEnvelope = codeboxPublicResultEnvelope(result, options);
   const envelopeOptions = { ...options, publicResultEnvelope };
+  const dispatchIdentity = agentTaskDispatchIdentityPassthrough(request, result);
   const normalizedEventEnvelope = normalizeCodeboxAgentTaskEvents(request, result, envelopeOptions);
   const runSummary = codeboxRunSummary(result, envelopeOptions);
   const recipeSummary = codeboxRecipeRunSummary(result, envelopeOptions);
@@ -3328,6 +3329,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary, envelopeOptions)),
       artifact_declarations: sanitizePublicMetadata(artifactDeclarationsMetadataFromRequest(request)),
       typed_artifacts: sanitizePublicMetadata(outputs.typed_artifacts || {}),
+      dispatch_identity: dispatchIdentity ? sanitizePublicMetadata(dispatchIdentity) : undefined,
       normalized_events: sanitizePublicMetadata(normalizedEventEnvelope.events),
       sandbox_policy: sanitizePublicMetadata({
         policy: result.task_input?.policy,
@@ -3343,6 +3345,33 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     outcome.failure_classification = 'execution_failed';
   }
   return outcomeWithOutputTypedArtifacts(outcomeWithNormalizedEvents(outcome, normalizedEventEnvelope.events), outputs);
+}
+
+function agentTaskDispatchIdentityPassthrough(request = {}, result = {}) {
+  return firstObject(
+    request.dispatch_identity,
+    request.dispatchIdentity,
+    request.inputs?.dispatch_identity,
+    request.inputs?.dispatchIdentity,
+    request.inputs?.input?.dispatch_identity,
+    request.inputs?.input?.dispatchIdentity,
+    request.inputs?.input?.metadata?.dispatch_identity,
+    request.inputs?.input?.metadata?.dispatchIdentity,
+    request.executor?.config?.runtime_task?.input?.dispatch_identity,
+    request.executor?.config?.runtime_task?.input?.dispatchIdentity,
+    request.executor?.config?.runtime_task?.input?.metadata?.dispatch_identity,
+    request.executor?.config?.runtime_task?.input?.metadata?.dispatchIdentity,
+    result.dispatch_identity,
+    result.dispatchIdentity,
+    result.metadata?.dispatch_identity,
+    result.metadata?.dispatchIdentity,
+    result.task_input?.dispatch_identity,
+    result.task_input?.dispatchIdentity,
+    result.task_input?.runtime_task?.input?.dispatch_identity,
+    result.task_input?.runtime_task?.input?.dispatchIdentity,
+    result.task_input?.runtime_task?.input?.metadata?.dispatch_identity,
+    result.task_input?.runtime_task?.input?.metadata?.dispatchIdentity,
+  );
 }
 
 function outcomeWithNormalizedEvents(outcome, events) {

--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -422,6 +422,7 @@ function buildHomeboyFuzzResultEnvelope({ runId, workloadId, seed, maxDuration, 
 	const artifacts = normalizeArray(codeboxResult?.artifacts);
 	const requiredArtifacts = requiredFuzzArtifactStatuses({ artifacts, runtimeTaskRequest, taskRequest, workload });
 	const failures = normalizeArray(codeboxResult?.failures || codeboxResult?.metadata?.diagnostics || codeboxResult?.diagnostics);
+	const dispatchIdentity = fuzzDispatchIdentityPassthrough({ codeboxResult, runtimeTaskRequest, taskRequest, workload });
 	return stripUndefined({
 		schema: HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA,
 		version: HOMEBOY_FUZZ_CONTRACT_VERSION,
@@ -451,6 +452,7 @@ function buildHomeboyFuzzResultEnvelope({ runId, workloadId, seed, maxDuration, 
 			failures: failures.length > 0 ? failures : undefined,
 		}),
 		dispatch: fuzzDispatchIdentity({ codeboxResult, runtimeTaskRequest, taskRequest }),
+		dispatch_identity: dispatchIdentity,
 	});
 }
 
@@ -522,6 +524,35 @@ function fuzzDispatchIdentity({ codeboxResult = {}, runtimeTaskRequest = {}, tas
 		runtime: taskRequest.executor?.runtime || runtimeTaskRequest.provider_metadata?.wp_codebox?.runtime,
 		ability: taskRequest.executor?.config?.runtime_task?.ability || runtimeTaskRequest.provider_metadata?.wp_codebox?.ability,
 	});
+}
+
+function fuzzDispatchIdentityPassthrough({ codeboxResult = {}, runtimeTaskRequest = {}, taskRequest = {}, workload = {} } = {}) {
+	return firstObject(
+		codeboxResult.dispatch_identity,
+		codeboxResult.dispatchIdentity,
+		codeboxResult.metadata?.dispatch_identity,
+		codeboxResult.metadata?.dispatchIdentity,
+		runtimeTaskRequest.dispatch_identity,
+		runtimeTaskRequest.dispatchIdentity,
+		runtimeTaskRequest.metadata?.dispatch_identity,
+		runtimeTaskRequest.metadata?.dispatchIdentity,
+		runtimeTaskRequest.input?.dispatch_identity,
+		runtimeTaskRequest.input?.dispatchIdentity,
+		runtimeTaskRequest.input?.metadata?.dispatch_identity,
+		runtimeTaskRequest.input?.metadata?.dispatchIdentity,
+		taskRequest.dispatch_identity,
+		taskRequest.dispatchIdentity,
+		taskRequest.inputs?.dispatch_identity,
+		taskRequest.inputs?.dispatchIdentity,
+		taskRequest.executor?.config?.runtime_task?.input?.dispatch_identity,
+		taskRequest.executor?.config?.runtime_task?.input?.dispatchIdentity,
+		taskRequest.executor?.config?.runtime_task?.input?.metadata?.dispatch_identity,
+		taskRequest.executor?.config?.runtime_task?.input?.metadata?.dispatchIdentity,
+		workload.dispatch_identity,
+		workload.dispatchIdentity,
+		workload.metadata?.dispatch_identity,
+		workload.metadata?.dispatchIdentity,
+	);
 }
 
 function homeboyFuzzCampaignArtifacts(codeboxResult = {}) {
@@ -644,6 +675,10 @@ function normalizeArray(value) {
 
 function objectOrUndefined(value) {
 	return value && typeof value === 'object' && !Array.isArray(value) ? value : undefined;
+}
+
+function firstObject(...values) {
+	return values.find(objectOrUndefined);
 }
 
 function numericValue(value) {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -163,7 +163,31 @@ assert.equal(privateRuntimeShapeOutcome.status, 'failed');
 assert.equal(privateRuntimeShapeOutcome.failure_classification, 'execution_failed');
 assert.equal(privateRuntimeShapeOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.public_result_envelope_missing'), true);
 assert.equal(privateRuntimeShapeOutcome.outputs.reply, undefined);
+assert.equal(privateRuntimeShapeOutcome.metadata.dispatch_identity, undefined);
 assert.deepEqual(publicEnvelopeBoundaryDiagnostic({ run: { agentResult: { reply: 'private' } } }).data.private_shapes, ['run.agentResult']);
+const dispatchIdentityOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...privateRuntimeShapeRequest,
+  task_id: 'dispatch-identity-boundary',
+  inputs: {
+    dispatch_identity: {
+      source: 'agents-api',
+      dispatch_id: 'dispatch-123',
+      conversation_id: 'conversation-456',
+    },
+  },
+}, {
+  success: true,
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: { outputs: { reply: 'Public reply' } },
+  },
+});
+assert.deepEqual(dispatchIdentityOutcome.metadata.dispatch_identity, {
+  source: 'agents-api',
+  dispatch_id: 'dispatch-123',
+  conversation_id: 'conversation-456',
+});
 const publicRuntimeShapeOutcome = agentTaskOutcomeFromCodeboxResult(privateRuntimeShapeRequest, {
   success: true,
   run: {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -113,6 +113,7 @@ assert.equal(result.homeboy_fuzz_result_envelope.campaign.max_duration_seconds, 
 assert.equal(result.homeboy_fuzz_result_envelope.gates.required_artifacts.some((artifact) => artifact.name === 'result-envelope' && artifact.status === 'present'), true);
 assert.equal(result.homeboy_fuzz_result_envelope.gates.required_artifacts.some((artifact) => artifact.name === 'wordpress-fuzz-coverage' && artifact.status === 'missing'), true);
 assert.equal(result.homeboy_fuzz_result_envelope.dispatch.task_id, 'run-from-env');
+assert.equal(result.homeboy_fuzz_result_envelope.dispatch_identity, undefined);
 assert.equal(result.homeboy_fuzz_campaign.metadata.fuzz_result_envelope.schema, HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA);
 assert.equal(result.observation.schema, 'homeboy/wordpress-fuzz-observation/v1');
 assert.equal(result.homeboy_fuzz_campaign.metadata.observation.schema, 'homeboy/wordpress-fuzz-observation/v1');
@@ -125,6 +126,14 @@ const executedResult = buildWordPressFuzzRunnerResult({
 	},
 	workload: {
 		...workload,
+		metadata: {
+			...(workload.metadata || {}),
+			dispatch_identity: {
+				source: 'homeboy-agent-task',
+				dispatch_id: 'dispatch-123',
+				conversation_id: 'conversation-456',
+			},
+		},
 		wp_codebox_suite_result: {
 			schema: 'wp-codebox/fuzz-suite-result/v1',
 			suite: { id: 'generic-wordpress-plan' },
@@ -143,6 +152,11 @@ assert.equal(executedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path
 assert.equal(executedResult.homeboy_fuzz_campaign.artifacts.some((artifact) => artifact.id === 'result-envelope' && artifact.kind === 'result_envelope'), true);
 assert.equal(executedResult.homeboy_fuzz_result_envelope.artifacts[0].path, 'artifacts/replay.json');
 assert.equal(executedResult.homeboy_fuzz_result_envelope.gates.required_artifacts.find((artifact) => artifact.name === 'result-envelope').status, 'present');
+assert.deepEqual(executedResult.homeboy_fuzz_result_envelope.dispatch_identity, {
+	source: 'homeboy-agent-task',
+	dispatch_id: 'dispatch-123',
+	conversation_id: 'conversation-456',
+});
 assert.equal(executedResult.observation.status, 'succeeded');
 
 const mutatingPlanResult = buildWordPressFuzzRunnerResult({


### PR DESCRIPTION
## Summary
- Echo explicit dispatch_identity into the canonical WordPress fuzz result envelope when request/input metadata already carries it.
- Echo explicit dispatch_identity into WP Codebox agent-task outcome metadata when request/input/result metadata already carries it.
- Preserve existing derived dispatch fields and omit dispatch_identity when no explicit identity is present.

## Tests
- npm run test:wordpress-fuzz-runner
- npm run test:wordpress-fuzz-runner-codebox-contract
- npm run test:wp-codebox-fuzz-run
- npm run test:codebox-agent-task-executor-boundary
- npm run lint:js -- lib/wordpress-fuzz-runner.js
- node --check ../agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
- node --check tests/wordpress-fuzz-runner-smoke.js
- node --check tests/codebox-agent-task-executor-boundary.test.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the dispatch identity passthrough, updating tests, and running verification.