### PR TITLE
Simplify Codebox runtime package contract mapping

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -911,7 +911,7 @@ function uniqueRuntimeRequirementObjects(entries) {
 }
 
 function providerPluginPathsFromRuntimeProfile(runtimeRequirements = {}, runtimeProfile = {}, options = {}) {
-  return uniquePaths([
+  return normalizeProviderPluginPaths([
     ...normalizeArray(options.providerPluginPaths),
     ...normalizeArray(options.provider_plugin_paths),
     ...providerPluginPathEntries(runtimeRequirements.provider_plugins),
@@ -920,7 +920,7 @@ function providerPluginPathsFromRuntimeProfile(runtimeRequirements = {}, runtime
 }
 
 function explicitProviderPluginPathsFromConfig(config = {}, options = {}) {
-  return uniquePaths(firstNonEmptyArray(
+  return normalizeProviderPluginPaths(firstNonEmptyArray(
     providerPluginPathsFromEnv(),
     options.providerPluginPaths,
     options.provider_plugin_paths,
@@ -964,6 +964,18 @@ function providerPluginPathEntries(value) {
     }
     return [entry.path, entry.source].filter(Boolean);
   });
+}
+
+function normalizeProviderPluginPaths(paths) {
+  return uniquePaths(normalizeArray(paths).map((entry) => {
+    if (typeof entry === 'string') {
+      return entry;
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return '';
+    }
+    return firstValue(entry.path, entry.source, entry.target, '');
+  }));
 }
 
 function abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) {
@@ -1028,7 +1040,8 @@ function runtimePackageTaskInputForCodebox(input, options = {}) {
     }
   }
   const packageDescriptor = normalized.runtime_package === undefined ? normalized.package : normalized.runtime_package;
-  const runtimePackage = runtimePackageImportPath(packageDescriptor, options);
+  const normalizedPackage = normalizeRuntimePackageTaskPackage(packageDescriptor, options);
+  const runtimePackage = normalizedPackage.runtime_package;
   const runtimePackageAgent = runtimePackageIdentifier(packageDescriptor);
   if (runtimePackage) {
     normalized.runtime_package = runtimePackage;
@@ -1039,11 +1052,35 @@ function runtimePackageTaskInputForCodebox(input, options = {}) {
   if (packageDescriptor && typeof packageDescriptor === 'object' && !Array.isArray(packageDescriptor)) {
     normalized.metadata = {
       ...(normalized.metadata && typeof normalized.metadata === 'object' && !Array.isArray(normalized.metadata) ? normalized.metadata : {}),
-      runtime_package_descriptor: runtimePackageDescriptorForCodebox(packageDescriptor, options),
+      runtime_package_descriptor: normalizedPackage.descriptor,
     };
   }
   delete normalized.package;
   return normalized;
+}
+
+function normalizeRuntimePackageTaskPackage(packageDescriptor, options = {}) {
+  if (!packageDescriptor || typeof packageDescriptor !== 'object' || Array.isArray(packageDescriptor)) {
+    return { runtime_package: runtimePackageImportPath(packageDescriptor, options), descriptor: packageDescriptor };
+  }
+
+  const descriptor = runtimePackageDescriptorForCodebox(packageDescriptor, options);
+  const sourceKeys = ['source', 'path', 'bundle_path', 'bundlePath'];
+  const declaredSources = sourceKeys
+    .map((key) => descriptor[key])
+    .filter((value) => typeof value === 'string' && value !== '');
+  const uniqueSources = Array.from(new Set(declaredSources));
+  if (uniqueSources.length > 1) {
+    throw new Error(`WP Codebox runtime_package descriptor source fields cannot diverge: ${uniqueSources.join(', ')}`);
+  }
+
+  const runtimePackage = uniqueSources[0] || firstValue(descriptor.slug, descriptor.id, descriptor.name, '');
+  for (const key of sourceKeys) {
+    if (descriptor[key]) {
+      descriptor[key] = runtimePackage;
+    }
+  }
+  return { runtime_package: runtimePackage, descriptor };
 }
 
 function runtimePackageIdentifier(value) {
@@ -1115,18 +1152,43 @@ function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, 
   const engineDataOutputs = {
     ...(input.engine_data_outputs && typeof input.engine_data_outputs === 'object' && !Array.isArray(input.engine_data_outputs) ? input.engine_data_outputs : {}),
   };
+  const artifacts = normalizeRuntimePackageTaskArtifacts(input.artifacts);
   for (const declaration of declarations) {
     const name = typedArtifactNameFromDeclaration(declaration);
     if (name && !engineDataOutputs[name]) {
-      engineDataOutputs[name] = `outputs.typed_artifacts.${name}.payload`;
+      engineDataOutputs[name] = runtimePackageOutputProjectionPath(name);
+    }
+    if (name && !artifacts.some((artifact) => artifact.name === name)) {
+      artifacts.push(runtimePackageArtifactFromDeclaration(declaration));
     }
   }
 
   return {
     ...input,
+    artifacts,
     required_artifacts: requiredArtifacts,
     engine_data_outputs: engineDataOutputs,
   };
+}
+
+function normalizeRuntimePackageTaskArtifacts(artifacts) {
+  return normalizeArray(artifacts)
+    .filter((artifact) => artifact && typeof artifact === 'object' && !Array.isArray(artifact))
+    .map((artifact) => ({ ...artifact }));
+}
+
+function runtimePackageArtifactFromDeclaration(declaration) {
+  const name = typedArtifactNameFromDeclaration(declaration);
+  return withoutUndefinedValues({
+    name,
+    required: declaration.required === true,
+    schema: declaration.artifact_schema || declaration.artifactSchema,
+    output: runtimePackageOutputProjectionPath(name),
+  });
+}
+
+function runtimePackageOutputProjectionPath(name) {
+  return `outputs.typed_artifacts.${name}.payload`;
 }
 
 function runtimeTaskInputFromAgentTaskRequest(request, config, inputs, declared = {}) {
@@ -1617,7 +1679,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
 }
 
 function defaultProviderPluginPaths(provider, config, options, settings, providerConfig, fallbackProviderPluginPath) {
-  return uniquePaths(firstProviderPathArray(
+  return normalizeProviderPluginPaths(firstProviderPathArray(
     providerPluginPathsFromEnv(),
     options.providerPluginPaths,
     options.provider_plugin_paths,
@@ -3554,6 +3616,9 @@ module.exports = {
   wpCodeboxAgentFanoutAdapterContract,
   codeboxTaskRequestFromAgentTaskRequest,
   codeboxFanoutRequestFromAgentTaskRequest,
+  normalizeProviderPluginPaths,
+  normalizeRuntimePackageTaskPackage,
+  runtimePackageTaskInputForCodebox,
   reconcileRunSummaryWithPublicEnvelope,
   normalizeCodeboxAgentTaskEvents,
   agentTaskOutcomeFromCodeboxResult,

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -59,9 +59,9 @@ function codeboxRuntimeProfilePayload({
     componentContracts,
   });
   const normalizedProviderPlugins = uniqueObjectsByRuntimeIdentity([
-    ...providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
     ...providerPluginEntries(normalizedProfile.provider_plugins),
     ...providerPluginEntries(normalizedRuntimeRequirements.provider_plugins),
+    ...providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
   ]);
   const payload = withoutEmptyObjectValues({
     ...normalizedProfile,

--- a/tests/wp-codebox-runtime-package-contract-smoke.mjs
+++ b/tests/wp-codebox-runtime-package-contract-smoke.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
+
+const {
+	codeboxTaskRequestFromAgentTaskRequest,
+	normalizeProviderPluginPaths,
+	normalizeRuntimePackageTaskPackage,
+	runtimePackageTaskInputForCodebox,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js'));
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-package-'));
+
+try {
+	const providerPath = path.join(tempRoot, 'ai-provider-for-openai');
+	const staleProviderPath = path.join(tempRoot, 'stale-ai-provider-for-openai');
+	const workspaceRoot = path.join(tempRoot, 'workspace');
+	fs.mkdirSync(providerPath, { recursive: true });
+	fs.mkdirSync(staleProviderPath, { recursive: true });
+	fs.mkdirSync(workspaceRoot, { recursive: true });
+
+	assert.deepEqual(normalizeProviderPluginPaths([
+		providerPath,
+		{ path: providerPath },
+		{ source: staleProviderPath },
+	]), [providerPath, staleProviderPath]);
+
+	const taskInput = codeboxTaskRequestFromAgentTaskRequest({
+		schema: 'homeboy/agent-task-request/v1',
+		task_id: 'runtime-package-contract-smoke',
+		instructions: 'Run a runtime package with declared artifacts.',
+		executor: {
+			backend: 'codebox',
+			model: 'gpt-5.5',
+			config: {
+				provider: 'codex',
+				provider_plugin_paths: [providerPath],
+				runtime_requirements: {
+					provider_plugins: [{ path: staleProviderPath }],
+				},
+				runtime_task: {
+					ability: 'homeboy/run-runtime-package',
+					input: {
+						runtime_package: {
+							slug: 'proof-loop',
+							source: 'packages/proof-loop',
+						},
+					},
+				},
+			},
+		},
+		inputs: { target: { root: workspaceRoot } },
+		artifact_declarations: [{
+			schema: 'homeboy/agent-task-artifact-declaration/v1',
+			name: 'review_packet',
+			artifact_schema: 'example/review-packet/v1',
+			required: true,
+		}],
+	}, {
+		settings: {
+			provider_plugin_paths: { codex: [staleProviderPath] },
+		},
+	});
+
+	assert.deepEqual(taskInput.provider_plugin_paths, [providerPath]);
+	assert.deepEqual(taskInput.runtime_requirements.provider_plugins, [{ path: providerPath }]);
+
+	const runtimeTask = taskInput.runtime_task;
+	assert.equal(runtimeTask.ability, 'wp-codebox/run-runtime-package');
+	assert.equal(runtimeTask.input.runtime_package, '/workspace/workspace/packages/proof-loop');
+	assert.equal(runtimeTask.input.metadata.runtime_package_descriptor.source, runtimeTask.input.runtime_package);
+	assert.equal(runtimeTask.input.required_artifacts.includes('review_packet'), true);
+	assert.deepEqual(runtimeTask.input.artifacts, [{
+		name: 'review_packet',
+		required: true,
+		schema: 'example/review-packet/v1',
+		output: 'outputs.typed_artifacts.review_packet.payload',
+	}]);
+	assert.equal(runtimeTask.input.engine_data_outputs.review_packet, 'outputs.typed_artifacts.review_packet.payload');
+
+	assert.deepEqual(runtimePackageTaskInputForCodebox({
+		package: { slug: 'proof-loop', source: 'packages/proof-loop' },
+	}, { workspaceTarget: '/workspace/source' }), {
+		runtime_package: '/workspace/source/packages/proof-loop',
+		agent: 'proof-loop',
+		metadata: {
+			runtime_package_descriptor: {
+				slug: 'proof-loop',
+				source: '/workspace/source/packages/proof-loop',
+			},
+		},
+	});
+
+	assert.throws(
+		() => normalizeRuntimePackageTaskPackage({ source: 'packages/one', path: 'packages/two' }, { workspaceTarget: '/workspace/source' }),
+		/runtime_package descriptor source fields cannot diverge/
+	);
+
+	console.log('wp-codebox runtime package contract smoke passed');
+} finally {
+	fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
+++ b/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
@@ -117,6 +117,7 @@ try {
 		runtimeRequirements: {
 			runtime_overlays: [{ kind: 'plugin', slug: 'agents-api', source: '/runtime/agents-api' }],
 			env: { REQUIREMENT_ENV: '1', SHARED_ENV: 'requirement' },
+			provider_plugins: [{ path: '/runtime/provider-from-requirement' }],
 		},
 		runtimeOverlays: [{ kind: 'mu-plugin', slug: 'runtime-tools', source: '/runtime/runtime-tools' }],
 		runtimeEnv: { REQUEST_ENV: '1', SHARED_ENV: 'request' },
@@ -135,6 +136,7 @@ try {
 	});
 	assert.deepEqual(mergedProfile.provider_plugins, [
 		{ path: '/runtime/provider-from-profile' },
+		{ path: '/runtime/provider-from-requirement' },
 		{ path: '/runtime/provider-from-request' },
 	]);
 


### PR DESCRIPTION
## Summary
- Normalize provider plugin path sources through one helper before they enter task input or runtime requirements.
- Normalize WP Codebox runtime-package task input through one boundary so descriptor source fields, runtime_package, and sandbox workspace source projection stay aligned.
- Map required Homeboy artifact declarations into public runtime-package contract artifacts while preserving legacy required_artifacts and engine_data_outputs compatibility fields.

## Tests
- `node tests/wp-codebox-runtime-package-contract-smoke.mjs`
- `node tests/wp-codebox-provider-plugin-env-override-smoke.mjs`
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `node tests/wp-codebox-runtime-contract-source-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node tests/wp-codebox-provider-plugin-defaults-smoke.mjs`
- `node tests/wp-codebox-artifact-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the adapter simplification, focused smoke coverage, and PR preparation.