### PR TITLE
Harden runtime dependency materialization targets

### DIFF
--- a/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
+++ b/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
@@ -9,17 +9,18 @@ const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../../../runti
 function main() {
   const printPlan = process.argv.includes('--print-plan');
   const entries = dependencyEntries(process.env);
-  const plan = resolvePlan(entries, printPlan);
+  const plan = resolvePlan(entries, printPlan, { workspace: process.env.GITHUB_WORKSPACE || process.cwd() });
   if (printPlan) {
     process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
     return;
   }
   for (const item of plan) {
-    fs.rmSync(item.target, { recursive: true, force: true });
+    assertSafeDependencyTargetPath(item.targetPath, process.env.GITHUB_WORKSPACE || process.cwd());
+    fs.rmSync(item.targetPath, { recursive: true, force: true });
     process.stdout.write(`Checking out validation dependency ${item.repo}@${item.ref} into ${item.target}\n`);
-    run('gh', ['repo', 'clone', item.repo, item.target, '--', '--depth=1']);
-    run('git', ['-C', item.target, 'fetch', '--depth=1', 'origin', item.ref]);
-    run('git', ['-C', item.target, 'checkout', '--quiet', 'FETCH_HEAD']);
+    run('gh', ['repo', 'clone', item.repo, item.targetPath, '--', '--depth=1']);
+    run('git', ['-C', item.targetPath, 'fetch', '--depth=1', 'origin', item.ref]);
+    run('git', ['-C', item.targetPath, 'checkout', '--quiet', 'FETCH_HEAD']);
   }
 }
 
@@ -49,7 +50,8 @@ function runtimeDependencyEntries(value) {
   return splitCsv(value);
 }
 
-function resolvePlan(entries, offline) {
+function resolvePlan(entries, offline, options = {}) {
+  const workspace = options.workspace || process.env.GITHUB_WORKSPACE || process.cwd();
   const seen = new Set();
   const plan = [];
   for (const rawEntry of entries) {
@@ -75,9 +77,58 @@ function resolvePlan(entries, offline) {
       continue;
     }
     seen.add(key);
-    plan.push({ repo, ref, target: target || path.join('.ci', repo.split('/')[1]) });
+    const safeTarget = resolveDependencyTarget(target || path.join('.ci', repo.split('/')[1]), workspace);
+    plan.push({ repo, ref, target: safeTarget.target, targetPath: safeTarget.targetPath });
   }
   return plan;
+}
+
+function resolveDependencyTarget(rawTarget, workspace) {
+  const target = String(rawTarget || '').trim();
+  if (!target || target === '.' || target === '..' || path.isAbsolute(target) || path.win32.isAbsolute(target)) {
+    throw new Error(`Dependency target must be a relative path under .ci/: ${target || '(empty)'}`);
+  }
+
+  const segments = target.split(/[\\/]+/);
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    throw new Error(`Dependency target must not contain empty, current-directory, or parent-directory segments: ${target}`);
+  }
+
+  const normalized = path.normalize(target);
+  const safeRoot = path.resolve(workspace, '.ci');
+  const targetPath = path.resolve(workspace, normalized);
+  const relativeToSafeRoot = path.relative(safeRoot, targetPath);
+  // Dependency materialization deletes the target before cloning; keep that write bounded to .ci/*.
+  if (relativeToSafeRoot === '' || relativeToSafeRoot.startsWith('..') || path.isAbsolute(relativeToSafeRoot)) {
+    throw new Error(`Dependency target must resolve under .ci/: ${target}`);
+  }
+
+  return { target: normalized, targetPath };
+}
+
+function assertSafeDependencyTargetPath(targetPath, workspace) {
+  const safeRoot = path.resolve(workspace, '.ci');
+  fs.mkdirSync(safeRoot, { recursive: true });
+  const workspaceRealPath = fs.realpathSync(path.resolve(workspace));
+  const safeRootRealPath = fs.realpathSync(safeRoot);
+  if (safeRootRealPath !== path.join(workspaceRealPath, '.ci')) {
+    throw new Error(`Dependency safe root must be a workspace-owned directory: ${safeRoot}`);
+  }
+
+  let existingParent = targetPath;
+  while (!fs.existsSync(existingParent)) {
+    const parent = path.dirname(existingParent);
+    if (parent === existingParent) {
+      break;
+    }
+    existingParent = parent;
+  }
+
+  const parentRealPath = fs.realpathSync(existingParent);
+  const relativeToSafeRoot = path.relative(safeRootRealPath, parentRealPath);
+  if (relativeToSafeRoot.startsWith('..') || path.isAbsolute(relativeToSafeRoot)) {
+    throw new Error(`Dependency target parent must resolve under .ci/: ${targetPath}`);
+  }
 }
 
 function normalizeDependencyEntry(rawEntry) {
@@ -110,4 +161,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { dependencyEntries, resolvePlan };
+module.exports = { assertSafeDependencyTargetPath, dependencyEntries, resolveDependencyTarget, resolvePlan };

--- a/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
+++ b/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
@@ -33,17 +33,35 @@ const explicitProviderPlugin = {
     connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
   },
 };
-assert.deepEqual(resolvePlan(dependencyEntries({
+const providerPluginPlan = resolvePlan(dependencyEntries({
   ...baseEnv,
   PROVIDER_PLUGIN: JSON.stringify(explicitProviderPlugin),
-}), true), [{
+}), true, { workspace: repoRoot });
+assert.deepEqual(providerPluginPlan, [{
   repo: 'WordPress/ai-provider-for-openai',
   ref: 'trunk',
   target: '.ci/ai-provider-for-openai',
+  targetPath: path.join(repoRoot, '.ci', 'ai-provider-for-openai'),
 }]);
 assert.deepEqual(normalizeProviderPlugin(JSON.stringify(explicitProviderPlugin), 'openai', true).provider_secret_env, {
   connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
 });
+
+for (const unsafeTarget of ['.', '/tmp/foo', '../repo']) {
+  assert.throws(
+    () => resolvePlan([{ repo: 'Extra-Chill/example', ref: 'main', target: unsafeTarget }], true, { workspace: repoRoot }),
+    /Dependency target must/,
+    `rejects unsafe dependency target ${unsafeTarget}`,
+  );
+}
+assert.deepEqual(resolvePlan([
+  { repo: 'Extra-Chill/example-dependency', ref: 'main', target: '.ci/dependencies/example-dependency' },
+], true, { workspace: repoRoot }), [{
+  repo: 'Extra-Chill/example-dependency',
+  ref: 'main',
+  target: '.ci/dependencies/example-dependency',
+  targetPath: path.join(repoRoot, '.ci', 'dependencies', 'example-dependency'),
+}]);
 
 const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutral-workspace-'));
 const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutral-runner-'));


### PR DESCRIPTION
## Summary
- Constrain runtime and validation dependency materialization targets to workspace-relative .ci/* paths.
- Reject absolute targets, current-directory targets, parent traversal, workspace root, and unsafe nested path segments before delete/clone.
- Resolve destructive operations to a workspace-owned target path and verify the .ci safe root/nearest existing parent do not resolve outside the workspace via symlinks.
- Add provider-neutral smoke coverage for target '.', '/tmp/foo', '../repo', and a valid nested dependency target.

## Local verification
- node tests/runtime-agent-full-run-provider-neutral-smoke.mjs
- node --check .github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
- env RUNTIME=local-shell PROVIDER=openai PROVIDER_PLUGIN='{}' VALIDATION_DEPENDENCIES='Extra-Chill/example@main' RUNTIME_DEPENDENCIES='' node .github/scripts/runtime-agent-full-run/materialize-dependencies.cjs --print-plan

## GitHub Actions
- GitHub Actions were not invoked for this PR.
- GHA rate-limit bypass: verification was performed locally with targeted Node checks instead of dispatching workflow runs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the target validation hardening, adding Node smoke coverage, and drafting the PR description.
