### PR TITLE
Clarify fuzz runtime artifact normalization

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -1731,7 +1731,7 @@ function normalizeWpCodeboxFuzzArtifacts(source = {}, result = {}) {
 }
 
 function appendInlineResultEnvelopeArtifact(artifacts, source = {}) {
-	if (!objectOrUndefined(source) || !source.schema || hasFuzzArtifactRole(artifacts, 'result_envelope')) {
+	if (artifacts.length > 0 || !objectOrUndefined(source) || !source.schema || hasFuzzArtifactRole(artifacts, 'result_envelope')) {
 		return;
 	}
 	artifacts.push({

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -390,7 +390,7 @@ const dispatchPromise = runWordPressFuzzRunnerResult({
 	assert.equal(dispatchedResult.succeeded, true);
 	assert.equal(dispatchedResult.wp_codebox_result.request_id, 'dispatch-run');
 	assert.equal(dispatchedResult.wp_codebox_result.coverage_summary.surface_count, 1);
-	assert.deepEqual(dispatchedResult.wp_codebox_result.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'result_envelope']);
+	assert.deepEqual(dispatchedResult.wp_codebox_result.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage']);
 	assert.equal(dispatchedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].semantic_key, 'fuzz.report');
 	assert.equal(dispatchedResult.homeboy_fuzz_campaign.metadata.artifact_refs[1].semantic_key, 'fuzz.coverage');
 });

--- a/wordpress/tests/wordpress-fuzz-runtime-task.test.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-task.test.js
@@ -156,7 +156,9 @@ Promise.all([
 		assert.equal(summary.status, 'succeeded');
 		assert.equal(summary.artifacts.length, 1);
 		assert.equal(summary.artifacts[0].semantic_key, 'fuzz.report');
+		assert.equal(summary.artifacts.some((artifact) => artifact.role === 'result_envelope'), false);
 		assert.equal(summary.runtime_task_result.artifacts.length, 1);
+		assert.equal(summary.runtime_task_result.artifacts[0].semantic_key, 'fuzz.report');
 	}),
 
 	runWpCodeboxFuzzSuite({

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -352,7 +352,7 @@ assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name 
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'case-log'), true);
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'replay-data'), true);
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'coverage-summary'), true);
-assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'result-envelope' && artifact.role === 'result_envelope'), true);
+assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'result-envelope' && artifact.role === 'result_envelope'), false);
 
 const genericPrimitiveManifest = {
 	schema: 'homeboy/fuzz-workload/v1',
@@ -593,7 +593,7 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.observation_set.observations.some((observation) => observation.case_id === 'case-000' && observation.metric === 'query_count'), true);
 	assert.equal(summary.runtime_task_result.observation_set.observations[0].fingerprint, 'select-posts');
 	assert.equal(summary.derived_artifacts.artifacts.some((artifact) => artifact.role === 'hotspot_summary'), true);
-	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'normalized_fuzz_result', 'coverage_gap_report', 'hotspot_summary', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case', 'repro_case', 'result_envelope']);
+	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'normalized_fuzz_result', 'coverage_gap_report', 'hotspot_summary', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case', 'repro_case']);
 	assert.equal(summary.artifacts[0].semantic_key, 'fuzz.report');
 	assert.equal(summary.artifacts[9].semantic_key, 'fuzz.case.repro');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').semantic_key, 'fuzz.coverage');
@@ -605,7 +605,7 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'failing_case').semantic_key, 'fuzz.case.failing');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'case_artifact').semantic_key, 'fuzz.case.artifact');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'repro_case').semantic_key, 'fuzz.case.repro');
-	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'result_envelope').semantic_key, 'fuzz.result.envelope');
+	assert.equal(summary.artifacts.some((artifact) => artifact.role === 'result_envelope'), false);
 	assert.equal(summary.artifacts.some((artifact) => artifact.name === 'placeholder-only'), false);
 	assert.equal(summary.observation.schema, WORDPRESS_FUZZ_OBSERVATION_SCHEMA);
 	assert.equal(summary.observation.status, 'succeeded');
@@ -679,7 +679,6 @@ runWpCodeboxFuzzSuite({
 		['case_log', 'fuzz.case.log'],
 		['replay_data', 'fuzz.replay.data'],
 		['coverage_summary', 'fuzz.coverage.summary'],
-		['result_envelope', 'fuzz.result.envelope'],
 	]);
 
 	const normalized = normalizeWpCodeboxFuzzSuiteResult({ status: 'failed', failures: [{ message: 'boom' }] });


### PR DESCRIPTION
## Summary
- Keep normalized fuzz runtime artifacts limited to concrete provider artifact references when the provider returns artifacts.
- Preserve the inline result-envelope fallback only for responses with no concrete artifact references.
- Update runtime/runner fuzz tests to make the provider-artifacts-only contract explicit.

## Tests
- npm run test:wordpress-fuzz-runtime-task
- npm run test:wordpress-fuzz-runner
- npm run test:wp-codebox-fuzz-suite

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the failing artifact normalization test, implementing the narrow runtime/test fix, and running local verification.