### PR TITLE
Expand WordPress live surface metadata discovery

### DIFF
--- a/wordpress/lib/wordpress-live-surface-discovery.js
+++ b/wordpress/lib/wordpress-live-surface-discovery.js
@@ -22,6 +22,17 @@ const WORDPRESS_LIVE_SURFACE_TYPES = Object.freeze({
 	db_table: 'Database tables',
 	frontend_url: 'Frontend URLs',
 	block: 'Blocks',
+	ajax_action: 'AJAX actions',
+	capability: 'Capabilities',
+	cron_event: 'Cron events',
+	media: 'Media',
+	option: 'Options',
+	post_type: 'Post types',
+	role: 'Roles',
+	setting: 'Settings',
+	taxonomy: 'Taxonomies',
+	user: 'Users',
+	wp_cli_command: 'WP-CLI commands',
 });
 
 function buildWordPressLiveSurfaceDiscoveryArtifact(input = {}, options = {}) {
@@ -32,6 +43,17 @@ function buildWordPressLiveSurfaceDiscoveryArtifact(input = {}, options = {}) {
 		{ tables: payload.databaseTables },
 		{ frontendUrls: payload.frontendUrls },
 		{ blocks: payload.blocks },
+		{ ajaxActions: payload.ajaxActions },
+		{ cronEvents: payload.cronEvents },
+		{ options: payload.options },
+		{ settings: payload.settings },
+		{ roles: payload.roles },
+		{ capabilities: payload.capabilities },
+		{ users: payload.users },
+		{ media: payload.media },
+		{ postTypes: payload.postTypes },
+		{ taxonomies: payload.taxonomies },
+		{ wpCliCommands: payload.wpCliCommands },
 	];
 	const unsupported = normalizeUnsupportedSurfaces(payload.unsupported, payload.supportedTypes);
 
@@ -101,6 +123,17 @@ function normalizeLiveSurfacePayload(input = {}) {
 		databaseTables: firstArray(payload.databaseTables, payload.database_tables, payload.database, payload.db, payload.tables),
 		frontendUrls: firstArray(payload.frontendUrls, payload.frontend_urls, payload.frontend, payload.urls),
 		blocks: firstArray(payload.blocks, payload.blockTypes, payload.block_types),
+		ajaxActions: firstArray(payload.ajaxActions, payload.ajax_actions, payload.ajax, payload.actions),
+		cronEvents: concatArrays(payload.cronEvents, payload.cron_events, payload.cron, payload.cronSchedules, payload.cron_schedules),
+		options: firstArray(payload.options),
+		settings: firstArray(payload.settings),
+		roles: firstArray(payload.roles),
+		capabilities: firstArray(payload.capabilities, payload.caps),
+		users: firstArray(payload.users),
+		media: firstArray(payload.media, payload.attachments),
+		postTypes: firstArray(payload.postTypes, payload.post_types),
+		taxonomies: firstArray(payload.taxonomies),
+		wpCliCommands: firstArray(payload.wpCliCommands, payload.wp_cli_commands, payload.wpCli, payload.wp_cli, payload.commands),
 		unsupported: firstArray(payload.unsupported, payload.unsupportedSurfaces, payload.unsupported_surfaces),
 		supportedTypes: firstArray(payload.supportedTypes, payload.supported_types),
 	};
@@ -108,6 +141,10 @@ function normalizeLiveSurfacePayload(input = {}) {
 
 function firstArray(...values) {
 	return values.find(Array.isArray) || [];
+}
+
+function concatArrays(...values) {
+	return values.filter(Array.isArray).flat();
 }
 
 function normalizeUnsupportedSurfaces(rows, supportedTypes = []) {

--- a/wordpress/lib/wordpress-runtime-surface-discovery.js
+++ b/wordpress/lib/wordpress-runtime-surface-discovery.js
@@ -171,7 +171,8 @@ function appendFuzzSurfaceArtifact(surfaces, artifact) {
 function appendArraySurfaces(surfaces, value, defaultType, source) {
 	if (Array.isArray(value)) {
 		for (const item of value) {
-			surfaces.push(isPlainObject(item) ? { ...item, type: item.type || item.kind || defaultType, source: item.source || source } : { label: item, value: item, type: defaultType, source });
+			const type = source === 'settings' && defaultType === 'setting' ? defaultType : undefined;
+			surfaces.push(isPlainObject(item) ? { ...item, type: type || item.type || item.kind || defaultType, source: item.source || source } : { label: item, value: item, type: defaultType, source });
 		}
 		return;
 	}

--- a/wordpress/lib/wordpress-surface-types.js
+++ b/wordpress/lib/wordpress-surface-types.js
@@ -58,6 +58,7 @@ const WORDPRESS_SURFACE_TYPE_ALIASES = new Map([
 	['rest', 'rest-route'],
 	['rest_route', 'rest-route'],
 	['roles', 'role'],
+	['setting', 'setting'],
 	['settings', 'setting'],
 	['taxonomy-term', 'taxonomy'],
 	['taxonomy_term', 'taxonomy'],

--- a/wordpress/scripts/runtime/wordpress-live-surface-discovery.php
+++ b/wordpress/scripts/runtime/wordpress-live-surface-discovery.php
@@ -15,6 +15,18 @@ $artifact = array(
 	'databaseTables' => array(),
 	'frontendUrls' => array(),
 	'blocks'       => array(),
+	'ajaxActions'  => array(),
+	'cronEvents'   => array(),
+	'cronSchedules' => array(),
+	'postTypes'    => array(),
+	'taxonomies'   => array(),
+	'roles'        => array(),
+	'capabilities' => array(),
+	'users'        => array(),
+	'options'      => array(),
+	'settings'     => array(),
+	'media'        => array(),
+	'wpCliCommands' => array(),
 	'unsupported'  => array(),
 );
 
@@ -23,6 +35,18 @@ $artifact['adminPages'] = homeboy_wordpress_live_discover_admin_pages( $artifact
 $artifact['databaseTables'] = homeboy_wordpress_live_discover_database_tables( $artifact );
 $artifact['frontendUrls'] = homeboy_wordpress_live_discover_frontend_urls( $artifact );
 $artifact['blocks'] = homeboy_wordpress_live_discover_blocks( $artifact );
+$artifact['ajaxActions'] = homeboy_wordpress_live_discover_ajax_actions( $artifact );
+$artifact['cronEvents'] = homeboy_wordpress_live_discover_cron_events( $artifact );
+$artifact['cronSchedules'] = homeboy_wordpress_live_discover_cron_schedules( $artifact );
+$artifact['postTypes'] = homeboy_wordpress_live_discover_post_types( $artifact );
+$artifact['taxonomies'] = homeboy_wordpress_live_discover_taxonomies( $artifact );
+$artifact['roles'] = homeboy_wordpress_live_discover_roles( $artifact );
+$artifact['capabilities'] = homeboy_wordpress_live_discover_capabilities( $artifact );
+$artifact['users'] = homeboy_wordpress_live_discover_users( $artifact );
+$artifact['options'] = homeboy_wordpress_live_discover_options( $artifact );
+$artifact['settings'] = homeboy_wordpress_live_discover_settings( $artifact );
+$artifact['media'] = homeboy_wordpress_live_discover_media( $artifact );
+$artifact['wpCliCommands'] = homeboy_wordpress_live_discover_wp_cli_commands( $artifact );
 
 echo wp_json_encode( $artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . PHP_EOL;
 
@@ -178,4 +202,291 @@ function homeboy_wordpress_live_discover_blocks( array &$artifact ) {
 	}
 
 	return $blocks;
+}
+
+function homeboy_wordpress_live_discover_ajax_actions( array &$artifact ) {
+	global $wp_filter;
+
+	if ( ! is_array( $wp_filter ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'ajax_action', 'missing_hook_registry', '$wp_filter is unavailable.' );
+		return array();
+	}
+
+	$actions = array();
+	foreach ( array_keys( $wp_filter ) as $hook ) {
+		if ( 0 === strpos( $hook, 'wp_ajax_' ) ) {
+			$actions[] = array(
+				'action'        => substr( $hook, strlen( 'wp_ajax_' ) ),
+				'authenticated' => true,
+				'source'        => 'wp_filter',
+			);
+			continue;
+		}
+		if ( 0 === strpos( $hook, 'wp_ajax_nopriv_' ) ) {
+			$actions[] = array(
+				'action'        => substr( $hook, strlen( 'wp_ajax_nopriv_' ) ),
+				'authenticated' => false,
+				'source'        => 'wp_filter',
+			);
+		}
+	}
+
+	return $actions;
+}
+
+function homeboy_wordpress_live_discover_cron_events( array &$artifact ) {
+	if ( ! function_exists( '_get_cron_array' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'cron_event', 'missing_cron_api', '_get_cron_array() is unavailable.' );
+		return array();
+	}
+
+	$events = array();
+	foreach ( (array) _get_cron_array() as $timestamp => $cronhooks ) {
+		foreach ( (array) $cronhooks as $hook => $instances ) {
+			foreach ( (array) $instances as $instance ) {
+				$events[] = array(
+					'event'     => $hook,
+					'timestamp' => (int) $timestamp,
+					'schedule'  => is_array( $instance ) && isset( $instance['schedule'] ) ? (string) $instance['schedule'] : '',
+					'source'    => '_get_cron_array',
+				);
+			}
+		}
+	}
+
+	return $events;
+}
+
+function homeboy_wordpress_live_discover_cron_schedules( array &$artifact ) {
+	if ( ! function_exists( 'wp_get_schedules' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'cron_event', 'missing_cron_schedules_api', 'wp_get_schedules() is unavailable.' );
+		return array();
+	}
+
+	$schedules = array();
+	foreach ( wp_get_schedules() as $name => $schedule ) {
+		$schedules[] = array(
+			'event'    => $name,
+			'label'    => isset( $schedule['display'] ) ? (string) $schedule['display'] : $name,
+			'interval' => isset( $schedule['interval'] ) ? (int) $schedule['interval'] : null,
+			'source'   => 'wp_get_schedules',
+		);
+	}
+
+	return $schedules;
+}
+
+function homeboy_wordpress_live_discover_post_types( array &$artifact ) {
+	if ( ! function_exists( 'get_post_types' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'post_type', 'missing_post_type_api', 'get_post_types() is unavailable.' );
+		return array();
+	}
+
+	$post_types = array();
+	foreach ( get_post_types( array(), 'objects' ) as $name => $post_type ) {
+		$post_types[] = array(
+			'name'       => $name,
+			'label'      => $post_type->label ?? $name,
+			'public'     => ! empty( $post_type->public ),
+			'showUi'     => ! empty( $post_type->show_ui ),
+			'restBase'   => $post_type->rest_base ?? '',
+			'source'     => 'get_post_types',
+		);
+	}
+
+	return $post_types;
+}
+
+function homeboy_wordpress_live_discover_taxonomies( array &$artifact ) {
+	if ( ! function_exists( 'get_taxonomies' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'taxonomy', 'missing_taxonomy_api', 'get_taxonomies() is unavailable.' );
+		return array();
+	}
+
+	$taxonomies = array();
+	foreach ( get_taxonomies( array(), 'objects' ) as $name => $taxonomy ) {
+		$taxonomies[] = array(
+			'name'       => $name,
+			'label'      => $taxonomy->label ?? $name,
+			'public'     => ! empty( $taxonomy->public ),
+			'hierarchical' => ! empty( $taxonomy->hierarchical ),
+			'objectTypes' => array_values( (array) ( $taxonomy->object_type ?? array() ) ),
+			'restBase'   => $taxonomy->rest_base ?? '',
+			'source'     => 'get_taxonomies',
+		);
+	}
+
+	return $taxonomies;
+}
+
+function homeboy_wordpress_live_discover_roles( array &$artifact ) {
+	if ( ! function_exists( 'wp_roles' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'role', 'missing_roles_api', 'wp_roles() is unavailable.' );
+		return array();
+	}
+
+	$roles = array();
+	foreach ( wp_roles()->roles as $role => $definition ) {
+		$roles[] = array(
+			'role'            => $role,
+			'label'           => $definition['name'] ?? $role,
+			'capabilityCount' => isset( $definition['capabilities'] ) && is_array( $definition['capabilities'] ) ? count( $definition['capabilities'] ) : 0,
+			'source'          => 'wp_roles',
+		);
+	}
+
+	return $roles;
+}
+
+function homeboy_wordpress_live_discover_capabilities( array &$artifact ) {
+	if ( ! function_exists( 'wp_roles' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'capability', 'missing_roles_api', 'wp_roles() is unavailable.' );
+		return array();
+	}
+
+	$capabilities = array();
+	foreach ( wp_roles()->roles as $role => $definition ) {
+		foreach ( array_keys( (array) ( $definition['capabilities'] ?? array() ) ) as $capability ) {
+			$capabilities[ $capability ][] = $role;
+		}
+	}
+
+	ksort( $capabilities );
+	return array_map(
+		function ( $capability, $roles ) {
+			return array(
+				'capability' => $capability,
+				'roleCount'   => count( array_unique( $roles ) ),
+				'source'      => 'wp_roles',
+			);
+		},
+		array_keys( $capabilities ),
+		array_values( $capabilities )
+	);
+}
+
+function homeboy_wordpress_live_discover_users( array &$artifact ) {
+	if ( ! function_exists( 'count_users' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'user', 'missing_user_api', 'count_users() is unavailable.' );
+		return array();
+	}
+
+	$counts = count_users();
+	$users  = array(
+		array(
+			'user'    => 'all',
+			'label'   => 'All users',
+			'count'   => isset( $counts['total_users'] ) ? (int) $counts['total_users'] : 0,
+			'source'  => 'count_users',
+		),
+	);
+	foreach ( (array) ( $counts['avail_roles'] ?? array() ) as $role => $count ) {
+		$users[] = array(
+			'user'   => 'role:' . $role,
+			'label'  => 'Users with role ' . $role,
+			'count'  => (int) $count,
+			'source' => 'count_users',
+		);
+	}
+
+	return $users;
+}
+
+function homeboy_wordpress_live_discover_options( array &$artifact ) {
+	global $wpdb;
+
+	if ( ! isset( $wpdb ) || ! method_exists( $wpdb, 'get_results' ) || empty( $wpdb->options ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'option', 'missing_wpdb', '$wpdb options table access is unavailable.' );
+		return array();
+	}
+
+	$rows = $wpdb->get_results( "SELECT option_name, autoload FROM {$wpdb->options} ORDER BY option_name", ARRAY_A );
+	if ( ! is_array( $rows ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'option', 'options_unavailable', 'Options metadata query returned no rows.' );
+		return array();
+	}
+
+	return array_map(
+		function ( $row ) {
+			return array(
+				'option'   => $row['option_name'] ?? '',
+				'autoload' => $row['autoload'] ?? '',
+				'source'   => 'wpdb_options_metadata',
+			);
+		},
+		$rows
+	);
+}
+
+function homeboy_wordpress_live_discover_settings( array &$artifact ) {
+	global $wp_registered_settings;
+
+	if ( ! is_array( $wp_registered_settings ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'setting', 'missing_settings_registry', '$wp_registered_settings is unavailable.' );
+		return array();
+	}
+
+	$settings = array();
+	foreach ( $wp_registered_settings as $name => $setting ) {
+		$settings[] = array(
+			'setting' => $name,
+			'settingType' => isset( $setting['type'] ) ? (string) $setting['type'] : '',
+			'group'   => isset( $setting['group'] ) ? (string) $setting['group'] : '',
+			'showInRest' => ! empty( $setting['show_in_rest'] ),
+			'source'  => 'wp_registered_settings',
+		);
+	}
+
+	return $settings;
+}
+
+function homeboy_wordpress_live_discover_media( array &$artifact ) {
+	if ( ! function_exists( 'wp_count_attachments' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'media', 'missing_media_api', 'wp_count_attachments() is unavailable.' );
+		return array();
+	}
+
+	$counts = wp_count_attachments();
+	$media  = array();
+	foreach ( get_object_vars( $counts ) as $mime_type => $count ) {
+		$media[] = array(
+			'media'  => $mime_type,
+			'label'  => $mime_type,
+			'count'  => (int) $count,
+			'source' => 'wp_count_attachments',
+		);
+	}
+
+	return $media;
+}
+
+function homeboy_wordpress_live_discover_wp_cli_commands( array &$artifact ) {
+	if ( ! class_exists( 'WP_CLI' ) || ! method_exists( 'WP_CLI', 'get_root_command' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'wp_cli_command', 'missing_wp_cli_runtime', 'WP_CLI command registry is unavailable.' );
+		return array();
+	}
+
+	$root = WP_CLI::get_root_command();
+	if ( ! is_object( $root ) || ! method_exists( $root, 'get_subcommands' ) ) {
+		homeboy_wordpress_live_unsupported( $artifact, 'wp_cli_command', 'missing_wp_cli_command_registry', 'WP_CLI root command registry is unavailable.' );
+		return array();
+	}
+
+	return homeboy_wordpress_live_collect_wp_cli_subcommands( $root, array() );
+}
+
+function homeboy_wordpress_live_collect_wp_cli_subcommands( $command, array $prefix ) {
+	$commands = array();
+	foreach ( $command->get_subcommands() as $name => $subcommand ) {
+		$path       = array_merge( $prefix, array( $name ) );
+		$commands[] = array(
+			'command' => implode( ' ', $path ),
+			'source'  => 'WP_CLI_command_registry',
+		);
+		if ( is_object( $subcommand ) && method_exists( $subcommand, 'get_subcommands' ) ) {
+			$commands = array_merge( $commands, homeboy_wordpress_live_collect_wp_cli_subcommands( $subcommand, $path ) );
+		}
+	}
+
+	return $commands;
 }

--- a/wordpress/tests/wordpress-live-surface-discovery-smoke.js
+++ b/wordpress/tests/wordpress-live-surface-discovery-smoke.js
@@ -14,6 +14,18 @@ const artifact = buildWordPressLiveSurfaceDiscoveryArtifact({
 	databaseTables: [{ name: 'wp_posts', source: 'wpdb' }],
 	frontendUrls: [{ url: 'https://example.test/', label: 'Home', source: 'home_url' }],
 	blocks: [{ name: 'core/paragraph', title: 'Paragraph', source: 'WP_Block_Type_Registry' }],
+	ajaxActions: [{ action: 'heartbeat', source: 'wp_filter' }],
+	cronEvents: [{ event: 'wp_version_check', source: '_get_cron_array' }],
+	cronSchedules: [{ event: 'hourly', interval: 3600, source: 'wp_get_schedules' }],
+	postTypes: [{ name: 'post', label: 'Posts', source: 'get_post_types' }],
+	taxonomies: [{ name: 'category', label: 'Categories', source: 'get_taxonomies' }],
+	roles: [{ role: 'administrator', label: 'Administrator', capabilityCount: 10, source: 'wp_roles' }],
+	capabilities: [{ capability: 'edit_posts', roleCount: 1, source: 'wp_roles' }],
+	users: [{ user: 'all', label: 'All users', count: 2, source: 'count_users' }],
+	options: [{ option: 'blogname', autoload: 'yes', source: 'wpdb_options_metadata' }],
+	settings: [{ setting: 'blogname', settingType: 'string', group: 'general', source: 'wp_registered_settings' }],
+	media: [{ media: 'image/jpeg', count: 3, source: 'wp_count_attachments' }],
+	wpCliCommands: [{ command: 'plugin list', source: 'WP_CLI_command_registry' }],
 	unsupported: [{ type: 'block', reason: 'ignored_when_supported' }],
 	supportedTypes: ['block'],
 });
@@ -21,11 +33,26 @@ const artifact = buildWordPressLiveSurfaceDiscoveryArtifact({
 assert.equal(artifact.schema, 'homeboy/wordpress-surface-discovery/v1');
 assert.deepEqual(artifact.surfaces.map((surface) => surface.id), [
 	'admin:/wp-admin/tools.php',
+	'ajax:heartbeat',
 	'block:core/paragraph',
 	'db:wp_posts',
 	'frontend:https://example.test/',
 	'rest:/wp/v2/posts',
 ]);
+assert.deepEqual(artifact.unsupported_surfaces.map((surface) => surface.id), [
+	'capability:edit_posts',
+	'cron:hourly',
+	'cron:wp_version_check',
+	'media:image/jpeg',
+	'option:blogname',
+	'post-type:post',
+	'role:administrator',
+	'setting:blogname',
+	'taxonomy:category',
+	'user:all',
+	'wp-cli:plugin list',
+]);
+assert.equal(artifact.diagnostics.length, 11);
 assert.deepEqual(artifact.metadata.unsupported_surfaces, []);
 
 const unsupportedArtifact = buildWordPressLiveSurfaceDiscoveryArtifact({

--- a/wordpress/tests/wordpress-runtime-surface-discovery-smoke.js
+++ b/wordpress/tests/wordpress-runtime-surface-discovery-smoke.js
@@ -40,6 +40,18 @@ const discovery = normalizeWordPressRuntimeSurfaceDiscovery({
 			surfaces: [{ id: 'front:home', type: 'frontend-url', path: '/' }],
 			blocks: [{ name: 'example/card', title: 'Card' }],
 		},
+		{
+			options: [{ option: 'blogname', autoload: 'yes' }],
+			settings: [{ setting: 'blogname', type: 'string' }],
+			postTypes: [{ name: 'post', label: 'Posts' }],
+			taxonomies: [{ name: 'category', label: 'Categories' }],
+			roles: [{ role: 'administrator', capabilityCount: 10 }],
+			capabilities: [{ capability: 'edit_posts', roleCount: 1 }],
+			users: [{ user: 'all', count: 2 }],
+			media: [{ media: 'image/jpeg', count: 3 }],
+			wpCliCommands: [{ command: 'plugin list' }],
+			cronEvents: [{ event: 'wp_version_check' }],
+		},
 	],
 });
 
@@ -53,6 +65,19 @@ assert.deepEqual(discovery.surfaces.map((surface) => surface.id), [
 	'rest:/wp/v2/posts',
 ]);
 assert.equal(discovery.surfaces.find((surface) => surface.id === 'rest:/wp/v2/posts').metadata.sources.includes('rest-index'), true);
+assert.deepEqual(discovery.unsupported_surfaces.map((surface) => surface.id), [
+	'capability:edit_posts',
+	'cron:wp_version_check',
+	'media:image/jpeg',
+	'option:blogname',
+	'post-type:post',
+	'role:administrator',
+	'setting:blogname',
+	'taxonomy:category',
+	'user:all',
+	'wp-cli:plugin list',
+]);
+assert.equal(discovery.diagnostics.length, 10);
 
 const manifest = buildWordPressRuntimeSurfaceCoverageManifest(discovery);
 assert.equal(manifest.schema, 'homeboy/wordpress-fuzz-coverage-manifest/v1');


### PR DESCRIPTION
## Summary
- Add read-only WordPress live collectors for AJAX actions, cron events/schedules, post types, taxonomies, roles/capabilities, user counts, option/setting metadata, media counts, and WP-CLI command inventory.
- Normalize the new live payload fields into runtime discovery, preserving metadata-only surfaces as non-executable unsupported diagnostics.
- Cover cron schedule merging and metadata-only unsupported surface diagnostics in smoke tests.

## Verification
- From `wordpress/`: `php -l scripts/runtime/wordpress-live-surface-discovery.php`
- From `wordpress/`: `npm run test:wordpress-live-surface-discovery`
- From `wordpress/`: `npm run test:wordpress-runtime-surface-discovery`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the read-only collectors, normalizer updates, tests, and local verification.