### PR TITLE
Fix Codebox runtime package handoff

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -349,7 +349,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const model = request.executor.model || config.model || runtimeOptions.model || defaults.model || '';
   const runtimeTask = runtimeTaskWithExecutionDefaults(
     inputs.runtime_task || inputs.runtimeTask || clientInputs.runtime_task || clientInputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || runtimeOptions.runtimeTask,
-    { provider, model, agentBundles, runtimePackage: runtimePackageDefaultFromProfile(config, runtimeOptions) }
+    { provider, model, agentBundles, runtimePackage: runtimePackageDefaultFromProfile(config, runtimeOptions), workspaceTarget: defaults.workspaceRoot ? defaultWorkspaceTarget(defaults.workspaceRoot) : '', request, config, inputs }
   );
   let componentContracts = componentContractsFromAgentTaskRequest(request, config, runtimeOptions);
   let components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
@@ -628,8 +628,11 @@ function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {
       ...normalizeArray(runtimeProfile.ability_requirements),
       ...normalizeArray(runtimeProfile.abilityRequirements),
     ]),
-    providerPluginPaths: providerPluginPathsFromRuntimeProfile(runtimeRequirements, runtimeProfile, mergedOptions),
-    runtimeOverlays: firstDefined(runtimeRequirements.runtime_overlays, runtimeProfile.runtime_overlays, mergedOptions.runtimeOverlays),
+    providerPluginPaths: firstNonEmptyArray(
+      explicitProviderPluginPathsFromConfig(config, mergedOptions),
+      providerPluginPathsFromRuntimeProfile(runtimeRequirements, runtimeProfile, mergedOptions)
+    ),
+    runtimeOverlays: firstNonEmptyArray(runtimeRequirements.runtime_overlays, runtimeProfile.runtime_overlays, mergedOptions.runtimeOverlays),
     runtimeEnv: firstNonEmptyObject(runtimeRequirements.env, runtimeRequirements.runtime_env, runtimeProfile.env, runtimeProfile.runtime_env, mergedOptions.runtimeEnv, mergedOptions.runtime_env),
     runtimeEnvAliases: firstObject(runtimeRequirements.runtime_env_aliases, runtimeRequirements.runtimeEnvAliases, runtimeProfile.runtime_env_aliases, runtimeProfile.runtimeEnvAliases, mergedOptions.runtimeEnvAliases, mergedOptions.runtime_env_aliases),
     runtimeStateMounts: firstDefined(runtimeRequirements.runtime_state_mounts, runtimeProfile.runtime_state_mounts, mergedOptions.runtimeStateMounts, mergedOptions.runtime_state_mounts),
@@ -784,7 +787,7 @@ class RuntimeOverlayConfigError extends Error {
 }
 
 function runtimeOverlaysFromConfig(config, options = {}, defaults = {}) {
-  return validateRuntimeOverlays(firstDefined(
+  return validateRuntimeOverlays(firstNonEmptyArray(
     config.runtime_overlays,
     config.runtime_requirements?.runtime_overlays,
     options.runtimeProfile?.runtime_overlays,
@@ -844,16 +847,23 @@ function codeboxRuntimeRequirementsFromAgentTaskRequest(config, options = {}, de
   const runtimeProfile = firstObject(options.runtimeProfile) || {};
   const runtimeRequirements = mergeRuntimeRequirements(defaults.runtimeRequirements, firstObject(config.runtime_requirements, config.runtimeRequirements) || {});
   const runtimeEnv = firstNonEmptyObject(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeRequirements.env, runtimeRequirements.runtime_env, runtimeProfile.env, runtimeProfile.runtime_env, options.runtimeEnv, defaults.runtimeEnv) || {};
+  const explicitProviderPluginPaths = explicitProviderPluginPathsFromConfig(config, options);
   const providerPluginPaths = firstNonEmptyArray(
+    explicitProviderPluginPaths,
     providerPluginPathsFromRuntimeProfile(runtimeRequirements, runtimeProfile, options),
-    config.provider_plugin_paths,
     defaults.providerPluginPaths,
     []
   );
+  const runtimeProfilePayloadSource = explicitProviderPluginPaths.length > 0
+    ? {
+        runtimeRequirements: withoutProviderPlugins(runtimeRequirements),
+        runtimeProfile: withoutProviderPlugins(runtimeProfile),
+      }
+    : { runtimeRequirements, runtimeProfile };
   return codeboxRuntimeProfilePayload({
     id: config.runtime_profile || config.runtimeProfile,
-    profile: runtimeProfile,
-    runtimeRequirements,
+    profile: runtimeProfilePayloadSource.runtimeProfile,
+    runtimeRequirements: runtimeProfilePayloadSource.runtimeRequirements,
     componentContracts,
     runtimeOverlays,
     runtimeEnv,
@@ -907,6 +917,41 @@ function providerPluginPathsFromRuntimeProfile(runtimeRequirements = {}, runtime
     ...providerPluginPathEntries(runtimeRequirements.provider_plugins),
     ...providerPluginPathEntries(runtimeProfile.provider_plugins),
   ]);
+}
+
+function explicitProviderPluginPathsFromConfig(config = {}, options = {}) {
+  return uniquePaths(firstNonEmptyArray(
+    providerPluginPathsFromEnv(),
+    options.providerPluginPaths,
+    options.provider_plugin_paths,
+    config.runtime_options?.providerPluginPaths,
+    config.runtime_options?.provider_plugin_paths,
+    config.runtimeOptions?.providerPluginPaths,
+    config.runtimeOptions?.provider_plugin_paths,
+    config.provider_plugin_paths,
+    config.providerPluginPaths,
+    []
+  ));
+}
+
+function providerPluginPathsFromEnv(env = process.env) {
+  return firstNonEmptyArray(
+    envPathList(env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS),
+    envPathList(env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATH),
+    envPathList(env.HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATHS),
+    envPathList(env.WP_CODEBOX_PROVIDER_PLUGIN_PATHS),
+    envPathList(env.HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH),
+    envPathList(env.WP_CODEBOX_PROVIDER_PLUGIN_PATH),
+  );
+}
+
+function withoutProviderPlugins(value = {}) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || !Object.prototype.hasOwnProperty.call(value, 'provider_plugins')) {
+    return value;
+  }
+  const rest = { ...value };
+  delete rest.provider_plugins;
+  return rest;
 }
 
 function providerPluginPathEntries(value) {
@@ -971,29 +1016,30 @@ function normalizeRuntimeTaskAbilityForCodebox(ability) {
   return RUNTIME_PACKAGE_ABILITY_ALIASES.has(ability) ? WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY : ability;
 }
 
-function runtimePackageTaskInputForCodebox(input) {
+function runtimePackageTaskInputForCodebox(input, options = {}) {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return input;
   }
   const normalized = { ...input };
-  const options = normalized.options && typeof normalized.options === 'object' && !Array.isArray(normalized.options) ? normalized.options : {};
+  const runtimeOptions = normalized.options && typeof normalized.options === 'object' && !Array.isArray(normalized.options) ? normalized.options : {};
   for (const key of ['provider', 'model']) {
-    if (!firstValue(normalized[key]) && firstValue(options[key])) {
-      normalized[key] = options[key];
+    if (!firstValue(normalized[key]) && firstValue(runtimeOptions[key])) {
+      normalized[key] = runtimeOptions[key];
     }
   }
   const packageDescriptor = normalized.runtime_package === undefined ? normalized.package : normalized.runtime_package;
-  const runtimePackage = runtimePackageIdentifier(packageDescriptor);
+  const runtimePackage = runtimePackageImportPath(packageDescriptor, options);
+  const runtimePackageAgent = runtimePackageIdentifier(packageDescriptor);
   if (runtimePackage) {
     normalized.runtime_package = runtimePackage;
     if (!firstValue(normalized.agent, normalized.agent_slug)) {
-      normalized.agent = runtimePackage;
+      normalized.agent = runtimePackageAgent || runtimePackage;
     }
   }
   if (packageDescriptor && typeof packageDescriptor === 'object' && !Array.isArray(packageDescriptor)) {
     normalized.metadata = {
       ...(normalized.metadata && typeof normalized.metadata === 'object' && !Array.isArray(normalized.metadata) ? normalized.metadata : {}),
-      runtime_package_descriptor: packageDescriptor,
+      runtime_package_descriptor: runtimePackageDescriptorForCodebox(packageDescriptor, options),
     };
   }
   delete normalized.package;
@@ -1008,6 +1054,51 @@ function runtimePackageIdentifier(value) {
     return '';
   }
   return firstValue(value.slug, value.id, value.name, value.source, '');
+}
+
+function runtimePackageImportPath(value, options = {}) {
+  if (typeof value === 'string') {
+    return runtimePackagePathForSandbox(value, options);
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return '';
+  }
+  const importPath = firstValue(value.source, value.path, value.bundle_path, value.bundlePath, '');
+  if (importPath) {
+    return runtimePackagePathForSandbox(importPath, options);
+  }
+  return firstValue(value.slug, value.id, value.name, '');
+}
+
+function runtimePackageDescriptorForCodebox(descriptor, options = {}) {
+  if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
+    return descriptor;
+  }
+  const normalized = { ...descriptor };
+  for (const key of ['source', 'path', 'bundle_path', 'bundlePath']) {
+    if (typeof normalized[key] === 'string' && normalized[key]) {
+      normalized[key] = runtimePackagePathForSandbox(normalized[key], options);
+    }
+  }
+  return normalized;
+}
+
+function runtimePackagePathForSandbox(value, options = {}) {
+  const raw = String(value || '');
+  if (!raw || !relativeRuntimePackagePath(raw)) {
+    return raw;
+  }
+  const workspaceTarget = String(options.workspaceTarget || '').replace(/\/+$/, '');
+  return workspaceTarget ? `${workspaceTarget}/${raw.replace(/^\.\//, '')}` : raw;
+}
+
+function relativeRuntimePackagePath(value) {
+  const raw = String(value || '');
+  return raw.includes('/')
+    && !raw.startsWith('/')
+    && !raw.startsWith('~/')
+    && !/^[A-Za-z]:[\\/]/.test(raw)
+    && !/^[a-z][a-z0-9+.-]*:/i.test(raw);
 }
 
 function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, inputs) {
@@ -1315,7 +1406,7 @@ function runtimeTaskWithExecutionDefaults(runtimeTask, defaults = {}) {
     normalizedRuntimeTask.ability_normalization = abilityNormalization;
   }
   if (normalizedRuntimeTask.ability === WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY) {
-    normalizedRuntimeTask.input = runtimePackageTaskInputForCodebox(normalizedRuntimeTask.input);
+    normalizedRuntimeTask.input = runtimePackageTaskInputForCodebox(runtimeTaskInputWithArtifactOutputs(normalizedRuntimeTask.input, defaults), defaults);
   }
   const applyExecutionDefaults = normalizedRuntimeTask.ability === WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY || (Array.isArray(defaults.agentBundles) && defaults.agentBundles.length > 0);
   if (!applyExecutionDefaults) {
@@ -1337,14 +1428,21 @@ function runtimeTaskWithExecutionDefaults(runtimeTask, defaults = {}) {
 
   return {
     ...normalizedRuntimeTask,
-    input: normalizedRuntimeTask.ability === WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY ? runtimePackageTaskInputForCodebox({
+    input: normalizedRuntimeTask.ability === WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY ? runtimePackageTaskInputForCodebox(runtimeTaskInputWithArtifactOutputs({
       ...defaultInput,
       ...input,
-    }) : {
+    }, defaults), defaults) : {
       ...defaultInput,
       ...input,
     },
   };
+}
+
+function runtimeTaskInputWithArtifactOutputs(input, defaults = {}) {
+  if (!defaults.request) {
+    return input;
+  }
+  return agentBundleRuntimeTaskInputWithArtifactOutputs(input, defaults.request, defaults.config || {}, defaults.inputs || {});
 }
 
 function runtimeTaskAbilityNormalization({ requestedAbility, normalizedAbility }) {
@@ -1520,8 +1618,11 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
 
 function defaultProviderPluginPaths(provider, config, options, settings, providerConfig, fallbackProviderPluginPath) {
   return uniquePaths(firstProviderPathArray(
+    providerPluginPathsFromEnv(),
     options.providerPluginPaths,
+    options.provider_plugin_paths,
     config.provider_plugin_paths,
+    config.providerPluginPaths,
     providerPathsFor(settings.wp_codebox_provider_plugin_paths, provider),
     providerPathsFor(settings.provider_plugin_paths, provider),
     providerConfig.provider_plugin_paths,
@@ -2785,7 +2886,17 @@ function normalizeOutputs(result, request = null, options = {}) {
     : outputs;
 
   const bundle = result.task_input?.agent_bundle || {};
-  const configuredOutputs = firstPlainObject(bundle.runtime_output_projections, bundle.runtimeOutputProjections, bundle.engine_data_outputs, bundle.engineDataOutputs) || {};
+  const runtimeTaskInput = result.task_input?.runtime_task?.input || result.taskInput?.runtimeTask?.input || {};
+  const configuredOutputs = firstPlainObject(
+    runtimeTaskInput.runtime_output_projections,
+    runtimeTaskInput.runtimeOutputProjections,
+    runtimeTaskInput.engine_data_outputs,
+    runtimeTaskInput.engineDataOutputs,
+    bundle.runtime_output_projections,
+    bundle.runtimeOutputProjections,
+    bundle.engine_data_outputs,
+    bundle.engineDataOutputs
+  ) || {};
   if (Object.keys(configuredOutputs).length === 0) {
     return sanitizePublicMetadata(appendTypedArtifacts(publicOutputs));
   }

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-readiness.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-readiness.js
@@ -102,6 +102,16 @@ function runtimeOverlayDiagnostics(overlay, index) {
   if (!fs.existsSync(path.join(resolvedSource, 'vendor', 'autoload.php'))) {
     return [runtimeOverlayDiagnostic(index, overlay, `Runtime overlay Composer dependencies are not installed: ${source}/vendor/autoload.php is missing.`, resolvedSource)];
   }
+  if (library === 'php-ai-client') {
+    const providerMetadataPath = path.join(resolvedSource, 'src', 'Providers', 'DTO', 'ProviderMetadata.php');
+    if (!fs.existsSync(providerMetadataPath)) {
+      return [runtimeOverlayDiagnostic(index, overlay, `PHP AI Client runtime overlay is missing ProviderMetadata.php: ${providerMetadataPath}.`, resolvedSource)];
+    }
+    const providerMetadata = fs.readFileSync(providerMetadataPath, 'utf8');
+    if (!/function\s+getDescription\s*\(/.test(providerMetadata)) {
+      return [runtimeOverlayDiagnostic(index, overlay, `PHP AI Client runtime overlay does not expose ProviderMetadata::getDescription(): ${providerMetadataPath}.`, resolvedSource)];
+    }
+  }
   return [];
 }
 

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -433,7 +433,7 @@ function providerPluginInspection(providerPath, validation) {
     return { status: 'invalid', reason: 'opencode_provider_plugin' };
   }
   if (!fs.existsSync(providerPath)) {
-    return { status: 'unknown', reason: 'path_not_available_on_parent' };
+    return { status: 'invalid', reason: 'path_not_available_on_parent' };
   }
   for (const filePath of collectProviderProbeFiles(providerPath)) {
     let contents = '';

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -50,6 +50,42 @@ function argValues(name) {
   return values;
 }
 
+function envPathList(value) {
+  if (!value) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(Boolean);
+    }
+  } catch {
+    // Fall through to PATH-style lists for simple environment configuration.
+  }
+  return String(value).split(path.delimiter).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function firstNonEmptyArray(...values) {
+  for (const value of values) {
+    const normalized = Array.isArray(value) ? value.filter(Boolean) : (value ? [value] : []);
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+  return [];
+}
+
+function providerPluginPathsFromEnv(env = process.env) {
+  return firstNonEmptyArray(
+    envPathList(env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS),
+    envPathList(env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATH),
+    envPathList(env.HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATHS),
+    envPathList(env.WP_CODEBOX_PROVIDER_PLUGIN_PATHS),
+    envPathList(env.HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH),
+    envPathList(env.WP_CODEBOX_PROVIDER_PLUGIN_PATH),
+  );
+}
+
 function hasFlag(name) {
   return process.argv.includes(name);
 }
@@ -1058,7 +1094,11 @@ function runnerInput(request, artifacts) {
     mode: argValue('--mode') || request.mode || 'sandbox',
     provider: argValue('--provider') || request.provider || '',
     model: argValue('--model') || request.model || '',
-    provider_plugin_paths: [...(request.provider_plugin_paths || []), ...argValues('--provider-plugin-path')],
+    provider_plugin_paths: uniqueStrings(firstNonEmptyArray(
+      providerPluginPathsFromEnv(),
+      argValues('--provider-plugin-path'),
+      request.provider_plugin_paths,
+    )),
     runtime_overlay_profiles: request.runtime_overlay_profiles || request.runtimeOverlayProfiles || [],
     ...providerCredentialRequestFields({ secret_env: secretEnvNames(request) }),
     mounts,
@@ -1107,12 +1147,53 @@ function pluginSlugFromPath(pluginPath) {
   return path.basename(source).split('@')[0].replace(/[^A-Za-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
 }
 
+function phpPluginHeaderFile(filePath) {
+  try {
+    const contents = fs.readFileSync(filePath, 'utf8').slice(0, 8192);
+    return /Plugin\s+Name\s*:/i.test(contents);
+  } catch {
+    return false;
+  }
+}
+
+function providerPluginSource(entry) {
+  return typeof entry === 'string' ? entry : entry?.source || entry?.path || '';
+}
+
+function providerPluginExplicitFile(entry) {
+  if (!entry || typeof entry === 'string' || typeof entry !== 'object' || Array.isArray(entry)) {
+    return '';
+  }
+  return entry.pluginFile || entry.plugin_file || entry.file || '';
+}
+
+function providerPluginEntryFile(source, slug, explicitFile = '') {
+  if (explicitFile) {
+    return explicitFile.includes('/') || explicitFile.includes('\\') ? explicitFile : `${slug}/${explicitFile}`;
+  }
+  if (!source || !fs.existsSync(source) || !fs.statSync(source).isDirectory()) {
+    return '';
+  }
+
+  const rootFiles = fs.readdirSync(source)
+    .filter((entry) => entry.toLowerCase().endsWith('.php'))
+    .sort();
+  const headerFile = rootFiles.find((entry) => phpPluginHeaderFile(path.join(source, entry)));
+  const selected = headerFile
+    || (rootFiles.includes('plugin.php') ? 'plugin.php' : '')
+    || (rootFiles.includes(`${slug}.php`) ? `${slug}.php` : '');
+  return selected ? `${slug}/${selected}` : '';
+}
+
 function providerPluginEntries(input) {
-  return (input.provider_plugin_paths || []).flatMap((source) => {
+  return (input.provider_plugin_paths || []).flatMap((entry) => {
+    const source = providerPluginSource(entry);
     const slug = pluginSlugFromPath(source);
+    const pluginFile = providerPluginEntryFile(source, slug, providerPluginExplicitFile(entry));
     return source && slug ? [{
       source,
       slug,
+      ...(pluginFile ? { pluginFile } : {}),
       loadAs: 'plugin',
       activate: true,
       metadata: { kind: 'provider-plugin-path', provider: input.provider || '' },

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -573,6 +573,31 @@
           "artifact_result_envelope": "wp-codebox/artifact-result-envelope/v1"
         }
       },
+      "agent_fanout_adapter": {
+        "schema": "homeboy-extensions/wp-codebox-agent-fanout-adapter/v1",
+        "canonical_path": "homeboy-durable-scheduler-to-homeboy-extensions-codebox-executor-to-wp-codebox-sandbox-fanout",
+        "ownership": {
+          "substrate": "agents-api",
+          "durable_scheduler": "homeboy",
+          "executor_adapter": "homeboy-extensions",
+          "sandbox_worker_runtime": "wp-codebox"
+        },
+        "accepted_request_schema": "wp-codebox/agent-fanout-request/v1",
+        "maps": [
+          "task_id",
+          "parent_plan_id",
+          "group_key",
+          "metadata",
+          "workspace",
+          "artifact_declarations",
+          "expected_artifacts",
+          "secret_env_names",
+          "provider",
+          "model",
+          "progress_callbacks",
+          "evidence_refs"
+        ]
+      },
       "role_aliases": {
         "artifact_roles": {
           "artifact_bundle": ["codebox-artifact-bundle", "artifact-bundle", "codebox-artifact-directory", "codebox-session-artifacts"],
@@ -602,17 +627,14 @@
           "provider_run_result": ["codebox_run_result"]
         }
       },
-      "result_contract": {
-        "typed_artifact_envelope": {
-          "schema": "wp-codebox/artifact-result-envelope/v1",
-          "output": "provider_run_result",
-          "provider_label": "WP Codebox",
-          "diagnostic_class_prefix": "codebox",
-          "private_shape_markers": ["agent_result", "metadata.agent_runtime"],
-          "require_typed_artifacts": true
-        }
-      },
       "upstream_primitive_requirements": [
+        {
+          "id": "agent-fanout-request",
+          "schema": "wp-codebox/agent-fanout-request/v1",
+          "owner": "wp-codebox",
+          "adapter_behavior": "project_homeboy_agent_task_metadata_without_product_assumptions",
+          "requirement": "Accept lower-level sandbox-native fanout requests with typed worker, artifact, event, and aggregation contracts. Homeboy owns durable fanout plan/run state; Homeboy Extensions only adapts generic task metadata, workspace, provider/model, secret-env names, progress/evidence callbacks, and artifact declarations into this request shape."
+        },
         {
           "id": "run-agent-task",
           "schema": "wp-codebox/run-agent-task/v1",

--- a/tests/wp-codebox-provider-plugin-env-override-smoke.mjs
+++ b/tests/wp-codebox-provider-plugin-env-override-smoke.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
+
+const { codeboxTaskRequestFromAgentTaskRequest } = require(
+	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js')
+);
+
+const taskRunner = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs');
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-provider-env-'));
+const staleProviderPath = path.join(tempRoot, 'ai-provider-for-openai@codex-oauth-provider');
+const explicitProviderPath = path.join(tempRoot, 'ai-provider-for-openai@proof-codex-provider-20260627');
+const workspaceRoot = path.join(tempRoot, 'workspace');
+const artifactsPath = path.join(tempRoot, 'artifacts');
+const capturePath = path.join(tempRoot, 'capture.json');
+const fakeWpCodebox = path.join(tempRoot, 'fake-wp-codebox.cjs');
+
+fs.mkdirSync(staleProviderPath, { recursive: true });
+fs.mkdirSync(explicitProviderPath, { recursive: true });
+fs.mkdirSync(workspaceRoot, { recursive: true });
+fs.writeFileSync(path.join(explicitProviderPath, 'composer.json'), JSON.stringify({ name: 'extra-chill/ai-provider-for-openai' }));
+fs.writeFileSync(path.join(explicitProviderPath, 'plugin.php'), '<?php\n/* Plugin Name: AI Provider for OpenAI Codex */\n// Registers the codex provider.\n');
+fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+if (process.argv[2] === 'run-agent-task' && process.argv[3] === '--help') {
+  process.exit(0);
+}
+const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
+const inputPath = inputArg ? inputArg.slice('--input-file='.length) : '';
+const envelope = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(envelope.task_input || envelope.input || envelope, null, 2));
+process.stdout.write(JSON.stringify({ schema: 'wp-codebox/agent-task-run/v1', success: true, status: 'completed', artifact_result: { schema: 'wp-codebox/artifact-result-envelope/v1', status: 'created' } }));
+`);
+fs.chmodSync(fakeWpCodebox, 0o755);
+
+const previousSettings = process.env.HOMEBOY_SETTINGS_JSON;
+const previousProviderPaths = process.env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS;
+try {
+	process.env.HOMEBOY_SETTINGS_JSON = JSON.stringify({
+		provider_plugin_paths: { codex: [staleProviderPath] },
+	});
+	process.env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS = explicitProviderPath;
+
+	const taskInput = codeboxTaskRequestFromAgentTaskRequest({
+		schema: 'homeboy/agent-task-request/v1',
+		task_id: 'provider-plugin-env-override',
+		executor: {
+			backend: 'codebox',
+			model: 'gpt-5.5',
+			config: {
+				provider: 'codex',
+				runtime_requirements: {
+					provider_plugins: [{ path: staleProviderPath }],
+				},
+			},
+		},
+		instructions: 'Verify generic provider plugin env override.',
+		inputs: { target: { root: workspaceRoot } },
+	});
+
+	assert.deepEqual(taskInput.provider_plugin_paths, [explicitProviderPath]);
+	assert.deepEqual(taskInput.runtime_requirements.provider_plugins, [{ path: explicitProviderPath }]);
+	assert.equal(JSON.stringify(taskInput.runtime_requirements).includes(staleProviderPath), false);
+
+	const result = spawnSync(process.execPath, [
+		taskRunner,
+		'--wp-codebox-bin', fakeWpCodebox,
+		'--artifacts', artifactsPath,
+	], {
+		encoding: 'utf8',
+		input: JSON.stringify({
+			...taskInput,
+			provider_plugin_paths: [staleProviderPath],
+		}),
+		env: {
+			...process.env,
+			HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS: explicitProviderPath,
+			AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'test-access-token',
+			AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'test-refresh-token',
+			AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '1893456000',
+			AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'test-account-id',
+			AI_PROVIDER_OPENAI_CODEX_FEDRAMP: 'false',
+		},
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	const captured = JSON.parse(fs.readFileSync(capturePath, 'utf8'));
+	assert.deepEqual(captured.provider_plugin_paths, [explicitProviderPath]);
+	assert.equal(captured.extra_plugins.some((plugin) => plugin.source.includes('codex-oauth-provider')), false);
+	const providerPlugin = captured.extra_plugins.find((plugin) => plugin.source === explicitProviderPath);
+	assert(providerPlugin);
+	assert.equal(providerPlugin.slug, 'ai-provider-for-openai');
+	assert.equal(providerPlugin.pluginFile, 'ai-provider-for-openai/plugin.php');
+	assert.equal(captured.extra_plugins.some((plugin) => String(plugin.pluginFile || '').includes('ai-provider-for-openai-proof-codex-provider-20260627.php')), false);
+	assert.equal(captured.extra_plugins.some((plugin) => String(plugin.pluginFile || '') === 'ai-provider-for-openai/ai-provider-for-openai.php'), false);
+
+	console.log('wp-codebox provider plugin env override smoke passed');
+} finally {
+	if (previousSettings === undefined) {
+		delete process.env.HOMEBOY_SETTINGS_JSON;
+	} else {
+		process.env.HOMEBOY_SETTINGS_JSON = previousSettings;
+	}
+	if (previousProviderPaths === undefined) {
+		delete process.env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS;
+	} else {
+		process.env.HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS = previousProviderPaths;
+	}
+	fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -437,7 +437,7 @@ assert.deepEqual(
   controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.ability_normalization.deprecated_compatibility_alias,
   legacyRuntimePackageAbilityAlias('runtime-package/run')
 );
-assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.runtime_package, 'website-idea-agent');
+assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.runtime_package, 'bundles/website-idea-agent');
 assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.agent, 'website-idea-agent');
 assert.deepEqual(controllerRuntimeTaskFanoutRequest.workers[0].ability_requirements, ['wp-codebox/run-runtime-package']);
 
@@ -478,7 +478,7 @@ const controllerAbilityRequestFanoutRequest = codeboxFanoutRequestFromAgentTaskR
 assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability, 'wp-codebox/run-runtime-package');
 assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability_normalization.requested_ability, 'homeboy/run-runtime-package');
 assert.equal(Object.hasOwn(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability_normalization, 'deprecated_compatibility_alias'), false);
-assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.input.runtime_package, 'design-agent');
+assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.input.runtime_package, 'bundles/design-agent');
 assert.deepEqual(controllerAbilityRequestFanoutRequest.workers[0].ability_requirements, ['wp-codebox/run-runtime-package', 'wordpress/site-health']);
 const stableCodeboxInvocation = codeboxRunAgentTaskInvocation({ taskInput });
 assert.equal(stableCodeboxInvocation.contract, runtimeContractSchemas().agentTask.runRequest);
@@ -853,7 +853,7 @@ assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.ability_
   deprecated_compatibility_alias: legacyRuntimePackageAbilityAlias('agents/run-runtime-package'),
 });
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task_ability_normalization, controllerClientContextArtifactsTaskInput.runtime_task.ability_normalization);
-assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.runtime_package, 'website-idea-agent');
+assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.runtime_package, 'bundles/website-idea-agent');
 assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.agent, 'website-idea-agent');
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.metadata.runtime_package_descriptor, { slug: 'website-idea-agent', source: 'bundles/website-idea-agent' });
 assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'package'), false);
@@ -905,7 +905,7 @@ assert.deepEqual(
   legacyRuntimePackageTaskInput.runtime_task.ability_normalization.deprecated_compatibility_alias,
   legacyRuntimePackageAbilityAlias('runtime-package/run')
 );
-assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.runtime_package, 'example-agent');
+assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.runtime_package, 'bundles/example-agent');
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent');
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.provider, 'codex');
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.model, 'gpt-5.5');
@@ -928,7 +928,7 @@ assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability, 'wp-codebox/ru
 assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability_normalization.requested_ability, 'homeboy/run-runtime-package');
 assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability_normalization.normalized_codebox_ability, 'wp-codebox/run-runtime-package');
 assert.equal(Object.hasOwn(neutralRuntimePackageTaskInput.runtime_task.ability_normalization, 'deprecated_compatibility_alias'), false);
-assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.runtime_package, 'example-agent');
+assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.runtime_package, 'bundles/example-agent');
 assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent');
 
 const neutralProfileRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskRequest({
@@ -1570,5 +1570,105 @@ try {
 assert.deepEqual(explicitCodexTaskInput.provider_plugin_paths, [explicitProviderPath]);
 assert.equal(explicitCodexTaskInput.runtime_requirements.provider_plugins[0].path, explicitProviderPath);
 assert.equal(JSON.stringify(explicitCodexTaskInput.runtime_requirements.provider_plugins).includes('/missing/stale-openai-provider'), false);
+
+const explicitProviderPathFromConfig = path.join(providerRoot, 'explicit-provider-plugin-from-config');
+fs.mkdirSync(explicitProviderPathFromConfig, { recursive: true });
+const staleProviderPathFromRuntimeRequirements = '/missing/stale-runtime-requirements-provider';
+const explicitCodexTaskInputFromConfig = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'explicit-codex-provider-path-config-codebox-task-1',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'codex',
+      provider_plugin_paths: [explicitProviderPathFromConfig],
+      runtime_requirements: {
+        provider_plugins: [{ path: staleProviderPathFromRuntimeRequirements }],
+      },
+    },
+  },
+  instructions: 'Run a Codex-backed Codebox task with an explicit provider checkout from request config.',
+  inputs: {},
+});
+assert.deepEqual(explicitCodexTaskInputFromConfig.provider_plugin_paths, [explicitProviderPathFromConfig]);
+assert.deepEqual(explicitCodexTaskInputFromConfig.runtime_requirements.provider_plugins, [{ path: explicitProviderPathFromConfig }]);
+assert.equal(JSON.stringify(explicitCodexTaskInputFromConfig.runtime_requirements).includes(staleProviderPathFromRuntimeRequirements), false);
+
+const explicitProviderPathFromRuntimeOptions = path.join(providerRoot, 'explicit-provider-plugin-from-runtime-options');
+fs.mkdirSync(explicitProviderPathFromRuntimeOptions, { recursive: true });
+const staleProviderPathFromRequestConfig = '/missing/stale-request-config-provider';
+const explicitCodexTaskInputFromRuntimeOptions = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'explicit-codex-provider-path-runtime-options-codebox-task-1',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'codex',
+      provider_plugin_paths: [staleProviderPathFromRequestConfig],
+    },
+  },
+  instructions: 'Run a Codex-backed Codebox task with an explicit provider checkout from runtime options.',
+  inputs: {},
+}, { providerPluginPaths: [explicitProviderPathFromRuntimeOptions] });
+assert.deepEqual(explicitCodexTaskInputFromRuntimeOptions.provider_plugin_paths, [explicitProviderPathFromRuntimeOptions]);
+assert.deepEqual(explicitCodexTaskInputFromRuntimeOptions.runtime_requirements.provider_plugins, [{ path: explicitProviderPathFromRuntimeOptions }]);
+assert.equal(JSON.stringify(explicitCodexTaskInputFromRuntimeOptions.runtime_requirements).includes(staleProviderPathFromRequestConfig), false);
+
+const runtimePackageWorkspaceRoot = path.join(workspaceRoot, 'example-runtime@proof-loop');
+fs.mkdirSync(runtimePackageWorkspaceRoot, { recursive: true });
+const runtimePackageTypedArtifactRequest = {
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'runtime-package-typed-artifact-codebox-task-1',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'codex',
+      runtime_task: {
+        ability: 'runtime-package/run',
+        input: {
+          package: { slug: 'store-idea-agent', source: 'bundles/store-idea-agent' },
+          workflow: { id: 'store-idea-artifact-flow' },
+        },
+      },
+    },
+  },
+  instructions: 'Produce a typed concept packet.',
+  artifact_declarations: [{
+    name: 'concept_packet',
+    artifact_schema: 'example/ConceptPacket/v1',
+    required: true,
+  }],
+  inputs: { target: { root: runtimePackageWorkspaceRoot } },
+};
+const runtimePackageTypedArtifactTaskInput = codeboxTaskRequestFromAgentTaskRequest(runtimePackageTypedArtifactRequest);
+assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.runtime_package, '/workspace/example-runtime/bundles/store-idea-agent');
+assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.agent, 'store-idea-agent');
+assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.metadata.runtime_package_descriptor, { slug: 'store-idea-agent', source: '/workspace/example-runtime/bundles/store-idea-agent' });
+assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.metadata.runtime_package_descriptor.source === 'bundles/store-idea-agent', false);
+assert.equal(JSON.stringify(runtimePackageTypedArtifactTaskInput.runtime_task).includes('"source":"bundles/store-idea-agent"'), false);
+assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
+assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.engine_data_outputs.concept_packet, 'outputs.typed_artifacts.concept_packet.payload');
+
+const runtimePackageTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult(runtimePackageTypedArtifactRequest, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  task_input: runtimePackageTypedArtifactTaskInput,
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {
+        typed_artifacts: {
+          concept_packet: {
+            payload: { title: 'Fixture concept' },
+          },
+        },
+      },
+    },
+  },
+});
+assert.equal(runtimePackageTypedArtifactOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
+assert.deepEqual(runtimePackageTypedArtifactOutcome.outputs.typed_artifacts.concept_packet.payload, { title: 'Fixture concept' });
 
 console.log('Codebox agent-task executor boundary contract passed');

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -18,6 +18,7 @@ const {
   providerPreflightManifest,
   providerRequiredSecretEnv,
   providerSecretEnv,
+  runtimeOverlayReadinessDiagnostics,
 } = require('../../agent-runtimes/wp-codebox');
 const {
   AGENT_TASK_FAILURE_CLASSIFICATIONS,
@@ -259,6 +260,19 @@ function writeBundleFixture(root) {
   fs.mkdirSync(bundle, { recursive: true });
   fs.writeFileSync(path.join(bundle, 'manifest.json'), '{}\n');
   return bundle;
+}
+
+function writePhpAiClientOverlay(root, options = {}) {
+  const overlay = path.join(root, options.name || 'php-ai-client-overlay');
+  const dtoDir = path.join(overlay, 'src', 'Providers', 'DTO');
+  fs.mkdirSync(path.join(overlay, 'vendor'), { recursive: true });
+  fs.mkdirSync(dtoDir, { recursive: true });
+  fs.writeFileSync(path.join(overlay, 'composer.json'), '{}\n');
+  fs.writeFileSync(path.join(overlay, 'vendor', 'autoload.php'), '<?php\n');
+  fs.writeFileSync(path.join(dtoDir, 'ProviderMetadata.php'), options.withoutDescription
+    ? '<?php\nclass ProviderMetadata {}\n'
+    : '<?php\nclass ProviderMetadata { public function getDescription(): ?string { return null; } }\n');
+  return overlay;
 }
 
 const request = {
@@ -975,6 +989,10 @@ assert.deepEqual(capabilityMatrixRecipeRequest.recipe.inputs.userSessions, [{
   metadata: { role: 'shop_manager', capabilities: ['manage_woocommerce', 'view_woocommerce_reports'] },
 }]);
 
+const codexProviderFixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-codex-provider-'));
+process.on('exit', () => fs.rmSync(codexProviderFixtureRoot, { recursive: true, force: true }));
+fs.writeFileSync(path.join(codexProviderFixtureRoot, 'plugin.php'), '<?php\n/* Plugin Name: Fixture Codex Provider */\n// Registers the codex provider for preflight fixture inspection.\n');
+
 const codexAgentRequest = {
   ...request,
   task_id: 'codex-task-123',
@@ -983,7 +1001,7 @@ const codexAgentRequest = {
     model: 'gpt-5.5',
     config: exampleAgentCiCodeboxExecutorConfig({
       provider: 'codex',
-      provider_plugin_paths: ['/components/ai-provider-for-openai'],
+      provider_plugin_paths: [codexProviderFixtureRoot],
       secret_env: [
         'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
         'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
@@ -997,7 +1015,7 @@ const codexAgentRequest = {
       },
       homeboy: '/components/homeboy',
       homeboy_extensions: '/components/homeboy-extensions',
-      wp_codebox_bin: '/bin/wp-codebox',
+      runtime_bin: '/bin/wp-codebox',
       max_turns: 8,
     }),
   },
@@ -1007,7 +1025,7 @@ assert.equal(Object.hasOwn(codexRequest, 'agent'), false);
 assert.equal(codexRequest.mode, 'sandbox');
 assert.equal(codexRequest.provider, 'codex');
 assert.equal(codexRequest.model, 'gpt-5.5');
-assert.deepEqual(codexRequest.provider_plugin_paths, ['/components/ai-provider-for-openai']);
+assert.deepEqual(codexRequest.provider_plugin_paths, [codexProviderFixtureRoot]);
 assert.equal(codexRequest.runtime_component_paths.agent_runtime, '/components/example-runtime');
 assert.equal(codexRequest.runtime_component_paths.agent_runtime_tools, '/components/example-runtime-tools');
 assert.equal(Object.hasOwn(codexRequest.runtime_component_paths, 'agents_api'), false);
@@ -1348,7 +1366,7 @@ try {
   });
   assert.deepEqual(explicitProviderRequest.provider_plugin_paths, [explicitProviderPath]);
 
-  const configuredLibraryPath = path.join(defaultsRoot, 'configured-library');
+  const configuredLibraryPath = writePhpAiClientOverlay(defaultsRoot, { name: 'configured-library' });
   const configuredRuntimeOverlays = [{
     kind: 'bundled-library',
     library: 'php-ai-client',
@@ -1378,8 +1396,31 @@ try {
   assert.deepEqual(configuredGenericStackRequest.runtime_overlays, configuredRuntimeOverlays);
   assert.deepEqual(configuredGenericStackRequest.secret_env, ['CONFIGURED_SECRET']);
 
-  const explicitPhpAiClientPath = path.join(defaultsRoot, 'explicit-php-ai-client');
-  fs.mkdirSync(explicitPhpAiClientPath, { recursive: true });
+  const configuredOverlayWithEmptyProfileRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'configured-overlay-empty-profile-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {
+        provider: 'codex',
+        runtime_requirements: { runtime_overlays: [] },
+        runtime_profiles: {
+          empty: { runtime_overlays: [] },
+        },
+        runtime_profile: 'empty',
+      },
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  }, {
+    settings: {
+      wp_codebox_runtime_overlays: configuredRuntimeOverlays,
+    },
+  });
+  assert.deepEqual(configuredOverlayWithEmptyProfileRequest.runtime_overlays, configuredRuntimeOverlays);
+
+  const explicitPhpAiClientPath = writePhpAiClientOverlay(defaultsRoot, { name: 'explicit-php-ai-client' });
   const explicitPhpAiClientRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
     task_id: 'explicit-php-ai-client-runtime-stack-task-123',
@@ -1395,6 +1436,14 @@ try {
   });
   assert.equal(fs.realpathSync(explicitPhpAiClientRequest.runtime_overlays[0].source), fs.realpathSync(explicitPhpAiClientPath));
   assert.equal(explicitPhpAiClientRequest.runtime_overlays[0].strategy, 'wordpress-scoped-bundle');
+  assert.deepEqual(runtimeOverlayReadinessDiagnostics(explicitPhpAiClientRequest), []);
+
+  const stalePhpAiClientPath = writePhpAiClientOverlay(defaultsRoot, { name: 'stale-php-ai-client', withoutDescription: true });
+  const stalePhpAiClientDiagnostics = runtimeOverlayReadinessDiagnostics({
+    runtime_overlays: [{ kind: 'bundled-library', library: 'php-ai-client', source: stalePhpAiClientPath }],
+  });
+  assert.equal(stalePhpAiClientDiagnostics[0].class, 'codebox.preflight.runtime_overlay_dependency_unprepared');
+  assert.match(stalePhpAiClientDiagnostics[0].message, /ProviderMetadata::getDescription/);
 
   const originalCwd = process.cwd();
   const labOffloadCwd = path.join(defaultsRoot, '_lab_workspaces', 'example-repo-pilot-homeboy-agent-loop');
@@ -2654,6 +2703,9 @@ try {
   providerPluginValidation() { return null; },
   providerSecretEnv() { return []; },
 };\n`);
+  fs.writeFileSync(path.join(installedRuntime, 'lib', 'wp-codebox-runtime-readiness.js'), `module.exports = {
+  wpCodeboxRuntimeReadinessDiagnostics() { return []; },
+};\n`);
   fs.writeFileSync(path.join(installedLayoutRoot, 'extensions', 'wordpress', 'lib', 'wp-codebox-core-loader.js'), `module.exports = { async loadWpCodeboxCore() { return {}; } };\n`);
   const installedLayoutResult = spawnSync(process.execPath, [path.join(installedRuntime, 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs')], {
     encoding: 'utf8',
@@ -2837,7 +2889,7 @@ try {
   const capturedCodex = JSON.parse(fs.readFileSync(capture, 'utf8'));
   assert.equal(capturedCodex.request.provider, 'codex');
   assert.equal(capturedCodex.request.model, 'gpt-5.5');
-  assert.deepEqual(capturedCodex.request.provider_plugin_paths, ['/components/ai-provider-for-openai']);
+  assert.deepEqual(capturedCodex.request.provider_plugin_paths, [codexProviderFixtureRoot]);
   assert.equal(Object.hasOwn(capturedCodex.request.runtime_component_paths, 'agents_api'), false);
   assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime, '/components/example-runtime');
   assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime_tools, '/components/example-runtime-tools');
@@ -3025,7 +3077,7 @@ try {
       model: 'gpt-5.5',
       config: {
         provider: 'openai',
-        provider_plugin_paths: ['/components/ai-provider-for-openai'],
+        provider_plugin_paths: [codexProviderFixtureRoot],
         runtime_component_paths: {
           agents_api: '/components/agents-api',
           agent_runtime: '/components/example-runtime',
@@ -3036,7 +3088,7 @@ try {
         runtime_state_mounts: fullRunnerRuntimeStateMounts,
         runtime_config_mounts: fullRunnerRuntimeConfigMounts,
         homeboy_extensions: path.join(__dirname, '..'),
-        wp_codebox_bin: fakeWpCodebox,
+        runtime_bin: fakeWpCodebox,
         bundle_path: bundle,
         agent_slug: 'example-agent',
         pipeline_slug: 'example-pipeline',
@@ -3091,7 +3143,7 @@ try {
       executor: {
         backend: 'codebox',
         config: {
-          wp_codebox_bin: recipeFakeWpCodebox,
+          runtime_bin: recipeFakeWpCodebox,
           recipe_pack: 'example-codebox-recipes',
           recipe_ref: 'release/v1',
           recipe: 'minimal-runtime',
@@ -3122,7 +3174,7 @@ try {
       executor: {
         backend: 'codebox',
         config: {
-          wp_codebox_bin: failedFakeWpCodebox,
+          runtime_bin: failedFakeWpCodebox,
           homeboy_extensions: path.join(__dirname, '..'),
         },
       },
@@ -3198,7 +3250,7 @@ try {
       executor: {
         backend: 'codebox',
         config: {
-          wp_codebox_bin: writeEmptyJsonTaskRunner(root),
+          runtime_bin: writeEmptyJsonTaskRunner(root),
           homeboy_extensions: path.join(__dirname, '..'),
         },
       },
@@ -3222,7 +3274,7 @@ try {
       executor: {
         backend: 'codebox',
         config: {
-          wp_codebox_bin: writeEmptyStdoutTaskRunner(root),
+          runtime_bin: writeEmptyStdoutTaskRunner(root),
           homeboy_extensions: path.join(__dirname, '..'),
         },
       },


### PR DESCRIPTION
## Summary
- Map explicit provider plugin path env/config to WP Codebox provider selection with replacement precedence and root plugin entry discovery.
- Map relative runtime-package sources into the sandbox workspace mount and rewrite matching descriptor path fields.
- Carry required artifact declarations into direct runtime-package tasks as generic required artifact/output projections.
- Align WP Codebox runtime manifest and smoke fixtures with the current generic runtime-bin/provider contract.

## Tests
- `node tests/wp-codebox-provider-plugin-env-override-smoke.mjs`
- `node tests/wp-codebox-provider-plugin-defaults-smoke.mjs`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node tests/wp-codebox-runtime-contract-source-smoke.mjs`
- `node tests/agent-runtime-package-surface-smoke.mjs`

Closes #1949.
Closes #1950.
Closes #1951.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and verified WP Codebox provider path and runtime-package handoff fixes in Homeboy Extensions.