### PR TITLE
Tier WordPress fuzz surface execution

### DIFF
--- a/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
+++ b/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
@@ -18,6 +18,7 @@ const {
 	wordpressSurfaceTypeFromCollectionKey,
 } = require('./wordpress-surface-types');
 const {
+	annotateWordPressFuzzCaseExecutionTier,
 	gateWordPressFuzzCaseForRuntimeCapabilities,
 	normalizeWordPressFuzzMutationMode,
 	requiredCapabilitiesForWordPressFuzzCase,
@@ -35,17 +36,19 @@ function buildWordPressFuzzPlanFromSurfaces(input = {}, options = {}) {
 		label: input.label || options.label || 'WordPress surface discovery',
 		surfaces: collectWordPressFuzzPlanSurfaces(input),
 	});
+	const targets = discovery.surfaces.map((surface) => targetFromSurface(surface, targetOptions));
 
 	return normalizeWordPressFuzzPlan({
 		schema: WORDPRESS_FUZZ_PLAN_SCHEMA,
 		id: options.id || input.plan_id || input.planId || `${discovery.id}-fuzz-plan`,
 		discovery_id: discovery.id,
-		targets: discovery.surfaces.map((surface) => targetFromSurface(surface, targetOptions)),
+		targets,
 		budget: options.budget || input.budget || {},
 		metadata: {
 			...(input.metadata || {}),
 			planner: 'homeboy/wordpress-fuzz-plan-from-surfaces/v1',
 			mutation_mode: mutationMode || undefined,
+			execution_tiers: summarizeExecutionTiers(targets),
 		},
 	});
 }
@@ -139,7 +142,7 @@ function restRouteTargetFromSurface(surface, options = {}) {
 	const operationId = surface.operation_id || surface.operationId || `${surface.id}:request-rest-route`;
 	const surfaceSkipReasons = reasonList(surface.skip_reasons || surface.skipReasons || surface.skip_reason || surface.skipReason);
 	const surfaceDestructiveReasons = reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons);
-	return {
+	const target = {
 		id: surface.id,
 		surface_id: surface.id,
 		type: surface.type,
@@ -154,12 +157,14 @@ function restRouteTargetFromSurface(surface, options = {}) {
 			...(surface.metadata || {}),
 		},
 	};
+	target.metadata.execution_tiers = summarizeExecutionTiers([target]);
+	return target;
 }
 
 function genericTargetFromSurface(surface, options = {}) {
 	const cases = casesForSurface(surface, options);
 	const operationId = cases[0]?.operation_id || surface.operation_id || surface.operationId || `${surface.id}:${caseIntent(surface.type)}`;
-	return {
+	const target = {
 		id: surface.id,
 		surface_id: surface.id,
 		type: surface.type,
@@ -173,6 +178,8 @@ function genericTargetFromSurface(surface, options = {}) {
 			...(surface.metadata || {}),
 		},
 	};
+	target.metadata.execution_tiers = summarizeExecutionTiers([target]);
+	return target;
 }
 
 function adminPageTargetFromSurface(surface, options = {}) {
@@ -180,7 +187,7 @@ function adminPageTargetFromSurface(surface, options = {}) {
 	const operationId = surface.operation_id || surface.operationId || `${surface.id}:request-admin-page`;
 	const skipReasons = reasonList(surface.skip_reasons || surface.skipReasons || surface.skip_reason || surface.skipReason);
 	const destructiveReasons = reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons);
-	const cases = [{
+	const cases = [annotateWordPressFuzzCaseExecutionTier({
 		id: `${surface.id}-generic-fuzz`,
 		intent: 'request-admin-page',
 		operation_id: operationId,
@@ -189,13 +196,13 @@ function adminPageTargetFromSurface(surface, options = {}) {
 		skip_reasons: skipReasons,
 		destructive_reasons: destructiveReasons,
 		metadata: { surface, executable: skipReasons.length === 0 && destructiveReasons.length === 0 },
-	}];
+	}, { executable: skipReasons.length === 0 && destructiveReasons.length === 0 })];
 
 	for (const interaction of collectAdminPageInteractions(surface)) {
 		cases.push(adminPageInteractionCase(surface, interaction, options));
 	}
 
-	return {
+	const target = {
 		id: surface.id,
 		surface_id: surface.id,
 		type: surface.type,
@@ -209,6 +216,8 @@ function adminPageTargetFromSurface(surface, options = {}) {
 			...(surface.metadata || {}),
 		},
 	};
+	target.metadata.execution_tiers = summarizeExecutionTiers([target]);
+	return target;
 }
 
 function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReasons, surfaceDestructiveReasons, options = {}) {
@@ -217,7 +226,7 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
 	const skipReasons = safeMethod || mutationMode === 'isolated' ? surfaceSkipReasons : reasonList([...surfaceSkipReasons, 'mutating_rest_method_requires_explicit_opt_in']);
 	const destructiveReasons = safeMethod ? surfaceDestructiveReasons : reasonList([...surfaceDestructiveReasons, 'rest_method_mutates_state']);
-	const testCase = {
+	const testCase = annotateWordPressFuzzCaseExecutionTier({
 		id: `${surface.id}-${method.toLowerCase()}-generic-fuzz`,
 		intent: 'request-rest-route',
 		operation_id: operationId,
@@ -233,7 +242,7 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 			planned: !safeMethod,
 			gated: !safeMethod,
 		},
-	};
+	}, { mutates: !safeMethod, executable: skipReasons.length === 0 && (safeMethod || mutationMode === 'isolated') });
 	if (safeMethod) {
 		return testCase;
 	}
@@ -273,7 +282,7 @@ function casesForSurface(surface, options = {}) {
 function genericCaseForSurface(surface, options = {}) {
 	const operation = operationForSurface(surface);
 	const operationId = surface.operation_id || surface.operationId || `${surface.id}:${caseIntent(surface.type)}`;
-	return {
+	return annotateWordPressFuzzCaseExecutionTier({
 		id: `${surface.id}-generic-fuzz`,
 		intent: caseIntent(surface.type),
 		operation_id: operationId,
@@ -282,19 +291,23 @@ function genericCaseForSurface(surface, options = {}) {
 		skip_reasons: reasonList(surface.skip_reasons || surface.skipReasons || surface.skip_reason || surface.skipReason),
 		destructive_reasons: reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons),
 		metadata: { surface },
-	};
+	}, { mutates: false });
 }
 
 function crudCaseForSurface(surface, resource, action, options = {}) {
 	const operation = crudOperationForSurface(surface, resource, action);
 	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
-	const gateReasons = mutatingCrudAction(action.action) && !allowsCrudMutation(surface, action.action) && mutationMode !== 'isolated' ? ['crud_mutation_requires_explicit_allow'] : [];
+	const mutates = mutatingCrudAction(action.action);
+	const gateReasons = mutates && !mutationMode
+		? (!allowsCrudMutation(surface, action.action) ? ['crud_mutation_requires_explicit_allow'] : ['requires-isolated-mutation-runtime'])
+		: [];
 	const testCase = {
 		id: `${surface.id}-${action.intent}-crud-fuzz`,
 		intent: action.intent,
 		operation_id: operation.id,
 		operation,
 		seed: options.seed,
+		required_capabilities: mutates ? requiredCapabilitiesForWordPressFuzzCase('mutating_crud') : undefined,
 		skip_reasons: [
 			...reasonList(surface.skip_reasons || surface.skipReasons || surface.skip_reason || surface.skipReason),
 			...gateReasons,
@@ -302,8 +315,8 @@ function crudCaseForSurface(surface, resource, action, options = {}) {
 		destructive_reasons: reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons),
 		metadata: { surface, crud: { resource_type: resource.type, intent: action.intent, action: action.action } },
 	};
-	if (!mutatingCrudAction(action.action) || gateReasons.length > 0) {
-		return testCase;
+	if (!mutates || gateReasons.length > 0) {
+		return annotateWordPressFuzzCaseExecutionTier(testCase, { mutates, executable: !mutates && testCase.skip_reasons.length === 0 });
 	}
 	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
 		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('mutating_crud'),
@@ -458,28 +471,28 @@ function blockCasesFromSurface(surface, operation, operationId, options = {}) {
 	const attributeSample = blockAttributeSample(surface);
 	const surfaceMetadata = blockSurfaceMetadata(surface, attributeSample);
 	const cases = [
-		{
+		annotateWordPressFuzzCaseExecutionTier({
 			id: `${surface.id}-render-block`,
 			intent: 'render-block',
 			operation_id: `${operationId}:render`,
 			operation: stripUndefined({ ...operation, lifecycle: 'render', attributes_sample: attributeSample }),
 			...shared,
 			metadata: stripUndefined({ surface, safety: { mutation: 'read_only' }, attributes_sample: attributeSample }),
-		},
+		}, { mutates: false }),
 	];
 
 	if (Object.keys(surfaceMetadata).length > 0) {
-		cases.push({
+		cases.push(annotateWordPressFuzzCaseExecutionTier({
 			id: `${surface.id}-serialize-parse-block`,
 			intent: 'serialize-parse-block',
 			operation_id: `${operationId}:serialize-parse`,
 			operation: stripUndefined({ ...operation, lifecycle: 'serialize-parse', attributes_sample: attributeSample }),
 			...shared,
 			metadata: stripUndefined({ surface, safety: { mutation: 'read_only' }, ...surfaceMetadata }),
-		});
+		}, { mutates: false }));
 	}
 
-	cases.push({
+	cases.push(annotateWordPressFuzzCaseExecutionTier({
 		id: `${surface.id}-editor-insert-block`,
 		intent: 'insert-block-in-editor',
 		operation_id: `${operationId}:editor-insert`,
@@ -494,7 +507,7 @@ function blockCasesFromSurface(surface, operation, operationId, options = {}) {
 			safety: { mutation: 'requires_isolated_editor_draft' },
 			attributes_sample: attributeSample,
 		}),
-	});
+	}, { mutates: true, executable: false }));
 
 	return cases;
 }
@@ -600,7 +613,7 @@ function adminPageInteractionCase(surface, interaction, options = {}) {
 		}),
 	};
 	if (!gated) {
-		return testCase;
+		return annotateWordPressFuzzCaseExecutionTier(testCase, { mutates: false });
 	}
 	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
 		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('admin_mutation'),
@@ -718,6 +731,17 @@ function safeIdPart(value) {
 
 function stripUndefined(value) {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function summarizeExecutionTiers(targets) {
+	const summary = {};
+	for (const target of targets) {
+		for (const testCase of target.cases || []) {
+			const tier = testCase.execution_tier || testCase.metadata?.execution_tier || 'discovered';
+			summary[tier] = (summary[tier] || 0) + 1;
+		}
+	}
+	return summary;
 }
 
 function isObject(value) {

--- a/wordpress/lib/wordpress-fuzz-runtime-capabilities.js
+++ b/wordpress/lib/wordpress-fuzz-runtime-capabilities.js
@@ -3,6 +3,7 @@
 const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA = 'homeboy/wordpress-fuzz-runtime-capabilities/v1';
 const WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA = 'homeboy/wordpress-fuzz-mutation-policy/v1';
 const WORDPRESS_FUZZ_MUTATION_MODES = Object.freeze(['isolated', 'read_only', 'destructive-deny']);
+const WORDPRESS_FUZZ_EXECUTION_TIERS = Object.freeze(['discovered', 'plan_only', 'read_only_executable', 'isolated_mutating_executable']);
 
 const WORDPRESS_FUZZ_RUNTIME_CAPABILITIES = Object.freeze([
 	'snapshot',
@@ -120,17 +121,28 @@ function gateWordPressFuzzCaseForRuntimeCapabilities(testCase, runtimeCapabiliti
 	const metadata = isObject(testCase.metadata) ? { ...testCase.metadata } : {};
 
 	if (missing.length === 0) {
-		const executable = testCase.executable !== false && skipReasons.length === 0;
+		const mutates = fuzzCaseMutates(testCase, options);
+		const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
+		const mutationTierGated = mutates && mutationMode !== 'isolated';
+		const gatedSkipReasons = mutationTierGated ? reasonList([...skipReasons, 'requires-isolated-mutation-runtime']) : skipReasons;
+		const executable = testCase.executable !== false && gatedSkipReasons.length === 0 && !mutationTierGated;
+		const executionTier = normalizeWordPressFuzzExecutionTier(
+			testCase.execution_tier || testCase.executionTier || testCase.metadata?.execution_tier || testCase.metadata?.executionTier,
+			{ executable, mutates }
+		);
 		return {
 			...testCase,
 			executable,
+			execution_tier: executionTier,
 			required_capabilities: required,
-			skip_reasons: skipReasons,
+			skip_reasons: gatedSkipReasons,
 			metadata: {
 				...metadata,
 				executable,
-				gated: metadata.gated === true && !executable,
+				execution_tier: executionTier,
+				gated: (metadata.gated === true || mutationTierGated) && !executable,
 				runtime_capability_gated: false,
+				execution_tier_gated: mutationTierGated,
 				runtime_capability_contract: WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
 				required_capabilities: required,
 			},
@@ -140,11 +152,13 @@ function gateWordPressFuzzCaseForRuntimeCapabilities(testCase, runtimeCapabiliti
 	return {
 		...testCase,
 		executable: false,
+		execution_tier: 'plan_only',
 		required_capabilities: required,
 		skip_reasons: reasonList([...skipReasons, 'missing-runtime-fuzz-capabilities']),
 		metadata: {
 			...metadata,
 			executable: false,
+			execution_tier: 'plan_only',
 			planned: true,
 			gated: true,
 			runtime_capability_gated: true,
@@ -162,7 +176,7 @@ function gateWordPressFuzzCaseForMutationPolicy(testCase = {}, options = {}) {
 	}
 
 	const destructiveReasons = reasonList(testCase.destructive_reasons || testCase.destructiveReasons || testCase.destructive_reason || testCase.destructiveReason);
-	const mutates = options.mutates === true || destructiveReasons.length > 0 || testCase.metadata?.safety?.mutates === true;
+	const mutates = fuzzCaseMutates(testCase, { mutates: options.mutates, destructive_reasons: destructiveReasons });
 	const policy = {
 		schema: WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA,
 		mode: mutationMode,
@@ -186,17 +200,62 @@ function gateWordPressFuzzCaseForMutationPolicy(testCase = {}, options = {}) {
 	return {
 		...testCase,
 		executable: false,
+		execution_tier: 'plan_only',
 		skip_reasons: reasonList([...skipReasons, denyReason]),
 		destructive_reasons: destructiveReasons,
 		metadata: {
 			...metadata,
 			executable: false,
+			execution_tier: 'plan_only',
 			planned: true,
 			gated: true,
 			mutation_policy_gated: true,
 			mutation_policy: policy,
 		},
 	};
+}
+
+function normalizeWordPressFuzzExecutionTier(value, context = {}) {
+	const normalized = String(value || '').trim().toLowerCase().replace(/-/g, '_');
+	if (WORDPRESS_FUZZ_EXECUTION_TIERS.includes(normalized)) {
+		return normalized;
+	}
+	if (context.discovered === true) {
+		return 'discovered';
+	}
+	if (context.executable === false || context.planned === true || context.gated === true) {
+		return 'plan_only';
+	}
+	return context.mutates === true ? 'isolated_mutating_executable' : 'read_only_executable';
+}
+
+function annotateWordPressFuzzCaseExecutionTier(testCase = {}, context = {}) {
+	const skipReasons = reasonList(testCase.skip_reasons || testCase.skipReasons || testCase.skip_reason || testCase.skipReason);
+	const mutates = fuzzCaseMutates(testCase, context);
+	const executable = context.executable ?? testCase.executable ?? (skipReasons.length === 0 && !mutates);
+	const executionTier = normalizeWordPressFuzzExecutionTier(
+		context.execution_tier || context.executionTier || testCase.execution_tier || testCase.executionTier || testCase.metadata?.execution_tier || testCase.metadata?.executionTier,
+		{ ...context, executable, mutates }
+	);
+	return {
+		...testCase,
+		executable,
+		execution_tier: executionTier,
+		metadata: {
+			...(isObject(testCase.metadata) ? testCase.metadata : {}),
+			executable,
+			execution_tier: executionTier,
+		},
+	};
+}
+
+function fuzzCaseMutates(testCase = {}, context = {}) {
+	const destructiveReasons = reasonList(context.destructive_reasons || context.destructiveReasons || testCase.destructive_reasons || testCase.destructiveReasons || testCase.destructive_reason || testCase.destructiveReason);
+	return context.mutates === true
+		|| destructiveReasons.length > 0
+		|| testCase.metadata?.safety?.mutates === true
+		|| testCase.metadata?.safety?.mutation === 'requires_isolated_editor_draft'
+		|| testCase.operation?.safety?.mutates === true;
 }
 
 function requiredCapabilitiesForWordPressFuzzCase(kind) {
@@ -230,11 +289,14 @@ function isObject(value) {
 module.exports = {
 	WORDPRESS_FUZZ_MUTATION_MODES,
 	WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA,
+	WORDPRESS_FUZZ_EXECUTION_TIERS,
 	WORDPRESS_FUZZ_RUNTIME_CAPABILITIES,
 	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_REQUIREMENTS,
 	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
+	annotateWordPressFuzzCaseExecutionTier,
 	gateWordPressFuzzCaseForMutationPolicy,
 	gateWordPressFuzzCaseForRuntimeCapabilities,
+	normalizeWordPressFuzzExecutionTier,
 	normalizeWordPressFuzzMutationMode,
 	normalizeWordPressFuzzRuntimeCapabilities,
 	normalizeWordPressFuzzRuntimeCapability,

--- a/wordpress/lib/wordpress-runtime-surface-discovery.js
+++ b/wordpress/lib/wordpress-runtime-surface-discovery.js
@@ -65,6 +65,7 @@ function buildWordPressRuntimeSurfaceCoverageManifest(input = {}, options = {}) 
 			type: surface.type,
 			label: surface.label,
 			required: surface.required !== false,
+			execution_tier: surface.execution_tier || 'read_only_executable',
 			metadata: surface.metadata || {},
 		})),
 	};
@@ -199,9 +200,12 @@ function normalizeRuntimeSurface(surface, index) {
 		type,
 		label: stringValue(surface.label || surface.title || surface.name || surface.path || surface.url || surface.route || surface.action || surface.table || surface.value, value),
 		required: surface.required !== false,
+		executable: true,
+		execution_tier: 'read_only_executable',
 		metadata: {
 			...(isPlainObject(surface.metadata) ? surface.metadata : {}),
 			source: stringValue(surface.source || surface.artifact, 'input'),
+			execution_tier: 'read_only_executable',
 			value,
 		},
 	};
@@ -227,10 +231,12 @@ function normalizeUnsupportedSurface(surface, index) {
 		canonical_type: canonicalType,
 		label: stringValue(surface.label || surface.title || surface.name || surface.path || surface.url || surface.route || surface.action || surface.hook || surface.option || surface.setting || surface.role || surface.capability || surface.table || surface.value, value),
 		executable: false,
+		execution_tier: 'discovered',
 		coverage_counted: false,
 		metadata: {
 			...(isPlainObject(surface.metadata) ? surface.metadata : {}),
 			source: stringValue(surface.source || surface.artifact, 'input'),
+			execution_tier: 'discovered',
 			value,
 		},
 	};

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -53,8 +53,10 @@ assert.deepEqual(targetTypes.option.cases.map((testCase) => testCase.intent), ['
 assert.equal(targetTypes.option.cases[0].operation.resource_type, 'option');
 assert.equal(targetTypes.option.cases[0].operation.input.option, 'blogname');
 assert.equal(targetTypes.option.cases[0].operation.safety.level, 'safe');
+assert.equal(targetTypes.option.cases[0].execution_tier, 'read_only_executable');
 assert.equal(targetTypes.option.cases[1].operation.capability_context.required[0], 'manage_options');
 assert.deepEqual(targetTypes.option.cases[1].skip_reasons, ['crud_mutation_requires_explicit_allow']);
+assert.equal(targetTypes.option.cases[1].execution_tier, 'plan_only');
 assert.deepEqual(targetTypes['post-type'].cases.map((testCase) => testCase.intent), ['list-posts', 'read-post', 'create-post', 'update-post', 'delete-post']);
 assert.equal(targetTypes['post-type'].cases[0].operation.resource_type, 'post');
 assert.equal(targetTypes['post-type'].cases[0].operation.input.post_type, 'post');
@@ -70,6 +72,7 @@ assert.equal(targetTypes['database-table'].cases[0].intent, 'inspect-database-ta
 assert.equal(targetTypes['db-query'].cases[0].intent, 'profile-database-query');
 assert.equal(targetTypes['database-table'].cases[1].intent, 'mutate-database-table');
 assert.equal(targetTypes['database-table'].cases[1].executable, false);
+assert.equal(targetTypes['database-table'].cases[1].execution_tier, 'plan_only');
 assert.deepEqual(targetTypes['database-table'].cases[1].required_capabilities, ['database', 'reset', 'snapshot', 'transaction']);
 assert.deepEqual(targetTypes['database-table'].cases[1].skip_reasons, ['missing-runtime-fuzz-capabilities']);
 assert.deepEqual(targetTypes['database-table'].cases[1].metadata.missing_capabilities, ['database', 'reset', 'snapshot', 'transaction']);
@@ -83,16 +86,21 @@ assert(targetTypes.role.operation_id.includes('check-role-boundary'));
 assert.equal(targetTypes.block.cases[0].operation.block_name, 'core/paragraph');
 assert.deepEqual(targetTypes.block.cases.map((testCase) => testCase.intent), ['render-block', 'serialize-parse-block', 'insert-block-in-editor']);
 assert.equal(targetTypes.block.cases[0].metadata.safety.mutation, 'read_only');
+assert.equal(targetTypes.block.cases[0].execution_tier, 'read_only_executable');
 assert.deepEqual(targetTypes.block.cases[1].metadata.attributes_schema, { content: { type: 'string' } });
 assert.deepEqual(targetTypes.block.cases[1].metadata.attributes_sample, { content: 'Sample paragraph' });
 assert.equal(targetTypes.block.cases[2].metadata.planned, true);
 assert.equal(targetTypes.block.cases[2].metadata.gated, true);
+assert.equal(targetTypes.block.cases[2].execution_tier, 'plan_only');
 assert.deepEqual(targetTypes.block.cases[2].metadata.requires_runtime, ['browser', 'block-editor']);
 assert(targetTypes.block.cases[2].skip_reasons.includes('requires_browser_editor_runtime'));
 assert.equal(targetTypes['frontend-url'].cases[0].operation.path, '/');
 assert.equal(targetTypes['admin-page'].cases[0].operation.path, '/wp-admin/edit.php');
 assert.equal(targetTypes['rest-route'].cases[0].operation.route, '/wp/v2/posts');
 assert.equal(targetTypes['rest-route'].cases[0].seed, 'seed-1');
+assert(targetTypes['rest-route'].cases[0].execution_tier === 'read_only_executable');
+assert(plan.metadata.execution_tiers.read_only_executable > 0);
+assert(plan.metadata.execution_tiers.plan_only > 0);
 assert(!JSON.stringify(plan).includes('woocommerce'), 'fuzz plan conversion must stay product-agnostic');
 
 const aliasPlan = buildWordPressFuzzPlanFromSurfaces({
@@ -125,6 +133,7 @@ const runtimeDiscovery = normalizeWordPressRuntimeSurfaceDiscovery({
 assert.deepEqual(runtimeDiscovery.surfaces.map((surface) => surface.type), ['admin_page', 'ajax_action', 'db_table', 'rest_route']);
 assert.deepEqual(runtimeDiscovery.unsupported_surfaces.map((surface) => surface.type), ['cron_event', 'db_query', 'hook', 'media', 'option', 'role', 'wp_cli_command']);
 assert.equal(runtimeDiscovery.unsupported_surfaces.every((surface) => surface.executable === false && surface.coverage_counted === false), true);
+assert.equal(runtimeDiscovery.unsupported_surfaces.every((surface) => surface.execution_tier === 'discovered'), true);
 assert.equal(runtimeDiscovery.diagnostics.every((diagnostic) => diagnostic.code === 'wordpress_surface_discovered_without_executable_runtime_collector'), true);
 const runtimePlan = buildWordPressFuzzPlanFromSurfaces(runtimeDiscovery);
 assert.deepEqual(runtimePlan.targets.map((target) => target.type), ['admin-page', 'ajax-action', 'database-table', 'rest-route']);
@@ -176,6 +185,7 @@ assert.equal(getCase.intent, 'request-rest-route');
 assert.deepEqual(getCase.skip_reasons, []);
 assert.deepEqual(getCase.destructive_reasons, []);
 assert.equal(getCase.metadata.safety.mutates, false);
+assert.equal(getCase.execution_tier, 'read_only_executable');
 assert.equal(getCase.metadata.surface.args.count, 2);
 assert.equal(getCase.metadata.surface.args.args[1].required, true);
 assert.equal(getCase.seed, 'seed-rest');
@@ -187,6 +197,7 @@ for (const method of ['POST', 'DELETE']) {
 	assert.deepEqual(testCase.required_capabilities, ['reset', 'rest', 'restore', 'snapshot']);
 	assert.equal(testCase.metadata.planned, true);
 	assert.equal(testCase.metadata.gated, true);
+	assert.equal(testCase.execution_tier, 'plan_only');
 	assert.equal(testCase.metadata.safety.requires_explicit_opt_in, true);
 	assert.deepEqual(testCase.metadata.auth, { required: true, source: 'permission_callback', capability: 'edit_posts' });
 }
@@ -200,10 +211,10 @@ const resourcePlan = buildWordPressFuzzPlanFromSurfaces({
 assert.deepEqual(resourcePlan.targets[0].cases.map((testCase) => testCase.intent), ['list-settings', 'read-setting', 'create-setting', 'update-setting', 'delete-setting']);
 assert.equal(resourcePlan.targets[0].cases[2].operation.resource_type, 'setting');
 assert.equal(resourcePlan.targets[0].cases[2].operation.capability_context.required[0], 'manage_options');
-assert.deepEqual(resourcePlan.targets[0].cases[2].skip_reasons, ['missing-runtime-fuzz-capabilities']);
+assert.deepEqual(resourcePlan.targets[0].cases[2].skip_reasons, ['requires-isolated-mutation-runtime']);
 assert.equal(resourcePlan.targets[0].cases[2].executable, false);
 assert.deepEqual(resourcePlan.targets[0].cases[2].required_capabilities, ['crud', 'reset', 'restore', 'snapshot']);
-assert.equal(resourcePlan.targets[0].cases[2].metadata.runtime_capability_gated, true);
+assert.equal(resourcePlan.targets[0].cases[2].execution_tier, 'plan_only');
 assert.equal(resourcePlan.targets[1].cases.length, 1);
 assert.equal(resourcePlan.targets[1].cases[0].intent, 'exercise-wordpress-surface');
 
@@ -225,11 +236,13 @@ const adminCases = adminInteractionPlan.targets[0].cases;
 assert.equal(adminCases.length, 3);
 assert.equal(adminCases[0].intent, 'request-admin-page');
 assert.equal(adminCases[0].metadata.executable, true);
+assert.equal(adminCases[0].execution_tier, 'read_only_executable');
 assert.equal(adminCases[1].intent, 'plan-admin-page-mutation');
 assert.deepEqual(adminCases[1].skip_reasons, ['missing-runtime-fuzz-capabilities', 'requires_explicit_mutation_opt_in']);
 assert.deepEqual(adminCases[1].destructive_reasons, ['form_mutation']);
 assert.equal(adminCases[1].metadata.executable, false);
 assert.equal(adminCases[1].metadata.gated, true);
+assert.equal(adminCases[1].execution_tier, 'plan_only');
 assert.deepEqual(adminCases[1].required_capabilities, ['admin', 'reset', 'restore', 'snapshot']);
 assert(adminCases[1].skip_reasons.includes('missing-runtime-fuzz-capabilities'));
 assert.deepEqual(adminCases[1].metadata.capability_context, { required: ['edit_posts'] });
@@ -238,6 +251,7 @@ assert.equal(adminCases[2].intent, 'exercise-admin-page-read-only-interaction');
 assert.deepEqual(adminCases[2].skip_reasons, []);
 assert.deepEqual(adminCases[2].destructive_reasons, []);
 assert.equal(adminCases[2].metadata.executable, true);
+assert.equal(adminCases[2].execution_tier, 'read_only_executable');
 
 const minimalBlockPlan = buildWordPressFuzzPlanFromSurfaces({
 	blocks: [{ id: 'block:minimal', block_name: 'example/minimal' }],
@@ -261,18 +275,20 @@ for (const testCase of capableCases.filter((entry) => entry.required_capabilitie
 	assert.equal(testCase.metadata.runtime_capability_gated, false);
 }
 const capableCrudMutation = capableCases.find((entry) => entry.intent === 'create-post');
-assert.equal(capableCrudMutation.executable, true);
+assert.equal(capableCrudMutation.executable, false);
 assert.deepEqual(capableCrudMutation.required_capabilities, ['crud', 'reset', 'restore', 'snapshot']);
-assert.deepEqual(capableCrudMutation.skip_reasons, []);
-assert.equal(capableCrudMutation.metadata.runtime_capability_gated, false);
+assert.deepEqual(capableCrudMutation.skip_reasons, ['requires-isolated-mutation-runtime']);
+assert.equal(capableCrudMutation.execution_tier, 'plan_only');
 const capableRestMutation = capableCases.find((entry) => entry.intent === 'request-rest-route');
 assert.equal(capableRestMutation.executable, false);
 assert.equal(capableRestMutation.metadata.runtime_capability_gated, false);
-assert.deepEqual(capableRestMutation.skip_reasons, ['mutating_rest_method_requires_explicit_opt_in']);
+assert.deepEqual(capableRestMutation.skip_reasons, ['mutating_rest_method_requires_explicit_opt_in', 'requires-isolated-mutation-runtime']);
+assert.equal(capableRestMutation.execution_tier, 'plan_only');
 const capableAdminMutation = capableCases.find((entry) => entry.intent === 'plan-admin-page-mutation');
 assert.equal(capableAdminMutation.executable, false);
 assert.equal(capableAdminMutation.metadata.runtime_capability_gated, false);
-assert.deepEqual(capableAdminMutation.skip_reasons, ['requires_explicit_mutation_opt_in']);
+assert.deepEqual(capableAdminMutation.skip_reasons, ['requires-isolated-mutation-runtime', 'requires_explicit_mutation_opt_in']);
+assert.equal(capableAdminMutation.execution_tier, 'plan_only');
 
 const isolatedMutationPlan = buildWordPressFuzzPlanFromSurfaces({
 	post_types: [{ id: 'post:isolated', post_type: 'post' }],
@@ -290,6 +306,7 @@ for (const intent of ['create-post', 'request-rest-route', 'plan-admin-page-muta
 	const testCase = isolatedCases.find((entry) => entry.intent === intent);
 	assert.equal(testCase.executable, true, `${intent} should execute in isolated mode with runtime capabilities`);
 	assert.deepEqual(testCase.skip_reasons, []);
+	assert.equal(testCase.execution_tier, 'isolated_mutating_executable');
 	assert.equal(testCase.metadata.runtime_capability_gated, false);
 }
 
@@ -306,5 +323,6 @@ assert.equal(readOnlyCreate.executable, false);
 assert.equal(readOnlyCreate.metadata.mutation_policy_gated, true);
 assert.equal(readOnlyCreate.metadata.mutation_policy.mode, 'read_only');
 assert.deepEqual(readOnlyCreate.skip_reasons, ['mutation-policy-read-only']);
+assert.equal(readOnlyCreate.execution_tier, 'plan_only');
 
 console.log('WordPress fuzz plan from surfaces smoke passed.');

--- a/wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js
@@ -7,6 +7,7 @@ const {
 	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
 	gateWordPressFuzzCaseForMutationPolicy,
 	gateWordPressFuzzCaseForRuntimeCapabilities,
+	normalizeWordPressFuzzExecutionTier,
 	normalizeWordPressFuzzMutationMode,
 	normalizeWordPressFuzzRuntimeCapabilities,
 	normalizeWordPressFuzzRuntimeCapability,
@@ -18,6 +19,10 @@ assert.equal(normalizeWordPressFuzzRuntimeCapability('database_reset'), 'reset')
 assert.equal(normalizeWordPressFuzzRuntimeCapability('unknown'), '');
 assert.equal(normalizeWordPressFuzzMutationMode('destructive_deny'), 'destructive-deny');
 assert.equal(normalizeWordPressFuzzMutationMode('read-only'), 'read_only');
+assert.equal(normalizeWordPressFuzzExecutionTier('read-only-executable'), 'read_only_executable');
+assert.equal(normalizeWordPressFuzzExecutionTier('', { discovered: true }), 'discovered');
+assert.equal(normalizeWordPressFuzzExecutionTier('', { executable: false }), 'plan_only');
+assert.equal(normalizeWordPressFuzzExecutionTier('', { executable: true, mutates: true }), 'isolated_mutating_executable');
 
 const contract = normalizeWordPressFuzzRuntimeCapabilities({
 	capabilities: ['snapshots', 'rollback', 'reset-db', 'crud-execution'],
@@ -41,6 +46,7 @@ const skipped = gateWordPressFuzzCaseForRuntimeCapabilities({
 	metadata: { planned: true },
 }, { capabilities: ['crud'] }, { required_capabilities: ['crud', 'snapshot', 'restore', 'reset'] });
 assert.equal(skipped.executable, false);
+assert.equal(skipped.execution_tier, 'plan_only');
 assert.deepEqual(skipped.required_capabilities, ['crud', 'reset', 'restore', 'snapshot']);
 assert.deepEqual(skipped.metadata.missing_capabilities, ['reset', 'restore', 'snapshot']);
 assert.deepEqual(skipped.skip_reasons, ['explicit-opt-in-required', 'missing-runtime-fuzz-capabilities']);
@@ -51,6 +57,7 @@ const executable = gateWordPressFuzzCaseForRuntimeCapabilities({
 	metadata: {},
 }, { capabilities: ['crud', 'snapshot', 'restore', 'reset'] }, { required_capabilities: ['crud', 'snapshot', 'restore', 'reset'] });
 assert.equal(executable.executable, true);
+assert.equal(executable.execution_tier, 'read_only_executable');
 assert.equal(executable.metadata.executable, true);
 assert.equal(executable.metadata.gated, false);
 assert.equal(executable.metadata.runtime_capability_gated, false);
@@ -61,6 +68,7 @@ const policyDenied = gateWordPressFuzzCaseForMutationPolicy({
 	metadata: { planned: true },
 }, { mutation_mode: 'read_only' });
 assert.equal(policyDenied.executable, false);
+assert.equal(policyDenied.execution_tier, 'plan_only');
 assert.equal(policyDenied.metadata.mutation_policy.schema, WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA);
 assert.equal(policyDenied.metadata.mutation_policy.mode, 'read_only');
 assert.deepEqual(policyDenied.skip_reasons, ['mutation-policy-read-only']);
@@ -75,6 +83,7 @@ const capabilityAndPolicyDenied = gateWordPressFuzzCaseForRuntimeCapabilities({
 	mutates: true,
 });
 assert.equal(capabilityAndPolicyDenied.executable, false);
+assert.equal(capabilityAndPolicyDenied.execution_tier, 'plan_only');
 assert.equal(capabilityAndPolicyDenied.metadata.runtime_capability_gated, undefined);
 assert.equal(capabilityAndPolicyDenied.metadata.mutation_policy_gated, true);
 assert.deepEqual(capabilityAndPolicyDenied.skip_reasons, ['mutation-policy-destructive-deny']);

--- a/wordpress/tests/wordpress-runtime-surface-discovery-smoke.js
+++ b/wordpress/tests/wordpress-runtime-surface-discovery-smoke.js
@@ -65,6 +65,7 @@ assert.deepEqual(discovery.surfaces.map((surface) => surface.id), [
 	'rest:/wp/v2/posts',
 ]);
 assert.equal(discovery.surfaces.find((surface) => surface.id === 'rest:/wp/v2/posts').metadata.sources.includes('rest-index'), true);
+assert.equal(discovery.surfaces.every((surface) => surface.execution_tier === 'read_only_executable'), true);
 assert.deepEqual(discovery.unsupported_surfaces.map((surface) => surface.id), [
 	'capability:edit_posts',
 	'cron:wp_version_check',
@@ -77,6 +78,7 @@ assert.deepEqual(discovery.unsupported_surfaces.map((surface) => surface.id), [
 	'user:all',
 	'wp-cli:plugin list',
 ]);
+assert.equal(discovery.unsupported_surfaces.every((surface) => surface.execution_tier === 'discovered'), true);
 assert.equal(discovery.diagnostics.length, 10);
 
 const manifest = buildWordPressRuntimeSurfaceCoverageManifest(discovery);
@@ -89,5 +91,6 @@ assert.deepEqual(manifest.surfaces.map((surface) => surface.type), [
 	'frontend_url',
 	'rest_route',
 ]);
+assert.equal(manifest.surfaces.every((surface) => surface.execution_tier === 'read_only_executable'), true);
 
 console.log('WordPress runtime surface discovery smoke passed.');


### PR DESCRIPTION
## Summary
- Add explicit WordPress fuzz execution tiers: `discovered`, `plan_only`, `read_only_executable`, and `isolated_mutating_executable`.
- Tag runtime discovery and coverage manifest surfaces with execution tiers while preserving existing unsupported-surface fields.
- Annotate fuzz-plan cases and plan/target metadata with execution-tier counts so read-only execution is distinct from isolated mutation-gated CRUD/REST/admin/database coverage.

## Tests
- `npm run test:wordpress-runtime-surface-discovery`
- `npm run test:wordpress-fuzz-plan-from-surfaces`
- `node tests/wordpress-fuzz-runtime-capabilities-smoke.js` (no npm script exists for this test)
- `npm run test:wordpress-surface-types`
- `npm run test:wordpress-live-surface-discovery`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, test updates, local verification, and PR drafting.