### PR TITLE
Use public Codebox artifact APIs

### DIFF
--- a/wordpress/lib/codebox-client.js
+++ b/wordpress/lib/codebox-client.js
@@ -46,12 +46,12 @@ class CodeboxClient {
 
 	publicCliBin(options = {}) {
 		const merged = { ...this.options, ...options };
-		if (merged.wpCliBin || merged.wp_cli_bin) {
-			return merged.wpCliBin || merged.wp_cli_bin;
+		if (merged.wpCliBin || merged.wp_cli_bin || merged.wpCli || merged.wpCommand) {
+			return merged.wpCliBin || merged.wp_cli_bin || merged.wpCli || merged.wpCommand;
 		}
 		const env = { ...process.env, ...(merged.env || {}) };
-		if (env.wpCliBin || env.wp_cli_bin || env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN) {
-			return env.wpCliBin || env.wp_cli_bin || env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN;
+		if (env.wpCliBin || env.wp_cli_bin || env.wpCli || env.wpCommand || env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN) {
+			return env.wpCliBin || env.wp_cli_bin || env.wpCli || env.wpCommand || env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN;
 		}
 		const identity = this.identity(merged);
 		return identity.selectionSource === 'default' ? resolver.DEFAULT_WP_CLI_BIN : identity.bin;
@@ -66,7 +66,10 @@ class CodeboxClient {
 		}
 		const invocation = this.command(bin);
 		const executable = path.basename(String(bin || '')).toLowerCase();
-		const usesWpCliNamespace = executable === 'wp' || executable === 'wp-cli' || executable === 'wp-cli.phar';
+		const usesWpCliNamespace = Boolean(merged.wpCli || merged.wpCommand)
+			|| executable === 'wp'
+			|| executable === 'wp-cli'
+			|| executable === 'wp-cli.phar';
 		return {
 			command: invocation.command,
 			args: usesWpCliNamespace ? [...invocation.args, 'codebox'] : invocation.args,
@@ -104,7 +107,21 @@ class CodeboxClient {
 		}
 	}
 
-	runArtifactApplyPreflight({ artifactId, artifactsPath, approvedFiles, cwd, env, wpCommand, wpCli } = {}) {
+	runArtifactApplyPreflight({ artifactId, artifactsPath, bundlePath, approvedFiles, cwd, env, wpCommand, wpCli } = {}) {
+		if (bundlePath) {
+			const args = publicArtifactApplyPreflightArgs({ bundlePath, approvedFiles });
+			const result = this.runPublicCliCommand(args, { cwd, env, wpCli, wpCommand });
+			if (result.status !== 0) {
+				const detail = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+				throw new Error(`${this.publicCliBin({ env, wpCli, wpCommand })} ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`);
+			}
+			return parseJsonCliOutput(result.stdout, args.join(' '));
+		}
+
+		return this.runLegacyArtifactApplyPreflight({ artifactId, artifactsPath, approvedFiles, cwd, env, wpCommand, wpCli });
+	}
+
+	runLegacyArtifactApplyPreflight({ artifactId, artifactsPath, approvedFiles, cwd, env, wpCommand, wpCli } = {}) {
 		const command = wpCommand || wpCli || process.env.HOMEBOY_WP_CLI || resolver.DEFAULT_WP_CLI_BIN;
 		const args = [
 			'codebox',
@@ -120,7 +137,27 @@ class CodeboxClient {
 			const detail = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
 			throw new Error(`${command} ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`);
 		}
-		return JSON.parse((result.stdout || '').trim());
+		return parseJsonCliOutput(result.stdout, args.join(' '));
+	}
+
+	runArtifactsDiscoverPartial({ artifactsRoot, sessionId, startedAt, finishedAt, cwd, env, wpCommand, wpCli } = {}) {
+		const args = ['artifacts', 'discover-partial', '--artifacts', artifactsRoot, '--json'];
+		if (sessionId) {
+			args.push('--session-id', sessionId);
+		}
+		if (startedAt) {
+			args.push('--started-at', startedAt);
+		}
+		if (finishedAt) {
+			args.push('--finished-at', finishedAt);
+		}
+
+		const result = this.runPublicCliCommand(args, { cwd, env, wpCommand, wpCli });
+		if (result.status !== 0) {
+			const detail = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+			throw new Error(`${this.publicCliBin({ env, wpCommand, wpCli })} ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`);
+		}
+		return parseJsonCliOutput(result.stdout, args.join(' '));
 	}
 
 	async loadCompatibilityExport(name, options = {}) {
@@ -152,6 +189,23 @@ function publicJsonArgs(command, inputFile, options = {}) {
 	return [command, '--input-file', inputFile, '--format=json'];
 }
 
+function publicArtifactApplyPreflightArgs({ bundlePath, approvedFiles } = {}) {
+	const args = ['artifacts', 'apply-preflight', '--bundle', bundlePath, '--json'];
+	for (const filePath of approvedFiles || []) {
+		args.push('--approved-file', filePath);
+	}
+	return args;
+}
+
+function parseJsonCliOutput(stdout, label = 'wp-codebox') {
+	const text = String(stdout || '').trim();
+	try {
+		return JSON.parse(text);
+	} catch (error) {
+		throw new Error(`${label} did not return valid JSON${text ? `: ${text}` : ''}`);
+	}
+}
+
 function normalizeCliResult(result = {}) {
 	let status = 0;
 	if (Number.isInteger(result.status)) {
@@ -172,5 +226,7 @@ module.exports = {
 	ARTIFACT_COMPATIBILITY_OPTIONS,
 	createCodeboxClient,
 	normalizeCliResult,
+	parseJsonCliOutput,
+	publicArtifactApplyPreflightArgs,
 	publicJsonArgs,
 };

--- a/wordpress/lib/wp-codebox-apply-adapter.js
+++ b/wordpress/lib/wp-codebox-apply-adapter.js
@@ -190,6 +190,7 @@ function runWpCodeboxApplyPreflight(options) {
   return createCodeboxClient(options).runArtifactApplyPreflight({
     artifactId,
     artifactsPath,
+    bundlePath,
     approvedFiles,
     cwd: options.cwd,
     env: options.env,
@@ -229,6 +230,7 @@ function normalizeWpCodeboxPreflight(input) {
     verifyWpCodeboxPayload(payload);
     return {
       ...preflight,
+      ready: preflight.ready !== false,
       payload,
     };
   }
@@ -247,28 +249,14 @@ function normalizeWpCodeboxPreflight(input) {
 }
 
 async function normalizeWpCodeboxPreflightAsync(input) {
-  const normalizeArtifactApplyPreflight = await createCodeboxClient(input).loadArtifactCompatibilityFunction('normalizeArtifactApplyPreflight', {
-    ...input,
-  });
-  if (!normalizeArtifactApplyPreflight) {
-    return normalizeWpCodeboxPreflight(input);
-  }
-  const preflight = await normalizeArtifactApplyPreflight(input);
-  if (!preflight.ready) {
-    const details = (preflight.violations || []).map((violation) => violation.message || violation.code).filter(Boolean).join('; ');
-    throw new Error(`WP Codebox apply preflight is not ready${details ? `: ${details}` : ''}`);
-  }
-  return preflight;
+  return normalizeWpCodeboxPreflight(input);
 }
 
 async function wpCodeboxApplyRequestFromBundleAsync(options) {
-  const createArtifactApplyRequest = await createCodeboxClient(options).loadArtifactCompatibilityFunction('createArtifactApplyRequest', {
+  return wpCodeboxApplyRequestFromBundle({
     ...options,
+    preflight: await normalizeWpCodeboxPreflightAsync(options),
   });
-  if (!createArtifactApplyRequest) {
-    return wpCodeboxApplyRequestFromBundle(options);
-  }
-  return createArtifactApplyRequest(options);
 }
 
 function normalizeApplyRequest(input) {

--- a/wordpress/tests/codebox-client-boundary.test.js
+++ b/wordpress/tests/codebox-client-boundary.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 
 const {
 	createCodeboxClient,
+	publicArtifactApplyPreflightArgs,
 	publicJsonArgs,
 } = require('../lib/codebox-client');
 
@@ -65,6 +66,10 @@ try {
 	assert.equal(client.identity().bin, bin);
 	assert.deepEqual(client.publicCliInvocation(), { command: process.execPath, args: [bin] });
 	assert.deepEqual(publicJsonArgs('run-fuzz-suite', '/tmp/input.json', { runnerMode: 'runtime-backed' }), ['run-fuzz-suite', '--runner-mode=runtime-backed', '--input-file', '/tmp/input.json', '--json']);
+	assert.deepEqual(publicArtifactApplyPreflightArgs({
+		bundlePath: '/tmp/bundle',
+		approvedFiles: ['wp-content/plugins/example/readme.txt'],
+	}), ['artifacts', 'apply-preflight', '--bundle', '/tmp/bundle', '--json', '--approved-file', 'wp-content/plugins/example/readme.txt']);
 
 	const cliResult = client.runPublicCliCommand(['run-fuzz-suite', '--help']);
 	assert.equal(cliResult.status, 0);
@@ -75,6 +80,30 @@ try {
 		runPublicCli: ({ command, args }) => ({ status: 0, stdout: JSON.stringify({ command, args }) }),
 	}).runPublicCliCommand(['run-wordpress-workload', '--help']);
 	assert.equal(JSON.parse(delegatedResult.stdout).command, 'wp');
+
+	const preflightResult = createCodeboxClient({
+		wpCodeboxBin: bin,
+		runPublicCli: ({ command, args }) => ({
+			status: 0,
+			stdout: JSON.stringify({ ready: true, command, args }),
+		}),
+	}).runArtifactApplyPreflight({
+		bundlePath: '/tmp/bundle',
+		approvedFiles: ['wp-content/plugins/example/readme.txt'],
+	});
+	assert.equal(preflightResult.ready, true);
+	assert.deepEqual(preflightResult.args, ['artifacts', 'apply-preflight', '--bundle', '/tmp/bundle', '--json', '--approved-file', 'wp-content/plugins/example/readme.txt']);
+
+	const discoveryResult = createCodeboxClient({
+		wpCodeboxBin: bin,
+		runPublicCli: ({ args }) => ({ status: 0, stdout: JSON.stringify({ artifacts: [], args }) }),
+	}).runArtifactsDiscoverPartial({
+		artifactsRoot: '/tmp/artifacts',
+		sessionId: 'session-1',
+		startedAt: '2026-01-01T00:00:00.000Z',
+		finishedAt: '2026-01-01T00:00:01.000Z',
+	});
+	assert.deepEqual(discoveryResult.args, ['artifacts', 'discover-partial', '--artifacts', '/tmp/artifacts', '--json', '--session-id', 'session-1', '--started-at', '2026-01-01T00:00:00.000Z', '--finished-at', '2026-01-01T00:00:01.000Z']);
 
 	console.log('codebox client boundary passed');
 } finally {

--- a/wordpress/tests/wp-codebox-apply-adapter-smoke.js
+++ b/wordpress/tests/wp-codebox-apply-adapter-smoke.js
@@ -250,39 +250,21 @@ async function main() {
   assert.deepEqual(requestCliResult.files_changed, ['readme.txt']);
   assert.equal(fs.readFileSync(path.join(requestCliRepo, 'readme.txt'), 'utf8'), 'after\n');
 
-  const coreModulePath = path.join(root, 'wp-codebox-core-fixture.mjs');
-  fs.writeFileSync(coreModulePath, [
-    'export async function normalizeArtifactApplyPreflight(input) {',
-    '  const payload = input.preflight?.payload || input.payload || input;',
-    '  if (payload.force_not_ready) {',
-    '    return { schema: "wp-codebox/artifact-apply-preflight/v1", ready: false, violations: [{ code: "missing-patch", message: "Fixture core preflight rejected the payload." }] };',
-    '  }',
-    '  return { schema: "wp-codebox/artifact-apply-preflight/v1", ready: true, violations: [], payload };',
-    '}',
-    'export async function createArtifactApplyRequest(input) {',
-    '  const preflight = await normalizeArtifactApplyPreflight(input);',
-    '  return { id: `core-request-${preflight.payload.artifact_id}`, artifact: { id: preflight.payload.artifact_id, type: "wp_codebox_patch" }, approval_scope: { scope: "artifact", artifact_id: preflight.payload.artifact_id }, inputs: { preflight }, policy: { approved_files: preflight.payload.approved_files, content_digest: preflight.payload.artifact_content_digest, patch_sha256: preflight.payload.patch_sha256, publish: { push: false, open_pull_request: false } } };',
-    '}',
-    '',
-  ].join('\n'));
   const corePreflight = await normalizeWpCodeboxPreflightAsync({
-    wpCodeboxCoreModule: coreModulePath,
     preflight,
   });
   assert.equal(corePreflight.ready, true);
   assert.equal(corePreflight.payload.artifact_id, fixture.artifactId);
   await assert.rejects(
     normalizeWpCodeboxPreflightAsync({
-      wpCodeboxCoreModule: coreModulePath,
       payload: { force_not_ready: true },
     }),
-    /Fixture core preflight rejected the payload/
+    /payload.patch must contain the approved canonical patch/
   );
   const coreRequest = await wpCodeboxApplyRequestFromBundleAsync({
-    wpCodeboxCoreModule: coreModulePath,
     preflight,
   });
-  assert.equal(coreRequest.id, `core-request-${fixture.artifactId}`);
+  assert.equal(coreRequest.id, `apply-request-${fixture.artifactId}`);
   assert.deepEqual(coreRequest.policy.approved_files, ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt']);
 
   const fakeWpCli = path.join(root, 'fake-wp-cli.cjs');
@@ -307,8 +289,8 @@ async function main() {
   });
   assert.equal(delegatedResult.status, 'applied');
   const delegatedArgs = JSON.parse(fs.readFileSync(fakeWpCliCapture, 'utf8'));
-  assert.deepEqual(delegatedArgs.slice(0, 4), ['codebox', 'artifacts', 'preflight-apply', fixture.artifactId]);
-  assert.equal(delegatedArgs.some((arg) => arg.startsWith('--approved-files=')), true);
+  assert.deepEqual(delegatedArgs.slice(0, 5), ['codebox', 'artifacts', 'apply-preflight', '--bundle', fs.realpathSync(fixture.bundle)]);
+  assert.equal(delegatedArgs.includes('--approved-file'), true);
 
   console.log('WP Codebox apply adapter smoke passed');
   } finally {


### PR DESCRIPTION
## Summary
- prefer public Codebox artifact apply-preflight CLI calls from the WordPress Codebox client
- quarantine legacy artifact preflight handling for ID-only compatibility paths
- update adapter tests around public CLI argument handling

## Verification
- npm run test:codebox-client-boundary
- npm run test:wp-codebox-apply-adapter
- npm run test:wp-codebox-artifacts
- npm run test:audit-wp-codebox-fanout

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Migrating Homeboy WordPress Codebox artifact handling to public Codebox APIs and updating tests.