### PR TITLE
Wire WordPress fuzz runtime readiness

### DIFF
--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -46,18 +46,7 @@ const DEFAULT_THIRD_PARTY_WATERFALL_GROUPS = [
 		domains: ['gstatic.com', 'googleapis.com', 'google.com'],
 	},
 ];
-const WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS = Object.freeze({
-	woocommerce: Object.freeze({
-		waterfallGroups: Object.freeze([
-			Object.freeze({
-				id: 'woocommerce-store-api',
-				label: 'WooCommerce Store API',
-				urlIncludes: Object.freeze(['/wp-json/wc/store/', 'rest_route=/wc/store/']),
-			}),
-		]),
-		firstPartyWaterfallGroupIds: Object.freeze(['woocommerce-store-api']),
-	}),
-});
+const WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS = Object.freeze({});
 const DEFAULT_GATE_THRESHOLDS = {
 	readyMsRegression: 250,
 	networkIdleMsRegression: 500,
@@ -304,9 +293,6 @@ function normalizeThirdPartyWaterfallGroups(groups) {
 function normalizeWaterfallProductAdapters(adapters) {
 	return (Array.isArray(adapters) ? adapters : [])
 		.map((adapter) => {
-			if (typeof adapter === 'string') {
-				return WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS[adapter] || null;
-			}
 			return isPlainObject(adapter) ? adapter : null;
 		})
 		.filter(Boolean);

--- a/wordpress/lib/wordpress-fuzz-campaign.js
+++ b/wordpress/lib/wordpress-fuzz-campaign.js
@@ -25,6 +25,9 @@ const {
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
 } = require('./wp-codebox-fuzz-run');
+const {
+	summarizeWordPressFuzzRuntimeWorkloadOperations,
+} = require('./wordpress-fuzz-runtime-workload-operations');
 
 const WORDPRESS_FUZZ_CAMPAIGN_SCHEMA = 'homeboy/wordpress-fuzz-campaign/v1';
 const HOMEBOY_FUZZ_WORKLOAD_SCHEMA = 'homeboy/fuzz-workload/v1';
@@ -47,7 +50,13 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 	if (input.mutation_mode || input.mutationMode || options.mutation_mode || options.mutationMode) {
 		planOptions.mutation_mode = input.mutation_mode || input.mutationMode || options.mutation_mode || options.mutationMode;
 	}
+	const fixturePlan = input.fixture_plan || input.fixturePlan || options.fixture_plan || options.fixturePlan;
+	const restMutationOptIns = input.rest_mutation_opt_ins || input.restMutationOptIns || input.rest_mutation_opt_in || input.restMutationOptIn || options.rest_mutation_opt_ins || options.restMutationOptIns || options.rest_mutation_opt_in || options.restMutationOptIn;
+	if (restMutationOptIns) {
+		planOptions.rest_mutation_opt_ins = restMutationOptIns;
+	}
 	const plan = buildWordPressFuzzPlanFromSurfaces(discovery, planOptions);
+	const runtimeOperationSummary = summarizeWordPressFuzzRuntimeWorkloadOperations(plan);
 	const coverageManifest = buildWordPressRuntimeSurfaceCoverageManifest(discovery);
 	const workload = buildWordPressFuzzCampaignWorkload({
 		id: input.workload_id || input.workloadId || `${plan.id}-workload`,
@@ -59,6 +68,7 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 			...(objectOrUndefined(input.metadata) || {}),
 			...(objectOrUndefined(options.metadata) || {}),
 			campaign_schema: WORDPRESS_FUZZ_CAMPAIGN_SCHEMA,
+			runtime_operations: runtimeOperationSummary,
 			production_campaign: production || undefined,
 		},
 		artifacts: input.artifacts || options.artifacts,
@@ -72,10 +82,15 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 		target: input.target || options.target,
 		coverage: campaignCoverageRequest(coverageManifest),
 		homeboyFuzzWorkload: workload,
+		fixture_plan: fixturePlan,
+		rest_mutation_opt_ins: restMutationOptIns,
 		metadata: {
 			...(objectOrUndefined(options.suiteInput?.metadata) || objectOrUndefined(options.suite_input?.metadata) || {}),
 			...(objectOrUndefined(input.suite_input?.metadata) || objectOrUndefined(input.suiteInput?.metadata) || {}),
 			coverage_manifest: coverageManifest,
+			fixture_plan: fixturePlan,
+			rest_mutation_opt_ins: restMutationOptIns,
+			runtime_operations: runtimeOperationSummary,
 			aggregation_hooks: campaignAggregationHooks(),
 			production_campaign: production || undefined,
 			output_requirements: production ? productionOutputRequirements() : undefined,
@@ -116,6 +131,7 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 
 function buildWordPressFuzzCampaignWorkload(input = {}) {
 	const plan = input.plan || {};
+	const runtimeOperationSummary = summarizeWordPressFuzzRuntimeWorkloadOperations(plan);
 	return {
 		schema: HOMEBOY_FUZZ_WORKLOAD_SCHEMA,
 		id: input.id || `${plan.id || 'wordpress-fuzz-plan'}-workload`,
@@ -133,6 +149,7 @@ function buildWordPressFuzzCampaignWorkload(input = {}) {
 		metadata: {
 			...(objectOrUndefined(input.metadata) || {}),
 			coverage_manifest: input.coverageManifest || input.coverage_manifest,
+			runtime_operations: runtimeOperationSummary,
 			aggregation_hooks: campaignAggregationHooks(),
 			postprocess_binding: objectOrUndefined(input.postprocess_binding || input.postprocessBinding),
 		},

--- a/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
+++ b/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
@@ -240,10 +240,12 @@ function adminPageTargetFromSurface(surface, options = {}) {
 
 function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReasons, surfaceDestructiveReasons, options = {}) {
 	const safeMethod = SAFE_REST_METHODS.has(method);
+	const restMutationOptIn = safeMethod ? undefined : restMutationOptInForSurfaceAction(surface, method, options);
 	const fixtureBinding = fixtureBindingForSurfaceAction(surface, method.toLowerCase(), options);
 	const operation = bindRestOperationFixtures({ ...operationForSurface(surface), method }, fixtureBinding);
 	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
-	const skipReasons = safeMethod || mutationMode === 'isolated' ? surfaceSkipReasons : reasonList([...surfaceSkipReasons, 'mutating_rest_method_requires_explicit_opt_in']);
+	const hasMutationOptIn = objectHasValues(restMutationOptIn);
+	const skipReasons = safeMethod || mutationMode === 'isolated' || hasMutationOptIn ? surfaceSkipReasons : reasonList([...surfaceSkipReasons, 'mutating_rest_method_requires_explicit_opt_in']);
 	const destructiveReasons = safeMethod ? surfaceDestructiveReasons : reasonList([...surfaceDestructiveReasons, 'rest_method_mutates_state']);
 	const fixtureMetadata = fixtureBindingMetadata(fixtureBinding);
 	const testCase = annotateWordPressFuzzCaseExecutionTier({
@@ -258,6 +260,7 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 			surface,
 			rest_method: method,
 			fixture_binding: fixtureMetadata,
+			rest_mutation_opt_in: restMutationOptIn,
 			auth: surface.auth || surface.authentication || surface.authorization || null,
 			safety: safeMethod ? { level: 'safe', mutates: false } : { level: 'mutating', mutates: true, requires_explicit_opt_in: true, rollback_required: true },
 			mutation_lifecycle: safeMethod ? undefined : mutationLifecycleContract({ kind: 'rest', surface, method }),
@@ -274,6 +277,52 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 		required_any_capabilities: REST_ROLLBACK_ANY_CAPABILITIES,
 		mutation_mode: mutationMode,
 		mutates: true,
+	});
+}
+
+function restMutationOptInForSurfaceAction(surface, method, options = {}) {
+	const manifest = normalizeRestMutationOptInManifest(options.rest_mutation_opt_ins || options.restMutationOptIns || options.rest_mutation_opt_in || options.restMutationOptIn);
+	const surfaceOptIn = normalizeRestMutationOptInEntry(surface.rest_mutation_opt_in || surface.restMutationOptIn || surface.mutation_opt_in || surface.mutationOptIn, { surface, method });
+	if (surfaceOptIn) {
+		return surfaceOptIn;
+	}
+	const normalizedMethod = String(method || '').toUpperCase();
+	for (const entry of manifest.entries) {
+		if (entry.allowed === false) {
+			continue;
+		}
+		if (entry.method && entry.method !== normalizedMethod) {
+			continue;
+		}
+		if ([entry.surface_id, entry.route, entry.path].filter(Boolean).some((value) => [surface.id, surface.route, surface.path, surface.name].includes(value))) {
+			return stripUndefined({ ...entry, manifest_id: manifest.id });
+		}
+	}
+	return undefined;
+}
+
+function normalizeRestMutationOptInManifest(value) {
+	const source = Array.isArray(value) ? value : (isObject(value) ? value : {});
+	const entries = (Array.isArray(source) ? source : source.entries || source.opt_ins || source.optIns || source.routes || [])
+		.map((entry) => normalizeRestMutationOptInEntry(entry))
+		.filter(Boolean);
+	return { id: source.id || source.manifest_id || source.manifestId, entries };
+}
+
+function normalizeRestMutationOptInEntry(value, fallback = {}) {
+	if (!isObject(value)) {
+		return undefined;
+	}
+	const method = String(value.method || fallback.method || '').toUpperCase();
+	return stripUndefined({
+		id: value.id || value.opt_in_id || value.optInId,
+		surface_id: value.surface_id || value.surfaceId || fallback.surface?.id,
+		route: value.route || value.path || fallback.surface?.route || fallback.surface?.path,
+		method: method || undefined,
+		allowed: value.allowed !== false,
+		fixture_ref: value.fixture_ref || value.fixtureRef,
+		contract_ref: value.contract_ref || value.contractRef,
+		metadata: isObject(value.metadata) ? value.metadata : undefined,
 	});
 }
 
@@ -626,6 +675,10 @@ function normalizeFixtureValue(entry) {
 
 function bindingHasValues(binding) {
 	return Boolean(binding && (binding.fixture_id || binding.artifact_ref || binding.request_body || Object.keys(binding.route_params || {}).length > 0));
+}
+
+function objectHasValues(value) {
+	return Boolean(value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length > 0);
 }
 
 function bindCrudOperationFixtures(operation, binding) {

--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -209,6 +209,8 @@ function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDurat
 		coverage: workload.coverage || { wordpress_fuzz_coverage: true },
 		runtimeProfile: workload.runtime_profile || workload.runtimeProfile,
 		artifacts: workload.artifacts,
+		fixture_plan: workload.fixture_plan || workload.fixturePlan || workload.metadata?.fixture_plan || workload.metadata?.fixturePlan,
+		rest_mutation_opt_ins: workload.rest_mutation_opt_ins || workload.restMutationOptIns || workload.rest_mutation_opt_in || workload.restMutationOptIn || workload.metadata?.rest_mutation_opt_ins || workload.metadata?.restMutationOptIns,
 		metadata: stripUndefined({ ...(workload.metadata || {}), runner: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA, runtime_capabilities: runtimeCapabilities, workload: stripUndefined({ id: workloadId }) }),
 	});
 }

--- a/wordpress/lib/wordpress-fuzz-runtime-workload-operations.js
+++ b/wordpress/lib/wordpress-fuzz-runtime-workload-operations.js
@@ -11,6 +11,7 @@ const {
 } = require('./wordpress-fuzz-mutation-lifecycle');
 
 const WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_SCHEMA = 'homeboy/wordpress-fuzz-runtime-workload-operation/v1';
+const WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_VALIDATION_SCHEMA = 'homeboy/wordpress-fuzz-runtime-workload-operation-validation/v1';
 
 const FAMILY_COMMANDS = Object.freeze({
 	crud: 'wordpress.crud',
@@ -41,8 +42,21 @@ function buildWordPressFuzzRuntimeWorkloadOperationDescriptor(testCase = {}, opt
 	const missingCapabilities = runtimeCapabilitiesProvided
 		? missingRuntimeCapabilities(requiredCapabilities, options.runtimeCapabilities ?? options.runtime_capabilities)
 		: [];
-	const skipped = missingCapabilities.length > 0;
-	const mutationLifecycle = normalizeWordPressFuzzMutationLifecycleContract(testCase.metadata?.mutation_lifecycle || testCase.metadata?.mutationLifecycle || testCase.mutation_lifecycle || testCase.mutationLifecycle);
+	const readinessBlocker = runtimeReadinessBlockerForOperation(family, testCase, options.runtimeReadiness ?? options.runtime_readiness);
+	const mutationLifecycle = normalizeWordPressFuzzMutationLifecycleContract(testCase.metadata?.mutation_lifecycle || testCase.metadata?.mutationLifecycle || testCase.mutation_lifecycle || testCase.mutationLifecycle) || {};
+	const input = runtimeOperationInput(testCase, { family });
+	const validation = validateWordPressFuzzRuntimeWorkloadOperationPayload({ family, input });
+	const blockers = [
+		...validation.diagnostics.map((diagnostic) => ({ ...diagnostic, blocker: true })),
+		...missingCapabilities.map((capability) => ({
+			code: 'missing-runtime-workload-capability',
+			message: `Runtime workload operation requires capability: ${capability}`,
+			capability,
+			blocker: true,
+		})),
+		...(readinessBlocker ? [readinessBlocker] : []),
+	];
+	const status = validation.ok ? (readinessBlocker?.blocking ? 'blocked' : (missingCapabilities.length > 0 || readinessBlocker ? 'skipped' : 'ready')) : 'blocked';
 
 	return stripUndefined({
 		schema: WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_SCHEMA,
@@ -50,11 +64,13 @@ function buildWordPressFuzzRuntimeWorkloadOperationDescriptor(testCase = {}, opt
 		case_id: testCase.case_id || testCase.caseId || testCase.id,
 		family,
 		command: FAMILY_COMMANDS[family],
-		status: skipped ? 'skipped' : 'ready',
+		status,
 		required_capabilities: requiredCapabilities,
-		missing_capabilities: skipped ? missingCapabilities : undefined,
-		skip_reason: skipped ? 'missing-runtime-workload-capability' : undefined,
-		input: runtimeOperationInput(testCase, { family }),
+		missing_capabilities: missingCapabilities.length > 0 ? missingCapabilities : undefined,
+		skip_reason: readinessBlocker?.skip_reason || (missingCapabilities.length > 0 ? 'missing-runtime-workload-capability' : undefined),
+		blockers: blockers.length > 0 ? blockers : undefined,
+		validation,
+		input,
 		mutation_lifecycle: mutationLifecycle,
 		metadata: stripUndefined({
 			intent: testCase.intent,
@@ -64,6 +80,110 @@ function buildWordPressFuzzRuntimeWorkloadOperationDescriptor(testCase = {}, opt
 	});
 }
 
+function runtimeReadinessBlockerForOperation(family, testCase = {}, readiness) {
+	const source = objectOrUndefined(readiness);
+	if (!source) {
+		return undefined;
+	}
+	if (source.command_available === false) {
+		return {
+			code: 'wp-codebox-fuzz-readiness-command-unavailable',
+			message: 'WP Codebox fuzz readiness command is unavailable; runtime workload operation support cannot be claimed.',
+			skip_reason: 'wp-codebox-fuzz-readiness-command-unavailable',
+			blocking: true,
+			blocker: true,
+		};
+	}
+	const operationKinds = normalizeArray(source.operationKinds || source.operation_kinds);
+	if (operationKinds.length === 0) {
+		return undefined;
+	}
+	const operationKind = readinessOperationKindForFamily(family, testCase);
+	if (!operationKinds.includes(operationKind)) {
+		return {
+			code: 'unsupported-runtime-workload-operation-kind',
+			message: `WP Codebox fuzz readiness does not support ${operationKind} operations for ${family}.`,
+			operation_kind: operationKind,
+			supported_operation_kinds: operationKinds,
+			skip_reason: 'unsupported-runtime-workload-operation-kind',
+			blocker: true,
+		};
+	}
+	if (operationKind === 'mutation' && !readinessSupportsMutationIsolation(source)) {
+		return {
+			code: 'wp-codebox-fuzz-mutation-isolation-unsupported',
+			message: 'WP Codebox fuzz readiness does not declare mutation isolation support; mutating REST operations cannot execute.',
+			operation_kind: operationKind,
+			skip_reason: 'wp-codebox-fuzz-mutation-isolation-unsupported',
+			blocking: true,
+			blocker: true,
+		};
+	}
+	if (operationKind === 'mutation' && restDeleteBoundaryRequired(testCase) && !readinessSupportsDeleteBoundary(source)) {
+		return {
+			code: 'wp-codebox-fuzz-delete-boundary-unsupported',
+			message: 'WP Codebox fuzz readiness does not declare delete-boundary support; DELETE mutation cases cannot execute.',
+			operation_kind: operationKind,
+			skip_reason: 'wp-codebox-fuzz-delete-boundary-unsupported',
+			blocking: true,
+			blocker: true,
+		};
+	}
+	if (source.status === 'unsupported') {
+		return {
+			code: 'wp-codebox-fuzz-readiness-unsupported',
+			message: 'WP Codebox fuzz readiness reports this runner as unsupported for the requested fuzz contract.',
+			skip_reason: 'wp-codebox-fuzz-readiness-unsupported',
+			blocker: true,
+		};
+	}
+	return undefined;
+}
+
+function readinessSupportsMutationIsolation(readiness = {}) {
+	const capabilities = objectOrUndefined(readiness.capabilities) || {};
+	const mutation = objectOrUndefined(readiness.mutation) || objectOrUndefined(capabilities.mutation) || {};
+	const isolation = objectOrUndefined(readiness.isolation) || objectOrUndefined(capabilities.isolation) || {};
+	return readiness.mutationIsolation === true
+		|| readiness.mutation_isolation === true
+		|| capabilities.mutationIsolation === true
+		|| capabilities.mutation_isolation === true
+		|| mutation.isolated === true
+		|| mutation.isolation === true
+		|| isolation.mutation === true
+		|| isolation.checkpoint === true
+		|| isolation.snapshot === true;
+}
+
+function restDeleteBoundaryRequired(testCase = {}) {
+	const mutationLifecycle = normalizeWordPressFuzzMutationLifecycleContract(testCase.metadata?.mutation_lifecycle || testCase.metadata?.mutationLifecycle || testCase.mutation_lifecycle || testCase.mutationLifecycle) || {};
+	return mutationLifecycle.delete_boundary_required === true || String(testCase.operation?.method || '').toUpperCase() === 'DELETE';
+}
+
+function readinessSupportsDeleteBoundary(readiness = {}) {
+	const capabilities = objectOrUndefined(readiness.capabilities) || {};
+	const mutation = objectOrUndefined(readiness.mutation) || objectOrUndefined(capabilities.mutation) || {};
+	const deleteBoundary = objectOrUndefined(readiness.delete_boundary) || objectOrUndefined(readiness.deleteBoundary) || objectOrUndefined(capabilities.delete_boundary) || objectOrUndefined(capabilities.deleteBoundary) || {};
+	return readiness.deleteBoundary === true
+		|| readiness.delete_boundary === true
+		|| capabilities.deleteBoundary === true
+		|| capabilities.delete_boundary === true
+		|| mutation.delete_boundary === true
+		|| mutation.deleteBoundary === true
+		|| deleteBoundary.supported === true;
+}
+
+function readinessOperationKindForFamily(family, testCase = {}) {
+	if (family === 'crud') {
+		return 'crud';
+	}
+	const mutationLifecycle = normalizeWordPressFuzzMutationLifecycleContract(testCase.metadata?.mutation_lifecycle || testCase.metadata?.mutationLifecycle || testCase.mutation_lifecycle || testCase.mutationLifecycle) || {};
+	if (mutationLifecycle.delete_boundary_required || mutationLifecycle.mutates || ['POST', 'PUT', 'PATCH', 'DELETE'].includes(String(testCase.operation?.method || '').toUpperCase())) {
+		return 'mutation';
+	}
+	return 'read';
+}
+
 function attachWordPressFuzzRuntimeWorkloadOperationDescriptor(testCase = {}, options = {}) {
 	const runtimeOperation = buildWordPressFuzzRuntimeWorkloadOperationDescriptor(testCase, options);
 	if (!runtimeOperation) {
@@ -71,7 +191,7 @@ function attachWordPressFuzzRuntimeWorkloadOperationDescriptor(testCase = {}, op
 	}
 
 	const metadata = objectOrUndefined(testCase.metadata) || {};
-	if (runtimeOperation.status !== 'skipped') {
+	if (runtimeOperation.status === 'ready') {
 		return stripUndefined({
 			...testCase,
 			runtime_operation: runtimeOperation,
@@ -84,12 +204,15 @@ function attachWordPressFuzzRuntimeWorkloadOperationDescriptor(testCase = {}, op
 
 	const skipReasons = reasonList(testCase.skip_reasons || testCase.skipReasons || testCase.skip_reason || testCase.skipReason);
 	const requiredCapabilities = mergeCapabilities(testCase.required_capabilities || testCase.requiredCapabilities, runtimeOperation.required_capabilities);
+	const operationSkipReasons = runtimeOperation.status === 'blocked'
+		? ['invalid-runtime-workload-operation']
+		: [runtimeOperation.skip_reason];
 	return stripUndefined({
 		...testCase,
 		executable: false,
 		execution_tier: 'plan_only',
 		required_capabilities: requiredCapabilities,
-		skip_reasons: reasonList([...skipReasons, runtimeOperation.skip_reason]),
+		skip_reasons: reasonList([...skipReasons, ...operationSkipReasons]),
 		runtime_operation: runtimeOperation,
 		metadata: stripUndefined({
 			...metadata,
@@ -97,11 +220,92 @@ function attachWordPressFuzzRuntimeWorkloadOperationDescriptor(testCase = {}, op
 			execution_tier: 'plan_only',
 			planned: true,
 			gated: true,
-			runtime_workload_capability_gated: true,
+			runtime_workload_capability_gated: runtimeOperation.missing_capabilities?.length > 0,
 			missing_runtime_workload_capabilities: runtimeOperation.missing_capabilities,
+			runtime_workload_operation_blocked: runtimeOperation.status === 'blocked' || undefined,
+			runtime_workload_operation_validation: runtimeOperation.validation,
 			runtime_operation: runtimeOperation,
 		}),
 	});
+}
+
+function validateWordPressFuzzRuntimeWorkloadOperationPayload(operation = {}) {
+	const family = operation.family;
+	const input = objectOrUndefined(operation.input) || {};
+	const diagnostics = [];
+	if (!FAMILY_COMMANDS[family]) {
+		diagnostics.push(validationDiagnostic('unsupported-runtime-workload-operation-family', `Unsupported runtime workload operation family: ${family || '(missing)'}`, 'family'));
+	}
+	for (const field of requiredInputFieldsForFamily(family, input)) {
+		if (input[field] === undefined || input[field] === null || String(input[field]).trim() === '') {
+			diagnostics.push(validationDiagnostic('missing-runtime-workload-operation-field', `Runtime workload operation ${family} requires input.${field}.`, `input.${field}`));
+		}
+	}
+	return {
+		schema: WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_VALIDATION_SCHEMA,
+		ok: diagnostics.length === 0,
+		family,
+		diagnostics,
+	};
+}
+
+function validateWordPressFuzzRuntimeWorkloadOperationDescriptor(descriptor = {}) {
+	if (!objectOrUndefined(descriptor)) {
+		return {
+			schema: WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_VALIDATION_SCHEMA,
+			ok: false,
+			diagnostics: [validationDiagnostic('runtime-workload-operation-must-be-object', 'Runtime workload operation descriptor must be an object.', '')],
+		};
+	}
+	return validateWordPressFuzzRuntimeWorkloadOperationPayload({ family: descriptor.family, input: descriptor.input });
+}
+
+function requiredInputFieldsForFamily(family, input = {}) {
+	if (family === 'crud') {
+		return ['action', 'resource_type'];
+	}
+	if (family === 'rest') {
+		return ['route'];
+	}
+	if (family === 'admin_page' || family === 'frontend_page') {
+		return ['path'];
+	}
+	if (family === 'block') {
+		return ['block_name'];
+	}
+	if (family === 'database') {
+		return input.table || input.query || input.statement ? [] : ['query'];
+	}
+	return [];
+}
+
+function validationDiagnostic(code, message, path) {
+	return stripUndefined({ code, message, path });
+}
+
+function summarizeWordPressFuzzRuntimeWorkloadOperations(plan = {}) {
+	const operations = normalizeArray(plan.targets).flatMap((target) => normalizeArray(target.cases).map((testCase) => testCase.runtime_operation).filter(Boolean));
+	const byStatus = {};
+	const byFamily = {};
+	const byFamilyStatus = {};
+	const blockers = [];
+	for (const operation of operations) {
+		byStatus[operation.status] = (byStatus[operation.status] || 0) + 1;
+		byFamily[operation.family] = (byFamily[operation.family] || 0) + 1;
+		byFamilyStatus[operation.family] = byFamilyStatus[operation.family] || {};
+		byFamilyStatus[operation.family][operation.status] = (byFamilyStatus[operation.family][operation.status] || 0) + 1;
+		for (const blocker of normalizeArray(operation.blockers)) {
+			blockers.push(stripUndefined({ operation_id: operation.id, case_id: operation.case_id, family: operation.family, ...blocker }));
+		}
+	}
+	return {
+		schema: 'homeboy/wordpress-fuzz-runtime-workload-operation-summary/v1',
+		total: operations.length,
+		by_status: byStatus,
+		by_family: byFamily,
+		by_family_status: byFamilyStatus,
+		blockers,
+	};
 }
 
 function requiredCapabilitiesForWordPressFuzzRuntimeOperation(testCase = {}, options = {}) {
@@ -149,20 +353,21 @@ function extraCapabilitiesForCase(testCase = {}, family) {
 
 function runtimeOperationInput(testCase = {}, { family } = {}) {
 	const operation = objectOrUndefined(testCase.operation) || {};
+	const surface = objectOrUndefined(testCase.metadata?.surface || testCase.target_metadata?.surface || testCase.target_metadata) || {};
 	if (family === 'crud') {
 		return operation;
 	}
 	if (family === 'rest') {
-		return stripUndefined({ method: operation.method || 'GET', route: operation.route || operation.path, route_params: operation.route_params, request_body: operation.request_body });
+		return stripUndefined({ method: operation.method || surface.method || 'GET', route: operation.route || operation.path || surface.route || surface.path || surface.metadata?.value, route_params: operation.route_params, request_body: operation.request_body });
 	}
 	if (family === 'admin_page' || family === 'frontend_page') {
-		return stripUndefined({ path: operation.path || operation.url, method: operation.method || 'GET', interaction: operation.interaction });
+		return stripUndefined({ path: operation.path || operation.url || surface.path || surface.url || surface.metadata?.value, method: operation.method || surface.method || 'GET', interaction: operation.interaction });
 	}
 	if (family === 'block') {
-		return stripUndefined({ block_name: operation.block_name || operation.blockName || operation.name, lifecycle: operation.lifecycle, attributes: operation.attributes_sample || operation.attributes });
+		return stripUndefined({ block_name: operation.block_name || operation.blockName || operation.name || surface.block_name || surface.blockName || surface.name, lifecycle: operation.lifecycle, attributes: operation.attributes_sample || operation.attributes || surface.attributes_sample || surface.attributes });
 	}
 	if (family === 'database') {
-		return stripUndefined({ table: operation.table, query: operation.query, statement: operation.statement, mutation: operation.mutation, observation: operation.observation || operation.profile });
+		return stripUndefined({ table: operation.table || surface.table, query: operation.query || surface.query, statement: operation.statement || surface.statement, mutation: operation.mutation, observation: operation.observation || operation.profile });
 	}
 	return operation;
 }
@@ -201,7 +406,11 @@ function stripUndefined(value) {
 
 module.exports = {
 	WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_SCHEMA,
+	WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_VALIDATION_SCHEMA,
 	attachWordPressFuzzRuntimeWorkloadOperationDescriptor,
 	buildWordPressFuzzRuntimeWorkloadOperationDescriptor,
 	requiredCapabilitiesForWordPressFuzzRuntimeOperation,
+	summarizeWordPressFuzzRuntimeWorkloadOperations,
+	validateWordPressFuzzRuntimeWorkloadOperationDescriptor,
+	validateWordPressFuzzRuntimeWorkloadOperationPayload,
 };

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -50,12 +50,23 @@ const {
 	requiredWpCodeboxContractsForFuzzPlan,
 } = require('./wordpress-fuzz-command-manifest');
 
+let loadCanonicalRuntimeContractSourceSync;
+
+try {
+	({
+		loadCanonicalRuntimeContractSourceSync,
+	} = require('../../agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source'));
+} catch {
+	loadCanonicalRuntimeContractSourceSync = null;
+}
+
 const WP_CODEBOX_FUZZ_SUITE_SCHEMA = 'wp-codebox/fuzz-suite/v1';
 const WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA = 'wp-codebox/fuzz-suite-result/v1';
 const WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA = 'wp-codebox/wordpress-hotspots/v1';
 const WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA = 'homeboy/wordpress-codebox-fuzz-suite-consumer/v1';
 const WP_CODEBOX_FUZZ_EXECUTION_SCHEMA = 'homeboy/wp-codebox-fuzz-execution/v1';
 const WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA = 'homeboy/wp-codebox-fuzz-preflight/v1';
+const WP_CODEBOX_FUZZ_RUNNER_READINESS_SCHEMA = 'wp-codebox/fuzz-runner-readiness/v1';
 const WORDPRESS_FUZZ_OBSERVATION_SCHEMA = 'homeboy/wordpress-fuzz-observation/v1';
 const DEFAULT_FUZZ_SUITE_ABILITY = 'wp-codebox/run-fuzz-suite';
 const DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY = 'wp-codebox/run-wordpress-workload';
@@ -188,36 +199,58 @@ const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 	coverage: 'fuzz.coverage',
 };
 
-const FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST = {
-	schema: 'wp-codebox/runtime-contract-manifest/v1',
-	version: 1,
-	schemas: {
-		wordpressRuntime: {
-			workloadRun: DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA,
-			fuzzSuite: WP_CODEBOX_FUZZ_SUITE_SCHEMA,
-			fuzzSuiteResult: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
-		},
-	},
-	abilities: {
-		wordpressRuntime: {
-			runWorkload: DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY,
-			runFuzzSuite: DEFAULT_FUZZ_SUITE_ABILITY,
-		},
-	},
-};
+const REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS = [
+	'abilities.wordpressRuntime.runFuzzSuite',
+	'abilities.wordpressRuntime.runWorkload',
+	'schemas.wordpressRuntime.fuzzSuite',
+	'schemas.wordpressRuntime.fuzzSuiteResult',
+	'schemas.wordpressRuntime.workloadRun',
+];
 
 function wpCodeboxRuntimeContractManifest(options = {}) {
 	const manifest = options.runtimeContractManifest || options.runtime_contract_manifest || options.manifest || options.contractManifest || options.contract_manifest;
-	return objectOrUndefined(manifest) ? manifest : FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST;
+	if (objectOrUndefined(manifest)) {
+		return manifest;
+	}
+	const source = wpCodeboxCanonicalRuntimeContractSource(options);
+	return source?.manifest || null;
 }
 
 function wpCodeboxWordPressRuntimeContracts(options = {}) {
 	const manifest = wpCodeboxRuntimeContractManifest(options);
 	return {
 		manifest,
-		abilities: objectOrUndefined(manifest.abilities?.wordpressRuntime) || FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST.abilities.wordpressRuntime,
-		schemas: objectOrUndefined(manifest.schemas?.wordpressRuntime) || FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST.schemas.wordpressRuntime,
+		abilities: objectOrUndefined(manifest?.abilities?.wordpressRuntime) || {},
+		schemas: objectOrUndefined(manifest?.schemas?.wordpressRuntime) || {},
 	};
+}
+
+function wpCodeboxCanonicalRuntimeContractSource(options = {}) {
+	if (typeof options.loadRuntimeContractSource === 'function') {
+		return options.loadRuntimeContractSource(options);
+	}
+	if (typeof options.loadCanonicalRuntimeContractSourceSync === 'function') {
+		return options.loadCanonicalRuntimeContractSourceSync({ ...options, required: false });
+	}
+	if (!loadCanonicalRuntimeContractSourceSync) {
+		return null;
+	}
+	try {
+		return loadCanonicalRuntimeContractSourceSync({ ...options, required: false });
+	} catch {
+		return null;
+	}
+}
+
+function missingWpCodeboxFuzzRuntimeContractPaths(manifest) {
+	if (!objectOrUndefined(manifest)) {
+		return [...REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS];
+	}
+	return REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS.filter((pathName) => typeof valueAtPath(manifest, pathName) !== 'string' || valueAtPath(manifest, pathName).trim() === '');
+}
+
+function valueAtPath(value, pathName) {
+	return pathName.split('.').reduce((current, part) => current?.[part], value);
 }
 
 function wpCodeboxFuzzSuiteAbility(options = {}) {
@@ -245,6 +278,8 @@ function wpCodeboxFuzzSuiteInput(options = {}) {
 	const cases = normalizeWpCodeboxFuzzSuiteCases(source || options);
 	const artifacts = source?.artifacts || options.artifacts;
 	const postprocessBinding = options.postprocessBinding || options.postprocess_binding || source?.postprocess_binding || source?.postprocessBinding;
+	const fixturePlan = normalizeFuzzFixturePlan(options.fixturePlan || options.fixture_plan || options.metadata?.fixture_plan || options.metadata?.fixturePlan || source?.fixture_plan || source?.fixturePlan || source?.metadata?.fixture_plan || source?.metadata?.fixturePlan);
+	const restMutationOptIns = normalizeRestMutationOptIns(options.restMutationOptIns || options.rest_mutation_opt_ins || options.restMutationOptIn || options.rest_mutation_opt_in || options.metadata?.rest_mutation_opt_ins || options.metadata?.restMutationOptIns || source?.rest_mutation_opt_ins || source?.restMutationOptIns || source?.metadata?.rest_mutation_opt_ins || source?.metadata?.restMutationOptIns);
 	return stripUndefined({
 		schema: wpCodeboxFuzzSuiteSchema(options),
 		id: options.id || options.runId || options.run_id,
@@ -257,6 +292,8 @@ function wpCodeboxFuzzSuiteInput(options = {}) {
 			...(objectOrUndefined(options.metadata) || {}),
 			workload: objectOrUndefined(options.workload),
 			seeds: normalizeArray(options.seeds).length > 0 ? normalizeArray(options.seeds) : undefined,
+			fixture_plan: fixturePlan,
+			rest_mutation_opt_ins: restMutationOptIns,
 			limits: objectOrUndefined(options.limits),
 			coverage: objectOrUndefined(options.coverage),
 			runtime_profile: objectOrUndefined(options.runtimeProfile || options.runtime_profile),
@@ -264,6 +301,70 @@ function wpCodeboxFuzzSuiteInput(options = {}) {
 			postprocess_binding: objectOrUndefined(postprocessBinding),
 		}),
 	});
+}
+
+function normalizeFuzzFixturePlan(value) {
+	const plan = objectOrUndefined(value);
+	if (!plan) {
+		return undefined;
+	}
+	const refs = normalizeManifestRefs(plan.refs || plan.ref || plan.artifact_refs || plan.artifactRefs);
+	const data = objectOrUndefined(plan.data || plan.fixtures || plan.fixture_data || plan.fixtureData);
+	return stripUndefined({
+		schema: plan.schema || 'homeboy/wordpress-fuzz-fixture-plan/v1',
+		id: plan.id || plan.plan_id || plan.planId,
+		refs: refs.length > 0 ? refs : undefined,
+		data,
+		metadata: objectOrUndefined(plan.metadata),
+	});
+}
+
+function normalizeRestMutationOptIns(value) {
+	const manifest = Array.isArray(value) ? value : objectOrUndefined(value);
+	if (!manifest) {
+		return undefined;
+	}
+	const manifestObject = Array.isArray(manifest) ? {} : manifest;
+	const refs = normalizeManifestRefs(manifestObject.refs || manifestObject.ref || manifestObject.artifact_refs || manifestObject.artifactRefs);
+	const entries = (Array.isArray(manifest) ? manifest : normalizeArray(manifest.entries || manifest.opt_ins || manifest.optIns || manifest.cases || manifest.routes))
+		.map(normalizeRestMutationOptInEntry)
+		.filter(Boolean);
+	return stripUndefined({
+		schema: manifestObject.schema || 'homeboy/wordpress-rest-mutation-opt-ins/v1',
+		id: manifestObject.id || manifestObject.manifest_id || manifestObject.manifestId,
+		refs: refs.length > 0 ? refs : undefined,
+		entries: entries.length > 0 ? entries : undefined,
+		data: objectOrUndefined(manifestObject.data),
+		metadata: objectOrUndefined(manifestObject.metadata),
+	});
+}
+
+function normalizeRestMutationOptInEntry(entry = {}) {
+	const source = objectOrUndefined(entry);
+	if (!source) {
+		return undefined;
+	}
+	return stripUndefined({
+		id: source.id || source.opt_in_id || source.optInId,
+		surface_id: source.surface_id || source.surfaceId,
+		route: source.route || source.path,
+		method: source.method ? String(source.method).toUpperCase() : undefined,
+		allowed: source.allowed !== false,
+		fixture_ref: source.fixture_ref || source.fixtureRef,
+		contract_ref: source.contract_ref || source.contractRef,
+		metadata: objectOrUndefined(source.metadata),
+	});
+}
+
+function normalizeManifestRefs(value) {
+	const refs = Array.isArray(value) ? value : (value === undefined || value === null ? [] : [value]);
+	return refs.map((entry) => {
+		if (typeof entry === 'string') {
+			return { ref: entry };
+		}
+		const source = objectOrUndefined(entry);
+		return source ? stripUndefined({ id: source.id, ref: source.ref || source.url || source.path, path: source.path, pointer: source.pointer, semantic_key: source.semantic_key || source.semanticKey }) : undefined;
+	}).filter(Boolean);
 }
 
 function wordpressFuzzPostprocessBinding(options = {}) {
@@ -331,6 +432,7 @@ function homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry = {}, manifest = {}, i
 	const artifacts = normalizeHomeboyFuzzCaseArtifacts(entry, manifest);
 	const command = homeboyFuzzPlanCaseRuntimeCommand(entry);
 	const input = homeboyFuzzPlanCaseRuntimeInput(entry, manifest, caseId);
+	const restMutationOptIn = objectOrUndefined(entry.metadata?.rest_mutation_opt_in || entry.metadata?.restMutationOptIn || entry.rest_mutation_opt_in || entry.restMutationOptIn);
 	return stripUndefined({
 		id: caseId,
 		case_id: caseId,
@@ -342,6 +444,7 @@ function homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry = {}, manifest = {}, i
 		artifacts,
 		metadata: stripUndefined({
 			...(objectOrUndefined(entry.metadata) || {}),
+			rest_mutation_opt_in: restMutationOptIn,
 			source_schema: HOMEBOY_FUZZ_WORKLOAD_SCHEMA,
 			source_manifest_id: manifest.id,
 			source_plan_case: true,
@@ -388,6 +491,8 @@ function homeboyFuzzPlanCaseRuntimeInput(entry = {}, manifest = {}, caseId) {
 	if (objectOrUndefined(entry.input)) {
 		return homeboyFuzzRuntimeCommandInput(entry.input);
 	}
+	const restMutationOptIn = objectOrUndefined(entry.metadata?.rest_mutation_opt_in || entry.metadata?.restMutationOptIn || entry.rest_mutation_opt_in || entry.restMutationOptIn);
+	const fixtureBinding = objectOrUndefined(entry.metadata?.fixture_binding || entry.metadata?.fixtureBinding || entry.fixture_binding || entry.fixtureBinding);
 	return stripUndefined({
 		case_id: caseId,
 		target_id: entry.target_id,
@@ -395,6 +500,8 @@ function homeboyFuzzPlanCaseRuntimeInput(entry = {}, manifest = {}, caseId) {
 		intent: entry.intent,
 		operation_id: entry.operation_id || entry.operationId,
 		operation: objectOrUndefined(entry.operation),
+		fixture_binding: fixtureBinding,
+		rest_mutation_opt_in: restMutationOptIn,
 		mutation_lifecycle: objectOrUndefined(entry.metadata?.mutation_lifecycle || entry.metadata?.mutationLifecycle || entry.mutation_lifecycle || entry.mutationLifecycle),
 		runtime_operation: objectOrUndefined(entry.runtime_operation || entry.runtimeOperation || entry.metadata?.runtime_operation || entry.metadata?.runtimeOperation),
 		seed: entry.seed || manifest.seed,
@@ -467,7 +574,7 @@ function homeboyFuzzRuntimeCommandInput(input) {
 	if (!direct) {
 		return undefined;
 	}
-	if (Array.isArray(direct.args)) {
+	if (Array.isArray(direct.args) || direct.operation || direct.runtime_operation || direct.fixture_binding || direct.rest_mutation_opt_in || direct.mutation_lifecycle) {
 		return direct;
 	}
 	const args = homeboyFuzzCommandArgs(direct);
@@ -981,6 +1088,9 @@ function wpCodeboxRuntimePluginSlug(runtimeRequirements = {}) {
 }
 
 function detectWpCodeboxPublicFuzzCapabilities(options = {}) {
+	if (options.publicCliReadiness || options.public_cli_readiness || options.readiness?.schema === WP_CODEBOX_FUZZ_RUNNER_READINESS_SCHEMA) {
+		return normalizeWpCodeboxPublicFuzzCapabilitiesFromReadiness(options.publicCliReadiness || options.public_cli_readiness || options.readiness);
+	}
 	if (options.publicCliCapabilities || options.public_cli_capabilities) {
 		return normalizeWpCodeboxPublicFuzzCapabilities(options.publicCliCapabilities || options.public_cli_capabilities);
 	}
@@ -988,12 +1098,31 @@ function detectWpCodeboxPublicFuzzCapabilities(options = {}) {
 		return normalizeWpCodeboxPublicFuzzCapabilities(options.capabilities.public_cli || options.capabilities.publicCli);
 	}
 
+	const readiness = runWpCodeboxPublicFuzzReadiness(options);
+	if (readiness.status === 0) {
+		return normalizeWpCodeboxPublicFuzzCapabilitiesFromReadiness(parseWpCodeboxPublicCliJson(readiness.stdout, { command: 'fuzz readiness' }));
+	}
+
 	const commands = {};
 	for (const command of WP_CODEBOX_PUBLIC_CLI_COMMANDS) {
 		const result = runWpCodeboxPublicCliHelp(command, options);
 		commands[command] = result.status === 0;
 	}
-	return normalizeWpCodeboxPublicFuzzCapabilities({ commands });
+	return normalizeWpCodeboxPublicFuzzCapabilities({
+		commands,
+		readiness: {
+			schema: WP_CODEBOX_FUZZ_RUNNER_READINESS_SCHEMA,
+			status: 'blocked',
+			command_available: false,
+			diagnostics: [{
+				severity: 'error',
+				code: 'wp_codebox_fuzz_readiness_command_unavailable',
+				message: 'WP Codebox public CLI must expose `fuzz readiness --format=json` before Homeboy dispatches WordPress fuzz workloads.',
+				stderr: readiness.stderr || undefined,
+				stdout: readiness.stdout || undefined,
+			}],
+		},
+	});
 }
 
 function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
@@ -1002,7 +1131,7 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 	const identityDiagnostics = wpCodeboxIdentityMismatchDiagnostics(wpCodeboxIdentity);
 	const capabilities = detectWpCodeboxPublicFuzzCapabilities(options);
 	const manifest = wpCodeboxRuntimeContractManifest(options);
-	const wordpressRuntimeAbilities = objectOrUndefined(manifest.abilities?.wordpressRuntime) || {};
+	const wordpressRuntimeAbilities = objectOrUndefined(manifest?.abilities?.wordpressRuntime) || {};
 	const commandManifest = buildWordPressFuzzCommandManifest();
 	const suiteInput = wpCodeboxFuzzRequestInput(request, options);
 	const plan = suiteInput.homeboy_fuzz_workload?.plan || suiteInput.homeboyFuzzWorkload?.plan || suiteInput.metadata?.workload?.plan || request?.input?.plan || options.plan || {};
@@ -1010,11 +1139,36 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 	const requiredAbilities = { ...WP_CODEBOX_FUZZ_PUBLIC_ABILITIES };
 	const requiredCommands = requiredPublicCommandsForRequest(request, requiredPlanContracts);
 	const missingContracts = [];
+	if (capabilities.readiness?.command_available === false) {
+		missingContracts.push({
+			type: 'public_cli_readiness_command',
+			command: 'fuzz readiness',
+			message: 'WP Codebox public CLI must expose `fuzz readiness --format=json` before Homeboy dispatches WordPress fuzz workloads.',
+			readiness: capabilities.readiness,
+		});
+	}
+	if (capabilities.readiness?.status === 'unsupported') {
+		missingContracts.push({
+			type: 'public_cli_readiness',
+			message: 'WP Codebox fuzz readiness reports this runtime as unsupported for the requested fuzz contract.',
+			unsupported_capabilities: normalizeArray(capabilities.readiness.unsupportedRequiredCapabilities || capabilities.readiness.unsupported_required_capabilities),
+			readiness: capabilities.readiness,
+		});
+	}
 	for (const diagnostic of identityDiagnostics) {
 		missingContracts.push({
 			type: 'identity_mismatch',
 			message: diagnostic.message,
 			diagnostic,
+		});
+	}
+
+	const missingManifestPaths = missingWpCodeboxFuzzRuntimeContractPaths(manifest);
+	if (missingManifestPaths.length > 0) {
+		missingContracts.push({
+			type: 'runtime_contract_manifest',
+			missing_paths: missingManifestPaths,
+			message: `WP Codebox runtime contract manifest must declare required WordPress fuzz contracts: ${missingManifestPaths.join(', ')}.`,
 		});
 	}
 
@@ -1138,12 +1292,50 @@ function unique(values) {
 function normalizeWpCodeboxPublicFuzzCapabilities(input = {}) {
 	const commands = objectOrUndefined(input.commands) || input;
 	const runtimeCapabilities = normalizeWordPressFuzzRuntimeCapabilities(input.capabilities || input.runtime_capabilities || input.runtimeCapabilities || input.supports || []);
+	const readiness = objectOrUndefined(input.readiness) || objectOrUndefined(input.runtime_readiness) || objectOrUndefined(input.runtimeReadiness);
 	return {
 		schema: 'homeboy/wp-codebox-public-fuzz-capabilities/v1',
 		commands: Object.fromEntries(WP_CODEBOX_PUBLIC_CLI_COMMANDS.map((command) => [command, commands[command] === true])),
 		capabilities: runtimeCapabilities.capabilities,
 		runner_modes: Object.fromEntries(WP_CODEBOX_FUZZ_PUBLIC_RUNNER_MODES.map((runnerMode) => [runnerMode, input.runner_modes?.[runnerMode] !== false && input.runnerModes?.[runnerMode] !== false])),
+		readiness,
 	};
+}
+
+function normalizeWpCodeboxPublicFuzzCapabilitiesFromReadiness(readiness = {}) {
+	const source = objectOrUndefined(readiness) || {};
+	const nestedCapabilities = objectOrUndefined(source.capabilities) || {};
+	const commands = new Set(normalizeArray(nestedCapabilities.commands));
+	return normalizeWpCodeboxPublicFuzzCapabilities({
+		commands: {
+			'run-fuzz-suite': source.entrypoint === 'run-fuzz-suite' || String(source.entrypoint || '').startsWith('run-fuzz-suite'),
+			'run-wordpress-workload': commands.has('wordpress.run-workload'),
+		},
+		capabilities: wordpressRuntimeCapabilitiesFromFuzzReadiness(source),
+		runner_modes: { [source.mode || 'runtime-backed']: source.status !== 'unsupported' },
+		readiness: {
+			...source,
+			command_available: source.schema === WP_CODEBOX_FUZZ_RUNNER_READINESS_SCHEMA,
+		},
+	});
+}
+
+function wordpressRuntimeCapabilitiesFromFuzzReadiness(readiness = {}) {
+	const capabilities = objectOrUndefined(readiness.capabilities) || {};
+	const runtimeActions = new Set(normalizeArray(capabilities.runtimeActionTypes || capabilities.runtime_action_types));
+	const commands = new Set(normalizeArray(capabilities.commands));
+	return unique([
+		...(runtimeActions.has('crud_operation') || commands.has('wordpress.crud-operation') ? ['crud'] : []),
+		...(runtimeActions.has('rest_request') || commands.has('wordpress.rest-request') ? ['rest'] : []),
+		...(runtimeActions.has('admin_page') || commands.has('wordpress.simulated-admin-page-load') ? ['admin'] : []),
+		...(runtimeActions.has('browser') || runtimeActions.has('page') || commands.has('wordpress.browser-page-load') || commands.has('wordpress.server-page-load') ? ['browser'] : []),
+		...(runtimeActions.has('editor_open') ? ['block-editor'] : []),
+		...(runtimeActions.has('db_operation') || commands.has('wordpress.db-operation') ? ['database', 'query-observation'] : []),
+	]);
+}
+
+function runWpCodeboxPublicFuzzReadiness(options = {}) {
+	return runWpCodeboxPublicCliCommand(['fuzz', 'readiness', '--format=json'], options);
 }
 
 function publicFuzzCliCommandForRequest(request = {}, capabilities = {}) {
@@ -2370,7 +2562,7 @@ module.exports = {
 	DEFAULT_FUZZ_SUITE_ABILITY,
 	DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY,
 	DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA,
-	FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST,
+	REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS,
 	DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
 	DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
 	ARTIFACT_POSTPROCESS_COMMAND,

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -196,7 +196,7 @@ function requiresCodeboxTaskAdapter(request) {
 }
 
 function wpCodeboxCommandFromPublicAbility(ability, options = {}) {
-	const contracts = wpCodeboxRuntimeContractManifest(options).abilities?.wordpressRuntime || {};
+	const contracts = wpCodeboxRuntimeContractManifest(options)?.abilities?.wordpressRuntime || {};
 	const publicAbilities = new Set([
 		contracts.runWorkload,
 		contracts.runFuzzSuite,

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -182,7 +182,7 @@ assert.equal(classifyResourceUrl('https://example.test/wp-content/themes/theme/s
 assert.equal(resourceFamily('https://example.test/wp-includes/js/dist/block-editor.min.js?ver=1'), '/wp-includes/js/dist/block-editor.js');
 assert.equal(resourceFamily('https://example.test/wp-content/plugins/example-plugin/assets/admin.js?ver=1'), '/wp-content/plugins/example-plugin');
 assert.equal(DEFAULT_THIRD_PARTY_WATERFALL_GROUPS.some((group) => group.id === 'woocommerce-store-api'), false);
-assert.equal(WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS.woocommerce.firstPartyWaterfallGroupIds[0], 'woocommerce-store-api');
+assert.deepEqual(WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS, {});
 
 const manifest = normalizePageManifest({
 	pages: [
@@ -703,7 +703,10 @@ process.stdout.write(JSON.stringify(output) + '\\n');
 		assert.equal(standaloneAttribution.groups.find((group) => group.id === 'woocommerce-store-api'), undefined);
 		const woocommerceAttribution = summarizeThirdPartyWaterfall(browserNetworkRows, {
 			baseUrl: 'https://example.test',
-			productAdapters: ['woocommerce'],
+			productAdapters: [{
+				waterfallGroups: [{ id: 'woocommerce-store-api', label: 'WooCommerce Store API', urlIncludes: ['/wp-json/wc/store/', 'rest_route=/wc/store/'] }],
+				firstPartyWaterfallGroupIds: ['woocommerce-store-api'],
+			}],
 		});
 		assert.equal(woocommerceAttribution.groups.find((group) => group.id === 'woocommerce-store-api').responseCount, 1);
 		assert.equal(woocommerceAttribution.thirdPartyGroupCount, 3);

--- a/wordpress/tests/wordpress-fuzz-campaign-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-campaign-smoke.js
@@ -37,9 +37,14 @@ assert.equal(campaign.workload.schema, 'homeboy/fuzz-workload/v1');
 assert.equal(campaign.wp_codebox.schema, 'wp-codebox/fuzz-suite/v1');
 assert.equal(campaign.wp_codebox.input.schema, 'wp-codebox/fuzz-suite/v1');
 assert.equal(campaign.wp_codebox.task_request.executor.config.runtime_task.input.schema, 'wp-codebox/fuzz-suite/v1');
-assert.equal(campaign.wp_codebox.task_request.executor.config.runtime_task.input.cases[0].target.entrypoint, 'wordpress.run-fuzz-case');
-assert.equal(campaign.wp_codebox.task_request.executor.config.runtime_task.input.cases[0].phases.action[0].command, 'wordpress.run-fuzz-case');
+assert.equal(campaign.wp_codebox.task_request.executor.config.runtime_task.input.cases[0].target.entrypoint, 'wordpress.load-admin-page');
+assert.equal(campaign.wp_codebox.task_request.executor.config.runtime_task.input.cases[0].phases.action[0].command, 'wordpress.load-admin-page');
 assert(campaign.wp_codebox.input.metadata.coverage_manifest.surfaces.length > 0);
+assert.equal(campaign.workload.metadata.runtime_operations.schema, 'homeboy/wordpress-fuzz-runtime-workload-operation-summary/v1');
+assert.equal(campaign.workload.metadata.runtime_operations.by_family.rest, 1);
+assert.equal(campaign.workload.metadata.runtime_operations.by_family.admin_page, 1);
+assert.equal(campaign.workload.metadata.runtime_operations.by_status.ready, 2);
+assert.equal(campaign.wp_codebox.input.metadata.runtime_operations.total, 2);
 assert.deepEqual(Object.keys(campaign.aggregation_hooks).sort(), ['coverage', 'gaps', 'performance']);
 assert.equal(campaign.metadata.surface_count, 2);
 assert.equal(campaign.metadata.target_count, 2);
@@ -92,6 +97,32 @@ const readOnlyCampaign = compileWordPressFuzzCampaign({
 	plan: { runtimeCapabilities: { capabilities: ['crud', 'snapshot', 'restore', 'reset'] } },
 });
 assert.equal(readOnlyCampaign.plan.metadata.mutation_mode, 'read_only');
+
+const optInCampaign = compileWordPressFuzzCampaign({
+	id: 'opt-in-campaign',
+	mutation_mode: 'isolated',
+	surfaces: [
+		{ id: 'rest:opt-in-items', type: 'rest_route', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'DELETE' },
+	],
+	fixture_plan: { id: 'campaign-fixtures', refs: [{ id: 'items', path: 'fixtures/items.json' }] },
+	rest_mutation_opt_ins: {
+		id: 'campaign-rest-opt-ins',
+		entries: [
+			{ id: 'post-item', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'POST' },
+			{ id: 'patch-item', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'PATCH' },
+			{ id: 'delete-item', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'DELETE' },
+		],
+	},
+}, {
+	plan: {
+		runtimeCapabilities: { capabilities: ['rest', 'checkpoint', 'rest-rollback', 'restore'] },
+		runtimeReadiness: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'ready', operationKinds: ['mutation'], mutationIsolation: true, deleteBoundary: true },
+		fixture_bindings: { 'rest:opt-in-items': { route_params: { id: 42 } } },
+	},
+});
+assert.equal(optInCampaign.wp_codebox.input.metadata.fixture_plan.id, 'campaign-fixtures');
+assert.equal(optInCampaign.wp_codebox.input.metadata.rest_mutation_opt_ins.id, 'campaign-rest-opt-ins');
+assert.equal(optInCampaign.wp_codebox.task_request.executor.config.runtime_task.input.metadata.rest_mutation_opt_ins.entries.length, 3);
 
 const productionCampaign = compileWordPressFuzzCampaign({
 	id: 'production-campaign',

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -356,7 +356,9 @@ assert.equal(capableRestMutation.execution_tier, 'plan_only');
 const capableAdminMutation = capableCases.find((entry) => entry.intent === 'plan-admin-page-mutation');
 assert.equal(capableAdminMutation.executable, false);
 assert.equal(capableAdminMutation.metadata.runtime_capability_gated, false);
-assert.deepEqual(capableAdminMutation.skip_reasons, ['requires-isolated-mutation-runtime', 'requires_explicit_mutation_opt_in']);
+assert.deepEqual(capableAdminMutation.skip_reasons, ['invalid-runtime-workload-operation', 'requires-isolated-mutation-runtime', 'requires_explicit_mutation_opt_in']);
+assert.equal(capableAdminMutation.runtime_operation.status, 'blocked');
+assert.equal(capableAdminMutation.runtime_operation.blockers[0].code, 'missing-runtime-workload-operation-field');
 assert.equal(capableAdminMutation.execution_tier, 'plan_only');
 
 const isolatedMutationPlan = buildWordPressFuzzPlanFromSurfaces({
@@ -371,18 +373,67 @@ const isolatedMutationPlan = buildWordPressFuzzPlanFromSurfaces({
 });
 assert.equal(isolatedMutationPlan.metadata.mutation_mode, 'isolated');
 const isolatedCases = isolatedMutationPlan.targets.flatMap((target) => target.cases);
-for (const intent of ['create-post', 'request-rest-route', 'plan-admin-page-mutation']) {
+for (const intent of ['create-post', 'request-rest-route']) {
 	const testCase = isolatedCases.find((entry) => entry.intent === intent);
 	assert.equal(testCase.executable, true, `${intent} should execute in isolated mode with runtime capabilities`);
 	assert.deepEqual(testCase.skip_reasons, []);
 	assert.equal(testCase.execution_tier, 'isolated_mutating_executable');
 	assert.equal(testCase.metadata.runtime_capability_gated, false);
 }
+const isolatedAdminMutation = isolatedCases.find((entry) => entry.intent === 'plan-admin-page-mutation');
+assert.equal(isolatedAdminMutation.executable, false);
+assert.deepEqual(isolatedAdminMutation.skip_reasons, ['invalid-runtime-workload-operation']);
+assert.equal(isolatedAdminMutation.runtime_operation.status, 'blocked');
+assert.equal(isolatedAdminMutation.execution_tier, 'plan_only');
 const isolatedRestMutation = isolatedCases.find((entry) => entry.intent === 'request-rest-route');
 const isolatedCrudDelete = isolatedCases.find((entry) => entry.intent === 'delete-post');
 assert.equal(isolatedRestMutation.metadata.rollback_contract.schema, 'homeboy/wordpress-rest-mutation-rollback-contract/v1');
 assert.deepEqual(isolatedRestMutation.metadata.required_any_capabilities, [['reset', 'restore']]);
 assert(isolatedCrudDelete.metadata.mutation_lifecycle.required_evidence.some((entry) => entry.kind === 'delete-boundary'));
+
+const optInRestMutationPlan = buildWordPressFuzzPlanFromSurfaces({
+	rest: [{ id: 'rest:generic-items', route: '/example/v1/items/(?P<id>[\\d]+)', methods: ['POST', 'PATCH', 'DELETE'] }],
+}, {
+	mutation_mode: 'isolated',
+	runtimeCapabilities: { capabilities: ['rest', 'checkpoint', 'rest-rollback', 'restore'] },
+	runtimeReadiness: {
+		schema: 'wp-codebox/fuzz-runner-readiness/v1',
+		status: 'ready',
+		operationKinds: ['mutation'],
+		mutationIsolation: true,
+		deleteBoundary: true,
+	},
+	rest_mutation_opt_ins: {
+		id: 'generic-rest-mutation-opt-ins',
+		entries: [
+			{ id: 'create-item-opt-in', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'POST', fixture_ref: 'fixture:items' },
+			{ id: 'patch-item-opt-in', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'PATCH', contract_ref: 'contract:patch' },
+			{ id: 'delete-item-opt-in', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'DELETE', contract_ref: 'contract:delete' },
+		],
+	},
+	fixture_bindings: {
+		'rest:generic-items': {
+			route_params: { id: 42 },
+			request_bodies: {
+				post: { title: 'Created fixture item' },
+				patch: { title: 'Patched fixture item' },
+				delete: { force: true },
+			},
+		},
+	},
+});
+const optInRestCases = optInRestMutationPlan.targets[0].cases;
+assert.deepEqual(optInRestCases.map((testCase) => testCase.operation.method), ['DELETE', 'PATCH', 'POST']);
+for (const method of ['POST', 'PATCH', 'DELETE']) {
+	const testCase = optInRestCases.find((entry) => entry.operation.method === method);
+	assert.equal(testCase.executable, true, `${method} should execute with isolated readiness and opt-in`);
+	assert.equal(testCase.runtime_operation.status, 'ready');
+	assert.equal(testCase.operation.route, '/example/v1/items/42');
+	assert.equal(testCase.metadata.rest_mutation_opt_in.method, method);
+	assert.equal(testCase.metadata.fixture_binding.route_params.id.value, 42);
+}
+assert.deepEqual(optInRestCases.find((entry) => entry.operation.method === 'PATCH').operation.request_body, { title: 'Patched fixture item' });
+assert.deepEqual(optInRestCases.find((entry) => entry.operation.method === 'DELETE').operation.request_body, { force: true });
 
 const readOnlyMutationPlan = buildWordPressFuzzPlanFromSurfaces({
 	post_types: [{ id: 'post:read-only', post_type: 'post', allowCrudMutations: true }],

--- a/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
+++ b/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
@@ -22,6 +22,7 @@ const workloadPath = path.join(tempDir, 'workload.json');
 const resultsPath = path.join(tempDir, 'campaign.json');
 const observedRequestPath = path.join(tempDir, 'observed-fuzz-suite-request.json');
 const emptyCodeboxInstallRoot = path.join(tempDir, 'empty-wp-codebox-install');
+const fakeCodeboxCoreModule = path.join(tempDir, 'wp-codebox-core-contracts.cjs');
 const fakeCodeboxBin = path.join(tempDir, 'wp-codebox');
 const runnerPath = path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs');
 
@@ -50,6 +51,12 @@ const workload = {
 
 fs.writeFileSync(workloadPath, `${JSON.stringify(workload, null, 2)}\n`);
 fs.mkdirSync(emptyCodeboxInstallRoot, { recursive: true });
+fs.writeFileSync(fakeCodeboxCoreModule, `module.exports.runtimeContractManifest = () => ({
+  schema: 'wp-codebox/runtime-contract-manifest/v1',
+  version: 1,
+  abilities: { wordpressRuntime: { runFuzzSuite: 'wp-codebox/run-fuzz-suite', runWorkload: 'wp-codebox/run-wordpress-workload' } },
+  schemas: { wordpressRuntime: { fuzzSuite: 'wp-codebox/fuzz-suite/v1', fuzzSuiteResult: 'wp-codebox/fuzz-suite-result/v1', workloadRun: 'wp-codebox/wordpress-workload-run/v1' } }
+});\n`);
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 
@@ -119,6 +126,7 @@ const cli = spawnSync(runnerPath, [], {
 		...process.env,
 		HOMEBOY_WP_CODEBOX_FUZZ_DISPATCH: 'legacy-codebox-bin',
 		HOMEBOY_WP_CODEBOX_BIN: fakeCodeboxBin,
+		HOMEBOY_WP_CODEBOX_CORE_MODULE: fakeCodeboxCoreModule,
 		HOMEBOY_WP_CODEBOX_INSTALL_DIR: emptyCodeboxInstallRoot,
 		HOMEBOY_FUZZ_WORKLOAD_PATH: workloadPath,
 		HOMEBOY_FUZZ_WORKLOAD_ID: 'contract-workload',

--- a/wordpress/tests/wordpress-fuzz-runtime-workload-operations-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-workload-operations-smoke.js
@@ -4,9 +4,12 @@ const assert = require('node:assert/strict');
 
 const {
 	WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_SCHEMA,
+	WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_VALIDATION_SCHEMA,
 	attachWordPressFuzzRuntimeWorkloadOperationDescriptor,
 	buildWordPressFuzzRuntimeWorkloadOperationDescriptor,
 	requiredCapabilitiesForWordPressFuzzRuntimeOperation,
+	summarizeWordPressFuzzRuntimeWorkloadOperations,
+	validateWordPressFuzzRuntimeWorkloadOperationDescriptor,
 } = require('../lib/wordpress-fuzz-runtime-workload-operations');
 const {
 	buildWordPressFuzzMutationLifecycleContract,
@@ -29,6 +32,8 @@ assert.equal(crudDescriptor.schema, WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_SC
 assert.equal(crudDescriptor.family, 'crud');
 assert.equal(crudDescriptor.command, 'wordpress.crud');
 assert.equal(crudDescriptor.status, 'ready');
+assert.equal(crudDescriptor.validation.schema, WORDPRESS_FUZZ_RUNTIME_WORKLOAD_OPERATION_VALIDATION_SCHEMA);
+assert.equal(crudDescriptor.validation.ok, true);
 assert.deepEqual(crudDescriptor.required_capabilities, ['crud']);
 
 const restDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor({
@@ -39,6 +44,31 @@ const restDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor({
 assert.equal(restDescriptor.family, 'rest');
 assert.equal(restDescriptor.command, 'wordpress.request-rest-route');
 assert.deepEqual(restDescriptor.input, { method: 'GET', route: '/wp/v2/posts' });
+
+const readinessSupportedRestDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor({
+	id: 'case:rest-readiness',
+	intent: 'request-rest-route',
+	operation: { method: 'GET', route: '/wp/v2/posts' },
+}, {
+	runtimeCapabilities: { capabilities: ['rest'] },
+	runtimeReadiness: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'ready', operationKinds: ['read'] },
+});
+assert.equal(readinessSupportedRestDescriptor.status, 'ready');
+
+const readinessUnsupportedCrudDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor(crudCase, {
+	runtimeCapabilities: { capabilities: ['crud'] },
+	runtimeReadiness: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'ready', operationKinds: ['read'] },
+});
+assert.equal(readinessUnsupportedCrudDescriptor.status, 'skipped');
+assert.equal(readinessUnsupportedCrudDescriptor.skip_reason, 'unsupported-runtime-workload-operation-kind');
+assert.deepEqual(readinessUnsupportedCrudDescriptor.blockers.map((blocker) => blocker.code), ['unsupported-runtime-workload-operation-kind']);
+
+const readinessMissingCommandDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor(crudCase, {
+	runtimeCapabilities: { capabilities: ['crud'] },
+	runtimeReadiness: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'blocked', command_available: false },
+});
+assert.equal(readinessMissingCommandDescriptor.status, 'blocked');
+assert.equal(readinessMissingCommandDescriptor.skip_reason, 'wp-codebox-fuzz-readiness-command-unavailable');
 
 const adminDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor({ intent: 'request-admin-page', operation: { path: '/wp-admin/edit.php' } }, { runtimeCapabilities: { capabilities: ['admin'] } });
 assert.equal(adminDescriptor.family, 'admin_page');
@@ -68,6 +98,43 @@ const mutatingDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor(
 assert.equal(mutatingDescriptor.mutation_lifecycle.delete_boundary_required, true);
 assert.equal(mutatingDescriptor.metadata.mutation_lifecycle.kind, 'rest');
 
+const mutationIsolationBlockedDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor({
+	id: 'case:rest-post-no-isolation',
+	intent: 'request-rest-route',
+	operation: { method: 'POST', route: '/example/v1/items' },
+	metadata: { mutation_lifecycle: buildWordPressFuzzMutationLifecycleContract({ kind: 'rest', method: 'POST' }) },
+}, {
+	runtimeCapabilities: { capabilities: ['rest'] },
+	runtimeReadiness: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'ready', operationKinds: ['mutation'] },
+});
+assert.equal(mutationIsolationBlockedDescriptor.status, 'blocked');
+assert.equal(mutationIsolationBlockedDescriptor.skip_reason, 'wp-codebox-fuzz-mutation-isolation-unsupported');
+assert.equal(mutationIsolationBlockedDescriptor.blockers[0].code, 'wp-codebox-fuzz-mutation-isolation-unsupported');
+
+const deleteBoundaryBlockedDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor({
+	id: 'case:rest-delete-no-boundary',
+	intent: 'request-rest-route',
+	operation: { method: 'DELETE', route: '/example/v1/items/42' },
+	metadata: { mutation_lifecycle: buildWordPressFuzzMutationLifecycleContract({ kind: 'rest', method: 'DELETE' }) },
+}, {
+	runtimeCapabilities: { capabilities: ['rest'] },
+	runtimeReadiness: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'ready', operationKinds: ['mutation'], mutationIsolation: true },
+});
+assert.equal(deleteBoundaryBlockedDescriptor.status, 'blocked');
+assert.equal(deleteBoundaryBlockedDescriptor.skip_reason, 'wp-codebox-fuzz-delete-boundary-unsupported');
+assert.equal(deleteBoundaryBlockedDescriptor.blockers[0].code, 'wp-codebox-fuzz-delete-boundary-unsupported');
+
+const readyMutationDescriptor = buildWordPressFuzzRuntimeWorkloadOperationDescriptor({
+	id: 'case:rest-delete-ready',
+	intent: 'request-rest-route',
+	operation: { method: 'DELETE', route: '/example/v1/items/42' },
+	metadata: { mutation_lifecycle: buildWordPressFuzzMutationLifecycleContract({ kind: 'rest', method: 'DELETE' }) },
+}, {
+	runtimeCapabilities: { capabilities: ['rest'] },
+	runtimeReadiness: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'ready', operationKinds: ['mutation'], mutationIsolation: true, deleteBoundary: true },
+});
+assert.equal(readyMutationDescriptor.status, 'ready');
+
 const skipped = attachWordPressFuzzRuntimeWorkloadOperationDescriptor({
 	id: 'case:block',
 	intent: 'render-block',
@@ -79,9 +146,33 @@ assert.equal(skipped.executable, false);
 assert.equal(skipped.execution_tier, 'plan_only');
 assert.equal(skipped.runtime_operation.status, 'skipped');
 assert.deepEqual(skipped.runtime_operation.missing_capabilities, ['block']);
+assert.deepEqual(skipped.runtime_operation.blockers.map((blocker) => blocker.code), ['missing-runtime-workload-capability']);
 assert.deepEqual(skipped.skip_reasons, ['existing-reason', 'missing-runtime-workload-capability']);
 assert.deepEqual(skipped.required_capabilities, ['block']);
 assert.equal(skipped.metadata.runtime_workload_capability_gated, true);
+
+const invalid = attachWordPressFuzzRuntimeWorkloadOperationDescriptor({
+	id: 'case:invalid-rest',
+	intent: 'request-rest-route',
+	operation: { method: 'GET' },
+}, { runtimeCapabilities: { capabilities: ['rest'] } });
+assert.equal(invalid.executable, false);
+assert.equal(invalid.execution_tier, 'plan_only');
+assert.equal(invalid.runtime_operation.status, 'blocked');
+assert.equal(invalid.runtime_operation.validation.ok, false);
+assert.deepEqual(invalid.runtime_operation.blockers.map((blocker) => blocker.code), ['missing-runtime-workload-operation-field']);
+assert.deepEqual(invalid.skip_reasons, ['invalid-runtime-workload-operation']);
+assert.equal(invalid.metadata.runtime_workload_operation_blocked, true);
+assert.equal(validateWordPressFuzzRuntimeWorkloadOperationDescriptor(invalid.runtime_operation).ok, false);
+
+const summary = summarizeWordPressFuzzRuntimeWorkloadOperations({
+	targets: [{ cases: [crudDescriptor, skipped.runtime_operation, invalid.runtime_operation, readinessUnsupportedCrudDescriptor, readinessMissingCommandDescriptor].map((runtime_operation) => ({ runtime_operation })) }],
+});
+assert.equal(summary.schema, 'homeboy/wordpress-fuzz-runtime-workload-operation-summary/v1');
+assert.equal(summary.total, 5);
+assert.deepEqual(summary.by_status, { ready: 1, skipped: 2, blocked: 2 });
+assert.deepEqual(summary.by_family_status.crud, { ready: 1, skipped: 1, blocked: 1 });
+assert.equal(summary.blockers.length, 4);
 
 assert(!JSON.stringify([crudDescriptor, restDescriptor, adminDescriptor, pageDescriptor, blockDescriptor, dbDescriptor]).includes('woocommerce'));
 

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -19,6 +19,7 @@ const {
 	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+	REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS,
 	buildWordPressFuzzCommandManifest,
 	wpCodeboxFuzzSuiteAbility,
 	wpCodeboxFuzzSuiteSchema,
@@ -35,6 +36,7 @@ const {
 	wpCodeboxFuzzExecutionRequest,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
+	wpCodeboxRuntimeContractManifest,
 } = require('../lib/wp-codebox-fuzz-run');
 
 const input = wpCodeboxFuzzSuiteInput({
@@ -53,6 +55,37 @@ assert.equal(input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 assert.equal(input.target.slug, 'sample-plugin');
 assert.deepEqual(input.metadata.limits, { max_cases: 1 });
 assert.equal(wpCodeboxFuzzSuiteInput({ id: 'suite-alias' }).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+
+const fixtureAndOptInInput = wpCodeboxFuzzSuiteInput({
+	id: 'fixture-opt-in-suite',
+	fixture_plan: {
+		id: 'generic-fixtures',
+		refs: [{ id: 'items', path: 'fixtures/items.json' }],
+		data: { items: [{ id: 42 }] },
+	},
+	rest_mutation_opt_ins: {
+		id: 'generic-rest-mutators',
+		refs: ['artifact://rest-mutator-opt-ins'],
+		entries: [
+			{ id: 'create-item', route: '/example/v1/items', method: 'POST', fixture_ref: 'items' },
+			{ id: 'patch-item', route: '/example/v1/items/42', method: 'PATCH', contract_ref: 'contract://patch-item' },
+			{ id: 'delete-item', route: '/example/v1/items/42', method: 'DELETE', contract_ref: 'contract://delete-item' },
+		],
+	},
+	cases: [{
+		id: 'delete-item-case',
+		input: {
+			operation: { method: 'DELETE', route: '/example/v1/items/42' },
+			rest_mutation_opt_in: { id: 'delete-item', route: '/example/v1/items/42', method: 'DELETE' },
+		},
+	}],
+});
+assert.equal(fixtureAndOptInInput.metadata.fixture_plan.schema, 'homeboy/wordpress-fuzz-fixture-plan/v1');
+assert.equal(fixtureAndOptInInput.metadata.fixture_plan.refs[0].path, 'fixtures/items.json');
+assert.equal(fixtureAndOptInInput.metadata.rest_mutation_opt_ins.schema, 'homeboy/wordpress-rest-mutation-opt-ins/v1');
+assert.deepEqual(fixtureAndOptInInput.metadata.rest_mutation_opt_ins.entries.map((entry) => entry.method), ['POST', 'PATCH', 'DELETE']);
+assert.equal(fixtureAndOptInInput.cases[0].input.rest_mutation_opt_in.method, 'DELETE');
+assert(!JSON.stringify(fixtureAndOptInInput).includes('woocommerce'));
 
 const manifest = {
 	schema: 'wp-codebox/runtime-contract-manifest/v1',
@@ -76,6 +109,14 @@ assert.equal(wpCodeboxFuzzSuiteAbility({ runtimeContractManifest: manifest }), D
 assert.equal(wpCodeboxFuzzSuiteSchema({ runtimeContractManifest: manifest }), WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 assert.equal(wpCodeboxWordPressWorkloadRunAbility({ runtimeContractManifest: manifest }), DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY);
 assert.equal(wpCodeboxWordPressWorkloadRunSchema({ runtimeContractManifest: manifest }), DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA);
+assert.deepEqual(REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS, [
+	'abilities.wordpressRuntime.runFuzzSuite',
+	'abilities.wordpressRuntime.runWorkload',
+	'schemas.wordpressRuntime.fuzzSuite',
+	'schemas.wordpressRuntime.fuzzSuiteResult',
+	'schemas.wordpressRuntime.workloadRun',
+]);
+assert.equal(wpCodeboxRuntimeContractManifest({ loadRuntimeContractSource: () => ({ manifest }) }), manifest);
 assert.deepEqual(wpCodeboxWordPressWorkloadRunInput({
 	id: 'workload-run',
 	steps: [{ command: 'wordpress.run-declarative-fuzz' }],
@@ -195,6 +236,16 @@ const preflightMissingAbility = preflightWpCodeboxFuzzCapabilityContract({
 });
 assert.equal(preflightMissingAbility.ok, false);
 assert.equal(preflightMissingAbility.missing_contracts.some((contract) => contract.ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY), true);
+assert.equal(preflightMissingAbility.missing_contracts.some((contract) => contract.type === 'runtime_contract_manifest' && contract.missing_paths.includes('schemas.wordpressRuntime.workloadRun')), true);
+
+const preflightMissingCanonicalContract = preflightWpCodeboxFuzzCapabilityContract({
+	request: taskRequest,
+	loadRuntimeContractSource: () => null,
+	publicCliCapabilities: { commands: { 'run-fuzz-suite': true, 'run-wordpress-workload': true } },
+});
+assert.equal(preflightMissingCanonicalContract.ok, false);
+assert.equal(preflightMissingCanonicalContract.missing_contracts.some((contract) => contract.type === 'runtime_contract_manifest'), true);
+assert.equal(preflightMissingCanonicalContract.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_runtime_contract_manifest'), true);
 
 const preflightPassed = preflightWpCodeboxFuzzCapabilityContract({
 	request: taskRequest,
@@ -202,6 +253,67 @@ const preflightPassed = preflightWpCodeboxFuzzCapabilityContract({
 	publicCliCapabilities: { commands: { 'run-fuzz-suite': true, 'run-wordpress-workload': true } },
 });
 assert.equal(preflightPassed.ok, true);
+
+const readinessContract = {
+	schema: 'wp-codebox/fuzz-runner-readiness/v1',
+	status: 'ready',
+	mode: 'runtime-backed',
+	entrypoint: 'run-fuzz-suite --runner-mode=runtime-backed',
+	operationKinds: ['read', 'crud', 'mutation'],
+	capabilities: {
+		schema: 'wp-codebox/fuzz-runner-capabilities/v1',
+		mode: 'runtime-backed',
+		capabilities: ['target:runtime', 'runtime'],
+		targetKinds: ['runtime'],
+		operationKinds: ['read', 'crud', 'mutation'],
+		runtimeActionTypes: ['crud_operation', 'rest_request', 'db_operation'],
+		commands: ['wordpress.crud-operation', 'wordpress.rest-request', 'wordpress.db-operation', 'wordpress.run-workload'],
+		unsupportedRequiredCapabilities: [],
+	},
+	unsupportedRequiredCapabilities: [],
+};
+const readinessCapabilities = detectWpCodeboxPublicFuzzCapabilities({
+	runPublicCli: ({ args }) => args.join(' ') === 'fuzz readiness --format=json'
+		? { status: 0, stdout: JSON.stringify(readinessContract) }
+		: { status: 1, stderr: 'unexpected command' },
+});
+assert.equal(readinessCapabilities.readiness.schema, 'wp-codebox/fuzz-runner-readiness/v1');
+assert.equal(readinessCapabilities.commands['run-fuzz-suite'], true);
+assert.equal(readinessCapabilities.commands['run-wordpress-workload'], true);
+assert.deepEqual(readinessCapabilities.capabilities, ['crud', 'database', 'query-observation', 'rest']);
+const preflightReadinessPassed = preflightWpCodeboxFuzzCapabilityContract({
+	request: taskRequest,
+	runtimeContractManifest: manifest,
+	runPublicCli: ({ args }) => args.join(' ') === 'fuzz readiness --format=json'
+		? { status: 0, stdout: JSON.stringify(readinessContract) }
+		: { status: 1, stderr: 'unexpected command' },
+});
+assert.equal(preflightReadinessPassed.ok, true);
+
+const unsupportedReadiness = {
+	...readinessContract,
+	status: 'unsupported',
+	unsupportedRequiredCapabilities: ['runtime-action:editor_insert_save'],
+};
+const preflightUnsupportedReadiness = preflightWpCodeboxFuzzCapabilityContract({
+	request: taskRequest,
+	runtimeContractManifest: manifest,
+	publicCliReadiness: unsupportedReadiness,
+});
+assert.equal(preflightUnsupportedReadiness.ok, false);
+assert.equal(preflightUnsupportedReadiness.missing_contracts.some((contract) => contract.type === 'public_cli_readiness'), true);
+assert.equal(preflightUnsupportedReadiness.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_public_cli_readiness'), true);
+
+const preflightMissingReadinessCommand = preflightWpCodeboxFuzzCapabilityContract({
+	request: taskRequest,
+	runtimeContractManifest: manifest,
+	runPublicCli: ({ args }) => args.join(' ') === 'fuzz readiness --format=json'
+		? { status: 1, stderr: 'unknown command: fuzz readiness' }
+		: { status: 0, stdout: 'legacy help' },
+});
+assert.equal(preflightMissingReadinessCommand.ok, false);
+assert.equal(preflightMissingReadinessCommand.missing_contracts.some((contract) => contract.type === 'public_cli_readiness_command'), true);
+assert.equal(preflightMissingReadinessCommand.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_public_cli_readiness_command'), true);
 
 const rollbackRestPlanRequest = wpCodeboxFuzzSuiteTaskRequest({
 	taskId: 'rollback-rest-plan-task',
@@ -1019,6 +1131,7 @@ runWpCodeboxFuzzSuite({
 	return runWpCodeboxFuzzSuite({
 		taskId: 'public-cli-suite-run',
 		input,
+		runtimeContractManifest: manifest,
 		wpCodeboxBin: '/custom/direct-wp-codebox',
 		runtimeRequirements: {
 			extra_plugins: [{ slug: 'sample-plugin', source: '/runner/components/sample-plugin', loadAs: 'plugin' }],
@@ -1026,6 +1139,9 @@ runWpCodeboxFuzzSuite({
 		},
 		runPublicCli: ({ command, args, stdin }) => {
 			assert.equal(command, '/custom/direct-wp-codebox');
+			if (args.join(' ') === 'fuzz readiness --format=json') {
+				return { status: 0, stdout: JSON.stringify(readinessContract) };
+			}
 			if (args.join(' ') === 'run-fuzz-suite --help') {
 				return { status: 0, stdout: 'usage' };
 			}
@@ -1089,10 +1205,12 @@ runWpCodeboxFuzzSuite({
 	return runWpCodeboxFuzzSuite({
 		taskId: 'public-cli-staged-helper-run',
 		input: stagedHelperInput,
+		runtimeContractManifest: manifest,
 		wpCodeboxBin: '/custom/direct-wp-codebox',
 		runtimeRequirements: { extra_plugins: [{ slug: 'sample-plugin', source: stagedHelperDir, loadAs: 'plugin' }] },
 		env: { resultsFile: path.join(stagedArtifactRoot, 'fuzz-results.json') },
 		runPublicCli: ({ args }) => {
+			if (args.join(' ') === 'fuzz readiness --format=json') return { status: 0, stdout: JSON.stringify(readinessContract) };
 			if (args.includes('--help')) return { status: 0, stdout: 'usage' };
 			assert.deepEqual([args[0], args[1], args[2], args[4]], ['run-fuzz-suite', '--runner-mode=runtime-backed', '--input-file', '--json']);
 			const publicCliInput = JSON.parse(fs.readFileSync(args[3], 'utf8'));
@@ -1111,6 +1229,10 @@ runWpCodeboxFuzzSuite({
 	const largeCli = path.join(largeCliDir, 'wp-codebox-large-output.cjs');
 	fs.writeFileSync(largeCli, `
 const args = process.argv.slice(2);
+if (args.join(' ') === 'fuzz readiness --format=json') {
+  process.stdout.write(${JSON.stringify(JSON.stringify(readinessContract))});
+  process.exit(0);
+}
 if (args.includes('--help')) {
   process.stdout.write('usage');
   process.exit(0);
@@ -1126,6 +1248,7 @@ process.stdout.write(JSON.stringify({
 	return runWpCodeboxFuzzSuite({
 		taskId: 'public-cli-large-output-run',
 		input,
+		runtimeContractManifest: manifest,
 		wpCodeboxBin: largeCli,
 	}).finally(() => fs.rmSync(largeCliDir, { recursive: true, force: true }));
 }).then((summary) => {
@@ -1138,11 +1261,12 @@ process.stdout.write(JSON.stringify({
 	return runWpCodeboxFuzzSuite({
 		taskId: 'public-cli-unsupported-run',
 		input,
+		runtimeContractManifest: manifest,
 		runPublicCli: () => ({ status: 1, stderr: 'unknown command' }),
 	});
 }).then((summary) => {
 	assert.equal(summary.succeeded, false);
-	assert.equal(summary.failures[0].code, 'wp_codebox_fuzz_missing_public_cli_command');
+	assert.equal(summary.failures[0].code, 'wp_codebox_fuzz_missing_public_cli_readiness_command');
 	assert.equal(summary.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_artifacts_missing'), false);
 
 	console.log('wp-codebox fuzz-run smoke passed');


### PR DESCRIPTION
## Summary
- consume WP Codebox fuzz readiness/capability output before legacy probing
- add generic WordPress fuzz runtime operation validation and summaries
- pass fixture plans and REST mutation opt-ins into Codebox suite metadata
- keep product-specific page profiler adapters caller-owned

## Tests
- npm run test:page-profiler
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner-codebox-contract
- node wordpress/tests/wordpress-fuzz-runtime-workload-operations-smoke.js
- node wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
- node wordpress/tests/wordpress-fuzz-campaign-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing HBEX fuzzing boundaries, implementing runtime readiness ingestion, operation scaffolding, fixture opt-in pass-through, and focused tests.