### PR TITLE
Add rollback-safe REST fuzz contract

### DIFF
--- a/wordpress/lib/wordpress-fuzz-command-manifest.js
+++ b/wordpress/lib/wordpress-fuzz-command-manifest.js
@@ -71,7 +71,10 @@ function requiredWpCodeboxContractsForFuzzPlan(plan = {}) {
 
 function requiredWpCodeboxContractsForFuzzCase(testCase = {}) {
 	const intent = String(testCase.intent || '').trim();
-	return cloneRequirements(CASE_INTENT_REQUIREMENTS[intent] || CASE_INTENT_REQUIREMENTS.workload);
+	return mergeRequirements([
+		CASE_INTENT_REQUIREMENTS[intent] || CASE_INTENT_REQUIREMENTS.workload,
+		{ capabilities: arrayOf(testCase.required_capabilities || testCase.requiredCapabilities || testCase.metadata?.required_capabilities || testCase.metadata?.requiredCapabilities) },
+	]);
 }
 
 function mergeRequirements(requirements) {

--- a/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
+++ b/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
@@ -26,6 +26,7 @@ const {
 
 const SAFE_REST_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 const DB_MUTATION_REQUIRED_CAPABILITIES = requiredCapabilitiesForWordPressFuzzCase('db_mutation');
+const REST_ROLLBACK_ANY_CAPABILITIES = Object.freeze([Object.freeze(['restore', 'reset'])]);
 
 function buildWordPressFuzzPlanFromSurfaces(input = {}, options = {}) {
 	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode || input.mutation_mode || input.mutationMode);
@@ -238,7 +239,8 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 			surface,
 			rest_method: method,
 			auth: surface.auth || surface.authentication || surface.authorization || null,
-			safety: safeMethod ? { level: 'safe', mutates: false } : { level: 'mutating', mutates: true, requires_explicit_opt_in: true },
+			safety: safeMethod ? { level: 'safe', mutates: false } : { level: 'mutating', mutates: true, requires_explicit_opt_in: true, rollback_required: true },
+			rollback_contract: safeMethod ? undefined : restMutationRollbackContract({ surface, method }),
 			planned: !safeMethod,
 			gated: !safeMethod,
 		},
@@ -248,6 +250,7 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 	}
 	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
 		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('mutating_rest'),
+		required_any_capabilities: REST_ROLLBACK_ANY_CAPABILITIES,
 		mutation_mode: mutationMode,
 		mutates: true,
 	});
@@ -298,6 +301,10 @@ function crudCaseForSurface(surface, resource, action, options = {}) {
 	const operation = crudOperationForSurface(surface, resource, action);
 	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
 	const mutates = mutatingCrudAction(action.action);
+	const restTransport = operation.transport?.type === 'rest';
+	const requiredCapabilities = mutates && restTransport
+		? requiredCapabilitiesForWordPressFuzzCase('rest_crud_mutation')
+		: requiredCapabilitiesForWordPressFuzzCase('mutating_crud');
 	const gateReasons = mutates && !mutationMode
 		? (!allowsCrudMutation(surface, action.action) ? ['crud_mutation_requires_explicit_allow'] : ['requires-isolated-mutation-runtime'])
 		: [];
@@ -307,21 +314,40 @@ function crudCaseForSurface(surface, resource, action, options = {}) {
 		operation_id: operation.id,
 		operation,
 		seed: options.seed,
-		required_capabilities: mutates ? requiredCapabilitiesForWordPressFuzzCase('mutating_crud') : undefined,
+		required_capabilities: mutates ? requiredCapabilities : undefined,
 		skip_reasons: [
 			...reasonList(surface.skip_reasons || surface.skipReasons || surface.skip_reason || surface.skipReason),
 			...gateReasons,
 		],
 		destructive_reasons: reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons),
-		metadata: { surface, crud: { resource_type: resource.type, intent: action.intent, action: action.action } },
+		metadata: stripUndefined({
+			surface,
+			crud: { resource_type: resource.type, intent: action.intent, action: action.action },
+			rollback_contract: mutates && restTransport ? restMutationRollbackContract({ surface, method: operation.transport.method, action: action.action }) : undefined,
+		}),
 	};
 	if (!mutates || gateReasons.length > 0) {
 		return annotateWordPressFuzzCaseExecutionTier(testCase, { mutates, executable: !mutates && testCase.skip_reasons.length === 0 });
 	}
 	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
-		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('mutating_crud'),
+		required_capabilities: requiredCapabilities,
+		required_any_capabilities: restTransport ? REST_ROLLBACK_ANY_CAPABILITIES : undefined,
 		mutation_mode: mutationMode,
 		mutates: true,
+	});
+}
+
+function restMutationRollbackContract({ surface = {}, method, action } = {}) {
+	return stripUndefined({
+		schema: 'homeboy/wordpress-rest-mutation-rollback-contract/v1',
+		strategy: 'checkpoint-restore-or-reset',
+		required_capabilities: requiredCapabilitiesForWordPressFuzzCase(action ? 'rest_crud_mutation' : 'mutating_rest'),
+		required_any_capabilities: REST_ROLLBACK_ANY_CAPABILITIES.map((group) => [...group]),
+		restore_boundary: 'after_each_case',
+		delete_boundary_artifacts: method === 'DELETE' || action === 'delete',
+		route: surface.route,
+		method,
+		action,
 	});
 }
 
@@ -429,10 +455,17 @@ function transportForCrudAction(surface, resource, action) {
 	}
 	return stripUndefined({
 		type: surface.route ? 'rest' : undefined,
-		method: action.action === 'read' ? (surface.method || 'GET') : undefined,
+		method: surface.route ? restMethodForCrudAction(surface, action.action) : undefined,
 		route: surface.route,
 		path: surface.path,
 	});
+}
+
+function restMethodForCrudAction(surface, action) {
+	if (surface.method && action === 'read') {
+		return surface.method;
+	}
+	return { create: 'POST', read: 'GET', update: 'PUT', delete: 'DELETE' }[action];
 }
 
 function inputForCrudAction(surface, resource, action) {

--- a/wordpress/lib/wordpress-fuzz-runtime-capabilities.js
+++ b/wordpress/lib/wordpress-fuzz-runtime-capabilities.js
@@ -9,6 +9,7 @@ const WORDPRESS_FUZZ_RUNTIME_CAPABILITIES = Object.freeze([
 	'snapshot',
 	'checkpoint',
 	'restore',
+	'rest-rollback',
 	'transaction',
 	'reset',
 	'crud',
@@ -25,6 +26,12 @@ const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_ALIASES = new Map([
 	['rollback', 'restore'],
 	['rollback-snapshot', 'restore'],
 	['rollback_snapshot', 'restore'],
+	['rest-rollback-safe', 'rest-rollback'],
+	['rest_rollback_safe', 'rest-rollback'],
+	['rest-mutation-rollback', 'rest-rollback'],
+	['rest_mutation_rollback', 'rest-rollback'],
+	['rollback-safe-rest', 'rest-rollback'],
+	['rollback_safe_rest', 'rest-rollback'],
 	['db-transaction', 'transaction'],
 	['db_transaction', 'transaction'],
 	['transactions', 'transaction'],
@@ -51,7 +58,8 @@ const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SET = new Set(WORDPRESS_FUZZ_RUNTIME_CAP
 
 const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_REQUIREMENTS = Object.freeze({
 	mutating_crud: Object.freeze(['crud', 'snapshot', 'restore', 'reset']),
-	mutating_rest: Object.freeze(['rest', 'snapshot', 'restore', 'reset']),
+	mutating_rest: Object.freeze(['rest', 'checkpoint', 'rest-rollback']),
+	rest_crud_mutation: Object.freeze(['crud', 'rest', 'checkpoint', 'rest-rollback']),
 	admin_mutation: Object.freeze(['admin', 'snapshot', 'restore', 'reset']),
 	db_mutation: Object.freeze(['database', 'snapshot', 'transaction', 'reset']),
 });
@@ -116,11 +124,13 @@ function gateWordPressFuzzCaseForRuntimeCapabilities(testCase, runtimeCapabiliti
 		return testCase;
 	}
 	const declared = new Set(normalizeWordPressFuzzRuntimeCapabilities(runtimeCapabilities).capabilities);
+	const requiredAny = normalizeRequiredCapabilityGroups(options.required_any_capabilities || options.requiredAnyCapabilities || testCase.required_any_capabilities || testCase.requiredAnyCapabilities);
 	const missing = required.filter((capability) => !declared.has(capability));
+	const missingAny = requiredAny.filter((group) => !group.some((capability) => declared.has(capability)));
 	const skipReasons = reasonList(testCase.skip_reasons || testCase.skipReasons || testCase.skip_reason || testCase.skipReason);
 	const metadata = isObject(testCase.metadata) ? { ...testCase.metadata } : {};
 
-	if (missing.length === 0) {
+	if (missing.length === 0 && missingAny.length === 0) {
 		const mutates = fuzzCaseMutates(testCase, options);
 		const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
 		const mutationTierGated = mutates && mutationMode !== 'isolated';
@@ -145,6 +155,7 @@ function gateWordPressFuzzCaseForRuntimeCapabilities(testCase, runtimeCapabiliti
 				execution_tier_gated: mutationTierGated,
 				runtime_capability_contract: WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
 				required_capabilities: required,
+				required_any_capabilities: requiredAny.length > 0 ? requiredAny : undefined,
 			},
 		};
 	}
@@ -164,7 +175,9 @@ function gateWordPressFuzzCaseForRuntimeCapabilities(testCase, runtimeCapabiliti
 			runtime_capability_gated: true,
 			runtime_capability_contract: WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
 			required_capabilities: required,
+			required_any_capabilities: requiredAny.length > 0 ? requiredAny : undefined,
 			missing_capabilities: missing,
+			missing_any_capabilities: missingAny.length > 0 ? missingAny : undefined,
 		},
 	};
 }
@@ -266,6 +279,12 @@ function normalizeRequiredCapabilities(value) {
 	return [...new Set((Array.isArray(value) ? value : [value])
 		.map(normalizeWordPressFuzzRuntimeCapability)
 		.filter(Boolean))].sort();
+}
+
+function normalizeRequiredCapabilityGroups(value) {
+	return (Array.isArray(value) ? value : [])
+		.map((group) => normalizeRequiredCapabilities(Array.isArray(group) ? group : [group]))
+		.filter((group) => group.length > 0);
 }
 
 function normalizeWordPressFuzzMutationMode(value) {

--- a/wordpress/lib/wordpress-fuzz-runtime-task.js
+++ b/wordpress/lib/wordpress-fuzz-runtime-task.js
@@ -136,7 +136,7 @@ function observationId({ defaults = {}, family, caseId, targetId, operationId, m
 
 function normalizeObservationFamily(value) {
 	const family = String(value || '').trim().toLowerCase().replace(/[\s.-]+/g, '_');
-	if (['action', 'query', 'resource', 'timing', 'counter'].includes(family)) {
+	if (['action', 'query', 'resource', 'timing', 'counter', 'rollback'].includes(family)) {
 		return family;
 	}
 	return undefined;

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -32,6 +32,9 @@ const {
 	wpCodeboxPluginStateStep,
 } = require('./wp-codebox-recipe-helper');
 const {
+	normalizeWordPressFuzzRuntimeCapabilities,
+} = require('./wordpress-fuzz-runtime-capabilities');
+const {
 	resolveWpCodeboxIdentity,
 	wpCodeboxIdentityMismatchDiagnostics,
 } = require('./wp-codebox-resolver');
@@ -175,6 +178,7 @@ const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 	coverage_gap_report: 'fuzz.coverage.gap_report',
 	observation_set: 'fuzz.observation_set',
 	hotspot_summary: 'fuzz.hotspot.summary',
+	rollback_boundary: 'fuzz.rollback.delete_boundary',
 	result_envelope: 'fuzz.result.envelope',
 	normalized_fuzz_result: 'fuzz.result.normalized',
 	coverage: 'fuzz.coverage',
@@ -1014,6 +1018,17 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 		}
 	}
 
+	const declaredRuntimeCapabilities = new Set(normalizeArray(capabilities.capabilities));
+	for (const capability of normalizeArray(requiredPlanContracts.capabilities)) {
+		if (!declaredRuntimeCapabilities.has(capability)) {
+			missingContracts.push({
+				type: 'runtime_capability',
+				capability,
+				message: `WP Codebox public fuzz runtime must declare \`${capability}\` before Homeboy dispatches matching WordPress fuzz workloads.`,
+			});
+		}
+	}
+
 	if (wordpressRuntimeAbilities.runFuzzSuite !== requiredAbilities.runFuzzSuite) {
 		missingContracts.push({
 			type: 'ability',
@@ -1112,9 +1127,11 @@ function unique(values) {
 
 function normalizeWpCodeboxPublicFuzzCapabilities(input = {}) {
 	const commands = objectOrUndefined(input.commands) || input;
+	const runtimeCapabilities = normalizeWordPressFuzzRuntimeCapabilities(input.capabilities || input.runtime_capabilities || input.runtimeCapabilities || input.supports || []);
 	return {
 		schema: 'homeboy/wp-codebox-public-fuzz-capabilities/v1',
 		commands: Object.fromEntries(WP_CODEBOX_PUBLIC_CLI_COMMANDS.map((command) => [command, commands[command] === true])),
+		capabilities: runtimeCapabilities.capabilities,
 		runner_modes: Object.fromEntries(WP_CODEBOX_FUZZ_PUBLIC_RUNNER_MODES.map((runnerMode) => [runnerMode, input.runner_modes?.[runnerMode] !== false && input.runnerModes?.[runnerMode] !== false])),
 	};
 }
@@ -1284,7 +1301,7 @@ function normalizeWpCodeboxFuzzSuiteResult(result = {}, context = {}) {
 		...normalizeArray(source?.coverage_gaps || source?.coverageGaps || source?.coverage?.gaps),
 		...normalizeArray(derivedArtifacts.coverage_gap_reports).flatMap((report) => normalizeArray(report.coverage_gaps)),
 	]);
-	const hotspotSummary = normalizeFuzzHotspotSummary(source?.hotspot_summary || source?.hotspotSummary || source?.hotspots || source?.performance_hotspots || source?.performanceHotspots || derivedArtifacts.hotspot_summary || fuzzHotspotSummaryFromObservationSet(observationSet, { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id }), { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id });
+	const hotspotSummary = normalizeFuzzHotspotSummary(source?.hotspot_summary || source?.hotspotSummary || source?.hotspots || source?.performance_hotspots || source?.performanceHotspots || source?.delete_boundary_rollback_hotspots || source?.deleteBoundaryRollbackHotspots || derivedArtifacts.hotspot_summary || fuzzHotspotSummaryFromObservationSet(observationSet, { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id }), { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id });
 	const normalizedResult = normalizeEmbeddedWordPressFuzzResult(source);
 	const contractFailures = wpCodeboxFuzzContractFailures({ source, result, context, artifacts, coverageSummary, normalizedResult, hotspotSummary, derivedArtifacts });
 	if (contractFailures.length > 0 && ['succeeded', 'success', 'passed', 'ok'].includes(String(status).toLowerCase())) {
@@ -1349,12 +1366,38 @@ function normalizeCodeboxFuzzObservationSet(source = {}, context = {}) {
 			...normalizeArray(source?.resources || source?.resource_measurements || source?.resourceMeasurements).map((entry) => objectOrUndefined(entry) ? { family: 'resource', ...entry } : entry),
 			...normalizeArray(source?.timings || source?.timing_measurements || source?.timingMeasurements).map((entry) => objectOrUndefined(entry) ? { family: 'timing', ...entry } : entry),
 			...normalizeArray(source?.counters || source?.counter_measurements || source?.counterMeasurements).map((entry) => objectOrUndefined(entry) ? { family: 'counter', ...entry } : entry),
+			...deleteBoundaryRollbackObservations(source),
 			...wordpressFuzzResultCaseObservations(source?.wordpress_fuzz_result || source?.wordpressFuzzResult || source?.normalized_result || source?.normalizedResult),
 		],
 		metadata: stripUndefined({
 			wp_codebox_result_schema: source?.schema,
 		}),
 	}, { provider: 'wp-codebox', taskId: source?.request_id || source?.requestId || context.request?.task_id });
+}
+
+function deleteBoundaryRollbackObservations(source = {}) {
+	return normalizeArray(source?.delete_boundary_rollback_artifacts || source?.deleteBoundaryRollbackArtifacts || source?.rollback_artifacts || source?.rollbackArtifacts)
+		.map((artifact) => {
+			if (!objectOrUndefined(artifact)) {
+				return undefined;
+			}
+			return stripUndefined({
+				family: 'rollback',
+				subject: 'delete_boundary',
+				metric: 'rollback_artifact',
+				value: ['failed', 'error', 'missing'].includes(String(artifact.status || '').toLowerCase()) ? 0 : 1,
+				case_id: artifact.case_id || artifact.caseId,
+				operation_id: artifact.operation_id || artifact.operationId,
+				fingerprint: artifact.fingerprint || artifact.id || artifact.name || artifact.path,
+				status: artifact.status,
+				metadata: stripUndefined({
+					artifact_name: artifact.name || artifact.id,
+					path: artifact.path || artifact.file || artifact.artifact || artifact.uri,
+					schema: artifact.schema || artifact.artifact_schema || artifact.artifactSchema || artifact.metadata?.schema,
+				}),
+			});
+		})
+		.filter(Boolean);
 }
 
 function wordpressFuzzResultCaseObservations(result = {}) {
@@ -1841,6 +1884,7 @@ function fuzzArtifactRefsFromSource(source = {}, result = {}) {
 		{ coverage: source?.coverage_artifact || source?.coverageArtifact || source?.wordpress_fuzz_coverage || source?.wordpressFuzzCoverage },
 		{ normalized_fuzz_result: source?.wordpress_fuzz_result_artifact || source?.wordpressFuzzResultArtifact || source?.normalized_fuzz_result || source?.normalizedFuzzResult },
 		{ hotspot_summary: source?.hotspot_summary_artifact || source?.hotspotSummaryArtifact || source?.hotspot_summary || source?.hotspotSummary },
+		{ rollback_boundary: source?.delete_boundary_rollback_artifacts || source?.deleteBoundaryRollbackArtifacts || source?.rollback_artifacts || source?.rollbackArtifacts },
 	];
 }
 
@@ -2111,6 +2155,9 @@ function normalizeFuzzArtifactRole(value) {
 	if (['hotspot_summary', 'fuzz_hotspot_summary', 'hotspots', 'performance_hotspots'].includes(label)) {
 		return 'hotspot_summary';
 	}
+	if (['rollback_boundary', 'delete_boundary_rollback', 'delete_boundary_rollback_artifact', 'rollback_artifact', 'rollback_artifacts'].includes(label)) {
+		return 'rollback_boundary';
+	}
 	if (['observation_set', 'observations', 'measurements', 'fuzz_observation_set'].includes(label)) {
 		return 'observation_set';
 	}
@@ -2155,6 +2202,9 @@ function normalizeFuzzArtifactRole(value) {
 	}
 	if (/hotspot/.test(label)) {
 		return 'hotspot_summary';
+	}
+	if (/rollback/.test(label) || /delete.*boundary|boundary.*delete/.test(label)) {
+		return 'rollback_boundary';
 	}
 	if (/report|summary|result/.test(label)) {
 		return 'fuzz_report';

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -194,7 +194,10 @@ for (const method of ['POST', 'DELETE']) {
 	assert(testCase.skip_reasons.includes('mutating_rest_method_requires_explicit_opt_in'));
 	assert(testCase.skip_reasons.includes('missing-runtime-fuzz-capabilities'));
 	assert(testCase.destructive_reasons.includes('rest_method_mutates_state'));
-	assert.deepEqual(testCase.required_capabilities, ['reset', 'rest', 'restore', 'snapshot']);
+	assert.deepEqual(testCase.required_capabilities, ['checkpoint', 'rest', 'rest-rollback']);
+	assert.deepEqual(testCase.metadata.required_any_capabilities, [['reset', 'restore']]);
+	assert.equal(testCase.metadata.rollback_contract.schema, 'homeboy/wordpress-rest-mutation-rollback-contract/v1');
+	assert.equal(testCase.metadata.rollback_contract.delete_boundary_artifacts, method === 'DELETE');
 	assert.equal(testCase.metadata.planned, true);
 	assert.equal(testCase.metadata.gated, true);
 	assert.equal(testCase.execution_tier, 'plan_only');
@@ -213,7 +216,8 @@ assert.equal(resourcePlan.targets[0].cases[2].operation.resource_type, 'setting'
 assert.equal(resourcePlan.targets[0].cases[2].operation.capability_context.required[0], 'manage_options');
 assert.deepEqual(resourcePlan.targets[0].cases[2].skip_reasons, ['requires-isolated-mutation-runtime']);
 assert.equal(resourcePlan.targets[0].cases[2].executable, false);
-assert.deepEqual(resourcePlan.targets[0].cases[2].required_capabilities, ['crud', 'reset', 'restore', 'snapshot']);
+assert.deepEqual(resourcePlan.targets[0].cases[2].required_capabilities, ['checkpoint', 'crud', 'rest', 'rest-rollback']);
+assert.equal(resourcePlan.targets[0].cases[2].metadata.rollback_contract.schema, 'homeboy/wordpress-rest-mutation-rollback-contract/v1');
 assert.equal(resourcePlan.targets[0].cases[2].execution_tier, 'plan_only');
 assert.equal(resourcePlan.targets[1].cases.length, 1);
 assert.equal(resourcePlan.targets[1].cases[0].intent, 'exercise-wordpress-surface');
@@ -265,7 +269,7 @@ const capablePlan = buildWordPressFuzzPlanFromSurfaces({
 	rest: [{ id: 'rest:posts', route: '/wp/v2/posts', methods: ['POST'] }],
 }, {
 	runtimeCapabilities: {
-		capabilities: ['crud', 'rest', 'admin', 'database', 'snapshot', 'restore', 'transaction', 'reset'],
+		capabilities: ['crud', 'rest', 'admin', 'database', 'snapshot', 'restore', 'transaction', 'reset', 'checkpoint', 'rest-rollback'],
 	},
 });
 const capableCases = capablePlan.targets.flatMap((target) => target.cases);
@@ -297,7 +301,7 @@ const isolatedMutationPlan = buildWordPressFuzzPlanFromSurfaces({
 }, {
 	mutation_mode: 'isolated',
 	runtimeCapabilities: {
-		capabilities: ['crud', 'rest', 'admin', 'snapshot', 'restore', 'reset'],
+		capabilities: ['crud', 'rest', 'admin', 'snapshot', 'restore', 'reset', 'checkpoint', 'rest-rollback'],
 	},
 });
 assert.equal(isolatedMutationPlan.metadata.mutation_mode, 'isolated');
@@ -309,6 +313,9 @@ for (const intent of ['create-post', 'request-rest-route', 'plan-admin-page-muta
 	assert.equal(testCase.execution_tier, 'isolated_mutating_executable');
 	assert.equal(testCase.metadata.runtime_capability_gated, false);
 }
+const isolatedRestMutation = isolatedCases.find((entry) => entry.intent === 'request-rest-route');
+assert.equal(isolatedRestMutation.metadata.rollback_contract.schema, 'homeboy/wordpress-rest-mutation-rollback-contract/v1');
+assert.deepEqual(isolatedRestMutation.metadata.required_any_capabilities, [['reset', 'restore']]);
 
 const readOnlyMutationPlan = buildWordPressFuzzPlanFromSurfaces({
 	post_types: [{ id: 'post:read-only', post_type: 'post', allowCrudMutations: true }],

--- a/wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js
@@ -16,6 +16,7 @@ const {
 
 assert.equal(normalizeWordPressFuzzRuntimeCapability('db-transaction'), 'transaction');
 assert.equal(normalizeWordPressFuzzRuntimeCapability('database_reset'), 'reset');
+assert.equal(normalizeWordPressFuzzRuntimeCapability('rollback-safe-rest'), 'rest-rollback');
 assert.equal(normalizeWordPressFuzzRuntimeCapability('unknown'), '');
 assert.equal(normalizeWordPressFuzzMutationMode('destructive_deny'), 'destructive-deny');
 assert.equal(normalizeWordPressFuzzMutationMode('read-only'), 'read_only');
@@ -39,6 +40,7 @@ assert.equal(contract.execution.rest, true);
 assert.deepEqual(contract.metadata, { runtime: 'fixture' });
 
 assert.deepEqual(requiredCapabilitiesForWordPressFuzzCase('mutating_crud'), ['crud', 'snapshot', 'restore', 'reset']);
+assert.deepEqual(requiredCapabilitiesForWordPressFuzzCase('mutating_rest'), ['rest', 'checkpoint', 'rest-rollback']);
 
 const skipped = gateWordPressFuzzCaseForRuntimeCapabilities({
 	id: 'case-1',
@@ -61,6 +63,33 @@ assert.equal(executable.execution_tier, 'read_only_executable');
 assert.equal(executable.metadata.executable, true);
 assert.equal(executable.metadata.gated, false);
 assert.equal(executable.metadata.runtime_capability_gated, false);
+
+const restMutationExecutable = gateWordPressFuzzCaseForRuntimeCapabilities({
+	id: 'case-rest',
+	skip_reasons: [],
+	metadata: { safety: { mutates: true } },
+}, { capabilities: ['rest', 'checkpoint', 'rest-rollback', 'reset'] }, {
+	required_capabilities: ['rest', 'checkpoint', 'rest-rollback'],
+	required_any_capabilities: [['restore', 'reset']],
+	mutation_mode: 'isolated',
+	mutates: true,
+});
+assert.equal(restMutationExecutable.executable, true);
+assert.equal(restMutationExecutable.execution_tier, 'isolated_mutating_executable');
+assert.deepEqual(restMutationExecutable.metadata.required_any_capabilities, [['reset', 'restore']]);
+
+const restMutationMissingRollback = gateWordPressFuzzCaseForRuntimeCapabilities({
+	id: 'case-rest-missing',
+	skip_reasons: [],
+	metadata: { safety: { mutates: true } },
+}, { capabilities: ['rest', 'checkpoint', 'rest-rollback'] }, {
+	required_capabilities: ['rest', 'checkpoint', 'rest-rollback'],
+	required_any_capabilities: [['restore', 'reset']],
+	mutation_mode: 'isolated',
+	mutates: true,
+});
+assert.equal(restMutationMissingRollback.executable, false);
+assert.deepEqual(restMutationMissingRollback.metadata.missing_any_capabilities, [['reset', 'restore']]);
 
 const policyDenied = gateWordPressFuzzCaseForMutationPolicy({
 	id: 'case-3',

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -203,6 +203,26 @@ const preflightPassed = preflightWpCodeboxFuzzCapabilityContract({
 });
 assert.equal(preflightPassed.ok, true);
 
+const rollbackRestPlanRequest = wpCodeboxFuzzSuiteTaskRequest({
+	taskId: 'rollback-rest-plan-task',
+	input: {
+		id: 'rollback-rest-plan-suite',
+		workload: {
+			plan: {
+				targets: [{ cases: [{ intent: 'request-rest-route', required_capabilities: ['rest', 'checkpoint', 'rest-rollback'] }] }],
+			},
+		},
+	},
+});
+const preflightMissingRuntimeCapability = preflightWpCodeboxFuzzCapabilityContract({
+	request: rollbackRestPlanRequest,
+	runtimeContractManifest: manifest,
+	publicCliCapabilities: { commands: { 'run-fuzz-suite': true, 'run-wordpress-workload': true }, capabilities: ['rest', 'checkpoint'] },
+});
+assert.equal(preflightMissingRuntimeCapability.ok, false);
+assert.equal(preflightMissingRuntimeCapability.missing_contracts.some((contract) => contract.type === 'runtime_capability' && contract.capability === 'rest-rollback'), true);
+assert.equal(preflightMissingRuntimeCapability.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_runtime_capability'), true);
+
 const mismatchRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-mismatch-'));
 const mismatchCliRoot = path.join(mismatchRoot, 'wp-codebox@cli');
 const mismatchCoreRoot = path.join(mismatchRoot, 'wp-codebox@core');
@@ -356,6 +376,31 @@ assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name 
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'replay-data'), true);
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'coverage-summary'), true);
 assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'result-envelope' && artifact.role === 'result_envelope'), false);
+
+const deleteBoundaryRollbackSummary = normalizeWpCodeboxFuzzSuiteResult({
+	schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+	request_id: 'delete-boundary-rollbacks',
+	status: 'passed',
+	cases: [{ id: 'delete-case', status: 'passed' }],
+	delete_boundary_rollback_artifacts: [{
+		name: 'delete-boundary-rollback',
+		path: 'rollback/delete-boundary.json',
+		content_type: 'application/json',
+		schema: 'wp-codebox/delete-boundary-rollback-artifact/v1',
+		case_id: 'delete-case',
+		operation_id: 'rest:posts:delete',
+		status: 'passed',
+	}],
+});
+const rollbackArtifact = deleteBoundaryRollbackSummary.artifacts.find((artifact) => artifact.role === 'rollback_boundary');
+assert.equal(rollbackArtifact.semantic_key, 'fuzz.rollback.delete_boundary');
+assert.equal(rollbackArtifact.path, 'rollback/delete-boundary.json');
+assert.equal(rollbackArtifact.metadata.schema, 'wp-codebox/delete-boundary-rollback-artifact/v1');
+const rollbackObservation = deleteBoundaryRollbackSummary.observation_set.observations.find((observation) => observation.family === 'rollback');
+assert.equal(rollbackObservation.subject, 'delete_boundary');
+assert.equal(rollbackObservation.case_id, 'delete-case');
+assert.equal(rollbackObservation.metric, 'rollback_artifact');
+assert.equal(rollbackObservation.value, 1);
 
 const genericPrimitiveManifest = {
 	schema: 'homeboy/fuzz-workload/v1',


### PR DESCRIPTION
## Summary
- Add rollback-safe REST mutation capability requirements for mutating REST routes and REST-backed CRUD plans.
- Include rollback contract metadata for isolated mutating REST execution, including delete-boundary artifact expectations.
- Normalize WP Codebox delete-boundary rollback artifacts into HBEX fuzz artifacts and rollback observations.
- Extend WP Codebox preflight to emit precise unsupported diagnostics for missing runtime capabilities.

## Tests
- npm run test:wordpress-fuzz-plan-from-surfaces
- npm run test:wordpress-fuzz-runtime-task
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner
- node tests/wordpress-fuzz-runtime-capabilities-smoke.js (npm script is not defined)
- npm run test:wordpress-rest-fuzz-surface-discovery
- npm run test:wordpress-fuzz-schemas

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the generic rollback-safe REST fuzz planning/execution contract, WP Codebox artifact normalization, tests, and PR preparation.