### PR TITLE
Harden runtime agent env and artifact evidence

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -43,6 +43,21 @@ const OPENCODE_CAPABILITIES = [
 ];
 
 const OPENCODE_COMMAND = 'node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs';
+const OPENCODE_PROCESS_ENV_ALLOWLIST = [
+	'CI',
+	'HOME',
+	'LANG',
+	'LC_ALL',
+	'LOGNAME',
+	'NODE_OPTIONS',
+	'PATH',
+	'PWD',
+	'SHELL',
+	'TMPDIR',
+	'USER',
+	'HOMEBOY_OPENCODE_COMMAND',
+	'HOMEBOY_OPENCODE_COMMAND_ARGS',
+];
 
 const OPENCODE_INVOCATION = {
 	schema: 'homeboy/command-invocation/v1',
@@ -194,7 +209,7 @@ function providerContract(options = {}) {
 }
 
 function outcome(request = {}, values = {}) {
-	return normalizeAgentTaskOutcome(outcomeRequest(request), values, {
+	return withDeclaredArtifactDiagnostics(outcomeRequest(request), normalizeAgentTaskOutcome(outcomeRequest(request), values, {
 		provider: OPENCODE_PROVIDER_ID,
 		providerLabel: 'OpenCode agent',
 		status: values.status || 'provider_error',
@@ -204,7 +219,7 @@ function outcome(request = {}, values = {}) {
 		artifacts: values.artifacts || [],
 		evidenceRefs: values.evidence_refs || [],
 		metadata: values.metadata || {},
-	});
+	}));
 }
 
 function outcomeRequest(request = {}) {
@@ -251,7 +266,7 @@ function executeOpenCodeAgentTask(request = {}, options = {}) {
 	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
 	const spawnResult = spawnSync(commandSpec.command, args, {
 		cwd: resolveCwd(request, config),
-		env: process.env,
+		env: opencodeSpawnEnv(request, options),
 		encoding: 'utf8',
 		maxBuffer: options.maxBuffer || 10 * 1024 * 1024,
 		...(timeoutSeconds > 0 ? { timeout: timeoutSeconds * 1000 } : {}),
@@ -298,6 +313,83 @@ function executeOpenCodeAgentTask(request = {}, options = {}) {
 			...(spawnResult.signal ? { signal: spawnResult.signal } : {}),
 		},
 	});
+}
+
+function opencodeSpawnEnv(request = {}, options = {}) {
+	const ambient = options.env && typeof options.env === 'object' && !Array.isArray(options.env) ? options.env : process.env;
+	const config = request.executor?.config || {};
+	if (config.inherit_env === true || config.inheritEnv === true) {
+		return { ...ambient, ...objectValue(config.runtime_env), ...objectValue(options.envOverrides || options.env_overrides) };
+	}
+	const names = new Set([
+		...OPENCODE_PROCESS_ENV_ALLOWLIST,
+		...arrayValue(config.env_allowlist || config.envAllowlist),
+		...arrayValue(config.runtime_env_allowlist || config.runtimeEnvAllowlist),
+		...arrayValue(config.secret_env),
+		...arrayValue(request.executor?.secret_env),
+	]);
+	const env = {};
+	for (const name of names) {
+		if (typeof name === 'string' && name && ambient[name] !== undefined) {
+			env[name] = ambient[name];
+		}
+	}
+	return { ...env, ...objectValue(config.runtime_env), ...objectValue(options.envOverrides || options.env_overrides) };
+}
+
+function withDeclaredArtifactDiagnostics(request = {}, normalized = {}) {
+	const missing = missingDeclaredArtifacts(request, normalized.artifacts || []);
+	if (missing.length === 0) {
+		return normalized;
+	}
+	const diagnostic = {
+		class: 'opencode.missing_declared_artifacts',
+		message: `OpenCode completed without producing declared artifact(s): ${missing.map((artifact) => artifact.name).join(', ')}. Check executor artifact paths or runtime artifact collection.`,
+		data: { missing_artifacts: missing },
+	};
+	return {
+		...normalized,
+		status: normalized.status === 'succeeded' ? 'failed' : normalized.status,
+		summary: normalized.status === 'succeeded' ? diagnostic.message : normalized.summary,
+		failure_classification: normalized.status === 'succeeded' ? 'execution_failed' : normalized.failure_classification,
+		failure_code: normalized.status === 'succeeded' ? 'agent_task.opencode_missing_declared_artifacts' : normalized.failure_code,
+		diagnostics: [...(Array.isArray(normalized.diagnostics) ? normalized.diagnostics : []), diagnostic],
+		metadata: {
+			...(normalized.metadata || {}),
+			missing_declared_artifacts: missing,
+		},
+	};
+}
+
+function missingDeclaredArtifacts(request = {}, artifacts = []) {
+	return declaredArtifactRequirements(request).filter((declaration) => !findArtifact(artifacts, declaration));
+}
+
+function declaredArtifactRequirements(request = {}) {
+	const expected = arrayValue(request.expected_artifacts).map((name) => ({ name: String(name), required: true }));
+	const declared = arrayValue(request.artifact_declarations || request.executor?.artifact_declarations)
+		.filter((artifact) => artifact && typeof artifact === 'object' && artifact.required === true)
+		.map((artifact) => ({ name: artifact.name || artifact.id || artifact.output_key, kind: artifact.kind, required: true }))
+		.filter((artifact) => artifact.name);
+	return [...expected, ...declared];
+}
+
+function findArtifact(artifacts, declaration) {
+	return arrayValue(artifacts).find((artifact) => {
+		if (!artifact || typeof artifact !== 'object') {
+			return false;
+		}
+		const names = [artifact.name, artifact.id, artifact.output_key, artifact.role].filter(Boolean);
+		return names.includes(declaration.name) && (!declaration.kind || artifact.kind === declaration.kind || artifact.type === declaration.kind);
+	});
+}
+
+function arrayValue(value) {
+	return Array.isArray(value) ? value : [];
+}
+
+function objectValue(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
 function validateRequest(request) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -84,6 +84,9 @@ try {
 const assert = require('node:assert/strict');
 assert.equal(process.argv[2], 'run');
 assert.equal(process.argv.at(-1), 'Prove the OpenCode provider boundary without leaking secrets.');
+assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN, 'refresh-token-must-not-leak');
+assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN, 'access-token-must-not-leak');
+assert.equal(process.env.UNDECLARED_SECRET, undefined);
 process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
 process.stderr.write(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN || 'missing secret');
 process.exit(0);
@@ -99,6 +102,10 @@ process.exit(0);
 		executor: {
 			backend: 'opencode',
 			runtime: 'opencode',
+			secret_env: [
+				'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+				'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+			],
 			config: {
 				provider: 'codex',
 				runtime_bin: process.execPath,
@@ -113,13 +120,30 @@ process.exit(0);
 			...process.env,
 			AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-must-not-leak',
 			AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-must-not-leak',
+			UNDECLARED_SECRET: 'must-not-reach-opencode',
 		},
 		input: JSON.stringify(request),
 	});
 	assert.equal(runResult.status, 0, runResult.stderr);
-	assert.deepEqual(JSON.parse(runResult.stdout), executeOpenCodeAgentTask(request));
+	const fixtureEnv = {
+		...process.env,
+		AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-must-not-leak',
+		AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-must-not-leak',
+		UNDECLARED_SECRET: 'must-not-reach-opencode',
+	};
+	assert.deepEqual(JSON.parse(runResult.stdout), executeOpenCodeAgentTask(request, { env: fixtureEnv }));
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('refresh-token-must-not-leak'), false);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('access-token-must-not-leak'), false);
+
+	const missingArtifactResult = executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-missing-artifact',
+		expected_artifacts: ['opencode-report'],
+	}, { env: fixtureEnv });
+	assert.equal(missingArtifactResult.status, 'failed');
+	assert.equal(missingArtifactResult.failure_code, 'agent_task.opencode_missing_declared_artifacts');
+	assert.match(missingArtifactResult.summary, /opencode-report/);
+	assert.equal(missingArtifactResult.metadata.missing_declared_artifacts[0].name, 'opencode-report');
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }

--- a/runtime-agent-ci/lib/artifact-fanout-materializer.js
+++ b/runtime-agent-ci/lib/artifact-fanout-materializer.js
@@ -55,8 +55,9 @@ function runArtifactFanout(input = {}) {
   }
 
   const homeboyBin = text(input.homeboy_bin || input.homeboyBin || config.homeboy_bin || config.homeboyBin || process.env.HOMEBOY_BIN) || 'homeboy';
-  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-artifact-fanout-'));
-  const planPath = path.join(tmpRoot, 'plan.json');
+  const planLocation = fanoutPlanLocation(input, config, result.plan.plan_id);
+  fs.mkdirSync(planLocation.dir, { recursive: true });
+  const planPath = path.join(planLocation.dir, 'plan.json');
   fs.writeFileSync(planPath, `${JSON.stringify(result.plan, null, 2)}\n`);
 
   const batchId = renderedText(input.batch_id || input.batchId || config.batch_id || config.batchId || result.plan.plan_id);
@@ -67,6 +68,15 @@ function runArtifactFanout(input = {}) {
   const submitted = runHomeboy(homeboyBin, submitArgs, input.cwd || config.cwd);
   result.status = submitted.status === 0 ? 'submitted' : 'failed';
   result.plan_path = planPath;
+  result.plan_location = planLocation.metadata;
+  if (planLocation.metadata.storage === 'scratch') {
+    result.scratch = {
+      kind: 'caller-owned-temporary-directory',
+      path: planLocation.dir,
+      cleanup: 'caller',
+      note: 'Temporary fanout plan scratch is retained for command diagnostics; caller may remove it after collecting evidence.',
+    };
+  }
   result.submit = commandResult(submitted);
   result.batch_id = jsonPath(submitted.parsed, 'batch.batch_id') || batchId;
 
@@ -92,6 +102,33 @@ function runArtifactFanout(input = {}) {
     result.batch_artifacts = commandResult(artifacts);
   }
   return result;
+}
+
+function fanoutPlanLocation(input = {}, config = {}, planId = 'artifact-fanout') {
+  const configuredDir = text(input.plan_dir || input.planDir || config.plan_dir || config.planDir || input.output_dir || input.outputDir || config.output_dir || config.outputDir);
+  if (configuredDir) {
+    return {
+      dir: configuredDir,
+      metadata: {
+        storage: 'persistent',
+        path: configuredDir,
+        cleanup: 'retained',
+      },
+    };
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `homeboy-artifact-fanout-${safePathSegment(planId)}-`));
+  return {
+    dir,
+    metadata: {
+      storage: 'scratch',
+      path: dir,
+      cleanup: 'caller',
+    },
+  };
+}
+
+function safePathSegment(value) {
+  return String(value || 'plan').replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'plan';
 }
 
 function artifactFromControllerInput(input, config = {}) {

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -17,6 +17,19 @@ const { assertLoopSuccess, loopEvidence, loopIteration, loopRun } = require('./l
 const { runtimeAgentArtifactPaths } = require('./artifact-paths.cjs');
 
 const DEFAULT_STDIO_SUMMARY_BYTES = 8192;
+const DEFAULT_RUNTIME_ENV_ALLOWLIST = [
+  'CI',
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LOGNAME',
+  'NODE_OPTIONS',
+  'PATH',
+  'PWD',
+  'SHELL',
+  'TMPDIR',
+  'USER',
+];
 
 function buildGenericAgentLoopRequest(options = {}) {
   const plan = requiredObject(options.plan, 'plan');
@@ -319,7 +332,7 @@ function executeRuntimeProvider(options = {}) {
     encoding: 'utf8',
     cwd: invocation.cwd || process.cwd(),
     input: invocationStdin(invocation, options.request),
-    env: { ...(options.env || process.env), ...(invocation.env || {}) },
+    env: runtimeInvocationEnv({ ...options, invocation }),
     maxBuffer: 1024 * 1024 * 20,
   });
   const stderrArtifact = handleRuntimeInvocationStderr(result.stderr, { ...options, invocation, result });
@@ -340,6 +353,32 @@ function executeRuntimeProvider(options = {}) {
   }
   const outcome = JSON.parse(stdout);
   return captureInvocationResult(outcome, invocation, result, { stderrArtifact });
+}
+
+function runtimeInvocationEnv(options = {}) {
+  const ambient = optionalObject(options.env || process.env);
+  const request = optionalObject(options.request);
+  const executor = optionalObject(request.executor);
+  const config = optionalObject(executor.config);
+  const invocation = optionalObject(options.invocation);
+  if (invocation.inherit_env === true || invocation.inheritEnv === true || config.inherit_env === true || config.inheritEnv === true) {
+    return { ...ambient, ...optionalObject(config.runtime_env), ...optionalObject(invocation.env) };
+  }
+
+  const names = new Set([
+    ...DEFAULT_RUNTIME_ENV_ALLOWLIST,
+    ...normalizeArray(config.env_allowlist || config.envAllowlist || invocation.env_allowlist || invocation.envAllowlist),
+    ...normalizeArray(config.runtime_env_allowlist || config.runtimeEnvAllowlist),
+    ...normalizeArray(config.secret_env),
+    ...normalizeArray(executor.secret_env),
+  ]);
+  const env = {};
+  for (const name of names) {
+    if (typeof name === 'string' && name && ambient[name] !== undefined) {
+      env[name] = ambient[name];
+    }
+  }
+  return { ...env, ...optionalObject(config.runtime_env), ...optionalObject(invocation.env) };
 }
 
 function handleRuntimeInvocationStderr(stderr, options = {}) {

--- a/runtime-agent-ci/tests/artifact-fanout-materializer.test.js
+++ b/runtime-agent-ci/tests/artifact-fanout-materializer.test.js
@@ -1,10 +1,14 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   AGENT_TASK_PLAN_SCHEMA,
   materializeArtifactFanout,
+  runArtifactFanout,
 } = require('../lib/artifact-fanout-materializer');
 
 const controllerInput = {
@@ -63,5 +67,55 @@ assert.equal(result.plan.tasks[0].executor.backend, 'fixture');
 assert.equal(result.plan.tasks[0].metadata.fanout_item_count, 2);
 
 assert.throws(() => materializeArtifactFanout({ config: { artifact: 'missing', requires_non_empty: true }, controller_input: controllerInput }), /did not produce any items/);
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-artifact-fanout-test-'));
+try {
+  const fakeHomeboy = path.join(tmpRoot, 'fake-homeboy.cjs');
+  fs.writeFileSync(fakeHomeboy, `#!/usr/bin/env node
+const fs = require('node:fs');
+const inputIndex = process.argv.indexOf('--input');
+if (inputIndex === -1 || !fs.existsSync(process.argv[inputIndex + 1])) {
+  process.exit(2);
+}
+process.stdout.write(JSON.stringify({ batch: { batch_id: 'fanout-batch-1' } }));
+`);
+  fs.chmodSync(fakeHomeboy, 0o755);
+  const fanoutSubmitInput = {
+    items: [{ id: 'a', owner: 'alpha', kind: 'css' }],
+    config: {
+      group_by: ['owner', 'kind'],
+      plan_id: 'generic-artifact-fanout',
+      task_request_template: {
+        task_id: 'repair-{{group.key}}',
+        executor: { backend: 'fixture' },
+        instructions: 'Handle {{group.item_count}} item(s) for {{group.key}}.',
+      },
+    },
+  };
+  const submitted = runArtifactFanout({
+    ...fanoutSubmitInput,
+    mode: 'submit',
+    homeboy_bin: fakeHomeboy,
+    batch_id: 'fanout-batch-1',
+  });
+  assert.equal(submitted.status, 'submitted');
+  assert.equal(submitted.plan_location.storage, 'scratch');
+  assert.equal(submitted.plan_location.cleanup, 'caller');
+  assert.equal(submitted.scratch.kind, 'caller-owned-temporary-directory');
+  assert.equal(fs.existsSync(submitted.plan_path), true);
+
+  const persistentDir = path.join(tmpRoot, 'persisted-plan');
+  const persisted = runArtifactFanout({
+    ...fanoutSubmitInput,
+    mode: 'submit',
+    homeboy_bin: fakeHomeboy,
+    plan_dir: persistentDir,
+  });
+  assert.equal(persisted.plan_location.storage, 'persistent');
+  assert.equal(persisted.plan_path, path.join(persistentDir, 'plan.json'));
+  assert.equal(Object.prototype.hasOwnProperty.call(persisted, 'scratch'), false);
+} finally {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+}
 
 console.log('artifact fanout materializer ok');

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -210,7 +210,7 @@ try {
   const shellExecutorPath = path.join(tmpRoot, 'fake-non-node-executor');
   fs.writeFileSync(shellExecutorPath, `#!/bin/sh
 cat > "$HOMEBOY_REQUEST_CAPTURE"
-printf '%s\n' '{"schema":"homeboy/agent-task-outcome/v1","task_id":"manifest-shell","status":"succeeded","summary":"Shell executor completed.","metadata":{"results":{"scenarios":[{"id":"manifest-shell","metrics":{"generic_agent_task_executor_mean":1},"metadata":{"job_status":"completed","success_status":"no_changes","completion_outcome":"done","completion_outcome_satisfied":true,"executor_env":"'"$HOMEBOY_EXECUTOR_ENV"'"}}]}}}'
+printf '%s\n' '{"schema":"homeboy/agent-task-outcome/v1","task_id":"manifest-shell","status":"succeeded","summary":"Shell executor completed.","metadata":{"results":{"scenarios":[{"id":"manifest-shell","metrics":{"generic_agent_task_executor_mean":1},"metadata":{"job_status":"completed","success_status":"no_changes","completion_outcome":"done","completion_outcome_satisfied":true,"executor_env":"'"$HOMEBOY_EXECUTOR_ENV"'","allowed_secret":"'"$ALLOWED_SECRET"'","leaked_env":"'"$UNDECLARED_SECRET"'"}}]}}}'
 `);
   fs.chmodSync(shellExecutorPath, 0o755);
 
@@ -232,12 +232,15 @@ printf '%s\n' '{"schema":"homeboy/agent-task-outcome/v1","task_id":"manifest-she
         },
       },
     },
-    plan: { ...plan, workload_id: 'manifest-shell' },
+    plan: { ...plan, workload_id: 'manifest-shell', secret_env: ['ALLOWED_SECRET'] },
     validationPolicy: { success_completion_outcomes: ['done'] },
+    env: { ...process.env, ALLOWED_SECRET: 'declared-secret', UNDECLARED_SECRET: 'ambient-secret' },
   });
   assert.equal(shellRun.outcome.status, 'succeeded');
   assert.equal(shellRun.outcome.metadata.runtime_invocation_result.command, shellExecutorPath);
   assert.equal(shellRun.results.scenarios[0].metadata.executor_env, 'from-manifest');
+  assert.equal(shellRun.results.scenarios[0].metadata.allowed_secret, 'declared-secret');
+  assert.equal(shellRun.results.scenarios[0].metadata.leaked_env, '');
   assert.equal(JSON.parse(fs.readFileSync(requestCapturePath, 'utf8')).task_id, 'manifest-shell');
 
   const nodeExecutorPath = path.join(tmpRoot, 'fake-node-executor.cjs');


### PR DESCRIPTION
## Summary
- restrict generic runtime and OpenCode process env forwarding to explicit allowlists plus declared runtime/secret env inputs
- turn missing declared OpenCode artifacts into actionable failed outcomes with diagnostics
- label artifact fanout plan storage as persistent or caller-owned scratch temp space

## Tests
- `npm test` in `runtime-agent-ci`
- `npm run test:opencode-agent-task-executor-boundary` in `agent-runtimes/opencode`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, tests, and PR preparation