### PR TITLE
Fix WordPress contract re-export layout

### DIFF
--- a/wordpress/lib/agent-task-runner-contract.js
+++ b/wordpress/lib/agent-task-runner-contract.js
@@ -1,4 +1,11 @@
 'use strict';
 
 // Compatibility re-export. New code should import from agent-task-contracts.
-module.exports = require('../../agent-task-contracts/agent-task-runner-contract');
+try {
+	module.exports = require('../../agent-task-contracts/agent-task-runner-contract');
+} catch (error) {
+	if (error.code !== 'MODULE_NOT_FOUND') {
+		throw error;
+	}
+	module.exports = require('../../../agent-task-contracts/agent-task-runner-contract');
+}

--- a/wordpress/lib/generic-agent-task-plan.js
+++ b/wordpress/lib/generic-agent-task-plan.js
@@ -1,3 +1,10 @@
 'use strict';
 
-module.exports = require('../../agent-task-contracts/generic-agent-task-plan');
+try {
+	module.exports = require('../../agent-task-contracts/generic-agent-task-plan');
+} catch (error) {
+	if (error.code !== 'MODULE_NOT_FOUND') {
+		throw error;
+	}
+	module.exports = require('../../../agent-task-contracts/generic-agent-task-plan');
+}


### PR DESCRIPTION
## Summary
- make WordPress compatibility re-exports resolve shared agent task contracts in both source-tree and installed-extension layouts
- preserve existing source-tree import path first, then fall back to the installed Homeboy layout

## Tests
- node wordpress/tests/generic-agent-contract-reexport-boundary.test.js
- installed-layout simulation with copied wordpress/lib and agent-task-contracts files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the lab fuzz runner module resolution failure and implementing the compatibility re-export fix.