### PR TITLE
Add Codebox runtime package task schema

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -80,6 +80,7 @@ const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 const AGENT_TASK_EVENT_SCHEMA = 'homeboy/agent-task-event/v1';
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
 const WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY = 'wp-codebox/run-runtime-package';
+const WP_CODEBOX_RUNTIME_PACKAGE_TASK_SCHEMA = 'wp-codebox/runtime-package-task/v1';
 const NEUTRAL_RUNTIME_PACKAGE_ABILITIES = new Set(['homeboy/run-runtime-package']);
 const LEGACY_RUNTIME_PACKAGE_ABILITIES = new Set(['agents/run-runtime-package', 'runtime-package/run']);
 const RUNTIME_PACKAGE_ABILITY_ALIASES = new Set([
@@ -1032,7 +1033,7 @@ function runtimePackageTaskInputForCodebox(input, options = {}) {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return input;
   }
-  const normalized = { ...input };
+  const normalized = { ...input, schema: WP_CODEBOX_RUNTIME_PACKAGE_TASK_SCHEMA };
   const runtimeOptions = normalized.options && typeof normalized.options === 'object' && !Array.isArray(normalized.options) ? normalized.options : {};
   for (const key of ['provider', 'model']) {
     if (!firstValue(normalized[key]) && firstValue(runtimeOptions[key])) {
@@ -1041,27 +1042,21 @@ function runtimePackageTaskInputForCodebox(input, options = {}) {
   }
   const packageDescriptor = normalized.runtime_package === undefined ? normalized.package : normalized.runtime_package;
   const normalizedPackage = normalizeRuntimePackageTaskPackage(packageDescriptor, options);
-  const runtimePackage = normalizedPackage.runtime_package;
-  const runtimePackageAgent = runtimePackageIdentifier(packageDescriptor);
-  if (runtimePackage) {
-    normalized.runtime_package = runtimePackage;
-    if (!firstValue(normalized.agent, normalized.agent_slug)) {
-      normalized.agent = runtimePackageAgent || runtimePackage;
-    }
+  if (normalizedPackage.package) {
+    normalized.package = normalizedPackage.package;
   }
-  if (packageDescriptor && typeof packageDescriptor === 'object' && !Array.isArray(packageDescriptor)) {
-    normalized.metadata = {
-      ...(normalized.metadata && typeof normalized.metadata === 'object' && !Array.isArray(normalized.metadata) ? normalized.metadata : {}),
-      runtime_package_descriptor: normalizedPackage.descriptor,
-    };
-  }
-  delete normalized.package;
+  delete normalized.runtime_package;
+  delete normalized.agent;
+  delete normalized.agent_slug;
   return normalized;
 }
 
 function normalizeRuntimePackageTaskPackage(packageDescriptor, options = {}) {
+  if (typeof packageDescriptor === 'string') {
+    return { package: runtimePackagePackageFromString(packageDescriptor, options) };
+  }
   if (!packageDescriptor || typeof packageDescriptor !== 'object' || Array.isArray(packageDescriptor)) {
-    return { runtime_package: runtimePackageImportPath(packageDescriptor, options), descriptor: packageDescriptor };
+    return { package: null };
   }
 
   const descriptor = runtimePackageDescriptorForCodebox(packageDescriptor, options);
@@ -1074,18 +1069,31 @@ function normalizeRuntimePackageTaskPackage(packageDescriptor, options = {}) {
     throw new Error(`WP Codebox runtime_package descriptor source fields cannot diverge: ${uniqueSources.join(', ')}`);
   }
 
-  const runtimePackage = uniqueSources[0] || firstValue(descriptor.slug, descriptor.id, descriptor.name, '');
-  for (const key of sourceKeys) {
-    if (descriptor[key]) {
-      descriptor[key] = runtimePackage;
-    }
-  }
-  return { runtime_package: runtimePackage, descriptor };
+  return { package: runtimePackagePackageFromDescriptor(descriptor, uniqueSources[0]) };
+}
+
+function runtimePackagePackageFromString(value, options = {}) {
+  const source = runtimePackageImportPath(value, options);
+  const slug = runtimePackageIdentifier(value);
+  return withoutUndefinedValues(relativeRuntimePackagePath(value) ? { slug, source } : { slug: source || slug });
+}
+
+function runtimePackagePackageFromDescriptor(descriptor, source = '') {
+  return withoutUndefinedValues({
+    ...descriptor,
+    slug: firstValue(descriptor.slug, descriptor.id, descriptor.name, runtimePackageIdentifier(source)),
+    ...(source ? { source } : {}),
+    path: undefined,
+    bundle_path: undefined,
+    bundlePath: undefined,
+    id: undefined,
+    name: undefined,
+  });
 }
 
 function runtimePackageIdentifier(value) {
   if (typeof value === 'string') {
-    return value;
+    return path.basename(String(value).replace(/\/+$/, '')) || value;
   }
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return '';
@@ -1145,19 +1153,9 @@ function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, 
     return input;
   }
 
-  const requiredArtifacts = Array.from(new Set([
-    ...normalizeArray(input.required_artifacts),
-    ...declarations.map((declaration) => typedArtifactNameFromDeclaration(declaration)).filter(Boolean),
-  ]));
-  const engineDataOutputs = {
-    ...(input.engine_data_outputs && typeof input.engine_data_outputs === 'object' && !Array.isArray(input.engine_data_outputs) ? input.engine_data_outputs : {}),
-  };
   const artifacts = normalizeRuntimePackageTaskArtifacts(input.artifacts);
   for (const declaration of declarations) {
     const name = typedArtifactNameFromDeclaration(declaration);
-    if (name && !engineDataOutputs[name]) {
-      engineDataOutputs[name] = runtimePackageOutputProjectionPath(name);
-    }
     if (name && !artifacts.some((artifact) => artifact.name === name)) {
       artifacts.push(runtimePackageArtifactFromDeclaration(declaration));
     }
@@ -1166,8 +1164,6 @@ function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, 
   return {
     ...input,
     artifacts,
-    required_artifacts: requiredArtifacts,
-    engine_data_outputs: engineDataOutputs,
   };
 }
 

--- a/tests/wp-codebox-runtime-package-contract-smoke.mjs
+++ b/tests/wp-codebox-runtime-package-contract-smoke.mjs
@@ -75,27 +75,29 @@ try {
 
 	const runtimeTask = taskInput.runtime_task;
 	assert.equal(runtimeTask.ability, 'wp-codebox/run-runtime-package');
-	assert.equal(runtimeTask.input.runtime_package, '/workspace/workspace/packages/proof-loop');
-	assert.equal(runtimeTask.input.metadata.runtime_package_descriptor.source, runtimeTask.input.runtime_package);
-	assert.equal(runtimeTask.input.required_artifacts.includes('review_packet'), true);
+	assert.equal(runtimeTask.input.schema, 'wp-codebox/runtime-package-task/v1');
+	assert.deepEqual(runtimeTask.input.package, {
+		slug: 'proof-loop',
+		source: '/workspace/workspace/packages/proof-loop',
+	});
 	assert.deepEqual(runtimeTask.input.artifacts, [{
 		name: 'review_packet',
 		required: true,
 		schema: 'example/review-packet/v1',
 		output: 'outputs.typed_artifacts.review_packet.payload',
 	}]);
-	assert.equal(runtimeTask.input.engine_data_outputs.review_packet, 'outputs.typed_artifacts.review_packet.payload');
+	assert.equal(Object.hasOwn(runtimeTask.input, 'runtime_package'), false);
+	assert.equal(Object.hasOwn(runtimeTask.input, 'agent'), false);
+	assert.equal(Object.hasOwn(runtimeTask.input, 'required_artifacts'), false);
+	assert.equal(Object.hasOwn(runtimeTask.input, 'engine_data_outputs'), false);
 
 	assert.deepEqual(runtimePackageTaskInputForCodebox({
 		package: { slug: 'proof-loop', source: 'packages/proof-loop' },
 	}, { workspaceTarget: '/workspace/source' }), {
-		runtime_package: '/workspace/source/packages/proof-loop',
-		agent: 'proof-loop',
-		metadata: {
-			runtime_package_descriptor: {
-				slug: 'proof-loop',
-				source: '/workspace/source/packages/proof-loop',
-			},
+		schema: 'wp-codebox/runtime-package-task/v1',
+		package: {
+			slug: 'proof-loop',
+			source: '/workspace/source/packages/proof-loop',
 		},
 	});
 

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -437,8 +437,8 @@ assert.deepEqual(
   controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.ability_normalization.deprecated_compatibility_alias,
   legacyRuntimePackageAbilityAlias('runtime-package/run')
 );
-assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.runtime_package, 'bundles/website-idea-agent');
-assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.agent, 'website-idea-agent');
+assert.equal(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(controllerRuntimeTaskFanoutRequest.workers[0].runtime_task.input.package, { slug: 'website-idea-agent', source: 'bundles/website-idea-agent' });
 assert.deepEqual(controllerRuntimeTaskFanoutRequest.workers[0].ability_requirements, ['wp-codebox/run-runtime-package']);
 
 const controllerAbilityRequestFanoutRequest = codeboxFanoutRequestFromAgentTaskRequest({
@@ -478,7 +478,8 @@ const controllerAbilityRequestFanoutRequest = codeboxFanoutRequestFromAgentTaskR
 assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability, 'wp-codebox/run-runtime-package');
 assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability_normalization.requested_ability, 'homeboy/run-runtime-package');
 assert.equal(Object.hasOwn(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.ability_normalization, 'deprecated_compatibility_alias'), false);
-assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.input.runtime_package, 'bundles/design-agent');
+assert.equal(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(controllerAbilityRequestFanoutRequest.workers[0].runtime_task.input.package, { slug: 'design-agent', source: 'bundles/design-agent' });
 assert.deepEqual(controllerAbilityRequestFanoutRequest.workers[0].ability_requirements, ['wp-codebox/run-runtime-package', 'wordpress/site-health']);
 const stableCodeboxInvocation = codeboxRunAgentTaskInvocation({ taskInput });
 assert.equal(stableCodeboxInvocation.contract, runtimeContractSchemas().agentTask.runRequest);
@@ -853,14 +854,19 @@ assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.ability_
   deprecated_compatibility_alias: legacyRuntimePackageAbilityAlias('agents/run-runtime-package'),
 });
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task_ability_normalization, controllerClientContextArtifactsTaskInput.runtime_task.ability_normalization);
-assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.runtime_package, 'bundles/website-idea-agent');
-assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.agent, 'website-idea-agent');
-assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.metadata.runtime_package_descriptor, { slug: 'website-idea-agent', source: 'bundles/website-idea-agent' });
-assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'package'), false);
-assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
-assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.engine_data_outputs, {
-  concept_packet: 'outputs.typed_artifacts.concept_packet.payload',
-});
+assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.package, { slug: 'website-idea-agent', source: 'bundles/website-idea-agent' });
+assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.artifacts, [{
+  name: 'concept_packet',
+  required: true,
+  schema: 'wp-site-generator/ConceptPacket/v1',
+  output: 'outputs.typed_artifacts.concept_packet.payload',
+}]);
+assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'runtime_package'), false);
+assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'agent'), false);
+assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'metadata'), false);
+assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'required_artifacts'), false);
+assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'engine_data_outputs'), false);
 
 const controllerClientContextRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -885,6 +891,7 @@ const controllerClientContextRuntimeTaskInput = codeboxTaskRequestFromAgentTaskR
   },
 });
 assert.equal(controllerClientContextRuntimeTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.equal(controllerClientContextRuntimeTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
 assert.equal(controllerClientContextRuntimeTaskInput.runtime_task.input.input.concept_packet.payload.title, 'Concept');
 assert.equal(controllerClientContextRuntimeTaskInput.runtime_task.input.input.design_packet.payload.design_system, 'Editorial');
 
@@ -905,12 +912,13 @@ assert.deepEqual(
   legacyRuntimePackageTaskInput.runtime_task.ability_normalization.deprecated_compatibility_alias,
   legacyRuntimePackageAbilityAlias('runtime-package/run')
 );
-assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.runtime_package, 'bundles/example-agent');
-assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent');
+assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(legacyRuntimePackageTaskInput.runtime_task.input.package, { slug: 'example-agent', source: 'bundles/example-agent' });
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.provider, 'codex');
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.model, 'gpt-5.5');
-assert.deepEqual(legacyRuntimePackageTaskInput.runtime_task.input.metadata.runtime_package_descriptor, { slug: 'example-agent', source: 'bundles/example-agent' });
-assert.equal(Object.hasOwn(legacyRuntimePackageTaskInput.runtime_task.input, 'package'), false);
+assert.equal(Object.hasOwn(legacyRuntimePackageTaskInput.runtime_task.input, 'runtime_package'), false);
+assert.equal(Object.hasOwn(legacyRuntimePackageTaskInput.runtime_task.input, 'agent'), false);
+assert.equal(Object.hasOwn(legacyRuntimePackageTaskInput.runtime_task.input, 'metadata'), false);
 
 const neutralRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -928,8 +936,8 @@ assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability, 'wp-codebox/ru
 assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability_normalization.requested_ability, 'homeboy/run-runtime-package');
 assert.equal(neutralRuntimePackageTaskInput.runtime_task.ability_normalization.normalized_codebox_ability, 'wp-codebox/run-runtime-package');
 assert.equal(Object.hasOwn(neutralRuntimePackageTaskInput.runtime_task.ability_normalization, 'deprecated_compatibility_alias'), false);
-assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.runtime_package, 'bundles/example-agent');
-assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent');
+assert.equal(neutralRuntimePackageTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(neutralRuntimePackageTaskInput.runtime_task.input.package, { slug: 'example-agent', source: 'bundles/example-agent' });
 
 const neutralProfileRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -953,8 +961,8 @@ const neutralProfileRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskReq
   instructions: 'Run a neutral runtime-package task through the selected runtime profile.',
 });
 assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
-assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.runtime_package, 'example-agent-profile');
-assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent-profile');
+assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(neutralProfileRuntimePackageTaskInput.runtime_task.input.package, { slug: 'example-agent-profile' });
 assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.provider, 'codex');
 assert.equal(neutralProfileRuntimePackageTaskInput.runtime_task.input.model, 'gpt-5.5');
 
@@ -1056,12 +1064,13 @@ assert.deepEqual(
   explicitLegacyRuntimeTaskInput.runtime_task.ability_normalization.deprecated_compatibility_alias,
   legacyRuntimePackageAbilityAlias('runtime-package/run')
 );
-assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.runtime_package, 'example-agent');
-assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.agent, 'example-agent');
+assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(explicitLegacyRuntimeTaskInput.runtime_task.input.package, { slug: 'example-agent' });
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.provider, 'codex');
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.model, 'gpt-5.5');
-assert.deepEqual(explicitLegacyRuntimeTaskInput.runtime_task.input.metadata.runtime_package_descriptor, { slug: 'example-agent' });
-assert.equal(Object.hasOwn(explicitLegacyRuntimeTaskInput.runtime_task.input, 'package'), false);
+assert.equal(Object.hasOwn(explicitLegacyRuntimeTaskInput.runtime_task.input, 'runtime_package'), false);
+assert.equal(Object.hasOwn(explicitLegacyRuntimeTaskInput.runtime_task.input, 'agent'), false);
+assert.equal(Object.hasOwn(explicitLegacyRuntimeTaskInput.runtime_task.input, 'metadata'), false);
 
 const runtimeConfigOptionsRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -1107,11 +1116,13 @@ const providerAndControllerArtifactsTaskInput = codeboxTaskRequestFromAgentTaskR
   },
 });
 assert.deepEqual(providerAndControllerArtifactsTaskInput.artifact_declarations.map((declaration) => declaration.name), ['concept_packet']);
-assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
-assert.equal(
-  providerAndControllerArtifactsTaskInput.runtime_task.input.engine_data_outputs.concept_packet,
-  'outputs.typed_artifacts.concept_packet.payload'
-);
+assert.equal(providerAndControllerArtifactsTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.artifacts, [{
+  name: 'concept_packet',
+  required: true,
+  schema: 'wp-site-generator/ConceptPacket/v1',
+  output: 'outputs.typed_artifacts.concept_packet.payload',
+}]);
 
 const placeholderArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
   schema: 'homeboy/agent-task-request/v1',
@@ -1642,13 +1653,22 @@ const runtimePackageTypedArtifactRequest = {
 };
 const runtimePackageTypedArtifactTaskInput = codeboxTaskRequestFromAgentTaskRequest(runtimePackageTypedArtifactRequest);
 assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
-assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.runtime_package, '/workspace/example-runtime/bundles/store-idea-agent');
-assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.agent, 'store-idea-agent');
-assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.metadata.runtime_package_descriptor, { slug: 'store-idea-agent', source: '/workspace/example-runtime/bundles/store-idea-agent' });
-assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.metadata.runtime_package_descriptor.source === 'bundles/store-idea-agent', false);
+assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
+assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.package, { slug: 'store-idea-agent', source: '/workspace/example-runtime/bundles/store-idea-agent' });
+assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.workflow, { id: 'store-idea-artifact-flow' });
+assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.package.source === 'bundles/store-idea-agent', false);
 assert.equal(JSON.stringify(runtimePackageTypedArtifactTaskInput.runtime_task).includes('"source":"bundles/store-idea-agent"'), false);
-assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
-assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.engine_data_outputs.concept_packet, 'outputs.typed_artifacts.concept_packet.payload');
+assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.artifacts, [{
+  name: 'concept_packet',
+  required: true,
+  schema: 'example/ConceptPacket/v1',
+  output: 'outputs.typed_artifacts.concept_packet.payload',
+}]);
+assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'runtime_package'), false);
+assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'agent'), false);
+assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'metadata'), false);
+assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'required_artifacts'), false);
+assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'engine_data_outputs'), false);
 
 const runtimePackageTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult(runtimePackageTypedArtifactRequest, {
   success: true,


### PR DESCRIPTION
## Summary
- Add the canonical `wp-codebox/runtime-package-task/v1` schema to public runtime-package task inputs sent to WP Codebox.
- Emit canonical `package.source` / `package.slug` task shape and preserve `workflow`, nested `input`, and artifact declarations without adding legacy runtime-package aliases.
- Update focused runtime-package and boundary coverage for `runtime_execution.kind: bundle` / `runtime-package/run` mapping.

## Tests
- `node tests/wp-codebox-runtime-package-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node tests/wp-codebox-provider-plugin-env-override-smoke.mjs`
- `node tests/wp-codebox-provider-plugin-defaults-smoke.mjs`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the WP Codebox adapter fix, updating focused tests, and PR preparation.