### PR TITLE
Use public Codebox runtime descriptor

### DIFF
--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js
@@ -151,15 +151,107 @@ function wpCodeboxSupportsRunAgentTaskCommand(options = {}) {
 		return false;
 	}
 
+	const descriptor = firstObject(options.runtimeDescriptor, options.runtime_descriptor)
+		|| wpCodeboxRuntimeDescriptor(options);
+	if (!descriptor) {
+		return false;
+	}
+	return runtimeDescriptorSupportsCommand(descriptor, WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND);
+}
+
+function wpCodeboxRuntimeDescriptor(options = {}) {
+	const env = options.env || process.env;
 	const bin = firstValue(options.bin, options.wpCodeboxBin, options.wp_codebox_bin, wpCodeboxBin({ ...options, env }));
-	const resolved = wpCodeboxResolveCommand(bin, [WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND, '--help']);
-	const result = spawnSync(resolved.command, resolved.args, {
+	if (!bin) {
+		return null;
+	}
+	const resolved = wpCodeboxResolveCommand(bin, ['runtime', 'descriptor', '--json']);
+	const spawn = options.spawnSync || spawnSync;
+	const result = spawn(resolved.command, resolved.args, {
 		encoding: 'utf8',
 		env,
 		maxBuffer: 1024 * 1024,
 		timeout: options.timeoutMs || options.timeout_ms || 5000,
 	});
-	return !result.error && result.status === 0;
+	if (result.error || result.status !== 0) {
+		return null;
+	}
+	return parseRuntimeDescriptorJson(result.stdout);
+}
+
+function parseRuntimeDescriptorJson(stdout) {
+	try {
+		const parsed = JSON.parse(stdout);
+		return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+function runtimeDescriptorSupportsCommand(descriptor, command) {
+	const commands = new Set(runtimeDescriptorCommandNames(descriptor));
+	if (commands.has(command)) {
+		return true;
+	}
+	const capabilities = new Set(runtimeDescriptorCapabilityNames(descriptor));
+	return capabilities.has(command)
+		|| capabilities.has(command.replace(/-/g, '_'))
+		|| capabilities.has(`wp-codebox/${command}`);
+}
+
+function runtimeDescriptorCommandNames(descriptor = {}) {
+	return uniqueStrings([
+		...commandNamesFromValue(descriptor.commands),
+		...commandNamesFromValue(descriptor.cli_commands),
+		...commandNamesFromValue(descriptor.cliCommands),
+		...commandNamesFromValue(descriptor.tasks),
+		...commandNamesFromValue(descriptor.abilities),
+		...commandNamesFromValue(descriptor.runtime?.commands),
+		...commandNamesFromValue(descriptor.runtime?.tasks),
+		...commandNamesFromValue(descriptor.runtime?.abilities),
+		...commandNamesFromValue(descriptor.agent_task?.commands),
+		...commandNamesFromValue(descriptor.agentTask?.commands),
+	]);
+}
+
+function runtimeDescriptorCapabilityNames(descriptor = {}) {
+	return uniqueStrings([
+		...commandNamesFromValue(descriptor.capabilities),
+		...commandNamesFromValue(descriptor.runtime_capabilities),
+		...commandNamesFromValue(descriptor.runtimeCapabilities),
+		...commandNamesFromValue(descriptor.runtime?.capabilities),
+	]);
+}
+
+function commandNamesFromValue(value) {
+	if (!value) {
+		return [];
+	}
+	if (typeof value === 'string') {
+		return [value];
+	}
+	if (Array.isArray(value)) {
+		return value.flatMap((entry) => commandNamesFromValue(entry));
+	}
+	if (typeof value !== 'object') {
+		return [];
+	}
+	return Object.entries(value).flatMap(([key, entry]) => {
+		if (entry === true) {
+			return [key];
+		}
+		if (typeof entry === 'string') {
+			return [key, entry];
+		}
+		if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+			return [key, entry.name, entry.command, entry.id, entry.capability].filter(Boolean);
+		}
+		return [key];
+	});
+}
+
+function uniqueStrings(values) {
+	return [...new Set(values.map((value) => String(value || '').trim()).filter(Boolean))];
 }
 
 function wpCodeboxProviderPluginPathsFromEnv(env = process.env) {
@@ -218,9 +310,16 @@ function firstValue(...values) {
   return values.find((value) => value !== undefined && value !== null && value !== '');
 }
 
+function firstObject(...values) {
+	return values.find((value) => value && typeof value === 'object' && !Array.isArray(value));
+}
+
 module.exports = {
   DEFAULT_WP_CODEBOX_CLI_DESCRIPTOR,
   WP_CODEBOX_CLI_DESCRIPTOR_SCHEMA,
+	parseRuntimeDescriptorJson,
+	runtimeDescriptorCommandNames,
+	runtimeDescriptorSupportsCommand,
 	homeboySettings,
 	managedWpCodeboxBin,
 	wpCodeboxBinaryDiagnostic,
@@ -230,5 +329,6 @@ module.exports = {
 	wpCodeboxCommand,
 	wpCodeboxProviderPluginPathsFromEnv,
 	wpCodeboxResolveCommand,
+	wpCodeboxRuntimeDescriptor,
 	wpCodeboxSupportsRunAgentTaskCommand,
 };

--- a/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
+++ b/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
@@ -7,9 +7,11 @@ const path = require('node:path');
 process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(__dirname, '..', '..', '..', 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 
 const {
-  wpCodeboxBinaryDiagnostic,
-  wpCodeboxProviderPluginPathsFromEnv,
-  wpCodeboxResolveCommand,
+	runtimeDescriptorSupportsCommand,
+	wpCodeboxBinaryDiagnostic,
+	wpCodeboxProviderPluginPathsFromEnv,
+	wpCodeboxResolveCommand,
+	wpCodeboxSupportsRunAgentTaskCommand,
 } = require('..');
 
 const runtimeRoot = path.join(__dirname, '..');
@@ -17,6 +19,10 @@ const runnerSource = fs.readFileSync(path.join(runtimeRoot, 'scripts', 'agent', 
 
 assert.doesNotMatch(runnerSource, /HOMEBOY_AGENT_RUNTIME_PROVIDER_PLUGIN_PATHS|WP_CODEBOX_PROVIDER_PLUGIN_PATHS/);
 assert.doesNotMatch(runnerSource, /packages\/cli\/dist|HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT|HOMEBOY_WP_CODEBOX_INSTALL_DIR/);
+
+const descriptorSource = fs.readFileSync(path.join(runtimeRoot, 'lib', 'wp-codebox-adapter-descriptor.js'), 'utf8');
+assert.match(descriptorSource, /runtime', 'descriptor', '--json/);
+assert.doesNotMatch(descriptorSource, /run-agent-task', '--help/);
 
 assert.deepEqual(wpCodeboxProviderPluginPathsFromEnv({
   WP_CODEBOX_PROVIDER_PLUGIN_PATHS: JSON.stringify(['/tmp/provider-a', '/tmp/provider-b']),
@@ -29,5 +35,21 @@ assert.deepEqual(wpCodeboxProviderPluginPathsFromEnv({
 assert.equal(wpCodeboxBinaryDiagnostic('').class, 'wp-codebox.config.missing_binary');
 assert.equal(wpCodeboxBinaryDiagnostic('wp-codebox'), null);
 assert.deepEqual(wpCodeboxResolveCommand('/tmp/wp-codebox.cjs', ['run-agent-task']).args, ['/tmp/wp-codebox.cjs', 'run-agent-task']);
+
+assert.equal(runtimeDescriptorSupportsCommand({ commands: { 'run-agent-task': true } }, 'run-agent-task'), true);
+assert.equal(runtimeDescriptorSupportsCommand({ runtime: { tasks: ['run-agent-task'] } }, 'run-agent-task'), true);
+assert.equal(runtimeDescriptorSupportsCommand({ capabilities: ['wp-codebox/run-agent-task'] }, 'run-agent-task'), true);
+assert.equal(wpCodeboxSupportsRunAgentTaskCommand({
+	bin: '/tmp/wp-codebox',
+	env: {},
+	spawnSync(command, args) {
+		assert.equal(command, '/tmp/wp-codebox');
+		assert.deepEqual(args, ['runtime', 'descriptor', '--json']);
+		return {
+			status: 0,
+			stdout: JSON.stringify({ commands: [{ command: 'run-agent-task' }] }),
+		};
+	},
+}), true);
 
 process.stdout.write('WP Codebox adapter boundary passed\n');


### PR DESCRIPTION
## Summary
- probe WP Codebox runtime capabilities through the public runtime descriptor
- remove run-agent-task --help probing from the adapter descriptor
- update adapter boundary tests for descriptor-first behavior

## Verification
- node tests/wp-codebox-adapter-boundary.test.js
- npm run test:codebox-agent-task-executor-boundary
- node --check on touched agent-runtimes WP Codebox JS/CJS files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Migrating Homeboy agent-runtimes Codebox probing to the public runtime descriptor and updating boundary tests.