### PR TITLE
Prefer packaged Codebox runtime over request bins

### DIFF
--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js
@@ -55,16 +55,19 @@ function wpCodeboxBin(options = {}) {
     wpCodeboxBinFromRuntimeComponent(env),
     managedWpCodeboxBin(env),
   ];
-  return firstValue(
+  const explicitBinCandidates = [
     options.runtimeBin,
     options.runtime_bin,
     options.wpCodeboxBin,
-    ...(options.preferPackagedRuntime ? packagedRuntimeCandidates : [options.wp_codebox_bin]),
+    options.wp_codebox_bin,
+  ];
+  return firstValue(
+    ...(options.preferPackagedRuntime ? packagedRuntimeCandidates : explicitBinCandidates),
     options.bin,
     ...descriptor.settings.map((key) => settings[key]),
     env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN,
     ...descriptor.env.map((key) => env[key]),
-    ...(options.preferPackagedRuntime ? [options.wp_codebox_bin] : packagedRuntimeCandidates),
+    ...(options.preferPackagedRuntime ? explicitBinCandidates : packagedRuntimeCandidates),
     options.executable === undefined ? descriptor.executable : options.executable,
   );
 }

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -75,6 +75,14 @@ try {
 		runtimeCli
 	);
 	assert.equal(
+		wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT: runtimeComponent }, wpCodeboxBin: '/path/request/wp-codebox', executable: '', preferPackagedRuntime: true }),
+		runtimeCli
+	);
+	assert.equal(
+		wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT: runtimeComponent }, runtime_bin: '/path/runtime/wp-codebox', executable: '', preferPackagedRuntime: true }),
+		runtimeCli
+	);
+	assert.equal(
 		wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT: runtimeComponent }, wp_codebox_bin: '/path/explicit/wp-codebox', executable: '' }),
 		'/path/explicit/wp-codebox'
 	);


### PR DESCRIPTION
## Summary
- Let packaged WP Codebox runtime candidates win over request-provided binary fields when packaged runtime preference is enabled
- Cover stale request/default binary overrides in the adapter smoke test

## Verification
- node tests/wp-codebox-adapter-contract-smoke.mjs
- node tests/runtime-provider-resolver-smoke.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runtime binary selection regression and drafting/verifying the fix.