### PR TITLE
Declare WordPress helper env provider

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -100,6 +100,7 @@
     "test:full-surface-coverage": "node tests/full-surface-coverage-smoke.js",
     "test:wordpress-fuzz-coverage-aggregate": "node tests/wordpress-fuzz-coverage-aggregate-smoke.js",
     "test:external-http-guardrail": "node tests/external-http-guardrail-smoke.js",
+    "test:env-provider": "node tests/env-provider-smoke.js",
     "test:wordpress-helper-consumer": "node tests/wordpress-helper-consumer-smoke.mjs",
     "test:materialized-site-quality": "node tests/materialized-site-quality-smoke.js",
     "test:timing-correlator": "node tests/timing-correlator-smoke.js",

--- a/wordpress/scripts/env-provider.js
+++ b/wordpress/scripts/env-provider.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const extensionRoot = path.resolve(__dirname, '..');
+const helperManifest = path.join(extensionRoot, 'lib', 'helper-manifest.js');
+
+const env = {};
+
+if (fs.existsSync(helperManifest)) {
+	env.HOMEBOY_WORDPRESS_HELPER_MANIFEST = helperManifest;
+}
+
+process.stdout.write(`${JSON.stringify(env)}\n`);

--- a/wordpress/tests/env-provider-smoke.js
+++ b/wordpress/tests/env-provider-smoke.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('node:assert');
+const childProcess = require('node:child_process');
+const path = require('node:path');
+
+const extensionRoot = path.resolve(__dirname, '..');
+const provider = path.join(extensionRoot, 'scripts', 'env-provider.js');
+const output = childProcess.execFileSync(process.execPath, [provider], {
+	cwd: extensionRoot,
+	encoding: 'utf8',
+});
+const env = JSON.parse(output);
+
+assert.deepEqual(Object.keys(env), ['HOMEBOY_WORDPRESS_HELPER_MANIFEST']);
+assert.equal(
+	env.HOMEBOY_WORDPRESS_HELPER_MANIFEST,
+	path.join(extensionRoot, 'lib', 'helper-manifest.js')
+);
+
+console.log('env provider smoke passed');

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -4,6 +4,9 @@
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
+  "env_provider": {
+    "script": "scripts/env-provider.js"
+  },
   "provides": {
     "file_extensions": ["php", "css", "ts", "tsx", "js", "jsx", "json"],
     "capabilities": ["fingerprint", "refactor", "crossref", "validate", "fuzz"]


### PR DESCRIPTION
## Summary
- Declare the WordPress extension env provider using Homeboy core's generic `env_provider` contract.
- Add a WordPress-owned provider script that emits `HOMEBOY_WORDPRESS_HELPER_MANIFEST` for this extension's packaged helper manifest.
- Add a smoke test for the provider output.

Fixes Extra-Chill/homeboy#6584.

## Testing
- `npm run test:env-provider && npm run test:wordpress-helper-consumer && npm run test:wp-codebox-recipe-helper`
- `node --check scripts/env-provider.js && node --check tests/env-provider-smoke.js`
- `jq empty wordpress.json package.json`
- Homeboy core generic env-provider transport tests run locally in `/Users/chubes/Developer/homeboy@fix-issue-6584-wordpress-helper-env`.

## Architecture
- Homeboy core remains generic and unchanged for this PR.
- WordPress-specific env ownership stays in the WordPress extension layer.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Inspected the Homeboy extension env-provider contract, implemented the WordPress extension declaration/script/test, and ran targeted verification.