### PR TITLE
Write empty WordPress hotspot artifacts

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -665,11 +665,16 @@ function writeHomeboyFuzzArtifactFiles(artifactRoot, result = {}) {
 		return [];
 	}
 	const files = [];
-	const hotspotSummary = result.hotspot_summary || result.wp_codebox_result?.hotspot_summary || result.coverage?.hotspot_summary;
+	const hotspotSummary = result.hotspot_summary || result.wp_codebox_result?.hotspot_summary || result.coverage?.hotspot_summary || rawWpCodeboxHotspotArtifact(result);
 	if (hotspotSummary) {
 		files.push(writeJsonArtifactFile({ artifactRoot, relativePath: 'files/wordpress-hotspots.json', payload: hotspotSummary }));
 	}
 	return files;
+}
+
+function rawWpCodeboxHotspotArtifact(result = {}) {
+	return result.wp_codebox_result?.wordpress_fuzz_result?.metadata?.artifacts?.wordpressHotspots
+		|| result.wp_codebox_result?.metadata?.artifacts?.wordpressHotspots;
 }
 
 function writeJsonArtifactFile({ artifactRoot, relativePath, payload }) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -32,6 +32,7 @@ const {
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
 	runWordPressFuzzRunnerResult,
+	writeHomeboyFuzzArtifactFiles,
 } = require('../lib/wordpress-fuzz-runner');
 
 Module._load = originalLoad;
@@ -590,6 +591,26 @@ assert.equal(dispatchCliResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].p
 const dispatchHotspots = JSON.parse(fs.readFileSync(path.join(dispatchArtifactsDir, 'files', 'wordpress-hotspots.json'), 'utf8'));
 assert.equal(dispatchHotspots.schema, 'homeboy/fuzz-hotspot-set/v1');
 assert.equal(dispatchHotspots.items[0].value, 42);
+
+const emptyHotspotArtifactsDir = path.join(tempDir, 'empty-hotspot-artifacts');
+writeHomeboyFuzzArtifactFiles(emptyHotspotArtifactsDir, {
+	wp_codebox_result: {
+		wordpress_fuzz_result: {
+			metadata: {
+				artifacts: {
+					wordpressHotspots: {
+						schema: 'wp-codebox/wordpress-hotspots/v1',
+						hotspots: [],
+						summary: { total: 0 },
+					},
+				},
+			},
+		},
+	},
+});
+const emptyHotspots = JSON.parse(fs.readFileSync(path.join(emptyHotspotArtifactsDir, 'files', 'wordpress-hotspots.json'), 'utf8'));
+assert.equal(emptyHotspots.schema, 'wp-codebox/wordpress-hotspots/v1');
+assert.deepEqual(emptyHotspots.hotspots, []);
 
 const taskAdapterCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-task-adapter-wp-codebox.js');
 fs.writeFileSync(taskAdapterCodeboxBin, `#!/usr/bin/env node


### PR DESCRIPTION
## Summary
- write the raw WP Codebox wordpressHotspots artifact when normalized hotspots are empty
- cover the zero-hotspot artifact shape produced by runtime-backed fuzz runs

## Tests
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing zero-hotspot fuzz artifact and implementing the follow-up artifact writer fix.