### PR TITLE
Emit Codebox runtime package artifact declarations

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1045,9 +1045,21 @@ function runtimePackageTaskInputForCodebox(input, options = {}) {
   if (normalizedPackage.package) {
     normalized.package = normalizedPackage.package;
   }
+  const artifactDeclarations = normalizeRuntimePackageTaskArtifactDeclarations(firstDefined(
+    normalized.artifact_declarations,
+    normalized.artifactDeclarations,
+    []
+  ));
+  normalized.artifact_declarations = artifactDeclarations;
+  const requiredArtifacts = runtimePackageRequiredArtifacts(normalized.required_artifacts, artifactDeclarations);
+  if (requiredArtifacts.length > 0 || normalized.required_artifacts !== undefined) {
+    normalized.required_artifacts = requiredArtifacts;
+  }
   delete normalized.runtime_package;
   delete normalized.agent;
   delete normalized.agent_slug;
+  delete normalized.artifactDeclarations;
+  delete normalized.artifacts;
   return normalized;
 }
 
@@ -1150,41 +1162,43 @@ function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, 
   const declarations = codeboxTaskArtifactDeclarations(artifactDeclarationsFromAgentTaskRequest(request, config, inputs))
     .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && typedArtifactNameFromDeclaration(declaration));
   if (declarations.length === 0) {
-    return input;
+    return {
+      ...input,
+      artifact_declarations: normalizeRuntimePackageTaskArtifactDeclarations(firstDefined(input.artifact_declarations, input.artifactDeclarations, [])),
+    };
   }
 
-  const artifacts = normalizeRuntimePackageTaskArtifacts(input.artifacts);
-  for (const declaration of declarations) {
-    const name = typedArtifactNameFromDeclaration(declaration);
-    if (name && !artifacts.some((artifact) => artifact.name === name)) {
-      artifacts.push(runtimePackageArtifactFromDeclaration(declaration));
-    }
-  }
+  const artifactDeclarations = uniqueArtifactDeclarations([
+    ...normalizeRuntimePackageTaskArtifactDeclarations(firstDefined(input.artifact_declarations, input.artifactDeclarations, [])),
+    ...declarations.map(runtimePackageArtifactDeclarationFromDeclaration).filter(Boolean),
+  ]);
+  const requiredArtifacts = runtimePackageRequiredArtifacts(input.required_artifacts, artifactDeclarations);
 
   return {
     ...input,
-    artifacts,
+    artifact_declarations: artifactDeclarations,
+    required_artifacts: requiredArtifacts,
   };
 }
 
-function normalizeRuntimePackageTaskArtifacts(artifacts) {
-  return normalizeArray(artifacts)
-    .filter((artifact) => artifact && typeof artifact === 'object' && !Array.isArray(artifact))
-    .map((artifact) => ({ ...artifact }));
+function normalizeRuntimePackageTaskArtifactDeclarations(declarations) {
+  return uniqueArtifactDeclarations(normalizeArray(declarations)
+    .map(runtimePackageArtifactDeclarationFromDeclaration)
+    .filter(Boolean));
 }
 
-function runtimePackageArtifactFromDeclaration(declaration) {
-  const name = typedArtifactNameFromDeclaration(declaration);
-  return withoutUndefinedValues({
-    name,
-    required: declaration.required === true,
-    schema: declaration.artifact_schema || declaration.artifactSchema,
-    output: runtimePackageOutputProjectionPath(name),
-  });
+function runtimePackageArtifactDeclarationFromDeclaration(declaration) {
+  return wpCodeboxArtifactDeclarationFromHomeboy(declaration);
 }
 
-function runtimePackageOutputProjectionPath(name) {
-  return `outputs.typed_artifacts.${name}.payload`;
+function runtimePackageRequiredArtifacts(requiredArtifacts, artifactDeclarations = []) {
+  return Array.from(new Set([
+    ...normalizeArray(requiredArtifacts),
+    ...artifactDeclarations
+      .filter((declaration) => declaration && declaration.required === true)
+      .map((declaration) => typedArtifactNameFromDeclaration(declaration))
+      .filter(Boolean),
+  ]));
 }
 
 function runtimeTaskInputFromAgentTaskRequest(request, config, inputs, declared = {}) {

--- a/tests/wp-codebox-runtime-package-contract-smoke.mjs
+++ b/tests/wp-codebox-runtime-package-contract-smoke.mjs
@@ -80,16 +80,17 @@ try {
 		slug: 'proof-loop',
 		source: '/workspace/workspace/packages/proof-loop',
 	});
-	assert.deepEqual(runtimeTask.input.artifacts, [{
+	assert.deepEqual(runtimeTask.input.artifact_declarations, [{
+		schema: 'wp-codebox/artifact-declaration/v1',
 		name: 'review_packet',
+		artifact_schema: 'example/review-packet/v1',
 		required: true,
-		schema: 'example/review-packet/v1',
-		output: 'outputs.typed_artifacts.review_packet.payload',
 	}]);
+	assert.deepEqual(runtimeTask.input.required_artifacts, ['review_packet']);
 	assert.equal(Object.hasOwn(runtimeTask.input, 'runtime_package'), false);
 	assert.equal(Object.hasOwn(runtimeTask.input, 'agent'), false);
-	assert.equal(Object.hasOwn(runtimeTask.input, 'required_artifacts'), false);
 	assert.equal(Object.hasOwn(runtimeTask.input, 'engine_data_outputs'), false);
+	assert.equal(Object.hasOwn(runtimeTask.input, 'artifacts'), false);
 
 	assert.deepEqual(runtimePackageTaskInputForCodebox({
 		package: { slug: 'proof-loop', source: 'packages/proof-loop' },
@@ -99,6 +100,7 @@ try {
 			slug: 'proof-loop',
 			source: '/workspace/source/packages/proof-loop',
 		},
+		artifact_declarations: [],
 	});
 
 	assert.throws(

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -856,17 +856,18 @@ assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.ability_
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task_ability_normalization, controllerClientContextArtifactsTaskInput.runtime_task.ability_normalization);
 assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.package, { slug: 'website-idea-agent', source: 'bundles/website-idea-agent' });
-assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.artifacts, [{
+assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.artifact_declarations, [{
+  schema: 'wp-codebox/artifact-declaration/v1',
   name: 'concept_packet',
+  artifact_schema: 'wp-site-generator/ConceptPacket/v1',
   required: true,
-  schema: 'wp-site-generator/ConceptPacket/v1',
-  output: 'outputs.typed_artifacts.concept_packet.payload',
 }]);
+assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
 assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'runtime_package'), false);
 assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'agent'), false);
 assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'metadata'), false);
-assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'required_artifacts'), false);
 assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'engine_data_outputs'), false);
+assert.equal(Object.hasOwn(controllerClientContextArtifactsTaskInput.runtime_task.input, 'artifacts'), false);
 
 const controllerClientContextRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -1117,12 +1118,13 @@ const providerAndControllerArtifactsTaskInput = codeboxTaskRequestFromAgentTaskR
 });
 assert.deepEqual(providerAndControllerArtifactsTaskInput.artifact_declarations.map((declaration) => declaration.name), ['concept_packet']);
 assert.equal(providerAndControllerArtifactsTaskInput.runtime_task.input.schema, 'wp-codebox/runtime-package-task/v1');
-assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.artifacts, [{
+assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.artifact_declarations, [{
+  schema: 'wp-codebox/artifact-declaration/v1',
   name: 'concept_packet',
+  artifact_schema: 'wp-site-generator/ConceptPacket/v1',
   required: true,
-  schema: 'wp-site-generator/ConceptPacket/v1',
-  output: 'outputs.typed_artifacts.concept_packet.payload',
 }]);
+assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
 
 const placeholderArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
   schema: 'homeboy/agent-task-request/v1',
@@ -1658,17 +1660,18 @@ assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.package
 assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.workflow, { id: 'store-idea-artifact-flow' });
 assert.equal(runtimePackageTypedArtifactTaskInput.runtime_task.input.package.source === 'bundles/store-idea-agent', false);
 assert.equal(JSON.stringify(runtimePackageTypedArtifactTaskInput.runtime_task).includes('"source":"bundles/store-idea-agent"'), false);
-assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.artifacts, [{
+assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.artifact_declarations, [{
+  schema: 'wp-codebox/artifact-declaration/v1',
   name: 'concept_packet',
+  artifact_schema: 'example/ConceptPacket/v1',
   required: true,
-  schema: 'example/ConceptPacket/v1',
-  output: 'outputs.typed_artifacts.concept_packet.payload',
 }]);
+assert.deepEqual(runtimePackageTypedArtifactTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
 assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'runtime_package'), false);
 assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'agent'), false);
 assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'metadata'), false);
-assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'required_artifacts'), false);
 assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'engine_data_outputs'), false);
+assert.equal(Object.hasOwn(runtimePackageTypedArtifactTaskInput.runtime_task.input, 'artifacts'), false);
 
 const runtimePackageTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult(runtimePackageTypedArtifactRequest, {
   success: true,


### PR DESCRIPTION
## Summary
- Emit canonical `artifact_declarations` on every public `wp-codebox/runtime-package-task/v1` input.
- Map Homeboy runtime-package output declarations into WP Codebox artifact declarations and preserve `required_artifacts` hints.
- Keep runtime-package task shape canonical: root schema, package source/slug, workflow/input payloads, artifact declarations, and no legacy `artifacts` alias.

## Tests
- `node tests/wp-codebox-runtime-package-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node tests/wp-codebox-provider-plugin-env-override-smoke.mjs`
- `node tests/wp-codebox-provider-plugin-defaults-smoke.mjs`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the WP Codebox adapter fix, updating focused contract tests, and PR preparation.