### PR TITLE
Write WordPress fuzz artifact files

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -37,7 +37,7 @@ function readWordPressFuzzRunnerEnv(env = process.env) {
 		seed: env.HOMEBOY_FUZZ_SEED,
 		maxDuration: env.HOMEBOY_FUZZ_MAX_DURATION,
 		resultsFile: env.HOMEBOY_FUZZ_RESULTS_FILE,
-		artifactRoot: env.HOMEBOY_ARTIFACT_ROOT || env.HOMEBOY_ARTIFACT_DIR || env.HOMEBOY_ARTIFACTS_DIR || env.HOMEBOY_RUN_ARTIFACT_ROOT || env.HOMEBOY_RUN_ARTIFACT_DIR,
+		artifactRoot: env.HOMEBOY_FUZZ_ARTIFACTS_DIR || env.HOMEBOY_ARTIFACT_ROOT || env.HOMEBOY_ARTIFACT_DIR || env.HOMEBOY_ARTIFACTS_DIR || env.HOMEBOY_RUN_ARTIFACT_ROOT || env.HOMEBOY_RUN_ARTIFACT_DIR,
 		wpCodeboxFuzzWorkloadRoot: env.WP_CODEBOX_FUZZ_WORKLOAD_ROOT,
 		wpCodeboxBin: env.HOMEBOY_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN,
 		wpCliBin: env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN,
@@ -660,6 +660,25 @@ function writeHomeboyFuzzResultsFile(filePath, campaign) {
 	fs.writeFileSync(filePath, `${JSON.stringify(campaign, null, 2)}\n`);
 }
 
+function writeHomeboyFuzzArtifactFiles(artifactRoot, result = {}) {
+	if (!artifactRoot) {
+		return [];
+	}
+	const files = [];
+	const hotspotSummary = result.hotspot_summary || result.wp_codebox_result?.hotspot_summary || result.coverage?.hotspot_summary;
+	if (hotspotSummary) {
+		files.push(writeJsonArtifactFile({ artifactRoot, relativePath: 'files/wordpress-hotspots.json', payload: hotspotSummary }));
+	}
+	return files;
+}
+
+function writeJsonArtifactFile({ artifactRoot, relativePath, payload }) {
+	const filePath = path.join(artifactRoot, relativePath);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+	return { path: filePath, relative_path: relativePath };
+}
+
 function readJsonFile(filePath) {
 	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
@@ -706,6 +725,7 @@ module.exports = {
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
 	runWordPressFuzzRunnerResult,
+	writeHomeboyFuzzArtifactFiles,
 	writeHomeboyFuzzResultsFile,
 	readWordPressFuzzRunnerEnv,
 };

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -16,6 +16,7 @@ const {
 	buildWordPressFuzzRunnerResult,
 	readWordPressFuzzRunnerEnv,
 	runWordPressFuzzRunnerResult,
+	writeHomeboyFuzzArtifactFiles,
 	writeHomeboyFuzzResultsFile,
 } = require('../../lib/wordpress-fuzz-runner');
 const { loadWpCodeboxCoreFunction } = require('../../lib/wp-codebox-core-loader');
@@ -37,6 +38,7 @@ async function main() {
 	const env = readWordPressFuzzRunnerEnv();
 	const result = await buildRunnerResult(env);
 	writeHomeboyFuzzResultsFile(env.resultsFile, result.homeboy_fuzz_campaign);
+	writeHomeboyFuzzArtifactFiles(env.artifactRoot, result);
 	process.stdout.write(`${JSON.stringify(fuzzRunnerStdoutSummary(result), null, 2)}\n`);
 	if (!result.succeeded) {
 		process.exitCode = 1;

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -509,6 +509,25 @@ const dispatchResultsPath = path.join(tempDir, 'dispatch-results.json');
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const subcommand = process.argv[2];
+if (subcommand === 'fuzz' && process.argv[3] === 'readiness' && process.argv.includes('--format=json')) {
+  process.stdout.write(JSON.stringify({
+    schema: 'wp-codebox/fuzz-runner-readiness/v1',
+    status: 'ready',
+    mode: 'runtime-backed',
+    entrypoint: 'run-fuzz-suite --runner-mode=runtime-backed',
+    capabilities: {
+      schema: 'wp-codebox/fuzz-runner-capabilities/v1',
+      mode: 'runtime-backed',
+      capabilities: ['target:runtime', 'runtime'],
+      targetKinds: ['runtime'],
+      operationKinds: ['read'],
+      commands: ['run-fuzz-suite', 'wordpress.run-workload'],
+      unsupportedRequiredCapabilities: []
+    },
+    unsupportedRequiredCapabilities: []
+  }));
+  process.exit(0);
+}
 if (subcommand === 'run-fuzz-suite' && process.argv.includes('--help')) {
   process.stdout.write('usage: wp-codebox run-fuzz-suite');
   process.exit(0);
@@ -539,12 +558,16 @@ process.stdout.write(JSON.stringify({
     { name: 'result-envelope', path: 'fake/envelope.json', contentType: 'application/json' },
     { name: 'case-log', path: 'fake/cases.jsonl', contentType: 'application/jsonl' },
     { name: 'replay-data', path: 'fake/replay.json', contentType: 'application/json' },
-    { name: 'coverage-summary', path: 'fake/summary.json', contentType: 'application/json' }
+    { name: 'coverage-summary', path: 'fake/summary.json', contentType: 'application/json' },
+    { name: 'wordpress-hotspots', path: 'fake/wordpress-hotspots.json', contentType: 'application/json', schema: 'wp-codebox/wordpress-hotspots/v1', semantic_key: 'fuzz.hotspot.codebox' }
   ],
+  hotspot_summary: { schema: 'wp-codebox/wordpress-hotspots/v1', api: [{ route: '/wc/store/products', method: 'GET', metric: 'duration_ms', duration_ms: 42 }] },
   coverage_summary: { surface_count: 1, exercised_count: 1 }
 }));
 `);
 fs.chmodSync(fakeCodeboxBin, 0o755);
+
+const dispatchArtifactsDir = path.join(tempDir, 'dispatch-artifacts');
 
 const dispatchCli = spawnSync(runnerPath, [], {
 	encoding: 'utf8',
@@ -555,14 +578,18 @@ const dispatchCli = spawnSync(runnerPath, [], {
 		HOMEBOY_FUZZ_WORKLOAD_ID: 'dispatch-cli-workload',
 		HOMEBOY_FUZZ_RUN_ID: 'dispatch-cli-run',
 		HOMEBOY_FUZZ_RESULTS_FILE: dispatchResultsPath,
+		HOMEBOY_FUZZ_ARTIFACTS_DIR: dispatchArtifactsDir,
 	},
 });
 
-assert.equal(dispatchCli.status, 0, dispatchCli.stderr);
+assert.equal(dispatchCli.status, 0, dispatchCli.stderr || dispatchCli.stdout);
 const dispatchCliResult = JSON.parse(dispatchCli.stdout);
 assert.equal(dispatchCliResult.succeeded, true, JSON.stringify(dispatchCliResult.wp_codebox_result));
 assert.equal(dispatchCliResult.wp_codebox_result.request_id, 'dispatch-cli-run');
 assert.equal(dispatchCliResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'fake/fuzz-report.json');
+const dispatchHotspots = JSON.parse(fs.readFileSync(path.join(dispatchArtifactsDir, 'files', 'wordpress-hotspots.json'), 'utf8'));
+assert.equal(dispatchHotspots.schema, 'homeboy/fuzz-hotspot-set/v1');
+assert.equal(dispatchHotspots.items[0].value, 42);
 
 const taskAdapterCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-task-adapter-wp-codebox.js');
 fs.writeFileSync(taskAdapterCodeboxBin, `#!/usr/bin/env node


### PR DESCRIPTION
## Summary
- read HOMEBOY_FUZZ_ARTIFACTS_DIR in the WordPress fuzz runner
- write normalized hotspot summaries to files/wordpress-hotspots.json for Homeboy artifact promotion
- extend the runner smoke test to cover public readiness and artifact file output

## Tests
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing Homeboy fuzz artifact output and implementing the runner artifact-directory fix.