### PR TITLE
Use runtime-backed WP Codebox fuzz suites

### DIFF
--- a/wordpress/lib/wordpress-fuzz-command-manifest.js
+++ b/wordpress/lib/wordpress-fuzz-command-manifest.js
@@ -12,17 +12,21 @@ const WP_CODEBOX_FUZZ_PUBLIC_ABILITIES = Object.freeze({
 	runWorkload: 'wp-codebox/run-wordpress-workload',
 });
 
+const WP_CODEBOX_FUZZ_PUBLIC_RUNNER_MODES = Object.freeze([
+	'runtime-backed',
+]);
+
 const CASE_INTENT_REQUIREMENTS = Object.freeze({
 	default: Object.freeze({ commands: ['run-fuzz-suite'], abilities: ['wp-codebox/run-fuzz-suite'] }),
-	workload: Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'] }),
-	'request-rest-route': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['rest'] }),
-	'request-admin-page': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'] }),
-	'exercise-admin-page-read-only-interaction': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'] }),
-	'plan-admin-page-mutation': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin', 'snapshot', 'restore', 'reset'] }),
-	'exercise-ajax-action': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'] }),
-	'render-block': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['browser'] }),
+	workload: Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], runner_modes: ['runtime-backed'] }),
+	'request-rest-route': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['rest'], runner_modes: ['runtime-backed'] }),
+	'request-admin-page': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'], runner_modes: ['runtime-backed'] }),
+	'exercise-admin-page-read-only-interaction': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'], runner_modes: ['runtime-backed'] }),
+	'plan-admin-page-mutation': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin', 'snapshot', 'restore', 'reset'], runner_modes: ['runtime-backed'] }),
+	'exercise-ajax-action': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'], runner_modes: ['runtime-backed'] }),
+	'render-block': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['browser'], runner_modes: ['runtime-backed'] }),
 	'serialize-parse-block': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'] }),
-	'insert-block-in-editor': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['browser'] }),
+	'insert-block-in-editor': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['browser'], runner_modes: ['runtime-backed'] }),
 	'inspect-database-table': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['database'] }),
 	'profile-database-query': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['database'] }),
 	'mutate-database-table': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['database', 'snapshot', 'transaction', 'reset'] }),
@@ -49,6 +53,7 @@ function buildWordPressFuzzCommandManifest() {
 		wp_codebox: {
 			public_commands: [...WP_CODEBOX_FUZZ_PUBLIC_COMMANDS],
 			abilities: { ...WP_CODEBOX_FUZZ_PUBLIC_ABILITIES },
+			runner_modes: [...WP_CODEBOX_FUZZ_PUBLIC_RUNNER_MODES],
 		},
 		case_intents: Object.fromEntries(Object.entries(CASE_INTENT_REQUIREMENTS).map(([intent, requirements]) => [intent, cloneRequirements(requirements)])),
 	};
@@ -74,6 +79,7 @@ function mergeRequirements(requirements) {
 		commands: unique(requirements.flatMap((requirement) => arrayOf(requirement.commands))),
 		abilities: unique(requirements.flatMap((requirement) => arrayOf(requirement.abilities))),
 		capabilities: unique(requirements.flatMap((requirement) => arrayOf(requirement.capabilities))),
+		runner_modes: unique(requirements.flatMap((requirement) => arrayOf(requirement.runner_modes || requirement.runnerModes))),
 	};
 }
 
@@ -82,6 +88,7 @@ function cloneRequirements(requirements = {}) {
 		commands: arrayOf(requirements.commands),
 		abilities: arrayOf(requirements.abilities),
 		capabilities: arrayOf(requirements.capabilities),
+		runner_modes: arrayOf(requirements.runner_modes || requirements.runnerModes),
 	};
 }
 
@@ -97,6 +104,7 @@ module.exports = {
 	WORDPRESS_FUZZ_COMMAND_MANIFEST_SCHEMA,
 	WP_CODEBOX_FUZZ_PUBLIC_ABILITIES,
 	WP_CODEBOX_FUZZ_PUBLIC_COMMANDS,
+	WP_CODEBOX_FUZZ_PUBLIC_RUNNER_MODES,
 	buildWordPressFuzzCommandManifest,
 	requiredWpCodeboxContractsForFuzzCase,
 	requiredWpCodeboxContractsForFuzzPlan,

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -38,6 +38,7 @@ const {
 const {
 	WP_CODEBOX_FUZZ_PUBLIC_ABILITIES,
 	WP_CODEBOX_FUZZ_PUBLIC_COMMANDS,
+	WP_CODEBOX_FUZZ_PUBLIC_RUNNER_MODES,
 	buildWordPressFuzzCommandManifest,
 	requiredWpCodeboxContractsForFuzzPlan,
 } = require('./wordpress-fuzz-command-manifest');
@@ -849,7 +850,8 @@ async function runWpCodeboxPublicFuzzOperation(options = {}) {
 		return unsupportedWpCodeboxPublicFuzzResult({ request, capabilities, preflight });
 	}
 
-	const cliResult = await runWpCodeboxPublicCli(command, wpCodeboxPublicCliInput(request, options), options);
+	const runnerMode = publicFuzzCliRunnerModeForRequest(request, { ...options, requiredPlanContracts: preflight.required });
+	const cliResult = await runWpCodeboxPublicCli(command, wpCodeboxPublicCliInput(request, options), { ...options, runnerMode });
 	if (cliResult.status !== 0) {
 		return {
 			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
@@ -1038,6 +1040,7 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 			commands: requiredCommands,
 			abilities: requiredAbilities,
 			capabilities: requiredPlanContracts.capabilities,
+			runner_modes: requiredPlanContracts.runner_modes,
 		},
 		command_manifest: commandManifest,
 		missing_contracts: missingContracts,
@@ -1057,13 +1060,40 @@ function requiredPublicCommandsForRequest(request = {}, requiredPlanContracts = 
 	}
 	if (ability === DEFAULT_FUZZ_SUITE_ABILITY) {
 		const input = wpCodeboxFuzzRequestInput(request);
+		const runnerMode = publicFuzzCliRunnerModeForRequest(request, { requiredPlanContracts });
 		return unique([
 			'run-fuzz-suite',
-			...normalizeArray(requiredPlanContracts.commands),
-			...(suiteInputRequiresWorkloadCommand(input) ? ['run-wordpress-workload'] : []),
+			...normalizeArray(requiredPlanContracts.commands).filter((command) => runnerMode === 'runtime-backed' ? command !== 'run-wordpress-workload' : true),
+			...(runnerMode === 'runtime-backed' || !suiteInputRequiresWorkloadCommand(input) ? [] : ['run-wordpress-workload']),
 		]);
 	}
 	return requiredPlanContracts.commands?.length > 0 ? unique(requiredPlanContracts.commands) : [...WP_CODEBOX_PUBLIC_CLI_COMMANDS];
+}
+
+function publicFuzzCliRunnerModeForRequest(request = {}, options = {}) {
+	const explicit = nonEmptyString(options.runnerMode || options.runner_mode || request.runner_mode || request.runnerMode || request.input?.runner_mode || request.input?.runnerMode || request.input?.metadata?.runner_mode || request.input?.metadata?.runnerMode);
+	if (explicit) {
+		return explicit;
+	}
+	const requiredPlanContracts = options.requiredPlanContracts || options.required_plan_contracts || {};
+	if (normalizeArray(requiredPlanContracts.runner_modes || requiredPlanContracts.runnerModes).includes('runtime-backed')) {
+		return 'runtime-backed';
+	}
+	const input = wpCodeboxFuzzRequestInput(request, options);
+	if (suiteInputRequiresWorkloadCommand(input) || suiteInputRequiresRuntimeBackedRunner(input)) {
+		return 'runtime-backed';
+	}
+	return undefined;
+}
+
+function suiteInputRequiresRuntimeBackedRunner(input = {}) {
+	return normalizeArray(input.cases).some((testCase) => {
+		const commands = normalizeArray(testCase.phases?.action).map((step) => step?.command).filter(Boolean);
+		const entrypoint = testCase.target?.entrypoint || testCase.target?.id;
+		return String(entrypoint || '').startsWith('wordpress.')
+			|| commands.some((command) => String(command || '').startsWith('wordpress.'))
+			|| normalizeArray(testCase.inputs?.observation_surfaces || testCase.inputs?.observationSurfaces).some((surface) => ['browser', 'editor', 'page', 'admin'].some((keyword) => String(surface).includes(keyword)));
+	});
 }
 
 function suiteInputRequiresWorkloadCommand(input = {}) {
@@ -1085,6 +1115,7 @@ function normalizeWpCodeboxPublicFuzzCapabilities(input = {}) {
 	return {
 		schema: 'homeboy/wp-codebox-public-fuzz-capabilities/v1',
 		commands: Object.fromEntries(WP_CODEBOX_PUBLIC_CLI_COMMANDS.map((command) => [command, commands[command] === true])),
+		runner_modes: Object.fromEntries(WP_CODEBOX_FUZZ_PUBLIC_RUNNER_MODES.map((runnerMode) => [runnerMode, input.runner_modes?.[runnerMode] !== false && input.runnerModes?.[runnerMode] !== false])),
 	};
 }
 
@@ -1142,10 +1173,18 @@ async function runWpCodeboxPublicCli(command, input, options = {}) {
 	const inputFile = path.join(tempDir, 'input.json');
 	try {
 		fs.writeFileSync(inputFile, `${JSON.stringify(input)}\n`, 'utf8');
-		return runWpCodeboxPublicCliCommand([command, '--input-file', inputFile, '--format=json'], options);
+		return runWpCodeboxPublicCliCommand(wpCodeboxPublicCliArgs(command, inputFile, options), options);
 	} finally {
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	}
+}
+
+function wpCodeboxPublicCliArgs(command, inputFile, options = {}) {
+	const runnerMode = nonEmptyString(options.runnerMode || options.runner_mode);
+	if (command === 'run-fuzz-suite' && runnerMode) {
+		return [command, `--runner-mode=${runnerMode}`, '--input-file', inputFile, '--json'];
+	}
+	return [command, '--input-file', inputFile, '--format=json'];
 }
 
 function runWpCodeboxPublicCliCommand(args, options = {}) {
@@ -2217,6 +2256,10 @@ function requiredString(value, name) {
 	return value;
 }
 
+function nonEmptyString(value) {
+	return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
+}
+
 function stripUndefined(value) {
 	if (!value || typeof value !== 'object' || Array.isArray(value)) {
 		return value;
@@ -2254,6 +2297,7 @@ module.exports = {
 	wordpressFuzzPostprocessExpectedArtifacts,
 	detectWpCodeboxPublicFuzzCapabilities,
 	preflightWpCodeboxFuzzCapabilityContract,
+	publicFuzzCliRunnerModeForRequest,
 	runWpCodeboxFuzzSuite,
 	runWpCodeboxPublicFuzzOperation,
 	wpCodeboxFuzzExecutionRequest,

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -20,6 +20,7 @@ const {
 } = require('../../lib/wordpress-fuzz-runner');
 const { loadWpCodeboxCoreFunction } = require('../../lib/wp-codebox-core-loader');
 const {
+	publicFuzzCliRunnerModeForRequest,
 	wpCodeboxFuzzSuiteAbility,
 	wpCodeboxRuntimeContractManifest,
 } = require('../../lib/wp-codebox-fuzz-run');
@@ -157,6 +158,7 @@ function wpCodeboxPublicRuntimeInvocation(request, options = {}) {
 	return {
 		ability,
 		command,
+		runnerMode: publicFuzzCliRunnerModeForRequest(request),
 		input: {
 			...(runtimeTask.input || {}),
 			metadata: {
@@ -210,10 +212,17 @@ function wpCodeboxCommandFromPublicAbility(ability, options = {}) {
 async function runWpCodeboxPublicRuntimeCommand(command, invocation, tempDir, options = {}) {
 	const inputFile = path.join(tempDir, `${invocation.command}-request.json`);
 	fs.writeFileSync(inputFile, `${JSON.stringify(invocation.input, null, 2)}\n`);
-	return spawnJson(command, [invocation.command, '--input-file', inputFile, '--format=json'], {
+	return spawnJson(command, wpCodeboxPublicRuntimeArgs(invocation, inputFile), {
 		cwd: process.cwd(),
 		env: options.env || process.env,
 	});
+}
+
+function wpCodeboxPublicRuntimeArgs(invocation, inputFile) {
+	if (invocation.command === 'run-fuzz-suite' && invocation.runnerMode) {
+		return [invocation.command, `--runner-mode=${invocation.runnerMode}`, '--input-file', inputFile, '--json'];
+	}
+	return [invocation.command, '--input-file', inputFile, '--format=json'];
 }
 
 function wpCodeboxRunAgentTaskInvocation(request) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -28,6 +28,7 @@ const {
 	normalizeWpCodeboxFuzzSuiteResult,
 	detectWpCodeboxPublicFuzzCapabilities,
 	preflightWpCodeboxFuzzCapabilityContract,
+	publicFuzzCliRunnerModeForRequest,
 	runWpCodeboxPublicFuzzOperation,
 	runWpCodeboxFuzzSuite,
 	wordpressFuzzPostprocessBinding,
@@ -180,10 +181,12 @@ assert.deepEqual(preflightMissingCommand.missing_contracts.map((contract) => con
 assert.equal(preflightMissingCommand.diagnostics[0].code, 'wp_codebox_fuzz_missing_public_cli_command');
 assert.equal(preflightMissingCommand.command_manifest.schema, 'homeboy/wordpress-fuzz-command-manifest/v1');
 assert.deepEqual(preflightMissingCommand.command_manifest.case_intents['request-rest-route'].commands, ['run-wordpress-workload']);
+assert.deepEqual(preflightMissingCommand.command_manifest.case_intents['request-rest-route'].runner_modes, ['runtime-backed']);
 
 const commandManifest = buildWordPressFuzzCommandManifest();
 assert.deepEqual(commandManifest.wp_codebox.public_commands, ['run-fuzz-suite', 'run-wordpress-workload']);
 assert.equal(commandManifest.wp_codebox.abilities.runWorkload, DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY);
+assert.deepEqual(commandManifest.wp_codebox.runner_modes, ['runtime-backed']);
 
 const preflightMissingAbility = preflightWpCodeboxFuzzCapabilityContract({
 	request: taskRequest,
@@ -484,8 +487,9 @@ const genericPlanPreflight = preflightWpCodeboxFuzzCapabilityContract({
 	runtimeContractManifest: manifest,
 	publicCliCapabilities: { commands: { 'run-fuzz-suite': true } },
 });
-assert.equal(genericPlanPreflight.ok, false);
-assert.equal(genericPlanPreflight.missing_contracts.some((contract) => contract.command === 'run-wordpress-workload'), true);
+assert.equal(genericPlanPreflight.ok, true);
+assert.deepEqual(genericPlanPreflight.required.commands, ['run-fuzz-suite']);
+assert.equal(publicFuzzCliRunnerModeForRequest(genericPlanTaskRequest), 'runtime-backed');
 
 let invoked = false;
 runWpCodeboxFuzzSuite({
@@ -1019,7 +1023,8 @@ runWpCodeboxFuzzSuite({
 		env: { resultsFile: path.join(stagedArtifactRoot, 'fuzz-results.json') },
 		runPublicCli: ({ args }) => {
 			if (args.includes('--help')) return { status: 0, stdout: 'usage' };
-			const publicCliInput = JSON.parse(fs.readFileSync(args[2], 'utf8'));
+			assert.deepEqual([args[0], args[1], args[2], args[4]], ['run-fuzz-suite', '--runner-mode=runtime-backed', '--input-file', '--json']);
+			const publicCliInput = JSON.parse(fs.readFileSync(args[3], 'utf8'));
 			const workload = publicCliInput.cases[0].input;
 			const stagedFiles = publicCliInput.cases[0].input.staged_files;
 			assert.equal(workload.steps[0].helperPath, 'tools/artifact-helper.mjs');


### PR DESCRIPTION
## Summary
- Add runtime-backed runner mode to the WordPress fuzz command contract for runtime/browser/editor/page-capable suite cases.
- Dispatch full runtime fuzz suites through `wp-codebox run-fuzz-suite --runner-mode=runtime-backed --input-file <suite.json> --json`.
- Keep injected runner callbacks, simple suite CLI dispatch, and legacy adapter fallback behavior intact.

## Tests
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wordpress-fuzz-runtime-task`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the runtime-backed WP Codebox fuzz dispatch path, updating tests, and running focused verification.