### PR TITLE
Move runtime setup behind adapters

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -363,7 +363,6 @@ function projectRuntimeConfig({ env, runtime, workspace, componentId, componentP
     ),
     wp_config_defines: {
       ...(plainObject(projection.wp_config_defines) ? projection.wp_config_defines : {}),
-      ...parseJsonInput('extra_wp_config_defines', env.EXTRA_WP_CONFIG_DEFINES || '{}', 'object', {}),
     },
     runtime_fields: runtimeFieldsFromProjection(projection.runtime_fields, env),
   };

--- a/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
+++ b/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
@@ -9,16 +9,11 @@ const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime
 function main() {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
   const runtime = resolveRuntimeProvider(process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || DEFAULT_RUNTIME_ID, { workspace });
-  if (requiresWordPressDependencies(runtime, process.env)) {
-    run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
-    run('npm', ['install'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
-  }
+  runRuntimeSetup(runtime, { phase: 'before_commands', workspace, env: process.env, run });
   for (const command of [...runtime.setupCommands, ...runtime.buildCommands]) {
     run(command.command, command.args, { cwd: path.join(workspace, command.cwd) });
   }
-  if (requiresWordPressDependencies(runtime, process.env)) {
-    installCheckedOutPhpDependencies(workspace);
-  }
+  runRuntimeSetup(runtime, { phase: 'after_commands', workspace, env: process.env, run, installCheckedOutPhpDependencies });
 }
 
 try {
@@ -30,27 +25,27 @@ try {
   process.exit(1);
 }
 
-function requiresWordPressDependencies(runtime, env = process.env) {
-  if (runtime?.manifest?.ci_materialization?.requires_wordpress_dependencies === true) {
-    return true;
+function runRuntimeSetup(runtime, context) {
+  const adapter = runtimeSetupAdapter(runtime);
+  if (!adapter) {
+    return;
   }
-  const runtimeProfileId = env.PROFILE || env.RUNTIME_PROFILE || '';
-  if (!runtimeProfileId) {
-    return false;
+  adapter({ runtime, ...context });
+}
+
+function runtimeSetupAdapter(runtime) {
+  const adapter = runtime?.manifest?.ci_materialization?.setup_adapter;
+  if (!adapter || typeof adapter !== 'object' || Array.isArray(adapter) || !adapter.module) {
+    return null;
   }
-  let profiles;
-  try {
-    profiles = env.RUNTIME_PROFILES ? JSON.parse(env.RUNTIME_PROFILES) : {};
-  } catch {
-    return false;
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const adapterPath = path.resolve(repoRoot, adapter.module);
+  const loaded = require(adapterPath);
+  const exportName = adapter.export || 'setupRuntime';
+  if (typeof loaded[exportName] !== 'function') {
+    throw new Error(`Runtime ${runtime.id} setup adapter ${adapter.module} does not export ${exportName}`);
   }
-  const profile = profiles && typeof profiles === 'object' && !Array.isArray(profiles) ? profiles[runtimeProfileId] : null;
-  return Boolean(
-    profile &&
-    typeof profile === 'object' &&
-    !Array.isArray(profile) &&
-    (profile.requires_wordpress_dependencies === true || profile.wordpress_dependencies === true)
-  );
+  return loaded[exportName];
 }
 
 function installCheckedOutPhpDependencies(workspace) {
@@ -84,5 +79,6 @@ function installCheckedOutPhpDependencies(workspace) {
 module.exports = {
   installCheckedOutPhpDependencies,
   main,
-  requiresWordPressDependencies,
+  runRuntimeSetup,
+  runtimeSetupAdapter,
 };

--- a/agent-runtimes/wp-codebox/lib/runtime-config-projection.js
+++ b/agent-runtimes/wp-codebox/lib/runtime-config-projection.js
@@ -4,13 +4,30 @@ const {
   normalizeCodeboxArtifactDeclaration,
 } = require('./codebox-artifact-contract');
 
-function projectRuntimeConfig({ artifactDeclarations = [], manifestProjection = {} } = {}) {
+function projectRuntimeConfig({ artifactDeclarations = [], manifestProjection = {}, env = process.env } = {}) {
   return {
     ...manifestProjection,
     artifact_declarations: artifactDeclarations
       .map((declaration, index) => normalizeCodeboxArtifactDeclaration(`artifact_${index + 1}`, declaration))
       .filter(Boolean),
+    wp_config_defines: {
+      ...(plainObject(manifestProjection.wp_config_defines) ? manifestProjection.wp_config_defines : {}),
+      ...parseObject(env.EXTRA_WP_CONFIG_DEFINES || '{}'),
+    },
   };
+}
+
+function parseObject(raw) {
+  try {
+    const value = JSON.parse(raw);
+    return plainObject(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
 }
 
 module.exports = { projectRuntimeConfig };

--- a/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
+++ b/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
@@ -1,0 +1,40 @@
+'use strict';
+
+const path = require('node:path');
+
+function setupRuntime({ phase, workspace, env = process.env, run, installCheckedOutPhpDependencies }) {
+  if (!requiresWordPressDependencies(env)) {
+    return;
+  }
+  if (phase === 'before_commands') {
+    run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
+    run('npm', ['install'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
+    return;
+  }
+  if (phase === 'after_commands') {
+    installCheckedOutPhpDependencies(workspace);
+  }
+}
+
+function requiresWordPressDependencies(env = process.env) {
+  const runtimeProfileId = env.PROFILE || env.RUNTIME_PROFILE || '';
+  if (!runtimeProfileId) {
+    return true;
+  }
+  let profiles;
+  try {
+    profiles = env.RUNTIME_PROFILES ? JSON.parse(env.RUNTIME_PROFILES) : {};
+  } catch {
+    return true;
+  }
+  const profile = profiles && typeof profiles === 'object' && !Array.isArray(profiles) ? profiles[runtimeProfileId] : null;
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    return true;
+  }
+  return profile.requires_wordpress_dependencies !== false && profile.wordpress_dependencies !== false;
+}
+
+module.exports = {
+  requiresWordPressDependencies,
+  setupRuntime,
+};

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -66,6 +66,10 @@
   },
   "ci_materialization": {
     "requires_wordpress_dependencies": true,
+    "setup_adapter": {
+      "module": "agent-runtimes/wp-codebox/lib/runtime-setup.cjs",
+      "export": "setupRuntime"
+    },
     "checkout": {
       "repo": "Automattic/wp-codebox",
       "target": ".ci/wp-codebox",

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -4,7 +4,8 @@ const assert = require('node:assert/strict');
 
 const { DEFAULT_RUNTIME_ID } = require('../lib/runtime-provider-resolver.cjs');
 const { runtimeAgentCiRunnerSpec } = require('..');
-const { requiresWordPressDependencies } = require('../../.github/scripts/runtime-agent-full-run/setup-runtime.cjs');
+const { runRuntimeSetup, runtimeSetupAdapter } = require('../../.github/scripts/runtime-agent-full-run/setup-runtime.cjs');
+const { requiresWordPressDependencies, setupRuntime } = require('../../agent-runtimes/wp-codebox/lib/runtime-setup.cjs');
 
 assert.equal(DEFAULT_RUNTIME_ID, 'local-shell');
 
@@ -18,21 +19,67 @@ assert.equal(
   'codebox'
 );
 
-assert.equal(requiresWordPressDependencies({ manifest: { ci_materialization: {} } }, {}), false);
-assert.equal(requiresWordPressDependencies({ manifest: { ci_materialization: { requires_wordpress_dependencies: true } } }, {}), true);
+assert.equal(runtimeSetupAdapter({ manifest: { ci_materialization: {} } }), null);
+assert.equal(runtimeSetupAdapter({ manifest: { ci_materialization: { requires_wordpress_dependencies: true } } }), null);
+
+const setupCalls = [];
+runRuntimeSetup({ manifest: { ci_materialization: {} } }, {
+  phase: 'before_commands',
+  workspace: '/tmp/workspace',
+  env: {
+    PROFILE: 'wordpress-ci',
+    RUNTIME_PROFILES: JSON.stringify({ 'wordpress-ci': { requires_wordpress_dependencies: true } }),
+  },
+  run: (...args) => setupCalls.push(args),
+});
+assert.deepEqual(setupCalls, []);
+
+assert.equal(requiresWordPressDependencies({}), true);
 assert.equal(
-  requiresWordPressDependencies({ manifest: { ci_materialization: {} } }, {
+  requiresWordPressDependencies({
     PROFILE: 'wordpress-ci',
     RUNTIME_PROFILES: JSON.stringify({ 'wordpress-ci': { requires_wordpress_dependencies: true } }),
   }),
   true
 );
 assert.equal(
-  requiresWordPressDependencies({ manifest: { ci_materialization: {} } }, {
+  requiresWordPressDependencies({
     PROFILE: 'generic-ci',
-    RUNTIME_PROFILES: JSON.stringify({ 'generic-ci': { runtime_task_ability: 'example/run-task' } }),
+    RUNTIME_PROFILES: JSON.stringify({ 'generic-ci': { runtime_task_ability: 'example/run-task', requires_wordpress_dependencies: false } }),
   }),
   false
 );
+
+const codeboxSetupCalls = [];
+setupRuntime({
+  phase: 'before_commands',
+  workspace: '/tmp/workspace',
+  env: {},
+  run: (...args) => codeboxSetupCalls.push(args),
+});
+assert.deepEqual(codeboxSetupCalls.map(([command, args, options]) => ({ command, args, cwd: options.cwd })), [
+  {
+    command: 'composer',
+    args: ['install', '--no-interaction', '--no-progress', '--prefer-dist'],
+    cwd: '/tmp/workspace/.ci/homeboy-extensions/wordpress',
+  },
+  {
+    command: 'npm',
+    args: ['install'],
+    cwd: '/tmp/workspace/.ci/homeboy-extensions/wordpress',
+  },
+]);
+
+let installedCheckedOutDependencies = false;
+setupRuntime({
+  phase: 'after_commands',
+  workspace: '/tmp/workspace',
+  env: {},
+  run: () => {},
+  installCheckedOutPhpDependencies: (workspace) => {
+    installedCheckedOutDependencies = workspace === '/tmp/workspace';
+  },
+});
+assert.equal(installedCheckedOutDependencies, true);
 
 process.stdout.write('Runtime provider boundary passed\n');

--- a/tests/architectural-boundary-smoke.mjs
+++ b/tests/architectural-boundary-smoke.mjs
@@ -145,6 +145,13 @@ assert.deepEqual(
   `WP Codebox audit fanout references must stay in the quarantined implementation, CLI, and package metadata. Violations: ${auditFanoutReferenceFiles.join(', ')}`,
 );
 
+const genericSetupRuntime = fs.readFileSync(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/setup-runtime.cjs'), 'utf8');
+assert.equal(
+  /WordPress|wordpress|wp-codebox|Codebox|requires_wordpress_dependencies|wordpress_dependencies/.test(genericSetupRuntime),
+  false,
+  'Generic runtime setup must delegate runtime-specific setup through manifest adapters instead of naming WordPress or WP Codebox concerns.',
+);
+
 const quarantineCounts = quarantinedTermFiles.reduce((counts, relativePath) => {
   const parts = relativePath.split('/');
   const root = parts[0] === '.github'

--- a/tests/runtime-agent-full-run-projection-boundary-smoke.mjs
+++ b/tests/runtime-agent-full-run-projection-boundary-smoke.mjs
@@ -8,12 +8,12 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(repoRoot, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const { buildConfig, projectRuntimeConfig } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
 
 const genericProjection = projectRuntimeConfig({
   env: {
     ARTIFACT_DECLARATIONS: JSON.stringify([{ name: 'packet', kind: 'application/vnd.example.packet+json' }]),
-    EXTRA_WP_CONFIG_DEFINES: JSON.stringify({ EXAMPLE_DEFINE: true }),
   },
   runtime: {
     id: 'generic-runtime',
@@ -22,7 +22,6 @@ const genericProjection = projectRuntimeConfig({
       id: 'generic-runtime',
       runner_config_projection: {
         transcript_guest_dir_template: '/runtime/{workload_id}/transcript',
-        wp_config_defines: { GENERIC_DEFINE: 'yes' },
         runtime_fields: {
           runtime_example_version: { env: 'RUNTIME_EXAMPLE_VERSION', default: '1.0' },
         },
@@ -41,7 +40,7 @@ assert.deepEqual(genericProjection.artifact_declarations, [
 ]);
 assert.equal(genericProjection.transcript_dir, '/runtime/projection-smoke/transcript');
 assert.equal(genericProjection.transcript_dir.includes('/wordpress/wp-content/plugins'), false);
-assert.deepEqual(genericProjection.wp_config_defines, { GENERIC_DEFINE: 'yes', EXAMPLE_DEFINE: true });
+assert.deepEqual(genericProjection.wp_config_defines, {});
 assert.deepEqual(genericProjection.runtime_fields, { runtime_example_version: '1.0' });
 
 const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-projection-'));


### PR DESCRIPTION
## Summary
- delegate generic full-run setup to runtime-owned manifest setup adapters
- move WordPress dependency setup into the WP Codebox runtime adapter
- keep legacy WP Codebox config aliases working through the WP Codebox projection adapter
- strengthen boundary coverage for generic setup/projection surfaces

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/1940

## Tests
- `node tests/architectural-boundary-smoke.mjs`
- `node tests/runtime-agent-full-run-projection-boundary-smoke.mjs`
- `node runtime-agent-ci/tests/runtime-provider-boundary.test.js`
- `node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the runtime setup delegation, boundary smoke coverage, and test updates.