### PR TITLE
Support WP Codebox PHPUnit source roots

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -265,9 +265,12 @@ WP_CODEBOX_BIN="$(homeboy_wp_codebox_resolve_bin "${HOMEBOY_SETTINGS_JSON:-}")" 
     exit 1
 }
 
-WP_CODEBOX_CORE_MODULE="${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}"
+WP_CODEBOX_CORE_MODULE="${HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE:-}"
 if [ -z "$WP_CODEBOX_CORE_MODULE" ] && [ "$settings_json" != "{}" ]; then
     WP_CODEBOX_CORE_MODULE=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_core_module // empty' 2>/dev/null || true)
+fi
+if [ -z "$WP_CODEBOX_CORE_MODULE" ]; then
+    WP_CODEBOX_CORE_MODULE="${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}"
 fi
 if [ -n "$WP_CODEBOX_CORE_MODULE" ]; then
     export HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE"

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -53,6 +53,45 @@ else
     PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
 fi
 
+settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+[ -n "$settings_json" ] || settings_json="{}"
+
+WP_CODEBOX_SOURCE_ROOT=""
+WP_CODEBOX_SOURCE_SUBPATH=""
+WP_CODEBOX_PLUGIN_SOURCE_PATH="$PLUGIN_PATH"
+if [ "$settings_json" != "{}" ]; then
+    WP_CODEBOX_SOURCE_ROOT=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_source_root // empty' 2>/dev/null || true)
+    WP_CODEBOX_SOURCE_SUBPATH=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_source_subpath // empty' 2>/dev/null || true)
+fi
+if [ -n "$WP_CODEBOX_SOURCE_ROOT" ]; then
+    if [[ "$WP_CODEBOX_SOURCE_ROOT" != /* ]] || [ ! -d "$WP_CODEBOX_SOURCE_ROOT" ]; then
+        echo "Error: wp_codebox_source_root must be an absolute existing directory." >&2
+        FAILED_STEP="WP Codebox source root setup"
+        exit 1
+    fi
+    if [ -z "$WP_CODEBOX_SOURCE_SUBPATH" ]; then
+        if [[ "$PLUGIN_PATH" = "$WP_CODEBOX_SOURCE_ROOT"/* ]]; then
+            WP_CODEBOX_SOURCE_SUBPATH="${PLUGIN_PATH#"$WP_CODEBOX_SOURCE_ROOT/"}"
+        else
+            echo "Error: wp_codebox_source_subpath is required when wp_codebox_source_root is not an ancestor of HOMEBOY_COMPONENT_PATH." >&2
+            FAILED_STEP="WP Codebox source root setup"
+            exit 1
+        fi
+    fi
+    if [[ "$WP_CODEBOX_SOURCE_SUBPATH" = /* ]] || [[ "$WP_CODEBOX_SOURCE_SUBPATH" == *..* ]]; then
+        echo "Error: wp_codebox_source_subpath must be a relative path under wp_codebox_source_root." >&2
+        FAILED_STEP="WP Codebox source root setup"
+        exit 1
+    fi
+    WP_CODEBOX_PLUGIN_SOURCE_PATH="${WP_CODEBOX_SOURCE_ROOT%/}/${WP_CODEBOX_SOURCE_SUBPATH}"
+    if [ ! -d "$WP_CODEBOX_PLUGIN_SOURCE_PATH" ]; then
+        echo "Error: wp_codebox_source_root/wp_codebox_source_subpath does not exist: $WP_CODEBOX_PLUGIN_SOURCE_PATH" >&2
+        FAILED_STEP="WP Codebox source root setup"
+        exit 1
+    fi
+    PLUGIN_PATH="$WP_CODEBOX_PLUGIN_SOURCE_PATH"
+fi
+
 detect_network_plugin_header() {
     local main_file
     for main_file in "${PLUGIN_PATH}"/*.php; do
@@ -219,9 +258,6 @@ WP_CODEBOX_BIN="$(homeboy_wp_codebox_resolve_bin "${HOMEBOY_SETTINGS_JSON:-}")" 
     FAILED_STEP="WP Codebox CLI setup"
     exit 1
 }
-
-settings_json="${HOMEBOY_SETTINGS_JSON:-}"
-[ -n "$settings_json" ] || settings_json="{}"
 
 WP_CODEBOX_CORE_MODULE="${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}"
 if [ -z "$WP_CODEBOX_CORE_MODULE" ] && [ "$settings_json" != "{}" ]; then
@@ -742,6 +778,7 @@ if [ -n "$SELECTED_TEST_FILE" ]; then
 fi
 
 MOUNTS_JSON="[]"
+EXTRA_PLUGINS_JSON="[]"
 homeboy_wp_codebox_add_recipe_mount() {
     local source="$1"
     local target="$2"
@@ -749,7 +786,15 @@ homeboy_wp_codebox_add_recipe_mount() {
     MOUNTS_JSON=$(jq -nc --argjson mounts "$MOUNTS_JSON" --arg source "$source" --arg target "$target" --arg mode "$mode" '$mounts + [{source: $source, target: $target, mode: $mode}]')
 }
 
-homeboy_wp_codebox_add_recipe_mount "${PLUGIN_PATH}" "/wordpress/wp-content/plugins/${PLUGIN_SLUG}"
+if [ -n "$WP_CODEBOX_SOURCE_ROOT" ]; then
+    EXTRA_PLUGINS_JSON=$(jq -nc \
+        --arg source "$WP_CODEBOX_SOURCE_ROOT" \
+        --arg sourceSubpath "$WP_CODEBOX_SOURCE_SUBPATH" \
+        --arg slug "$PLUGIN_SLUG" \
+        '[{source: $source, sourceRoot: $source, sourceSubpath: $sourceSubpath, slug: $slug, activate: false}]')
+else
+    homeboy_wp_codebox_add_recipe_mount "${PLUGIN_PATH}" "/wordpress/wp-content/plugins/${PLUGIN_SLUG}"
+fi
 
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
@@ -873,6 +918,7 @@ wp_codebox_command=("${HOMEBOY_WP_CODEBOX_COMMAND[@]}")
 
 jq -n \
     --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \
+    --argjson extraPlugins "$EXTRA_PLUGINS_JSON" \
     --argjson mounts "$MOUNTS_JSON" \
     --arg pluginSlug "$PLUGIN_SLUG" \
     --arg selectedTestFile "$SELECTED_TEST_FILE_REL" \
@@ -887,6 +933,7 @@ jq -n \
     --arg multisite "$WP_CODEBOX_MULTISITE" \
     --argjson diagnostics "$WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON" \
     '({
+        extra_plugins: $extraPlugins,
         mounts: $mounts,
         pluginSlug: $pluginSlug,
         selectedTestFile: $selectedTestFile,

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -63,6 +63,12 @@ if [ "$settings_json" != "{}" ]; then
     WP_CODEBOX_SOURCE_ROOT=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_source_root // empty' 2>/dev/null || true)
     WP_CODEBOX_SOURCE_SUBPATH=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_source_subpath // empty' 2>/dev/null || true)
 fi
+if [ -z "$WP_CODEBOX_SOURCE_ROOT" ] && [ -n "${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT:-}" ]; then
+    WP_CODEBOX_SOURCE_ROOT="$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT"
+fi
+if [ -z "$WP_CODEBOX_SOURCE_SUBPATH" ] && [ -n "${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH:-}" ]; then
+    WP_CODEBOX_SOURCE_SUBPATH="$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH"
+fi
 if [ -n "$WP_CODEBOX_SOURCE_ROOT" ]; then
     if [[ "$WP_CODEBOX_SOURCE_ROOT" != /* ]] || [ ! -d "$WP_CODEBOX_SOURCE_ROOT" ]; then
         echo "Error: wp_codebox_source_root must be an absolute existing directory." >&2

--- a/wordpress/scripts/test/wp-codebox-core-module-setting-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-core-module-setting-smoke.sh
@@ -9,11 +9,14 @@ trap 'rm -rf "$TMPDIR"' EXIT
 PLUGIN_DIR="${TMPDIR}/sample-plugin"
 FAKE_BIN="${TMPDIR}/wp-codebox"
 FAKE_BUILDER="${TMPDIR}/build-recipe.mjs"
+RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
 CAPTURED_CORE_MODULE="${TMPDIR}/captured-core-module.txt"
 CONFIGURED_CORE_MODULE="${TMPDIR}/runtime-core/dist/index.js"
+DEFAULT_CORE_MODULE="${TMPDIR}/default-runtime-core/dist/index.js"
 
-mkdir -p "$PLUGIN_DIR/tests" "$(dirname "$CONFIGURED_CORE_MODULE")"
+mkdir -p "$PLUGIN_DIR/tests" "$(dirname "$CONFIGURED_CORE_MODULE")" "$(dirname "$DEFAULT_CORE_MODULE")"
 touch "$CONFIGURED_CORE_MODULE"
+touch "$DEFAULT_CORE_MODULE"
 cat > "${PLUGIN_DIR}/sample-plugin.php" <<'PHP'
 <?php
 /**
@@ -47,11 +50,25 @@ printf '%s\n' '{"executions":[{"stdout":"NO_TEST_FILES"}]}'
 SH
 chmod +x "$FAKE_BIN"
 
+cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
+#!/usr/bin/env bash
+homeboy_resolve_context() {
+    PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+    COMPONENT_ID="$HOMEBOY_COMPONENT_ID"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+SH
+chmod +x "$RESOLVE_CONTEXT_HELPER"
+
 HOMEBOY_COMPONENT_ID="sample-plugin" \
 HOMEBOY_COMPONENT_PATH="$PLUGIN_DIR" \
 HOMEBOY_PROJECT_PATH="$PLUGIN_DIR" \
+HOMEBOY_EXTENSION_PATH="${SCRIPT_DIR}/.." \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
 HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
 HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="$FAKE_BUILDER" \
+HOMEBOY_WP_CODEBOX_CORE_MODULE="$DEFAULT_CORE_MODULE" \
 CAPTURED_CORE_MODULE="$CAPTURED_CORE_MODULE" \
 HOMEBOY_SETTINGS_JSON="{\"wp_codebox_core_module\":\"$CONFIGURED_CORE_MODULE\",\"phpunit_no_tests\":\"skip\"}" \
 bash "$RUNNER" >/dev/null

--- a/wordpress/tests/fixtures/wp-codebox-core-recipe-builder.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-recipe-builder.mjs
@@ -28,6 +28,7 @@ export function buildWordPressPhpunitRecipe(options = {}) {
 	return {
 		schema: 'wp-codebox/workspace-recipe/v1',
 		inputs: {
+			extra_plugins: options.extra_plugins ?? [],
 			mounts: normalizeRecipeMounts(options.mounts, 'readwrite'),
 		},
 		workflow: {

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -20,6 +20,13 @@ const input = {
 	dependencyMounts: ['/wordpress/wp-content/plugins/dependency-one'],
 	multisite: true,
 	diagnosticsCapture: ['errors'],
+	extra_plugins: [{
+		source: '/tmp/fixture-monorepo',
+		sourceRoot: '/tmp/fixture-monorepo',
+		sourceSubpath: 'plugins/fixture-plugin',
+		slug: 'fixture-plugin',
+		activate: false,
+	}],
 	mounts: [{ source: '/tmp/fixture-plugin', target: '/wordpress/wp-content/plugins/fixture-plugin' }],
 };
 
@@ -34,6 +41,7 @@ assert.equal(result.status, 0, result.stderr);
 const recipe = JSON.parse(result.stdout);
 
 assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
+assert.deepEqual(recipe.inputs.extra_plugins, input.extra_plugins);
 assert.equal(recipe.inputs.mounts[0].mode, 'readwrite');
 assert.deepEqual(recipe.workflow.steps, [{
 	command: 'fixture.wordpress.phpunit',

--- a/wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh
+++ b/wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RUNNER="${ROOT_DIR}/scripts/test/test-runner-wp-codebox.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+MONOREPO_DIR="${TMPDIR}/monorepo"
+PLUGIN_DIR="${MONOREPO_DIR}/plugins/sample-plugin"
+FAKE_BIN="${TMPDIR}/wp-codebox"
+RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
+CAPTURED_RECIPE="${TMPDIR}/recipe.json"
+CORE_MODULE="${ROOT_DIR}/tests/fixtures/wp-codebox-core-recipe-builder.mjs"
+
+mkdir -p "${PLUGIN_DIR}/tests"
+cat > "${PLUGIN_DIR}/sample-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Sample Plugin
+ */
+PHP
+cat > "${PLUGIN_DIR}/tests/SampleTest.php" <<'PHP'
+<?php
+
+class SampleTest extends WP_UnitTestCase {
+	public function test_sample(): void {
+		$this->assertTrue( true );
+	}
+}
+PHP
+
+cat > "$FAKE_BIN" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+recipe=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--recipe)
+			shift
+			recipe="${1:-}"
+			;;
+	esac
+	shift || true
+done
+
+if [ -z "$recipe" ]; then
+	echo "missing --recipe" >&2
+	exit 2
+fi
+
+cp "$recipe" "$CAPTURED_RECIPE"
+printf '%s\n' 'NO_TEST_FILES' > "${HOMEBOY_PLUGIN_PATH}/.pg-test-result.txt"
+printf '%s\n' '{"executions":[{"stdout":"NO_TEST_FILES"}]}'
+SH
+chmod +x "$FAKE_BIN"
+
+cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
+#!/usr/bin/env bash
+homeboy_resolve_context() {
+	PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+	COMPONENT_ID="$HOMEBOY_COMPONENT_ID"
+	EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+SH
+chmod +x "$RESOLVE_CONTEXT_HELPER"
+
+HOMEBOY_COMPONENT_ID="sample-plugin" \
+HOMEBOY_COMPONENT_PATH="$PLUGIN_DIR" \
+HOMEBOY_PROJECT_PATH="$PLUGIN_DIR" \
+HOMEBOY_EXTENSION_PATH="$ROOT_DIR" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
+HOMEBOY_WP_CODEBOX_CORE_MODULE="$CORE_MODULE" \
+HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT="$MONOREPO_DIR" \
+HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH="plugins/sample-plugin" \
+CAPTURED_RECIPE="$CAPTURED_RECIPE" \
+HOMEBOY_SETTINGS_JSON="{\"phpunit_no_tests\":\"skip\"}" \
+bash "$RUNNER" >/dev/null
+
+node - "$CAPTURED_RECIPE" "$MONOREPO_DIR" <<'NODE'
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const recipe = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const monorepo = process.argv[3];
+
+assert.deepEqual(recipe.inputs.extra_plugins, [{
+	source: monorepo,
+	sourceRoot: monorepo,
+	sourceSubpath: 'plugins/sample-plugin',
+	slug: 'sample-plugin',
+	activate: false,
+}]);
+NODE
+
+echo "WP Codebox PHPUnit source-root recipe smoke passed"

--- a/wordpress/tests/wp-codebox-phpunit-source-root-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-source-root-smoke.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-phpunit-source-root-'));
+
+try {
+  const extensionSource = path.join(__dirname, '..');
+  const extensionPath = path.join(root, 'wordpress-extension');
+  fs.cpSync(extensionSource, extensionPath, {
+    recursive: true,
+    filter: (source) => !source.includes(`${path.sep}node_modules${path.sep}`),
+  });
+  fs.mkdirSync(path.join(extensionPath, 'vendor'), { recursive: true });
+
+  const componentPath = path.join(root, 'isolated-snapshot', 'phpunit-source-root-fixture');
+  const sourceRoot = path.join(root, 'monorepo');
+  const sourceSubpath = path.join('plugins', 'phpunit-source-root-fixture');
+  const sourcePluginPath = path.join(sourceRoot, sourceSubpath);
+  const generatedPath = path.join(sourcePluginPath, 'includes', 'react-admin', 'feature-config.php');
+  fs.mkdirSync(path.join(sourcePluginPath, 'tests'), { recursive: true });
+  fs.mkdirSync(componentPath, { recursive: true });
+  fs.mkdirSync(path.join(sourceRoot, 'packages', 'php', 'monorepo-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(sourceRoot, 'packages', 'php', 'monorepo-plugin', 'composer.json'), '{}\n');
+  fs.writeFileSync(path.join(sourcePluginPath, 'phpunit-source-root-fixture.php'), "<?php\n/* Plugin Name: PHPUnit Source Root Fixture */\n");
+  fs.writeFileSync(path.join(sourcePluginPath, 'tests', 'ExampleTest.php'), "<?php\nfinal class ExampleTest extends WP_UnitTestCase {}\n");
+
+  const prepareScript = path.join(sourcePluginPath, 'bin', 'generate-feature-config.php');
+  fs.mkdirSync(path.dirname(prepareScript), { recursive: true });
+  fs.writeFileSync(prepareScript, `#!/usr/bin/env php
+<?php
+$target = __DIR__ . '/../includes/react-admin/feature-config.php';
+if (!is_dir(dirname($target))) {
+    mkdir(dirname($target), 0777, true);
+}
+file_put_contents($target, "<?php return ['prepared' => true];\n");
+`);
+  fs.chmodSync(prepareScript, 0o755);
+
+  const fakeRecipeBuilder = path.join(root, 'fake-phpunit-recipe-builder.js');
+  fs.writeFileSync(fakeRecipeBuilder, `#!/usr/bin/env node
+const fs = require('node:fs');
+const options = JSON.parse(fs.readFileSync(0, 'utf8'));
+process.stdout.write(JSON.stringify({
+  schema: 'wp-codebox/workspace-recipe/v1',
+  inputs: {
+    extra_plugins: options.extra_plugins || [],
+    mounts: options.mounts || [],
+  },
+  workflow: { steps: [{ command: 'wordpress.phpunit', args: [] }] },
+}, null, 2) + '\\n');
+`);
+  fs.chmodSync(fakeRecipeBuilder, 0o755);
+
+  const fakeWpCodebox = path.join(root, 'fixture-wp-codebox.js');
+  fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const recipeIndex = process.argv.indexOf('--recipe');
+if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
+  process.exit(2);
+}
+const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
+const extraPlugins = recipe.inputs.extraPlugins || recipe.inputs.extra_plugins || [];
+const plugin = extraPlugins.find((entry) => entry.slug === 'phpunit-source-root-fixture');
+if (!plugin || plugin.source !== plugin.sourceRoot || plugin.sourceSubpath !== 'plugins/phpunit-source-root-fixture') {
+  process.stderr.write('monorepo source root/subpath missing from phpunit plugin recipe input\\n');
+  process.exit(10);
+}
+if (!fs.existsSync(path.join(plugin.source, 'packages', 'php', 'monorepo-plugin', 'composer.json'))) {
+  process.stderr.write('monorepo composer path repository missing from phpunit source context\\n');
+  process.exit(11);
+}
+if (!fs.existsSync(path.join(plugin.source, plugin.sourceSubpath, 'includes', 'react-admin', 'feature-config.php'))) {
+  process.stderr.write('generated feature config missing before wp-codebox launch\\n');
+  process.exit(12);
+}
+fs.writeFileSync(path.join(plugin.source, plugin.sourceSubpath, '.pg-test-result.txt'), 'STAGE_BEGIN:run_tests\\nSTAGE_OK:run_tests\\n');
+process.stdout.write(JSON.stringify({
+  success: true,
+  executions: [{ stdout: 'OK (1 test, 1 assertion)\\n' }],
+}) + '\\n');
+`);
+  fs.chmodSync(fakeWpCodebox, 0o755);
+
+  const resolveContextHelper = path.join(root, 'resolve-context-helper.sh');
+  fs.writeFileSync(resolveContextHelper, `#!/usr/bin/env bash
+homeboy_resolve_context() {
+  PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+  COMPONENT_ID="$HOMEBOY_COMPONENT_ID"
+  EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+`);
+  fs.chmodSync(resolveContextHelper, 0o755);
+
+  const result = spawnSync('bash', [path.join(extensionPath, 'scripts', 'test', 'test-runner-wp-codebox.sh'), 'tests/ExampleTest.php'], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_COMPONENT_ID: 'phpunit-source-root-fixture',
+      HOMEBOY_COMPONENT_PATH: componentPath,
+      HOMEBOY_EXTENSION_PATH: extensionPath,
+      HOMEBOY_RUNTIME_RESOLVE_CONTEXT: resolveContextHelper,
+      HOMEBOY_RUNTIME_RUNNER_STEPS: path.join(root, 'missing-runner-steps.sh'),
+      HOMEBOY_WP_CODEBOX_BIN: fakeWpCodebox,
+      HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER: fakeRecipeBuilder,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({
+        wp_codebox_source_root: sourceRoot,
+        wp_codebox_source_subpath: sourceSubpath,
+        wp_codebox_prepare_steps: [
+          { command: 'php', args: ['bin/generate-feature-config.php'] },
+        ],
+      }),
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(fs.existsSync(generatedPath), true);
+  assert.match(result.stdout, /WP Codebox test run complete/);
+
+  console.log('WP Codebox PHPUnit source root smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Root cause: the WP Codebox PHPUnit runner did not understand `wp_codebox_source_root` / `wp_codebox_source_subpath`, so monorepo plugins like WooCommerce could not build PHPUnit recipes from the correct source subtree.
- Fix: the runner now threads source-root and source-subpath settings into WP Codebox PHPUnit recipes, including values exposed by Homeboy Lab through `HOMEBOY_SETTINGS_*` environment variables.
- Fix: explicit `wp_codebox_core_module` settings now take precedence over the default `HOMEBOY_WP_CODEBOX_CORE_MODULE` exported by extension setup.
- Coverage: PHPUnit recipe builder smoke coverage now preserves `extra_plugins` for source-root recipes.

## Validation
- `bash wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh`
- `node wordpress/tests/wp-codebox-phpunit-source-root-smoke.js`
- `bash wordpress/scripts/test/wp-codebox-core-module-setting-smoke.sh`
- `node wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/wp-codebox-core-module-setting-smoke.sh wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** PR creation and description drafting from the prepared branch changes.