### PR TITLE
Harden reviewer-facing evidence refs

### DIFF
--- a/runtime-agent-ci/lib/controller-loop-proof-validator.js
+++ b/runtime-agent-ci/lib/controller-loop-proof-validator.js
@@ -189,12 +189,10 @@ function validateReviewerFacingUrls(options) {
   if (!reviewerFacing || options.policy.allow_local_reviewer_evidence === true) {
     return;
   }
-  const url = refUrl(options.ref);
-  if (!url) {
-    return;
-  }
-  if (localOnlyUrl(url)) {
-    options.failures.push(failure(options.failureClass, `Reviewer-facing evidence must use a durable non-local URL: ${options.label}`, { url }));
+  for (const ref of reviewerFacingRefs(options.ref)) {
+    if (localOnlyReviewerFacingRef(ref.value)) {
+      options.failures.push(failure(options.failureClass, `Reviewer-facing evidence must use a durable non-local ref: ${options.label}`, { field: ref.field, ref: ref.value }));
+    }
   }
 }
 
@@ -331,20 +329,47 @@ function refUrl(ref) {
   return ref.url || ref.uri || ref.href || ref.public_url || ref.publicUrl || ref.artifact_url || ref.artifactUrl || ref.path || '';
 }
 
-function durableUrl(url) {
-  return typeof url === 'string' && /^https?:\/\//i.test(url) && !localOnlyUrl(url);
+function reviewerFacingRefs(ref) {
+  if (!isObject(ref)) {
+    return [];
+  }
+  const publicFields = [
+    'url',
+    'uri',
+    'href',
+    'public_url',
+    'publicUrl',
+    'artifact_url',
+    'artifactUrl',
+    'ref',
+    'reference',
+  ]
+    .filter((field) => typeof ref[field] === 'string' && ref[field].trim() !== '')
+    .map((field) => ({ field, value: ref[field].trim() }));
+  if (publicFields.length > 0) {
+    return publicFields;
+  }
+  return typeof ref.path === 'string' && ref.path.trim() !== ''
+    ? [{ field: 'path', value: ref.path.trim() }]
+    : [];
 }
 
-function localOnlyUrl(url) {
-  if (typeof url !== 'string' || url.trim() === '') {
+function durableUrl(url) {
+  return typeof url === 'string' && /^https?:\/\//i.test(url) && !localOnlyReviewerFacingRef(url);
+}
+
+function localOnlyReviewerFacingRef(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
     return false;
   }
-  return /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(url)
-    || /^file:\/\//i.test(url)
-    || /^\/Users\//.test(url)
-    || /^\/private\//.test(url)
-    || /^\/tmp\//.test(url)
-    || /^\.\.?\//.test(url);
+  const ref = value.trim();
+  return /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(ref)
+    || /^file:\/\//i.test(ref)
+    || /^\/Users\//.test(ref)
+    || /^\/private\//.test(ref)
+    || /^\/tmp(?:\/|$)/.test(ref)
+    || /^\.\.?(?:\/|$)/.test(ref)
+    || /^[^:/?#]+(?:\/|$)/.test(ref);
 }
 
 function failure(className, message, data) {
@@ -370,5 +395,6 @@ function isObject(value) {
 
 module.exports = {
   assertControllerLoopProof,
+  localOnlyReviewerFacingRef,
   validateControllerLoopProof,
 };

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { runDeterministicLoop } = require('./deterministic-loop-runner');
-const { validateControllerLoopProof } = require('./controller-loop-proof-validator');
+const { localOnlyReviewerFacingRef, validateControllerLoopProof } = require('./controller-loop-proof-validator');
 const {
   CONTINUE,
   evaluateLoopPolicy,
@@ -723,6 +723,11 @@ function validateGenericAgentLoopOutcomeContract(options = {}) {
     const ref = findEvidenceRef(evidenceRefs, requirement);
     if (!ref) {
       errors.push(`missing required evidence ref ${requirement.name || requirement.kind || requirement.url || requirement.uri || '(unnamed)'}`);
+      continue;
+    }
+    const refValue = evidenceRefUrl(ref);
+    if (localOnlyReviewerFacingRef(refValue)) {
+      errors.push(`required evidence ref ${requirement.name || requirement.kind || requirement.url || requirement.uri || '(unnamed)'} uses local-only evidence: ${refValue}`);
     }
   }
 

--- a/tests/controller-loop-proof-validator.test.mjs
+++ b/tests/controller-loop-proof-validator.test.mjs
@@ -12,6 +12,7 @@ const validator = require(path.join(repoRoot, 'runtime-agent-ci/lib/controller-l
 assert.equal(typeof runtimeAgentCi.validateControllerLoopProof, 'function');
 assert.equal(runtimeAgentCi.validateControllerLoopProof, validator.validateControllerLoopProof);
 assert.equal(typeof runtimeAgentCi.assertControllerLoopProof, 'function');
+assert.equal(typeof runtimeAgentCi.localOnlyReviewerFacingRef, 'function');
 
 const baseSpec = {
   schema: 'example/controller-loop-spec/v1',
@@ -57,6 +58,36 @@ assert.equal(hasFailure(report, 'artifact.required_missing'), true);
 report = validator.validateControllerLoopProof({
   spec: baseSpec,
   proof: { ...baseProof, artifacts: [{ id: 'run-log', url: 'http://localhost:8888/run-log' }] },
+});
+assert.equal(report.valid, false);
+assert.equal(hasFailure(report, 'artifact.local_reviewer_evidence'), true);
+
+for (const localRef of [
+  'http://127.0.0.1:8888/run-log',
+  'file:///tmp/run-log',
+  '/tmp/run-log',
+  '/Users/chris/run-log',
+  './run-log',
+  '../run-log',
+  'run-log.json',
+]) {
+  report = validator.validateControllerLoopProof({
+    spec: baseSpec,
+    proof: { ...baseProof, artifacts: [{ id: 'run-log', path: localRef }] },
+  });
+  assert.equal(report.valid, false, `${localRef} should be rejected`);
+  assert.equal(hasFailure(report, 'artifact.local_reviewer_evidence'), true, `${localRef} should report local reviewer evidence`);
+}
+
+report = validator.validateControllerLoopProof({
+  spec: baseSpec,
+  proof: { ...baseProof, artifacts: [{ id: 'run-log', public_url: 'https://example.test/artifacts/run-log', path: '/tmp/private-run-log' }] },
+});
+assert.equal(report.valid, true);
+
+report = validator.validateControllerLoopProof({
+  spec: baseSpec,
+  proof: { ...baseProof, artifacts: [{ id: 'run-log', url: 'file:///tmp/private-run-log', public_url: 'https://example.test/artifacts/run-log' }] },
 });
 assert.equal(report.valid, false);
 assert.equal(hasFailure(report, 'artifact.local_reviewer_evidence'), true);


### PR DESCRIPTION
## Summary
- Centralize generic reviewer-facing evidence ref screening in the controller loop proof validator.
- Reject local-only refs including localhost/127.0.0.1/0.0.0.0/[::1], file://, /tmp, /Users, /private, and relative paths when they are reviewer-facing proof refs.
- Preserve local artifact paths as private metadata when a durable public ref is also present.
- Reuse the same generic helper for required generic loop evidence refs.

## Local verification
- `node tests/controller-loop-proof-validator.test.mjs`
- `node tests/generic-agent-loop-runner-smoke.mjs`

## GitHub Actions
- Not invoked per task instruction. Local verification is documented here as the GHA rate-limit bypass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing validator hardening, focused tests, local verification, and PR preparation.
