### PR TITLE
Preserve WP Codebox runtime artifacts

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1405,8 +1405,10 @@ function runtimeComponentPaths(config, options = {}) {
   const aliases = runtimeComponentPathAliases(options);
   const resolved = {
     ...contractPaths,
-    agent_runtime: config.agent_runtime || options.agentRuntime,
+    agents_api: contractPaths.agents_api || firstValue(process.env.WP_CODEBOX_AGENTS_API_PATH, process.env.HOMEBOY_WP_CODEBOX_AGENTS_API_PATH),
+    agent_runtime: contractPaths.agent_runtime || explicit.agent_runtime || config.agent_runtime || options.agentRuntime,
     agent_runtime_tools: config.agent_runtime_tools || options.agentRuntimeTools,
+    data_machine_code: contractPaths.data_machine_code || firstValue(process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH, process.env.HOMEBOY_WP_CODEBOX_DATA_MACHINE_CODE_PATH),
     ...explicit,
     runtime: explicit.runtime || runtimeComponents.runtime,
   };
@@ -1423,6 +1425,8 @@ function runtimeComponentPaths(config, options = {}) {
       options,
     })));
   }
+
+  resolved.agent_runtime = resolved.agent_runtime || firstValue(process.env.WP_CODEBOX_DATA_MACHINE_PATH, process.env.HOMEBOY_WP_CODEBOX_DATA_MACHINE_PATH);
 
   return Object.fromEntries(Object.entries(resolved).filter(([, value]) => value !== undefined && value !== ''));
 }

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -343,6 +343,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   assertProviderCredentialBoundaryNamesOnly(request.inputs || {});
   const runtimeOptions = runtimeOptionsFromExecutorConfig(config, options);
   const inputs = request.inputs || {};
+  const clientContext = agentTaskClientContext(request, config, inputs, runtimeOptions);
+  const clientInputs = firstObject(clientContext.inputs) || {};
   const defaults = defaultCodeboxRuntimeConfig(request, config, inputs, runtimeOptions);
   const workspaceMaterialization = defaultWorkspaceMaterialization(defaults.workspaceRoot, request, config, inputs, runtimeOptions);
   const target = defaultWorkspaceTargetPayload(inputs.target || request.workspace || {}, workspaceMaterialization);
@@ -354,7 +356,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const provider = config.provider || runtimeOptions.provider || defaults.provider || '';
   const model = request.executor.model || config.model || runtimeOptions.model || defaults.model || '';
   const runtimeTask = runtimeTaskWithExecutionDefaults(
-    inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || runtimeOptions.runtimeTask,
+    inputs.runtime_task || inputs.runtimeTask || clientInputs.runtime_task || clientInputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || runtimeOptions.runtimeTask,
     { provider, model, agentBundles, runtimePackage: runtimePackageDefaultFromProfile(config, runtimeOptions) }
   );
   let componentContracts = componentContractsFromAgentTaskRequest(request, config, runtimeOptions);
@@ -390,6 +392,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
   const runtimeTaskAbilityNormalization = runtimeTaskAbilityNormalizationEvidence(runtimeTask);
   const context = {
+    ...clientContext,
+    ...(clientInputs.context || {}),
     ...(inputs.context || {}),
     agent_task_id: request.task_id,
     group_key: request.group_key,

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -325,6 +325,7 @@ function artifactResultEnvelopeFromCodeboxResult(result, options = {}) {
   const candidates = [
     result,
     result?.artifact_result,
+    result?.outputs?.artifact_result,
   ];
   return candidates.map(normalizeArtifactResultEnvelope).find(Boolean) || null;
 }

--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -243,6 +243,7 @@ function normalizeControllerExecution(value) {
     policy_result: stringValue(value.policy_result || value.policyResult || value.policy_result_path || value.policyResultPath),
     output: stringValue(value.output || value.output_path || value.outputPath),
     max_actions: positiveInteger(value.max_actions || value.maxActions) || 100,
+    reconcile_stale: booleanValue(value.reconcile_stale || value.reconcileStale || process.env.HOMEBOY_CONTROLLER_RECONCILE_STALE),
     prepare: normalizeArray(value.prepare || value.prepare_commands || value.prepareCommands),
     env: optionalObject(value.env),
     metadata: optionalObject(value.metadata),
@@ -307,6 +308,9 @@ function defaultExecuteControllerExecution(options = {}) {
   }
   if (controllerExecution.output) {
     args.push('--output', controllerExecution.output);
+  }
+  if (controllerExecution.reconcile_stale) {
+    args.push('--reconcile-stale');
   }
   const run = spawnSync(homeboyBin, args, { cwd, env, encoding: 'utf8' });
   if (run.status !== 0) {
@@ -1048,6 +1052,14 @@ function loopStatus(taskResults) {
 function positiveInteger(value) {
   const parsed = Number.parseInt(value || '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function booleanValue(value) {
+  if (value === true) {
+    return true;
+  }
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(normalized);
 }
 
 function optionalObject(value) {

--- a/runtime-agent-ci/scripts/homeboy-artifact-fanout.cjs
+++ b/runtime-agent-ci/scripts/homeboy-artifact-fanout.cjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CONFIG_SCHEMA = 'homeboy-extensions/artifact-fanout-materializer-config/v1';
+const BATCH_SCHEMA = 'homeboy-extensions/ArtifactFanoutBatch/v1';
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const configPath = args.config || process.env.HOMEBOY_ARTIFACT_FANOUT_CONFIG || '';
+  if (!configPath) {
+    throw new Error('Pass --config <path> or HOMEBOY_ARTIFACT_FANOUT_CONFIG.');
+  }
+  const config = readJson(resolvePath(configPath));
+  if (config.schema && config.schema !== CONFIG_SCHEMA) {
+    throw new Error(`Unsupported artifact fanout config schema: ${config.schema}`);
+  }
+  const actionInput = readJson(requiredEnv('HOMEBOY_LOOP_ACTION_INPUT'));
+  const actionOutput = requiredEnv('HOMEBOY_LOOP_ACTION_OUTPUT');
+  const artifactId = requiredString(config.artifact, 'config.artifact');
+  const outputArtifact = requiredString(config.output_artifact || config.outputArtifact, 'config.output_artifact');
+  const artifact = actionInput?.request?.inputs?.artifacts?.[artifactId]
+    || actionInput?.request?.inputs?.[artifactId];
+  const items = extractItems(artifact, config.item_path || config.itemPath || 'items');
+  const groups = groupItems(items, normalizeStringArray(config.group_by || config.groupBy), config.requires_non_empty === true);
+  const taskRequests = groups.map((group) => renderValue(config.task_request_template || {}, {
+    group,
+    config,
+    env: process.env,
+    action: {
+      loop_id: process.env.HOMEBOY_LOOP_ID || actionInput.loop_id || '',
+      action_id: process.env.HOMEBOY_LOOP_ACTION_ID || actionInput.action_id || '',
+    },
+  }));
+  const batch = {
+    schema: BATCH_SCHEMA,
+    mode: config.mode || 'run',
+    plan_id: renderString(config.plan_id || 'artifact-fanout', { env: process.env }),
+    batch_id: renderString(config.batch_id || `${process.env.HOMEBOY_LOOP_ID || 'loop'}-${process.env.HOMEBOY_LOOP_ACTION_ID || 'action'}-${outputArtifact}`, { env: process.env }),
+    source_artifact: artifactId,
+    output_artifact: outputArtifact,
+    item_count: items.length,
+    group_count: groups.length,
+    groups,
+    task_requests: taskRequests,
+  };
+  writeJson(actionOutput, { artifacts: { [outputArtifact]: batch } });
+} catch (error) {
+  process.stderr.write(`${error?.stack || error?.message || String(error)}\n`);
+  process.exitCode = 1;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2).replace(/-/g, '_');
+    args[key] = argv[index + 1];
+    index += 1;
+  }
+  return args;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function resolvePath(filePath) {
+  return path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath);
+}
+
+function extractItems(artifact, itemPath) {
+  const payload = artifact?.payload || artifact;
+  const configured = getPath(payload, itemPath);
+  const value = Array.isArray(configured) ? configured : Array.isArray(payload) ? payload : [];
+  return value.map((item, index) => (item && typeof item === 'object' ? { ...item, index } : { value: item, index }));
+}
+
+function groupItems(items, groupBy, requiresNonEmpty) {
+  if (requiresNonEmpty && items.length === 0) {
+    throw new Error('Artifact fanout requires at least one item.');
+  }
+  const map = new Map();
+  for (const item of items) {
+    const key = groupBy.length > 0
+      ? groupBy.map((field) => text(getPath(item, field))).filter(Boolean).join(':')
+      : text(item.group_key || item.groupKey || item.id || item.index);
+    const groupKey = key || 'default';
+    if (!map.has(groupKey)) {
+      map.set(groupKey, { key: groupKey, index: map.size, items: [] });
+    }
+    map.get(groupKey).items.push(item);
+  }
+  return Array.from(map.values()).map((group) => ({
+    ...group,
+    item_count: group.items.length,
+    item_ids: group.items.map((item) => text(item.id || item.finding_id || item.packet_id || item.index)).filter(Boolean),
+  }));
+}
+
+function renderValue(value, context) {
+  if (typeof value === 'string') return renderString(value, context);
+  if (Array.isArray(value)) return value.map((entry) => renderValue(entry, context));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, renderValue(entry, context)]));
+  }
+  return value;
+}
+
+function renderString(value, context) {
+  return String(value || '').replace(/\{\{\s*([^}]+)\s*\}\}/g, (_match, expression) => {
+    const resolved = getPath(context, expression.trim());
+    if (resolved === undefined || resolved === null) return '';
+    return typeof resolved === 'object' ? JSON.stringify(resolved) : String(resolved);
+  });
+}
+
+function getPath(value, expression) {
+  return String(expression || '').split('.').filter(Boolean).reduce((current, segment) => {
+    if (current === undefined || current === null) return undefined;
+    return current[segment];
+  }, value);
+}
+
+function normalizeStringArray(value) {
+  return Array.isArray(value) ? value.map(text).filter(Boolean) : [];
+}
+
+function text(value) {
+  return String(value ?? '').trim();
+}
+
+function requiredString(value, name) {
+  const result = text(value);
+  if (!result) throw new Error(`${name} is required.`);
+  return result;
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -278,6 +278,7 @@ const controllerBacked = await runHeadlessDeterministicLoop({
       policy_result: '.ci/controller-policy.json',
       output: '.ci/controller-result.json',
       max_actions: 42,
+      reconcile_stale: true,
       prepare: [{ argv: ['node', '.github/scripts/build-homeboy-controller-run-inputs.mjs'] }],
     },
   },
@@ -303,6 +304,7 @@ assert.equal(controllerBacked.status, 'succeeded');
 assert.equal(controllerBacked.tasks[0].request.schema, 'homeboy/headless-controller-execution-request/v1');
 assert.equal(controllerBacked.tasks[0].request.executor, undefined, 'controller tasks do not create runtime-package executor requests');
 assert.equal(controllerBacked.tasks[0].outcome.metadata.controller_execution.max_actions, 42);
+assert.equal(controllerBacked.tasks[0].outcome.metadata.controller_execution.reconcile_stale, true);
 assert.equal(controllerBacked.tasks[0].outcome.metadata.controller_result.loop_id, 'controller-backed-loop');
 assert.equal(controllerRequest.controller_execution.spec, '.github/homeboy/controllers/static-site-generation-loop.controller.json');
 

--- a/runtime-agent-ci/tests/homeboy-artifact-fanout.test.js
+++ b/runtime-agent-ci/tests/homeboy-artifact-fanout.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = path.resolve(__dirname, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-artifact-fanout-'));
+
+try {
+  const configPath = path.join(tmp, 'config.json');
+  const inputPath = path.join(tmp, 'input.json');
+  const outputPath = path.join(tmp, 'output.json');
+  fs.writeFileSync(configPath, JSON.stringify({
+    schema: 'homeboy-extensions/artifact-fanout-materializer-config/v1',
+    artifact: 'finding_group',
+    item_path: 'items',
+    group_by: ['owner_repo', 'root_cause'],
+    requires_non_empty: true,
+    plan_id: 'fixture-plan',
+    batch_id: '{{env.HOMEBOY_LOOP_ID}}-{{env.HOMEBOY_LOOP_ACTION_ID}}',
+    output_artifact: 'iterator_fanout_batch',
+    task_request_template: {
+      task_id: 'task-{{group.key}}',
+      inputs: { finding_group: '{{group.items}}' },
+    },
+  }));
+  fs.writeFileSync(inputPath, JSON.stringify({
+    request: {
+      inputs: {
+        artifacts: {
+          finding_group: {
+            payload: {
+              items: [
+                { id: 'a', owner_repo: 'repo-a', root_cause: 'cause-1' },
+                { id: 'b', owner_repo: 'repo-a', root_cause: 'cause-1' },
+              ],
+            },
+          },
+        },
+      },
+    },
+  }));
+
+  const result = spawnSync(process.execPath, [path.join(root, 'scripts/homeboy-artifact-fanout.cjs'), '--config', configPath], {
+    cwd: root,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_LOOP_ID: 'loop-1',
+      HOMEBOY_LOOP_ACTION_ID: 'action-2',
+      HOMEBOY_LOOP_ACTION_INPUT: inputPath,
+      HOMEBOY_LOOP_ACTION_OUTPUT: outputPath,
+    },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  const batch = output.artifacts.iterator_fanout_batch;
+  assert.equal(batch.schema, 'homeboy-extensions/ArtifactFanoutBatch/v1');
+  assert.equal(batch.batch_id, 'loop-1-action-2');
+  assert.equal(batch.item_count, 2);
+  assert.equal(batch.group_count, 1);
+  assert.equal(batch.task_requests[0].task_id, 'task-repo-a:cause-1');
+  assert.match(batch.task_requests[0].inputs.finding_group, /"id":"a"/);
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log('homeboy artifact fanout test passed');

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -838,6 +838,32 @@ assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.en
   concept_packet: 'outputs.typed_artifacts.concept_packet.payload',
 });
 
+const controllerClientContextRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'controller-client-context-runtime-task-1',
+  executor: { backend: 'codebox', config: { provider: 'openai' } },
+  instructions: 'Run a controller workflow with hydrated runtime task input in client context.',
+  dispatch: {
+    client_context: JSON.stringify({
+      inputs: {
+        runtime_task: {
+          ability: 'runtime-package/run',
+          input: {
+            package: { slug: 'static-site-agent', source: 'bundles/static-site-agent' },
+            input: {
+              concept_packet: { payload: { title: 'Concept' } },
+              design_packet: { payload: { design_system: 'Editorial' } },
+            },
+          },
+        },
+      },
+    }),
+  },
+});
+assert.equal(controllerClientContextRuntimeTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.equal(controllerClientContextRuntimeTaskInput.runtime_task.input.input.concept_packet.payload.title, 'Concept');
+assert.equal(controllerClientContextRuntimeTaskInput.runtime_task.input.input.design_packet.payload.design_system, 'Editorial');
+
 const legacyRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'legacy-runtime-package-task-1',

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -143,6 +143,8 @@ assert.equal(artifactResultEnvelope.evidenceRefs.length, 2);
 assert.equal(artifactResultEnvelope.evidenceRefs[0].uri, 'artifacts/run-1');
 assert.deepEqual(typedArtifactsFromCodeboxResult({ artifact_result: artifactResultEnvelope }).review.payload, { ok: true });
 assert.deepEqual(normalizeCodeboxPublicResultEnvelope({ artifact_result: artifactResultEnvelope }).outputs, {});
+assert.deepEqual(typedArtifactsFromCodeboxResult({ outputs: { artifact_result: artifactResultEnvelope } }).review.payload, { ok: true });
+assert.equal(normalizeCodeboxPublicResultEnvelope({ outputs: { artifact_result: artifactResultEnvelope } }).artifact_result.schema, 'wp-codebox/artifact-result-envelope/v1');
 const privateRuntimeShapeRequest = {
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'private-runtime-shape-boundary',
@@ -1010,6 +1012,9 @@ restoreEnv('WP_CODEBOX_AGENTS_API_PATH', previousAgentsApiPath);
 restoreEnv('WP_CODEBOX_DATA_MACHINE_PATH', previousDataMachinePath);
 restoreEnv('WP_CODEBOX_DATA_MACHINE_CODE_PATH', previousDataMachineCodePath);
 assert.deepEqual(runtimePackageEnvSubstrateTaskInput.component_contracts, []);
+assert.equal(runtimePackageEnvSubstrateTaskInput.runtime_component_paths.agents_api, workspaceRoot);
+assert.equal(runtimePackageEnvSubstrateTaskInput.runtime_component_paths.agent_runtime, workspaceRoot);
+assert.equal(runtimePackageEnvSubstrateTaskInput.runtime_component_paths.data_machine_code, workspaceRoot);
 
 const explicitLegacyRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',


### PR DESCRIPTION
## Summary
- Preserve runtime-task input supplied through controller client context for WP Codebox agent-task execution.
- Project runtime component paths from environment fallbacks without overriding explicit config.
- Recognize the public WP Codebox artifact-result envelope under `outputs.artifact_result`.

## Validation
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## Notes
- This keeps Homeboy Extensions generic while allowing Homeboy controller actions to pass hydrated runtime-task artifacts through the WP Codebox runtime adapter.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runtime artifact handoff failure, implementing adapter normalization, and adding boundary coverage.