### PR TITLE
Expose runtime provider source metadata

### DIFF
--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -2,8 +2,10 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const childProcess = require('node:child_process');
 
 const DEFAULT_RUNTIME_ID = 'local-shell';
+const RUNTIME_SOURCE_METADATA = Symbol('homeboy.runtimeSourceMetadata');
 
 function repoRootFromHere() {
 	return path.resolve(__dirname, '..', '..');
@@ -22,20 +24,176 @@ function runtimeRegistry(options = {}) {
 	const manifests = {};
 	const runtimesRoot = path.join(repoRoot, 'agent-runtimes');
 	for (const manifestPath of runtimeManifestPaths(runtimesRoot)) {
-		let manifest;
-		try {
-			manifest = readJson(manifestPath);
-		} catch {
-			continue;
-		}
-		if (!isRuntimeManifest(manifest)) {
+		const manifest = loadRuntimeManifest(manifestPath, {
+			kind: 'repo',
+			source_path: path.dirname(manifestPath),
+		});
+		if (!manifest) {
 			continue;
 		}
 		if (!manifests[manifest.id]) {
 			manifests[manifest.id] = manifest;
 		}
 	}
+	for (const manifestPath of explicitRuntimeManifestPaths(options)) {
+		const manifest = loadRuntimeManifest(manifestPath, {
+			kind: 'manifest',
+			source_path: path.dirname(manifestPath),
+		});
+		if (!manifest) {
+			continue;
+		}
+		if (!manifests[manifest.id]) {
+			manifests[manifest.id] = manifest;
+		}
+	}
+	for (const runtimePackage of explicitRuntimePackages(options)) {
+		const manifest = loadRuntimePackageManifest(runtimePackage, options);
+		if (!manifests[manifest.id]) {
+			manifests[manifest.id] = manifest;
+		}
+	}
 	return manifests;
+}
+
+function loadRuntimeManifest(manifestPath, source = {}) {
+	const resolvedManifestPath = path.resolve(manifestPath);
+	let manifest;
+	try {
+		manifest = readJson(resolvedManifestPath);
+	} catch {
+		return null;
+	}
+	if (!isRuntimeManifest(manifest)) {
+		return null;
+	}
+	return attachRuntimeSourceMetadata(manifest, {
+		...source,
+		manifest_path: resolvedManifestPath,
+		source_path: source.source_path ? path.resolve(source.source_path) : path.dirname(resolvedManifestPath),
+		...gitSourceRevision(source.source_path || path.dirname(resolvedManifestPath)),
+	});
+}
+
+function loadRuntimePackageManifest(runtimePackage, options = {}) {
+	const spec = typeof runtimePackage === 'string' ? runtimePackage : runtimePackage?.package || runtimePackage?.name;
+	if (!spec || typeof spec !== 'string') {
+		throw new Error('Runtime package entries require a package name or specifier.');
+	}
+	const packageRoot = resolveRuntimePackageRoot(spec, options);
+	const packageJsonPath = path.join(packageRoot, 'package.json');
+	const packageJson = readJson(packageJsonPath);
+	const manifestRelativePath = firstString(
+		typeof runtimePackage === 'object' ? runtimePackage.manifest : '',
+		packageJson.homeboy?.agent_runtime_manifest,
+		packageJson.homeboy?.runtime_manifest,
+		packageJson.agent_runtime_manifest,
+		packageJson.runtime_manifest,
+		'agent-runtime.json',
+		'runtime.json'
+	);
+	const manifestPath = path.resolve(packageRoot, manifestRelativePath);
+	const manifest = loadRuntimeManifest(manifestPath, {
+		kind: 'package',
+		package: spec,
+		source_path: packageRoot,
+	});
+	if (!manifest) {
+		throw new Error(`Runtime package ${spec} does not expose a valid Homeboy agent runtime manifest at ${manifestPath}. Add package.json homeboy.agent_runtime_manifest or pass an explicit manifest path.`);
+	}
+	return manifest;
+}
+
+function resolveRuntimePackageRoot(spec, options = {}) {
+	const basePaths = runtimePackageBasePaths(options);
+	try {
+		return path.dirname(require.resolve(`${spec}/package.json`, { paths: basePaths }));
+	} catch (error) {
+		throw new Error(`Runtime package ${spec} could not be resolved from ${basePaths.join(', ')}. Install the package or pass runtimeManifests/runtimeManifestPath for local iteration. Original error: ${error.message}`);
+	}
+}
+
+function explicitRuntimeManifestPaths(options = {}) {
+	return normalizeStringList(
+		options.runtimeManifests,
+		options.runtime_manifest_paths,
+		options.runtimeManifestPaths,
+		options.runtimeManifest,
+		options.runtime_manifest,
+		options.runtimeManifestPath,
+		options.runtime_manifest_path,
+		options.env?.AGENT_RUNTIME_MANIFESTS,
+		options.env?.AGENT_RUNTIME_MANIFEST,
+		process.env.AGENT_RUNTIME_MANIFESTS,
+		process.env.AGENT_RUNTIME_MANIFEST
+	).map((manifestPath) => path.resolve(manifestPath));
+}
+
+function explicitRuntimePackages(options = {}) {
+	return [
+		...normalizeList(options.runtimePackages, options.runtime_packages, options.runtimePackage, options.runtime_package),
+		...normalizeStringList(options.env?.AGENT_RUNTIME_PACKAGES, options.env?.AGENT_RUNTIME_PACKAGE, process.env.AGENT_RUNTIME_PACKAGES, process.env.AGENT_RUNTIME_PACKAGE),
+	];
+}
+
+function runtimePackageBasePaths(options = {}) {
+	return normalizeStringList(options.packageBasePaths, options.package_base_paths, options.packageBasePath, options.package_base_path, process.cwd());
+}
+
+function normalizeStringList(...values) {
+	return normalizeList(...values).flatMap((value) => typeof value === 'string' ? value.split(path.delimiter).map((entry) => entry.trim()).filter(Boolean) : []);
+}
+
+function normalizeList(...values) {
+	const entries = [];
+	for (const value of values) {
+		if (Array.isArray(value)) {
+			entries.push(...value.filter(Boolean));
+			continue;
+		}
+		if (value) {
+			entries.push(value);
+		}
+	}
+	return entries;
+}
+
+function attachRuntimeSourceMetadata(manifest, source) {
+	Object.defineProperty(manifest, RUNTIME_SOURCE_METADATA, {
+		value: normalizeRuntimeSource(source),
+		enumerable: false,
+		configurable: true,
+	});
+	return manifest;
+}
+
+function runtimeSourceMetadata(manifest, fallback = {}) {
+	return normalizeRuntimeSource(manifest?.[RUNTIME_SOURCE_METADATA] || fallback);
+}
+
+function normalizeRuntimeSource(source = {}) {
+	const sourcePath = firstString(source.source_path, source.path);
+	return {
+		kind: firstString(source.kind, 'registry'),
+		...(source.package ? { package: source.package } : {}),
+		...(sourcePath ? { source_path: sourcePath } : {}),
+		...(source.manifest_path ? { manifest_path: source.manifest_path } : {}),
+		...(source.revision ? { revision: source.revision } : {}),
+		...(source.ref ? { ref: source.ref } : {}),
+	};
+}
+
+function gitSourceRevision(sourcePath) {
+	try {
+		const revision = childProcess.execFileSync('git', ['-C', sourcePath, 'rev-parse', 'HEAD'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+		const ref = childProcess.execFileSync('git', ['-C', sourcePath, 'rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+		return {
+			...(revision ? { revision } : {}),
+			...(ref && ref !== 'HEAD' ? { ref } : {}),
+		};
+	} catch {
+		return {};
+	}
 }
 
 function runtimeManifestPaths(runtimesRoot) {
@@ -125,6 +283,11 @@ function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 	if (!manifest) {
 		throw new Error(`Unsupported agent_runtime: ${id}. Registered runtimes: ${Object.keys(registry).sort().join(', ') || '(none)'}.`);
 	}
+	const source = runtimeSourceMetadata(manifest, {
+		kind: 'registry',
+		source_path: path.join(options.repoRoot || repoRootFromHere(), 'agent-runtimes', id),
+		manifest_path: runtimeManifestPath(id, options.repoRoot || repoRootFromHere()),
+	});
 
 	const materialization = manifest.ci_materialization || {};
 	const workspace = options.workspace || process.env.GITHUB_WORKSPACE || process.cwd();
@@ -141,12 +304,13 @@ function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 		id,
 		requested_id: requestedId,
 		...(aliasDeprecation ? { deprecated_runtime_alias: aliasDeprecation } : {}),
+		source,
 		manifest,
 		checkout,
 		setupCommands: normalizeCommands(materialization.setup_commands || []),
 		buildCommands: normalizeCommands(materialization.build_commands || []),
 		paths: resolvePaths(materialization.paths || {}, workspace, options.env || process.env),
-		executor: resolveExecutor(manifest, options.repoRoot || repoRootFromHere(), options),
+		executor: resolveExecutor(manifest, source, options),
 	};
 }
 
@@ -249,9 +413,9 @@ function isWorkspaceRelativePath(value) {
 	return value.startsWith('.') || value.includes('/') || value.includes('\\');
 }
 
-function resolveExecutor(manifest, repoRoot, options = {}) {
+function resolveExecutor(manifest, source, options = {}) {
 	const provider = selectExecutor(manifest, executorSelectionFromOptions(options));
-	const runtimePath = path.join(repoRoot, 'agent-runtimes', manifest.id);
+	const runtimePath = source.source_path || path.join(options.repoRoot || repoRootFromHere(), 'agent-runtimes', manifest.id);
 	const invocation = resolveExecutorInvocation(provider, runtimePath, options);
 	const scriptArg = invocation.argv.find((arg) => typeof arg === 'string' && arg.includes(runtimePath)) || executorScriptArg(provider);
 	return {

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
@@ -24,6 +26,9 @@ assert.ok(registry.opencode, 'opencode is registered as a selectable runtime pro
 
 const defaultRuntime = resolveRuntimeProvider(undefined, { repoRoot: rootDir, workspace });
 assert.equal(defaultRuntime.id, 'local-shell');
+assert.equal(defaultRuntime.source.kind, 'repo');
+assert.equal(defaultRuntime.source.source_path, path.join(rootDir, 'agent-runtimes/local-shell'));
+assert.equal(defaultRuntime.source.manifest_path, path.join(rootDir, 'agent-runtimes/local-shell/local-shell.json'));
 assert.equal(defaultRuntime.executor.backend, 'local-shell');
 assert.equal(defaultRuntime.executor.path, path.join(rootDir, 'agent-runtimes/local-shell/scripts/agent/homeboy-local-shell-agent-task-executor.cjs'));
 
@@ -100,6 +105,54 @@ assert.equal(opencodeRuntime.executor.backend, 'opencode');
 assert.equal(opencodeRuntime.executor.path, path.join(rootDir, 'agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs'));
 assert.equal(opencodeRuntime.manifest.agent_task_executors[0].status, 'active');
 assert.equal(opencodeRuntime.manifest.agent_task_executors[0].capabilities.includes('nested_orchestrator'), true);
+
+const tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-provider-')));
+const externalRuntimeDir = path.join(tempDir, 'external-runtime');
+fs.mkdirSync(path.join(externalRuntimeDir, 'scripts'), { recursive: true });
+const externalManifestPath = path.join(externalRuntimeDir, 'external-runtime.json');
+fs.writeFileSync(externalManifestPath, JSON.stringify({
+	schema: 'homeboy/agent-runtime-manifest/v1',
+	id: 'external-runtime',
+	agent_task_executors: [executorFixture('external.agent', 'external-shell', 'active', [])],
+}, null, 2));
+const externalRuntime = resolveRuntimeProvider('external-runtime', {
+	repoRoot: rootDir,
+	runtimeManifestPath: externalManifestPath,
+	workspace,
+});
+assert.equal(externalRuntime.source.kind, 'manifest');
+assert.equal(externalRuntime.source.source_path, externalRuntimeDir);
+assert.equal(externalRuntime.source.manifest_path, externalManifestPath);
+assert.equal(externalRuntime.executor.path, path.join(externalRuntimeDir, 'scripts/external.agent.cjs'));
+
+const packageRoot = path.join(tempDir, 'node_modules/@example/homeboy-runtime');
+fs.mkdirSync(packageRoot, { recursive: true });
+fs.writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({
+	name: '@example/homeboy-runtime',
+	version: '1.0.0',
+	homeboy: { agent_runtime_manifest: 'runtime-manifest.json' },
+}, null, 2));
+fs.writeFileSync(path.join(packageRoot, 'runtime-manifest.json'), JSON.stringify({
+	schema: 'homeboy/agent-runtime-manifest/v1',
+	id: 'packaged-runtime',
+	agent_task_executors: [executorFixture('packaged.agent', 'package-shell', 'active', [])],
+}, null, 2));
+const packagedRuntime = resolveRuntimeProvider('packaged-runtime', {
+	repoRoot: rootDir,
+	runtimePackage: '@example/homeboy-runtime',
+	packageBasePath: tempDir,
+	workspace,
+});
+assert.equal(packagedRuntime.source.kind, 'package');
+assert.equal(packagedRuntime.source.package, '@example/homeboy-runtime');
+assert.equal(packagedRuntime.source.source_path, packageRoot);
+assert.equal(packagedRuntime.source.manifest_path, path.join(packageRoot, 'runtime-manifest.json'));
+assert.equal(packagedRuntime.executor.path, path.join(packageRoot, 'scripts/packaged.agent.cjs'));
+
+assert.throws(
+	() => runtimeRegistry({ repoRoot: rootDir, runtimePackage: '@example/missing-runtime', packageBasePath: tempDir }),
+	/Runtime package @example\/missing-runtime could not be resolved .* Install the package or pass runtimeManifests\/runtimeManifestPath for local iteration\./
+);
 
 const multiRegistry = {
 	'multi-executor': {


### PR DESCRIPTION
## Summary
- record runtime source metadata for repo, explicit manifest, and package-loaded runtime manifests
- resolve executor runtime paths from the selected source path instead of assuming the monorepo agent-runtimes layout
- add smoke coverage for explicit external manifests, package manifest entrypoints, and missing runtime package diagnostics

## Tests
- `node --check runtime-agent-ci/lib/runtime-provider-resolver.cjs`
- `node --check tests/runtime-provider-resolver-smoke.mjs`
- `node tests/runtime-provider-resolver-smoke.mjs`
- `node runtime-agent-ci/tests/runtime-provider-boundary.test.js`

## Notes
- `npm test` in `runtime-agent-ci` currently fails on an existing assertion/message mismatch in `generic-agent-loop-runner.test.js`: expected `durable non-local URL`, actual `durable non-local ref`. This PR does not change that path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing runtime resolver source metadata/package loading seam, adding tests, and running verification.