### PR TITLE
fix(wordpress): detect block themes by templates/index.html, not theme.json

### DIFF
--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -804,10 +804,18 @@ validate_build() {
         fi
 
     elif [ "$PROJECT_TYPE" = "theme" ]; then
-        # Theme validation: classic themes need index.php; block themes use
-        # templates/index.html as the fallback template.
+        # Theme validation: every theme needs style.css plus a root fallback
+        # template. Block themes provide templates/index.html; classic themes
+        # provide index.php. Detect by the canonical block-theme signal
+        # (presence of templates/index.html, which is what WP core's
+        # wp_is_block_theme() checks) -- NOT by the presence of theme.json.
+        # A theme.json does NOT make a theme a block theme: classic themes
+        # legitimately ship theme.json for global styles, color palettes, and
+        # font registration (wp_theme_json_data_theme) while still rendering
+        # via index.php. Keying off theme.json misdetects those classic themes
+        # as block themes and wrongly requires templates/index.html.
         local required_files=("style.css")
-        if [ -f "$staging_dir/theme.json" ]; then
+        if [ -f "$staging_dir/templates/index.html" ]; then
             required_files+=("templates/index.html")
         else
             required_files+=("index.php")


### PR DESCRIPTION
## Summary
The WordPress build extension's theme structure validation (`wordpress/scripts/build/build.sh`) decided block-vs-classic by the **presence of `theme.json`**, then required `templates/index.html` for the "block" branch. That misdetects classic themes that ship a `theme.json`.

A `theme.json` does **not** make a theme a block theme — classic themes legitimately ship one for global styles, color palettes, and font registration (`wp_theme_json_data_theme`) while still rendering via `index.php`. Those classic-themes-with-theme.json got flagged `Essential theme files missing: templates/index.html` and failed the build (exit 1), blocking release — and since the failure is inside the build script, `--skip-build-validation` couldn't rescue it.

## The fix
Detect by the canonical block-theme signal — presence of `templates/index.html` (what WP core's `wp_is_block_theme()` checks) — not `theme.json`:
```bash
if [ -f "$staging_dir/templates/index.html" ]; then
    required_files+=("templates/index.html")
else
    required_files+=("index.php")
fi
```

## Repro (real)
The `extrachill` theme is classic (`index.php`, no `templates/` dir) but its build generates a `theme.json` from design tokens (`cp node_modules/@extrachill/tokens/css/theme.json theme.json`). Staging dir then has `theme.json` → old logic assumes block theme → requires `templates/index.html` → fail. It released fine as v2.6.3 before this validation tightened; now it blocks every release of the theme (and any classic-theme-with-theme.json on the fleet).

## Verify
- `bash -n build.sh` clean.
- A classic theme (index.php + theme.json, no templates/) now validates via the index.php branch.
- A block theme (templates/index.html) still validates via that branch.

Closes Extra-Chill/homeboy#6730