### PR TITLE
Trust fuzz readiness preflight

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -1138,6 +1138,10 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 	const requiredAbilities = { ...WP_CODEBOX_FUZZ_PUBLIC_ABILITIES };
 	const requiredCommands = requiredPublicCommandsForRequest(request, requiredPlanContracts);
 	const missingContracts = [];
+	const readinessStatus = capabilities.readiness?.status;
+	const publicReadinessSatisfied = capabilities.readiness?.command_available !== false
+		&& readinessStatus === 'ready'
+		&& capabilities.readiness?.mode === 'runtime-backed';
 	if (capabilities.readiness?.command_available === false) {
 		missingContracts.push({
 			type: 'public_cli_readiness_command',
@@ -1163,7 +1167,7 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 	}
 
 	const missingManifestPaths = missingWpCodeboxFuzzRuntimeContractPaths(manifest);
-	if (missingManifestPaths.length > 0) {
+	if (!publicReadinessSatisfied && missingManifestPaths.length > 0) {
 		missingContracts.push({
 			type: 'runtime_contract_manifest',
 			missing_paths: missingManifestPaths,
@@ -1192,14 +1196,14 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 		}
 	}
 
-	if (wordpressRuntimeAbilities.runFuzzSuite !== requiredAbilities.runFuzzSuite) {
+	if (!publicReadinessSatisfied && wordpressRuntimeAbilities.runFuzzSuite !== requiredAbilities.runFuzzSuite) {
 		missingContracts.push({
 			type: 'ability',
 			ability: requiredAbilities.runFuzzSuite,
 			message: `WP Codebox runtime contract must declare \`${requiredAbilities.runFuzzSuite}\` for fuzz-suite dispatch.`,
 		});
 	}
-	if (wordpressRuntimeAbilities.runWorkload !== requiredAbilities.runWorkload) {
+	if (!publicReadinessSatisfied && wordpressRuntimeAbilities.runWorkload !== requiredAbilities.runWorkload) {
 		missingContracts.push({
 			type: 'ability',
 			ability: requiredAbilities.runWorkload,

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -289,6 +289,18 @@ const preflightReadinessPassed = preflightWpCodeboxFuzzCapabilityContract({
 		: { status: 1, stderr: 'unexpected command' },
 });
 assert.equal(preflightReadinessPassed.ok, true);
+const preflightReadinessOnlyPassed = preflightWpCodeboxFuzzCapabilityContract({
+	request: taskRequest,
+	loadRuntimeContractSource: () => null,
+	runPublicCli: ({ args }) => args.join(' ') === 'fuzz readiness --format=json'
+		? { status: 0, stdout: JSON.stringify(readinessContract) }
+		: { status: 1, stderr: 'unexpected command' },
+});
+assert.equal(preflightReadinessOnlyPassed.ok, true);
+assert.equal(
+	preflightReadinessOnlyPassed.missing_contracts.some((contract) => contract.type === 'runtime_contract_manifest' || contract.type === 'ability'),
+	false,
+);
 
 const unsupportedReadiness = {
 	...readinessContract,


### PR DESCRIPTION
## Summary
- allow runtime-backed WP Codebox fuzz readiness to satisfy fuzz preflight without legacy runtime contract manifest/ability declarations
- keep legacy manifest checks when readiness is unavailable or unsupported

## Tests
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the offloaded Woo fuzz preflight blocker and implementing the readiness-based preflight path.