### PR TITLE
Extract shared CLI agent-task executor factory

### DIFF
--- a/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
+++ b/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
@@ -1,25 +1,17 @@
 'use strict';
 
 /**
- * External dependencies
- */
-const { spawnSync } = require('node:child_process');
-const fs = require('node:fs');
-const path = require('node:path');
-
-/**
  * Internal dependencies
  */
 const {
-	AGENT_TASK_REQUEST_SCHEMA,
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 	agentTaskProviderContractFields,
 	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
-	normalizeAgentTaskOutcome,
-} = require('../../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
+	createCliAgentTaskExecutor,
+} = require('../../lib/cli-agent-task-executor');
 
 const CLAUDE_CODE_PROVIDER_ID = 'claude-code.agent-task-executor';
 const CLAUDE_CODE_PROVIDER_LABEL = 'Claude Code agent task executor';
@@ -94,187 +86,6 @@ function providerContract(options = {}) {
 	};
 }
 
-function outcome(request = {}, values = {}) {
-	return normalizeAgentTaskOutcome(outcomeRequest(request), values, {
-		provider: CLAUDE_CODE_PROVIDER_ID,
-		providerLabel: 'Claude Code agent',
-		status: values.status || 'provider_error',
-		failureClassification: values.failure_classification,
-		failureCode: values.failure_code,
-		summary: values.summary || 'Claude Code agent task executor failed before producing a detailed outcome.',
-		artifacts: values.artifacts || [],
-		evidenceRefs: values.evidence_refs || [],
-		metadata: values.metadata || {},
-	});
-}
-
-function outcomeRequest(request = {}) {
-	return request.task_id ? request : { ...request, task_id: 'unknown-task' };
-}
-
-function validationFailure(request, message) {
-	return outcome(request, {
-		status: 'provider_error',
-		failure_classification: 'invalid_input',
-		failure_code: 'agent_task.invalid_claude_code_request',
-		summary: 'Claude Code request validation failed.',
-		diagnostics: [{ classification: 'request_validation', message }],
-	});
-}
-
-function executeClaudeCodeAgentTask(request = {}, options = {}) {
-	const validationError = validateRequest(request);
-	if (validationError) {
-		return validationFailure(request, validationError);
-	}
-
-	if (!process.env.AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN) {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: 'provider',
-			failure_code: 'agent_task.claude_code_oauth_missing',
-			summary: 'Claude Code OAuth refresh token is missing.',
-			diagnostics: [{ classification: 'provider_setup', message: 'Set AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN for the provider adapter.' }],
-		});
-	}
-
-	const config = request.executor.config || {};
-	const commandSpec = resolveCommandSpec(config, options);
-	if (commandSpec.error) {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: commandSpec.classification || 'provider',
-			failure_code: commandSpec.code || 'agent_task.invalid_claude_code_command',
-			summary: commandSpec.summary || 'Claude Code command configuration is invalid.',
-			diagnostics: [{ classification: 'provider_setup', message: commandSpec.error }],
-		});
-	}
-
-	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
-	const spawnResult = spawnSync(commandSpec.command, commandSpec.args, {
-		cwd: resolveCwd(request, config),
-		env: process.env,
-		input: JSON.stringify(request),
-		encoding: 'utf8',
-		maxBuffer: options.maxBuffer || 10 * 1024 * 1024,
-		...(timeoutSeconds > 0 ? { timeout: timeoutSeconds * 1000 } : {}),
-	});
-	const processEvidence = processArtifacts(request, config, spawnResult, 'claude-code');
-
-	if (spawnResult.error?.code === 'ENOENT') {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: 'provider',
-			failure_code: 'agent_task.claude_code_command_not_found',
-			summary: 'Claude Code adapter command was not found.',
-			diagnostics: [{ classification: 'provider_setup', message: 'Set executor.config.command to an installed adapter command.' }],
-		});
-	}
-
-	if (spawnResult.error) {
-		const timedOut = spawnResult.error.code === 'ETIMEDOUT';
-		return outcome(request, {
-			status: timedOut ? 'timeout' : 'provider_error',
-			failure_classification: timedOut ? 'timeout' : 'provider',
-			failure_code: timedOut ? 'agent_task.claude_code_timeout' : 'agent_task.claude_code_spawn_failed',
-			summary: timedOut ? 'Claude Code execution timed out.' : 'Claude Code adapter process failed to start or complete.',
-			diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: spawnResult.error.message }],
-		});
-	}
-
-	if (spawnResult.status === 0) {
-		return outcome(request, {
-			status: 'succeeded',
-			summary: 'Claude Code adapter completed successfully.',
-			diagnostics: [{ classification: 'provider', message: 'Claude Code adapter exited with status 0.' }],
-			metadata: { exit_code: 0 },
-			...processEvidence,
-		});
-	}
-
-	return outcome(request, {
-		status: 'failed',
-		failure_classification: 'execution_failed',
-		failure_code: 'agent_task.claude_code_failed',
-		summary: 'Claude Code adapter execution failed.',
-		diagnostics: [{ classification: 'execution_failed', message: `Claude Code adapter exited with status ${spawnResult.status}.` }],
-		metadata: {
-			exit_code: spawnResult.status,
-			...(spawnResult.signal ? { signal: spawnResult.signal } : {}),
-		},
-		...processEvidence,
-	});
-}
-
-function processArtifacts(request, config, spawnResult, provider) {
-	const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
-	if (!artifactDir) {
-		return {};
-	}
-	const artifacts = [];
-	const evidence_refs = [];
-	for (const stream of ['stdout', 'stderr']) {
-		const content = redactSecrets(String(spawnResult[stream] || ''), CLAUDE_CODE_SECRET_ENV);
-		if (!content) {
-			continue;
-		}
-		const filePath = path.join(artifactDir, `${safeFileSegment(request.task_id)}-${provider}-${stream}.txt`);
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, content);
-		const artifact = { id: `${provider}-${stream}`, name: `${provider}-${stream}`, kind: 'provider-process-stream', stream, path: filePath, bytes: Buffer.byteLength(content) };
-		artifacts.push(artifact);
-		evidence_refs.push({ kind: 'provider-process-stream', label: `${provider} ${stream}`, path: filePath });
-	}
-	return { artifacts, evidence_refs };
-}
-
-function safeFileSegment(value) {
-	return String(value || 'agent-task').replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'agent-task';
-}
-
-function redactSecrets(content, secretEnvNames) {
-	let redacted = content;
-	for (const name of secretEnvNames) {
-		const value = process.env[name];
-		if (value) {
-			redacted = redacted.split(value).join('[redacted]');
-		}
-	}
-	return redacted;
-}
-
-function validateRequest(request) {
-	if (!request || typeof request !== 'object' || Array.isArray(request)) {
-		return 'Request must be a JSON object.';
-	}
-	if (request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
-		return `Request schema must be ${AGENT_TASK_REQUEST_SCHEMA}.`;
-	}
-	if (!request.task_id || typeof request.task_id !== 'string') {
-		return 'Request task_id is required.';
-	}
-	if (request.executor?.backend !== 'claude-code') {
-		return 'Request executor.backend must be claude-code.';
-	}
-	if (request.executor?.runtime !== undefined && request.executor.runtime !== 'claude-code') {
-		return 'Request executor.runtime must be claude-code.';
-	}
-	if (!request.executor.config || typeof request.executor.config !== 'object' || Array.isArray(request.executor.config)) {
-		return 'Request executor.config is required.';
-	}
-	if (!request.instructions || typeof request.instructions !== 'string') {
-		return 'Request instructions are required.';
-	}
-	return null;
-}
-
-function timeoutSecondsFromLimits(limits = {}, fallbackSeconds = 0) {
-	if (limits.timeout_ms || limits.max_runtime_ms) {
-		return Math.ceil(Number(limits.timeout_ms || limits.max_runtime_ms) / 1000);
-	}
-	return Number(limits.task_timeout_seconds || limits.taskTimeoutSeconds || fallbackSeconds || 0);
-}
-
 function resolveCommandSpec(config = {}, options = {}) {
 	const configuredCommand = options.command || config.command || process.env.HOMEBOY_CLAUDE_CODE_AGENT_TASK_COMMAND || '';
 	const configuredArgs = options.commandArgs || config.command_args || parseEnvCommandArgs();
@@ -304,9 +115,40 @@ function parseEnvCommandArgs() {
 	}
 }
 
-function resolveCwd(request = {}, config = {}) {
-	return config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
-}
+const { execute: executeClaudeCodeAgentTask, outcome, validationFailure } = createCliAgentTaskExecutor({
+	backend: 'claude-code',
+	runtime: 'claude-code',
+	providerId: CLAUDE_CODE_PROVIDER_ID,
+	providerLabel: 'Claude Code agent',
+	defaultSummary: 'Claude Code agent task executor failed before producing a detailed outcome.',
+	secretEnv: CLAUDE_CODE_SECRET_ENV,
+	artifactProvider: 'claude-code',
+	collectArtifacts: true,
+	resolveCommandSpec,
+	preflight: (request) => {
+		if (!process.env.AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN) {
+			return {
+				status: 'provider_error',
+				failure_classification: 'provider',
+				failure_code: 'agent_task.claude_code_oauth_missing',
+				summary: 'Claude Code OAuth refresh token is missing.',
+				diagnostics: [{ classification: 'provider_setup', message: 'Set AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN for the provider adapter.' }],
+			};
+		}
+		return null;
+	},
+	buildArgs: (request, config, commandSpec) => commandSpec.args,
+	buildSpawn: (request) => ({ env: process.env, input: JSON.stringify(request) }),
+	messages: {
+		invalidRequest: { code: 'agent_task.invalid_claude_code_request', summary: 'Claude Code request validation failed.' },
+		invalidCommand: { code: 'agent_task.invalid_claude_code_command', summary: 'Claude Code command configuration is invalid.' },
+		notFound: { code: 'agent_task.claude_code_command_not_found', summary: 'Claude Code adapter command was not found.', hint: 'Set executor.config.command to an installed adapter command.' },
+		timeout: { code: 'agent_task.claude_code_timeout', summary: 'Claude Code execution timed out.' },
+		spawnFailed: { code: 'agent_task.claude_code_spawn_failed', summary: 'Claude Code adapter process failed to start or complete.' },
+		success: { summary: 'Claude Code adapter completed successfully.', diag: 'Claude Code adapter exited with status 0.' },
+		failed: { code: 'agent_task.claude_code_failed', summary: 'Claude Code adapter execution failed.', diag: (status) => `Claude Code adapter exited with status ${status}.` },
+	},
+});
 
 module.exports = {
 	CLAUDE_CODE_OPTIONAL_SECRET_ENV,

--- a/agent-runtimes/claude-code/scripts/agent/homeboy-claude-code-agent-task-executor.cjs
+++ b/agent-runtimes/claude-code/scripts/agent/homeboy-claude-code-agent-task-executor.cjs
@@ -1,44 +1,17 @@
 #!/usr/bin/env node
 'use strict';
 
-/* eslint-disable no-console */
-
-const fs = require('node:fs');
+const {
+	runCliAgentTaskExecutorBin,
+} = require('../../../lib/cli-agent-task-executor-bin');
 const {
 	executeClaudeCodeAgentTask,
 	outcome,
 	providerContract,
 } = require('../../lib/claude-code-agent-task-executor');
 
-function readStdin() {
-	try {
-		return fs.readFileSync(0, 'utf8');
-	} catch {
-		return '';
-	}
-}
-
-if (process.argv.includes('--provider-contract')) {
-	process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
-	process.exit(0);
-}
-
-let request = {};
-const raw = process.env.HOMEBOY_AGENT_TASK_REQUEST || readStdin();
-if (raw.trim()) {
-	try {
-		request = JSON.parse(raw);
-	} catch (error) {
-		process.stdout.write(`${JSON.stringify(outcome({}, {
-			status: 'provider_error',
-			failure_classification: 'invalid_input',
-			failure_code: 'agent_task.invalid_json',
-			summary: 'Invalid AgentTaskRequest JSON.',
-			diagnostics: [{ classification: 'request_validation', message: error.message }],
-		}), null, 2)}\n`);
-		process.exit(0);
-	}
-}
-
-process.stdout.write(`${JSON.stringify(executeClaudeCodeAgentTask(request), null, 2)}\n`);
-process.exit(0);
+runCliAgentTaskExecutorBin({
+	execute: executeClaudeCodeAgentTask,
+	outcome,
+	providerContract,
+});

--- a/agent-runtimes/codex/lib/codex-agent-task-executor.js
+++ b/agent-runtimes/codex/lib/codex-agent-task-executor.js
@@ -1,25 +1,17 @@
 'use strict';
 
 /**
- * External dependencies
- */
-const { spawnSync } = require('node:child_process');
-const fs = require('node:fs');
-const path = require('node:path');
-
-/**
  * Internal dependencies
  */
 const {
-	AGENT_TASK_REQUEST_SCHEMA,
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 	agentTaskProviderContractFields,
 	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
-	normalizeAgentTaskOutcome,
-} = require('../../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
+	createCliAgentTaskExecutor,
+} = require('../../lib/cli-agent-task-executor');
 
 const CODEX_RUNTIME_ID = 'codex';
 const CODEX_PROVIDER_ID = 'codex.agent-task-executor';
@@ -85,181 +77,6 @@ function providerContract(options = {}) {
 	};
 }
 
-function outcome(request = {}, values = {}) {
-	return normalizeAgentTaskOutcome(outcomeRequest(request), values, {
-		provider: CODEX_PROVIDER_ID,
-		providerLabel: 'Codex agent',
-		status: values.status || 'provider_error',
-		failureClassification: values.failure_classification,
-		failureCode: values.failure_code,
-		summary: values.summary || 'Codex agent task executor failed before producing a detailed outcome.',
-		artifacts: values.artifacts || [],
-		evidenceRefs: values.evidence_refs || [],
-		metadata: values.metadata || {},
-	});
-}
-
-function outcomeRequest(request = {}) {
-	return request.task_id ? request : { ...request, task_id: 'unknown-task' };
-}
-
-function validationFailure(request, message) {
-	return outcome(request, {
-		status: 'provider_error',
-		failure_classification: 'invalid_input',
-		failure_code: 'agent_task.invalid_codex_request',
-		summary: 'Codex request validation failed.',
-		diagnostics: [{ classification: 'request_validation', message }],
-	});
-}
-
-function executeCodexAgentTask(request = {}, options = {}) {
-	const validationError = validateRequest(request);
-	if (validationError) {
-		return validationFailure(request, validationError);
-	}
-
-	const config = request.executor.config || {};
-	const commandSpec = resolveCommandSpec(config, options);
-	if (commandSpec.error) {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: 'provider',
-			failure_code: 'agent_task.invalid_codex_command',
-			summary: 'Codex command configuration is invalid.',
-			diagnostics: [{ classification: 'provider_setup', message: commandSpec.error }],
-		});
-	}
-
-	const args = [
-		...commandSpec.args,
-		...(config.model ? ['--model', config.model] : []),
-		request.instructions,
-	];
-	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
-	const spawnResult = spawnSync(commandSpec.command, args, {
-		cwd: resolveCwd(request, config),
-		env: process.env,
-		encoding: 'utf8',
-		maxBuffer: options.maxBuffer || 10 * 1024 * 1024,
-		...(timeoutSeconds > 0 ? { timeout: timeoutSeconds * 1000 } : {}),
-	});
-	const processEvidence = processArtifacts(request, config, spawnResult, 'codex');
-
-	if (spawnResult.error?.code === 'ENOENT') {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: 'provider',
-			failure_code: 'agent_task.codex_command_not_found',
-			summary: 'Codex command was not found.',
-			diagnostics: [{ classification: 'provider_setup', message: 'Install Codex CLI or configure executor.config.command.' }],
-		});
-	}
-
-	if (spawnResult.error) {
-		const timedOut = spawnResult.error.code === 'ETIMEDOUT';
-		return outcome(request, {
-			status: timedOut ? 'timeout' : 'provider_error',
-			failure_classification: timedOut ? 'timeout' : 'provider',
-			failure_code: timedOut ? 'agent_task.codex_timeout' : 'agent_task.codex_spawn_failed',
-			summary: timedOut ? 'Codex execution timed out.' : 'Codex process failed to start or complete.',
-			diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: spawnResult.error.message }],
-		});
-	}
-
-	if (spawnResult.status === 0) {
-		return outcome(request, {
-			status: 'succeeded',
-			summary: 'Codex completed successfully.',
-			diagnostics: [{ classification: 'provider', message: 'Codex CLI exited with status 0.' }],
-			metadata: { exit_code: 0 },
-			...processEvidence,
-		});
-	}
-
-	return outcome(request, {
-		status: 'failed',
-		failure_classification: 'execution_failed',
-		failure_code: 'agent_task.codex_failed',
-		summary: 'Codex execution failed.',
-		diagnostics: [{ classification: 'execution_failed', message: `Codex CLI exited with status ${spawnResult.status}.` }],
-		metadata: {
-			exit_code: spawnResult.status,
-			...(spawnResult.signal ? { signal: spawnResult.signal } : {}),
-		},
-		...processEvidence,
-	});
-}
-
-function processArtifacts(request, config, spawnResult, provider) {
-	const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
-	if (!artifactDir) {
-		return {};
-	}
-	const artifacts = [];
-	const evidence_refs = [];
-	for (const stream of ['stdout', 'stderr']) {
-		const content = redactSecrets(String(spawnResult[stream] || ''), CODEX_SECRET_ENV);
-		if (!content) {
-			continue;
-		}
-		const filePath = path.join(artifactDir, `${safeFileSegment(request.task_id)}-${provider}-${stream}.txt`);
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, content);
-		const artifact = { id: `${provider}-${stream}`, name: `${provider}-${stream}`, kind: 'provider-process-stream', stream, path: filePath, bytes: Buffer.byteLength(content) };
-		artifacts.push(artifact);
-		evidence_refs.push({ kind: 'provider-process-stream', label: `${provider} ${stream}`, path: filePath });
-	}
-	return { artifacts, evidence_refs };
-}
-
-function safeFileSegment(value) {
-	return String(value || 'agent-task').replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'agent-task';
-}
-
-function redactSecrets(content, secretEnvNames) {
-	let redacted = content;
-	for (const name of secretEnvNames) {
-		const value = process.env[name];
-		if (value) {
-			redacted = redacted.split(value).join('[redacted]');
-		}
-	}
-	return redacted;
-}
-
-function validateRequest(request) {
-	if (!request || typeof request !== 'object' || Array.isArray(request)) {
-		return 'Request must be a JSON object.';
-	}
-	if (request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
-		return `Request schema must be ${AGENT_TASK_REQUEST_SCHEMA}.`;
-	}
-	if (!request.task_id || typeof request.task_id !== 'string') {
-		return 'Request task_id is required.';
-	}
-	if (request.executor?.backend !== CODEX_RUNTIME_ID) {
-		return 'Request executor.backend must be codex.';
-	}
-	if (request.executor?.runtime !== undefined && request.executor.runtime !== CODEX_RUNTIME_ID) {
-		return 'Request executor.runtime must be codex.';
-	}
-	if (!request.executor.config || typeof request.executor.config !== 'object' || Array.isArray(request.executor.config)) {
-		return 'Request executor.config is required.';
-	}
-	if (!request.instructions || typeof request.instructions !== 'string') {
-		return 'Request instructions are required.';
-	}
-	return null;
-}
-
-function timeoutSecondsFromLimits(limits = {}, fallbackSeconds = 0) {
-	if (limits.timeout_ms || limits.max_runtime_ms) {
-		return Math.ceil(Number(limits.timeout_ms || limits.max_runtime_ms) / 1000);
-	}
-	return Number(limits.task_timeout_seconds || limits.taskTimeoutSeconds || fallbackSeconds || 0);
-}
-
 function resolveCommandSpec(config = {}, options = {}) {
 	const configuredCommand = options.command || config.command || process.env.HOMEBOY_CODEX_COMMAND || CODEX_DEFAULT_COMMAND;
 	const configuredArgs = options.commandArgs || config.command_args || parseEnvCommandArgs() || CODEX_DEFAULT_COMMAND_ARGS;
@@ -284,9 +101,32 @@ function parseEnvCommandArgs() {
 	}
 }
 
-function resolveCwd(request = {}, config = {}) {
-	return config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
-}
+const { execute: executeCodexAgentTask, outcome, validationFailure } = createCliAgentTaskExecutor({
+	backend: CODEX_RUNTIME_ID,
+	runtime: CODEX_RUNTIME_ID,
+	providerId: CODEX_PROVIDER_ID,
+	providerLabel: 'Codex agent',
+	defaultSummary: 'Codex agent task executor failed before producing a detailed outcome.',
+	secretEnv: CODEX_SECRET_ENV,
+	artifactProvider: 'codex',
+	collectArtifacts: true,
+	resolveCommandSpec,
+	buildArgs: (request, config, commandSpec) => [
+		...commandSpec.args,
+		...(config.model ? ['--model', config.model] : []),
+		request.instructions,
+	],
+	buildSpawn: () => ({ env: process.env }),
+	messages: {
+		invalidRequest: { code: 'agent_task.invalid_codex_request', summary: 'Codex request validation failed.' },
+		invalidCommand: { code: 'agent_task.invalid_codex_command', summary: 'Codex command configuration is invalid.' },
+		notFound: { code: 'agent_task.codex_command_not_found', summary: 'Codex command was not found.', hint: 'Install Codex CLI or configure executor.config.command.' },
+		timeout: { code: 'agent_task.codex_timeout', summary: 'Codex execution timed out.' },
+		spawnFailed: { code: 'agent_task.codex_spawn_failed', summary: 'Codex process failed to start or complete.' },
+		success: { summary: 'Codex completed successfully.', diag: 'Codex CLI exited with status 0.' },
+		failed: { code: 'agent_task.codex_failed', summary: 'Codex execution failed.', diag: (status) => `Codex CLI exited with status ${status}.` },
+	},
+});
 
 module.exports = {
 	CODEX_CAPABILITIES,

--- a/agent-runtimes/codex/scripts/agent/homeboy-codex-agent-task-executor.cjs
+++ b/agent-runtimes/codex/scripts/agent/homeboy-codex-agent-task-executor.cjs
@@ -1,44 +1,17 @@
 #!/usr/bin/env node
 'use strict';
 
-/* eslint-disable no-console */
-
-const fs = require('node:fs');
+const {
+	runCliAgentTaskExecutorBin,
+} = require('../../../lib/cli-agent-task-executor-bin');
 const {
 	executeCodexAgentTask,
 	outcome,
 	providerContract,
 } = require('../../lib/codex-agent-task-executor');
 
-function readStdin() {
-	try {
-		return fs.readFileSync(0, 'utf8');
-	} catch {
-		return '';
-	}
-}
-
-if (process.argv.includes('--provider-contract')) {
-	process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
-	process.exit(0);
-}
-
-let request = {};
-const raw = process.env.HOMEBOY_AGENT_TASK_REQUEST || readStdin();
-if (raw.trim()) {
-	try {
-		request = JSON.parse(raw);
-	} catch (error) {
-		process.stdout.write(`${JSON.stringify(outcome({}, {
-			status: 'provider_error',
-			failure_classification: 'invalid_input',
-			failure_code: 'agent_task.invalid_json',
-			summary: 'Invalid AgentTaskRequest JSON.',
-			diagnostics: [{ classification: 'request_validation', message: error.message }],
-		}), null, 2)}\n`);
-		process.exit(0);
-	}
-}
-
-process.stdout.write(`${JSON.stringify(executeCodexAgentTask(request), null, 2)}\n`);
-process.exit(0);
+runCliAgentTaskExecutorBin({
+	execute: executeCodexAgentTask,
+	outcome,
+	providerContract,
+});

--- a/agent-runtimes/lib/cli-agent-task-executor-bin.js
+++ b/agent-runtimes/lib/cli-agent-task-executor-bin.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+
+/**
+ * Drive a CLI agent-task executor from a standalone runtime bin.
+ *
+ * Every per-provider `homeboy-<runtime>-agent-task-executor.cjs` wrapper shares
+ * the same stdin/argv contract: print the provider contract for
+ * `--provider-contract`, otherwise read an AgentTaskRequest from
+ * HOMEBOY_AGENT_TASK_REQUEST or stdin, parse it, and emit a normalized
+ * AgentTaskOutcome. This helper centralizes that contract so each runtime bin is
+ * a one-line invocation with its own executor module.
+ *
+ * @param {{execute: Function, outcome: Function, providerContract: Function}} executor Provider executor surface.
+ */
+function runCliAgentTaskExecutorBin({ execute, outcome, providerContract }) {
+	if (process.argv.includes('--provider-contract')) {
+		process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
+		process.exit(0);
+	}
+
+	let request = {};
+	const raw = process.env.HOMEBOY_AGENT_TASK_REQUEST || readStdin();
+	if (raw.trim()) {
+		try {
+			request = JSON.parse(raw);
+		} catch (error) {
+			process.stdout.write(`${JSON.stringify(outcome({}, {
+				status: 'provider_error',
+				failure_classification: 'invalid_input',
+				failure_code: 'agent_task.invalid_json',
+				summary: 'Invalid AgentTaskRequest JSON.',
+				diagnostics: [{ classification: 'request_validation', message: error.message }],
+			}), null, 2)}\n`);
+			process.exit(0);
+		}
+	}
+
+	process.stdout.write(`${JSON.stringify(execute(request), null, 2)}\n`);
+	process.exit(0);
+}
+
+function readStdin() {
+	try {
+		return fs.readFileSync(0, 'utf8');
+	} catch {
+		return '';
+	}
+}
+
+module.exports = {
+	runCliAgentTaskExecutorBin,
+};

--- a/agent-runtimes/lib/cli-agent-task-executor.js
+++ b/agent-runtimes/lib/cli-agent-task-executor.js
@@ -1,0 +1,273 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Internal dependencies
+ */
+const {
+	AGENT_TASK_REQUEST_SCHEMA,
+} = require('../../agent-task-contracts/agent-task-provider-contract');
+const {
+	normalizeAgentTaskOutcome,
+} = require('../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
+
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+
+/**
+ * Build a CLI agent-task executor from a per-provider configuration.
+ *
+ * The four standalone CLI runtimes (codex, claude-code, opencode, pi) share a
+ * single execution spine: validate the AgentTaskRequest, optionally run a
+ * provider preflight, resolve the command, spawn it synchronously, and map the
+ * spawn result onto a normalized AgentTaskOutcome. Every genuine per-provider
+ * delta is expressed through the `spec` passed here, so the shared spine stays
+ * the single source of truth for control flow while each runtime keeps its own
+ * explicit configuration.
+ *
+ * @param {Object} spec Provider configuration.
+ * @return {{execute: Function, outcome: Function, validationFailure: Function}} Executor surface.
+ */
+function createCliAgentTaskExecutor(spec) {
+	const {
+		backend,
+		runtime = backend,
+		providerId,
+		providerLabel,
+		defaultSummary,
+		validateRuntime = true,
+		requireConfig = true,
+		emitArtifacts = true,
+		secretEnv = [],
+		artifactProvider = backend,
+		collectArtifacts = false,
+		timeoutFallback = (config) => config.timeout_seconds,
+		resolveCommandSpec,
+		buildArgs,
+		buildSpawn,
+		preflight,
+		onEmptyCommand,
+		finalizeOutcome,
+		messages = {},
+		invalidCommandOutcome,
+		notFoundOutcome,
+		spawnErrorOutcome,
+		successOutcome,
+		failureOutcome,
+	} = spec;
+
+	const buildInvalidCommand = invalidCommandOutcome || ((commandSpec) => ({
+		status: 'provider_error',
+		failure_classification: commandSpec.classification || 'provider',
+		failure_code: commandSpec.code || messages.invalidCommand.code,
+		summary: commandSpec.summary || messages.invalidCommand.summary,
+		diagnostics: [{ classification: 'provider_setup', message: commandSpec.error }],
+	}));
+
+	const buildNotFound = notFoundOutcome || (() => ({
+		status: 'provider_error',
+		failure_classification: 'provider',
+		failure_code: messages.notFound.code,
+		summary: messages.notFound.summary,
+		diagnostics: [{ classification: 'provider_setup', message: messages.notFound.hint }],
+	}));
+
+	const buildSpawnError = spawnErrorOutcome || ((context, timedOut) => ({
+		status: timedOut ? 'timeout' : 'provider_error',
+		failure_classification: timedOut ? 'timeout' : 'provider',
+		failure_code: timedOut ? messages.timeout.code : messages.spawnFailed.code,
+		summary: timedOut ? messages.timeout.summary : messages.spawnFailed.summary,
+		diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: context.spawnResult.error.message }],
+	}));
+
+	const buildSuccess = successOutcome || (() => ({
+		status: 'succeeded',
+		summary: messages.success.summary,
+		diagnostics: [{ classification: 'provider', message: messages.success.diag }],
+		metadata: { exit_code: 0 },
+	}));
+
+	const buildFailure = failureOutcome || ((context) => ({
+		status: 'failed',
+		failure_classification: 'execution_failed',
+		failure_code: messages.failed.code,
+		summary: messages.failed.summary,
+		diagnostics: [{ classification: 'execution_failed', message: messages.failed.diag(context.spawnResult.status) }],
+		metadata: {
+			exit_code: context.spawnResult.status,
+			...(context.spawnResult.signal ? { signal: context.spawnResult.signal } : {}),
+		},
+	}));
+
+	function outcomeRequest(request = {}) {
+		return request.task_id ? request : { ...request, task_id: 'unknown-task' };
+	}
+
+	function outcome(request = {}, values = {}) {
+		const normalizedRequest = outcomeRequest(request);
+		const normalized = normalizeAgentTaskOutcome(normalizedRequest, values, {
+			provider: providerId,
+			providerLabel,
+			status: values.status || 'provider_error',
+			failureClassification: values.failure_classification,
+			failureCode: values.failure_code,
+			summary: values.summary || defaultSummary,
+			artifacts: emitArtifacts ? (values.artifacts || []) : [],
+			evidenceRefs: emitArtifacts ? (values.evidence_refs || []) : [],
+			metadata: values.metadata || {},
+		});
+		return finalizeOutcome ? finalizeOutcome(normalizedRequest, normalized) : normalized;
+	}
+
+	function validationFailure(request, message) {
+		return outcome(request, {
+			status: 'provider_error',
+			failure_classification: 'invalid_input',
+			failure_code: messages.invalidRequest.code,
+			summary: messages.invalidRequest.summary,
+			diagnostics: [{ classification: 'request_validation', message }],
+		});
+	}
+
+	function validateRequest(request) {
+		if (!request || typeof request !== 'object' || Array.isArray(request)) {
+			return 'Request must be a JSON object.';
+		}
+		if (request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
+			return `Request schema must be ${AGENT_TASK_REQUEST_SCHEMA}.`;
+		}
+		if (!request.task_id || typeof request.task_id !== 'string') {
+			return 'Request task_id is required.';
+		}
+		if (request.executor?.backend !== backend) {
+			return `Request executor.backend must be ${backend}.`;
+		}
+		if (validateRuntime && request.executor?.runtime !== undefined && request.executor.runtime !== runtime) {
+			return `Request executor.runtime must be ${runtime}.`;
+		}
+		if (requireConfig && (!request.executor.config || typeof request.executor.config !== 'object' || Array.isArray(request.executor.config))) {
+			return 'Request executor.config is required.';
+		}
+		if (!request.instructions || typeof request.instructions !== 'string') {
+			return 'Request instructions are required.';
+		}
+		return null;
+	}
+
+	function processArtifacts(request, config, spawnResult) {
+		const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
+		if (!artifactDir) {
+			return {};
+		}
+		const artifacts = [];
+		const evidence_refs = [];
+		for (const stream of ['stdout', 'stderr']) {
+			const content = redactSecrets(String(spawnResult[stream] || ''), secretEnv);
+			if (!content) {
+				continue;
+			}
+			const filePath = path.join(artifactDir, `${safeFileSegment(request.task_id)}-${artifactProvider}-${stream}.txt`);
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, content);
+			const artifact = { id: `${artifactProvider}-${stream}`, name: `${artifactProvider}-${stream}`, kind: 'provider-process-stream', stream, path: filePath, bytes: Buffer.byteLength(content) };
+			artifacts.push(artifact);
+			evidence_refs.push({ kind: 'provider-process-stream', label: `${artifactProvider} ${stream}`, path: filePath });
+		}
+		return { artifacts, evidence_refs };
+	}
+
+	function execute(request = {}, options = {}) {
+		const validationError = validateRequest(request);
+		if (validationError) {
+			return validationFailure(request, validationError);
+		}
+
+		if (preflight) {
+			const preflightOutcome = preflight(request, options);
+			if (preflightOutcome) {
+				return outcome(request, preflightOutcome);
+			}
+		}
+
+		const config = request.executor.config || {};
+		const commandSpec = resolveCommandSpec(config, options);
+		if (commandSpec.error) {
+			return outcome(request, buildInvalidCommand(commandSpec));
+		}
+
+		const cwd = resolveCwd(request, config);
+		if (onEmptyCommand && !commandSpec.command) {
+			return outcome(request, onEmptyCommand({ request, config, commandSpec, cwd }));
+		}
+
+		const args = buildArgs(request, config, commandSpec);
+		const timeoutSeconds = timeoutSecondsFromLimits(request.limits, timeoutFallback(config));
+		const spawnExtra = buildSpawn(request, config, options);
+		const spawnResult = spawnSync(commandSpec.command, args, {
+			cwd,
+			encoding: 'utf8',
+			maxBuffer: options.maxBuffer || DEFAULT_MAX_BUFFER,
+			...spawnExtra,
+			...(timeoutSeconds > 0 ? { timeout: timeoutSeconds * 1000 } : {}),
+		});
+
+		const processEvidence = collectArtifacts ? processArtifacts(request, config, spawnResult) : {};
+		const context = { request, config, commandSpec, cwd, spawnResult };
+
+		if (spawnResult.error?.code === 'ENOENT') {
+			return outcome(request, buildNotFound(context));
+		}
+
+		if (spawnResult.error) {
+			const timedOut = spawnResult.error.code === 'ETIMEDOUT';
+			return outcome(request, buildSpawnError(context, timedOut));
+		}
+
+		if (spawnResult.status === 0) {
+			return outcome(request, { ...buildSuccess(context), ...processEvidence });
+		}
+
+		return outcome(request, { ...buildFailure(context), ...processEvidence });
+	}
+
+	return { execute, outcome, validationFailure };
+}
+
+function timeoutSecondsFromLimits(limits = {}, fallbackSeconds = 0) {
+	if (limits.timeout_ms || limits.max_runtime_ms) {
+		return Math.ceil(Number(limits.timeout_ms || limits.max_runtime_ms) / 1000);
+	}
+	return Number(limits.task_timeout_seconds || limits.taskTimeoutSeconds || fallbackSeconds || 0);
+}
+
+function resolveCwd(request = {}, config = {}) {
+	return config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
+}
+
+function safeFileSegment(value) {
+	return String(value || 'agent-task').replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'agent-task';
+}
+
+function redactSecrets(content, secretEnvNames) {
+	let redacted = content;
+	for (const name of secretEnvNames) {
+		const value = process.env[name];
+		if (value) {
+			redacted = redacted.split(value).join('[redacted]');
+		}
+	}
+	return redacted;
+}
+
+module.exports = {
+	createCliAgentTaskExecutor,
+	timeoutSecondsFromLimits,
+	resolveCwd,
+	safeFileSegment,
+	redactSecrets,
+};

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -1,23 +1,17 @@
 'use strict';
 
 /**
- * External dependencies
- */
-const { spawnSync } = require('node:child_process');
-
-/**
  * Internal dependencies
  */
 const {
-	AGENT_TASK_REQUEST_SCHEMA,
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 	agentTaskProviderContractFields,
 	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
-	normalizeAgentTaskOutcome,
-} = require('../../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
+	createCliAgentTaskExecutor,
+} = require('../../lib/cli-agent-task-executor');
 
 const OPENCODE_PROVIDER_ID = 'opencode.agent-task-executor';
 const OPENCODE_PROVIDER_LABEL = 'OpenCode agent task executor';
@@ -208,113 +202,6 @@ function providerContract(options = {}) {
 	};
 }
 
-function outcome(request = {}, values = {}) {
-	return withDeclaredArtifactDiagnostics(outcomeRequest(request), normalizeAgentTaskOutcome(outcomeRequest(request), values, {
-		provider: OPENCODE_PROVIDER_ID,
-		providerLabel: 'OpenCode agent',
-		status: values.status || 'provider_error',
-		failureClassification: values.failure_classification,
-		failureCode: values.failure_code,
-		summary: values.summary || 'OpenCode agent task executor failed before producing a detailed outcome.',
-		artifacts: values.artifacts || [],
-		evidenceRefs: values.evidence_refs || [],
-		metadata: values.metadata || {},
-	}));
-}
-
-function outcomeRequest(request = {}) {
-	return request.task_id ? request : { ...request, task_id: 'unknown-task' };
-}
-
-function validationFailure(request, message) {
-	return outcome(request, {
-		status: 'provider_error',
-		failure_classification: 'invalid_input',
-		failure_code: 'agent_task.invalid_opencode_request',
-		summary: 'OpenCode request validation failed.',
-		diagnostics: [{ classification: 'request_validation', message }],
-	});
-}
-
-function executeOpenCodeAgentTask(request = {}, options = {}) {
-	const validationError = validateRequest(request);
-	if (validationError) {
-		return validationFailure(request, validationError);
-	}
-
-	const config = request.executor.config || {};
-	const commandSpec = resolveCommandSpec(config, options);
-	if (commandSpec.error) {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: 'provider',
-			failure_code: 'agent_task.invalid_opencode_command',
-			summary: 'OpenCode command configuration is invalid.',
-			diagnostics: [{ classification: 'provider_setup', message: commandSpec.error }],
-		});
-	}
-
-	const args = [
-		...commandSpec.args,
-		'run',
-		...(config.model ? ['--model', config.model] : []),
-		...(config.agent ? ['--agent', config.agent] : []),
-		...(config.variant ? ['--variant', config.variant] : []),
-		...(config.title ? ['--title', config.title] : []),
-		request.instructions,
-	];
-	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
-	const spawnResult = spawnSync(commandSpec.command, args, {
-		cwd: resolveCwd(request, config),
-		env: opencodeSpawnEnv(request, options),
-		encoding: 'utf8',
-		maxBuffer: options.maxBuffer || 10 * 1024 * 1024,
-		...(timeoutSeconds > 0 ? { timeout: timeoutSeconds * 1000 } : {}),
-	});
-
-	if (spawnResult.error?.code === 'ENOENT') {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: 'provider',
-			failure_code: 'agent_task.opencode_command_not_found',
-			summary: 'OpenCode command was not found.',
-			diagnostics: [{ classification: 'provider_setup', message: 'Install opencode or configure executor.config.command.' }],
-		});
-	}
-
-	if (spawnResult.error) {
-		const timedOut = spawnResult.error.code === 'ETIMEDOUT';
-		return outcome(request, {
-			status: timedOut ? 'timeout' : 'provider_error',
-			failure_classification: timedOut ? 'timeout' : 'provider',
-			failure_code: timedOut ? 'agent_task.opencode_timeout' : 'agent_task.opencode_spawn_failed',
-			summary: timedOut ? 'OpenCode execution timed out.' : 'OpenCode process failed to start or complete.',
-			diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: spawnResult.error.message }],
-		});
-	}
-
-	if (spawnResult.status === 0) {
-		return outcome(request, {
-			status: 'succeeded',
-			summary: 'OpenCode completed successfully.',
-			diagnostics: [{ classification: 'provider', message: 'OpenCode CLI exited with status 0.' }],
-			metadata: { exit_code: 0 },
-		});
-	}
-
-	return outcome(request, {
-		status: 'failed',
-		failure_classification: 'execution_failed',
-		failure_code: 'agent_task.opencode_failed',
-		summary: 'OpenCode execution failed.',
-		diagnostics: [{ classification: 'execution_failed', message: `OpenCode CLI exited with status ${spawnResult.status}.` }],
-		metadata: {
-			exit_code: spawnResult.status,
-			...(spawnResult.signal ? { signal: spawnResult.signal } : {}),
-		},
-	});
-}
-
 function opencodeSpawnEnv(request = {}, options = {}) {
 	const ambient = options.env && typeof options.env === 'object' && !Array.isArray(options.env) ? options.env : process.env;
 	const config = request.executor?.config || {};
@@ -392,35 +279,6 @@ function objectValue(value) {
 	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
-function validateRequest(request) {
-	if (!request || typeof request !== 'object' || Array.isArray(request)) {
-		return 'Request must be a JSON object.';
-	}
-	if (request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
-		return `Request schema must be ${AGENT_TASK_REQUEST_SCHEMA}.`;
-	}
-	if (!request.task_id || typeof request.task_id !== 'string') {
-		return 'Request task_id is required.';
-	}
-	if (request.executor?.backend !== 'opencode') {
-		return 'Request executor.backend must be opencode.';
-	}
-	if (!request.executor.config || typeof request.executor.config !== 'object' || Array.isArray(request.executor.config)) {
-		return 'Request executor.config is required.';
-	}
-	if (!request.instructions || typeof request.instructions !== 'string') {
-		return 'Request instructions are required.';
-	}
-	return null;
-}
-
-function timeoutSecondsFromLimits(limits = {}, fallbackSeconds = 0) {
-	if (limits.timeout_ms || limits.max_runtime_ms) {
-		return Math.ceil(Number(limits.timeout_ms || limits.max_runtime_ms) / 1000);
-	}
-	return Number(limits.task_timeout_seconds || limits.taskTimeoutSeconds || fallbackSeconds || 0);
-}
-
 function resolveCommandSpec(config = {}, options = {}) {
 	const configuredCommand = options.command || config.runtime_bin || config.runtimeBin || config.command || process.env.HOMEBOY_OPENCODE_COMMAND || 'opencode';
 	const configuredArgs = options.commandArgs || config.command_args || parseEnvCommandArgs();
@@ -445,9 +303,34 @@ function parseEnvCommandArgs() {
 	}
 }
 
-function resolveCwd(request = {}, config = {}) {
-	return config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
-}
+const { execute: executeOpenCodeAgentTask, outcome, validationFailure } = createCliAgentTaskExecutor({
+	backend: 'opencode',
+	providerId: OPENCODE_PROVIDER_ID,
+	providerLabel: 'OpenCode agent',
+	defaultSummary: 'OpenCode agent task executor failed before producing a detailed outcome.',
+	validateRuntime: false,
+	finalizeOutcome: withDeclaredArtifactDiagnostics,
+	resolveCommandSpec,
+	buildArgs: (request, config, commandSpec) => [
+		...commandSpec.args,
+		'run',
+		...(config.model ? ['--model', config.model] : []),
+		...(config.agent ? ['--agent', config.agent] : []),
+		...(config.variant ? ['--variant', config.variant] : []),
+		...(config.title ? ['--title', config.title] : []),
+		request.instructions,
+	],
+	buildSpawn: (request, config, options) => ({ env: opencodeSpawnEnv(request, options) }),
+	messages: {
+		invalidRequest: { code: 'agent_task.invalid_opencode_request', summary: 'OpenCode request validation failed.' },
+		invalidCommand: { code: 'agent_task.invalid_opencode_command', summary: 'OpenCode command configuration is invalid.' },
+		notFound: { code: 'agent_task.opencode_command_not_found', summary: 'OpenCode command was not found.', hint: 'Install opencode or configure executor.config.command.' },
+		timeout: { code: 'agent_task.opencode_timeout', summary: 'OpenCode execution timed out.' },
+		spawnFailed: { code: 'agent_task.opencode_spawn_failed', summary: 'OpenCode process failed to start or complete.' },
+		success: { summary: 'OpenCode completed successfully.', diag: 'OpenCode CLI exited with status 0.' },
+		failed: { code: 'agent_task.opencode_failed', summary: 'OpenCode execution failed.', diag: (status) => `OpenCode CLI exited with status ${status}.` },
+	},
+});
 
 module.exports = {
 	OPENCODE_PROVIDER_ID,

--- a/agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
+++ b/agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
@@ -1,44 +1,17 @@
 #!/usr/bin/env node
 'use strict';
 
-/* eslint-disable no-console */
-
-const fs = require('node:fs');
+const {
+	runCliAgentTaskExecutorBin,
+} = require('../../../lib/cli-agent-task-executor-bin');
 const {
 	executeOpenCodeAgentTask,
 	outcome,
 	providerContract,
 } = require('../../lib/opencode-agent-task-executor');
 
-function readStdin() {
-	try {
-		return fs.readFileSync(0, 'utf8');
-	} catch {
-		return '';
-	}
-}
-
-if (process.argv.includes('--provider-contract')) {
-	process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
-	process.exit(0);
-}
-
-let request = {};
-const raw = process.env.HOMEBOY_AGENT_TASK_REQUEST || readStdin();
-if (raw.trim()) {
-	try {
-		request = JSON.parse(raw);
-	} catch (error) {
-		process.stdout.write(`${JSON.stringify(outcome({}, {
-			status: 'provider_error',
-			failure_classification: 'invalid_input',
-			failure_code: 'agent_task.invalid_json',
-			summary: 'Invalid AgentTaskRequest JSON.',
-			diagnostics: [{ classification: 'request_validation', message: error.message }],
-		}), null, 2)}\n`);
-		process.exit(0);
-	}
-}
-
-process.stdout.write(`${JSON.stringify(executeOpenCodeAgentTask(request), null, 2)}\n`);
-process.exit(0);
+runCliAgentTaskExecutorBin({
+	execute: executeOpenCodeAgentTask,
+	outcome,
+	providerContract,
+});

--- a/agent-runtimes/pi/lib/pi-agent-task-executor.js
+++ b/agent-runtimes/pi/lib/pi-agent-task-executor.js
@@ -1,21 +1,15 @@
 'use strict';
 
 /**
- * External dependencies
- */
-const { spawnSync } = require('node:child_process');
-
-/**
  * Internal dependencies
  */
 const {
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
-	AGENT_TASK_REQUEST_SCHEMA,
 	agentTaskProviderContractFields,
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
-	normalizeAgentTaskOutcome,
-} = require('../../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
+	createCliAgentTaskExecutor,
+} = require('../../lib/cli-agent-task-executor');
 
 const PI_PROVIDER_ID = 'pi.agent-task-executor';
 const PI_PROVIDER_LABEL = 'Pi agent task executor';
@@ -53,156 +47,6 @@ function providerContract(options = {}) {
 	};
 }
 
-function outcome(request = {}, values = {}) {
-	return normalizeAgentTaskOutcome(outcomeRequest(request), values, {
-		provider: PI_PROVIDER_ID,
-		providerLabel: 'Pi agent',
-		status: values.status || 'provider_error',
-		failureClassification: values.failure_classification,
-		failureCode: values.failure_code,
-		summary: values.summary || 'Pi agent task executor did not produce a detailed outcome.',
-		artifacts: [],
-		evidenceRefs: [],
-		metadata: values.metadata || {},
-	});
-}
-
-function outcomeRequest(request = {}) {
-	return request.task_id ? request : { ...request, task_id: 'unknown-task' };
-}
-
-function validationFailure(request, message) {
-	return outcome(request, {
-		status: 'provider_error',
-		failure_classification: 'invalid_input',
-		failure_code: 'agent_task.invalid_pi_request',
-		summary: 'Pi request validation failed.',
-		diagnostics: [{ classification: 'request_validation', message }],
-	});
-}
-
-function executePiAgentTask(request = {}, options = {}) {
-	const validationError = validateRequest(request);
-	if (validationError) {
-		return validationFailure(request, validationError);
-	}
-
-	const config = request.executor.config || {};
-	const commandSpec = resolveCommandSpec(config, options);
-	if (commandSpec.error) {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: 'provider',
-			failure_code: 'agent_task.invalid_pi_command',
-			summary: 'Pi command configuration is invalid.',
-			diagnostics: [{ classification: 'provider_setup', message: commandSpec.error }],
-		});
-	}
-
-	if (!commandSpec.command) {
-		return outcome(request, {
-			status: 'no_op',
-			summary: 'Pi runtime is not configured with an explicit command.',
-			diagnostics: [{
-				classification: 'provider_setup',
-				message: 'Set executor.config.command or HOMEBOY_PI_COMMAND when the Pi runtime contract is available.',
-			}],
-			metadata: { configured: false },
-		});
-	}
-
-	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds || DEFAULT_TIMEOUT_SECONDS);
-	const cwd = resolveCwd(request, config);
-	const requestJson = JSON.stringify(request);
-	const spawnResult = spawnSync(commandSpec.command, commandSpec.args, {
-		cwd,
-		env: {
-			...process.env,
-			HOMEBOY_AGENT_TASK_REQUEST: requestJson,
-		},
-		input: requestJson,
-		encoding: 'utf8',
-		maxBuffer: options.maxBuffer || 10 * 1024 * 1024,
-		...(timeoutSeconds > 0 ? { timeout: timeoutSeconds * 1000 } : {}),
-	});
-
-	if (spawnResult.error?.code === 'ENOENT') {
-		return outcome(request, {
-			status: 'provider_error',
-			failure_classification: 'provider',
-			failure_code: 'agent_task.pi_command_not_found',
-			summary: 'Pi command was not found.',
-			diagnostics: [{ classification: 'provider_setup', message: 'Configure executor.config.command with an installed Pi runtime adapter command.' }],
-			metadata: { command: commandSpec.command, args_count: commandSpec.args.length, cwd },
-		});
-	}
-
-	if (spawnResult.error) {
-		const timedOut = spawnResult.error.code === 'ETIMEDOUT';
-		return outcome(request, {
-			status: timedOut ? 'timeout' : 'provider_error',
-			failure_classification: timedOut ? 'timeout' : 'provider',
-			failure_code: timedOut ? 'agent_task.pi_timeout' : 'agent_task.pi_spawn_failed',
-			summary: timedOut ? 'Pi command timed out.' : 'Pi command failed to start or complete.',
-			diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: spawnResult.error.message }],
-			metadata: { command: commandSpec.command, args_count: commandSpec.args.length, cwd },
-		});
-	}
-
-	if (spawnResult.status === 0) {
-		return outcome(request, {
-			status: 'no_op',
-			summary: 'Pi command completed; no Pi-specific outcome contract is implemented yet.',
-			diagnostics: [{ classification: 'provider', message: 'Configured Pi command exited with status 0.' }],
-			metadata: { command: commandSpec.command, args_count: commandSpec.args.length, cwd, exit_code: 0 },
-		});
-	}
-
-	return outcome(request, {
-		status: 'provider_error',
-		failure_classification: 'provider',
-		failure_code: 'agent_task.pi_command_failed',
-		summary: 'Pi command failed before producing a normalized outcome.',
-		diagnostics: [{ classification: 'provider', message: `Configured Pi command exited with status ${spawnResult.status}.` }],
-		metadata: {
-			command: commandSpec.command,
-			args_count: commandSpec.args.length,
-			cwd,
-			exit_code: spawnResult.status,
-			...(spawnResult.signal ? { signal: spawnResult.signal } : {}),
-		},
-	});
-}
-
-function validateRequest(request) {
-	if (!request || typeof request !== 'object' || Array.isArray(request)) {
-		return 'Request must be a JSON object.';
-	}
-	if (request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
-		return `Request schema must be ${AGENT_TASK_REQUEST_SCHEMA}.`;
-	}
-	if (!request.task_id || typeof request.task_id !== 'string') {
-		return 'Request task_id is required.';
-	}
-	if (request.executor?.backend !== PI_BACKEND) {
-		return `Request executor.backend must be ${PI_BACKEND}.`;
-	}
-	if (request.executor?.runtime !== undefined && request.executor.runtime !== PI_BACKEND) {
-		return `Request executor.runtime must be ${PI_BACKEND}.`;
-	}
-	if (!request.instructions || typeof request.instructions !== 'string') {
-		return 'Request instructions are required.';
-	}
-	return null;
-}
-
-function timeoutSecondsFromLimits(limits = {}, fallbackSeconds = 0) {
-	if (limits.timeout_ms || limits.max_runtime_ms) {
-		return Math.ceil(Number(limits.timeout_ms || limits.max_runtime_ms) / 1000);
-	}
-	return Number(limits.task_timeout_seconds || limits.taskTimeoutSeconds || fallbackSeconds || 0);
-}
-
 function resolveCommandSpec(config = {}, options = {}) {
 	const configuredCommand = options.command || config.command || process.env.HOMEBOY_PI_COMMAND || '';
 	const configuredArgs = options.commandArgs || config.command_args || parseEnvCommandArgs();
@@ -227,9 +71,83 @@ function parseEnvCommandArgs() {
 	}
 }
 
-function resolveCwd(request = {}, config = {}) {
-	return config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
+function piMetadata(context, extra = {}) {
+	return {
+		command: context.commandSpec.command,
+		args_count: context.commandSpec.args.length,
+		cwd: context.cwd,
+		...extra,
+	};
 }
+
+const { execute: executePiAgentTask, outcome, validationFailure } = createCliAgentTaskExecutor({
+	backend: PI_BACKEND,
+	runtime: PI_BACKEND,
+	providerId: PI_PROVIDER_ID,
+	providerLabel: 'Pi agent',
+	defaultSummary: 'Pi agent task executor did not produce a detailed outcome.',
+	requireConfig: false,
+	emitArtifacts: false,
+	timeoutFallback: (config) => config.timeout_seconds || DEFAULT_TIMEOUT_SECONDS,
+	resolveCommandSpec,
+	buildArgs: (request, config, commandSpec) => commandSpec.args,
+	buildSpawn: (request) => {
+		const requestJson = JSON.stringify(request);
+		return {
+			env: {
+				...process.env,
+				HOMEBOY_AGENT_TASK_REQUEST: requestJson,
+			},
+			input: requestJson,
+		};
+	},
+	onEmptyCommand: () => ({
+		status: 'no_op',
+		summary: 'Pi runtime is not configured with an explicit command.',
+		diagnostics: [{
+			classification: 'provider_setup',
+			message: 'Set executor.config.command or HOMEBOY_PI_COMMAND when the Pi runtime contract is available.',
+		}],
+		metadata: { configured: false },
+	}),
+	notFoundOutcome: (context) => ({
+		status: 'provider_error',
+		failure_classification: 'provider',
+		failure_code: 'agent_task.pi_command_not_found',
+		summary: 'Pi command was not found.',
+		diagnostics: [{ classification: 'provider_setup', message: 'Configure executor.config.command with an installed Pi runtime adapter command.' }],
+		metadata: piMetadata(context),
+	}),
+	spawnErrorOutcome: (context, timedOut) => ({
+		status: timedOut ? 'timeout' : 'provider_error',
+		failure_classification: timedOut ? 'timeout' : 'provider',
+		failure_code: timedOut ? 'agent_task.pi_timeout' : 'agent_task.pi_spawn_failed',
+		summary: timedOut ? 'Pi command timed out.' : 'Pi command failed to start or complete.',
+		diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: context.spawnResult.error.message }],
+		metadata: piMetadata(context),
+	}),
+	successOutcome: (context) => ({
+		status: 'no_op',
+		summary: 'Pi command completed; no Pi-specific outcome contract is implemented yet.',
+		diagnostics: [{ classification: 'provider', message: 'Configured Pi command exited with status 0.' }],
+		metadata: piMetadata(context, { exit_code: 0 }),
+	}),
+	failureOutcome: (context) => ({
+		status: 'provider_error',
+		failure_classification: 'provider',
+		failure_code: 'agent_task.pi_command_failed',
+		summary: 'Pi command failed before producing a normalized outcome.',
+		diagnostics: [{ classification: 'provider', message: `Configured Pi command exited with status ${context.spawnResult.status}.` }],
+		metadata: piMetadata(context, {
+			exit_code: context.spawnResult.status,
+			...(context.spawnResult.signal ? { signal: context.spawnResult.signal } : {}),
+		}),
+	}),
+	messages: {
+		invalidRequest: { code: 'agent_task.invalid_pi_request', summary: 'Pi request validation failed.' },
+		invalidCommand: { code: 'agent_task.invalid_pi_command', summary: 'Pi command configuration is invalid.' },
+	},
+});
 
 module.exports = {
 	PI_BACKEND,

--- a/agent-runtimes/pi/scripts/agent/homeboy-pi-agent-task-executor.cjs
+++ b/agent-runtimes/pi/scripts/agent/homeboy-pi-agent-task-executor.cjs
@@ -1,44 +1,17 @@
 #!/usr/bin/env node
 'use strict';
 
-/* eslint-disable no-console */
-
-const fs = require('node:fs');
+const {
+	runCliAgentTaskExecutorBin,
+} = require('../../../lib/cli-agent-task-executor-bin');
 const {
 	executePiAgentTask,
 	outcome,
 	providerContract,
 } = require('../../lib/pi-agent-task-executor');
 
-function readStdin() {
-	try {
-		return fs.readFileSync(0, 'utf8');
-	} catch {
-		return '';
-	}
-}
-
-if (process.argv.includes('--provider-contract')) {
-	process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
-	process.exit(0);
-}
-
-let request = {};
-const raw = process.env.HOMEBOY_AGENT_TASK_REQUEST || readStdin();
-if (raw.trim()) {
-	try {
-		request = JSON.parse(raw);
-	} catch (error) {
-		process.stdout.write(`${JSON.stringify(outcome({}, {
-			status: 'provider_error',
-			failure_classification: 'invalid_input',
-			failure_code: 'agent_task.invalid_json',
-			summary: 'Invalid AgentTaskRequest JSON.',
-			diagnostics: [{ classification: 'request_validation', message: error.message }],
-		}), null, 2)}\n`);
-		process.exit(0);
-	}
-}
-
-process.stdout.write(`${JSON.stringify(executePiAgentTask(request), null, 2)}\n`);
-process.exit(0);
+runCliAgentTaskExecutorBin({
+	execute: executePiAgentTask,
+	outcome,
+	providerContract,
+});


### PR DESCRIPTION
Closes #1974.

## What

The four standalone CLI agent-task runtimes (`codex`, `claude-code`, `opencode`, `pi`) each shipped a near-identical executor. Their `lib/*-agent-task-executor.js` files were 45-50% copy-paste and the four `scripts/agent/homeboy-*-agent-task-executor.cjs` wrapper bins were near-zero-diff clones.

This adds two shared modules under `agent-runtimes/lib/`:

- **`cli-agent-task-executor.js`** — `createCliAgentTaskExecutor(spec)`. Owns the shared execution spine: request validation, optional provider preflight, command resolution, synchronous `spawnSync`, artifact capture + secret redaction, and outcome normalization. Also exports the previously-duplicated helpers (`timeoutSecondsFromLimits`, `resolveCwd`, `safeFileSegment`, `redactSecrets`).
- **`cli-agent-task-executor-bin.js`** — `runCliAgentTaskExecutorBin({ execute, outcome, providerContract })`. The single `--provider-contract` / stdin-request / outcome-stdout wrapper contract shared by all four bins.

Each provider lib now keeps only its real configuration — constants, `providerContract()`, `resolveCommandSpec()`, `parseEnvCommandArgs()` — and wires the factory with its genuine deltas:

- **opencode**: env allowlist (`opencodeSpawnEnv`) + declared-artifact diagnostics (`withDeclaredArtifactDiagnostics`) via `finalizeOutcome`, `validateRuntime: false`.
- **claude-code**: OAuth refresh-token `preflight` + structured adapter-missing command error.
- **pi**: `no_op` success / empty-command (`onEmptyCommand`) semantics, `provider_error` failure mapping, `emitArtifacts: false`, 300s default timeout.
- **codex**: model arg building + default `codex exec` command.

The 8 owned source files drop 829 lines and add 204; the two new shared modules add ~410.

## Preservation

Provider contract output and the per-runtime `*.json` manifests are byte-for-byte unchanged — the boundary tests assert `manifest.agent_task_executors[0]` deep-equals `providerContract()`, and they pass untouched.

## Verification

All run via `node <file>` (no node_modules required — node builtins + relative requires only):

- `agent-runtimes/{codex,claude-code,opencode,pi}/tests/*-boundary.test.js` — all 4 pass.
- `tests/agent-task-provider-contract-smoke.mjs` — pass.
- `tests/runtime-provider-resolver-smoke.mjs` — pass.
- `tests/agent-runtime-contract-smoke.mjs`, `tests/architectural-boundary-smoke.mjs` — pass.
- Behavioral-parity harness comparing the pre-refactor executors against the refactored ones across 16 request scenarios per provider plus `providerContract()`: **68/68 outcomes identical**. The claude-code OAuth-missing branch was verified separately with the refresh token unset.

Pre-existing unrelated failure (NOT introduced here, fails on base `main` too, out of scope): `wordpress/tests/generic-agent-runtime-contract.test.js` asserts `runtimeAgentCiRunnerSpec(...).executor.runtime === undefined` but gets `'opencode'` — that lives in `runtime-agent-ci`, not in the executor files touched here. Flagged for a separate fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Analyzing the four executors for duplication, designing and implementing the shared factory + wrapper-bin modules, refactoring each provider to delegate while preserving its deltas, and building the OLD-vs-NEW parity verification harness.