### PR TITLE
fix: probe wp-codebox with `commands` instead of unsupported --version

### DIFF
--- a/wordpress/scripts/lib/wp-codebox-paths.sh
+++ b/wordpress/scripts/lib/wp-codebox-paths.sh
@@ -90,7 +90,7 @@ homeboy_wp_codebox_resolve_bin() {
             echo "Error: wp-codebox not found; set HOMEBOY_WP_CODEBOX_BIN, settings wp_codebox_bin, or install wp-codebox." >&2
         fi
     else
-        echo "Error: wp-codebox was found, but no candidate passed 'wp-codebox --version'. Remove stale wrappers or set HOMEBOY_WP_CODEBOX_BIN to a working binary." >&2
+        echo "Error: wp-codebox was found, but no candidate passed 'wp-codebox commands'. Remove stale wrappers or set HOMEBOY_WP_CODEBOX_BIN to a working binary." >&2
     fi
 
     return 1
@@ -145,7 +145,7 @@ homeboy_wp_codebox_bin_is_runnable() {
         esac
     fi
 
-    "$bin" --version >/dev/null 2>&1
+    "$bin" commands >/dev/null 2>&1
 }
 
 homeboy_wp_codebox_set_command() {

--- a/wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh
@@ -43,11 +43,11 @@ SH
 chmod +x "${stale_path}/wp-codebox"
 cat > "${valid_path}/wp-codebox" <<'SH'
 #!/usr/bin/env bash
-if [ "${1:-}" = "--version" ]; then
-    echo "fixture-wp-codebox 1.0.0"
+if [ "${1:-}" = "commands" ]; then
+    echo "fixture-wp-codebox commands"
     exit 0
 fi
-exit 0
+exit 1
 SH
 chmod +x "${valid_path}/wp-codebox"
 


### PR DESCRIPTION
## Root cause

`homeboy_wp_codebox_bin_is_runnable()` in `wordpress/scripts/lib/wp-codebox-paths.sh` ended its probe with:

```sh
"$bin" --version >/dev/null 2>&1
```

This required `wp-codebox --version` to exit 0. But **no wp-codebox release implements a `--version` command** — the CLI command router (`Automattic/wp-codebox`, `packages/cli/src/command-router.ts`) only handles `help` / `--help` / `-h`; anything else (including `--version`) hits the "Unknown command" branch and exits 1. Verified across v0.8.5 (the version vendored in the WP Codebox WP plugin) and current main.

As a result the probe rejected every working binary, the "no candidate passed ..." error fired, and the "WP Codebox CLI setup" phase of every `homeboy test` run for WordPress components failed. This regressed in the extension v3.19.15 → v3.19.16 window.

## The fix

Probe with `wp-codebox commands` instead, which prints the command surface and exits 0 on all wp-codebox releases:

- `homeboy_wp_codebox_bin_is_runnable()`: changed the final probe line from `"$bin" --version` to `"$bin" commands`.
- Updated the user-facing error message that referenced `'wp-codebox --version'` to reference `'wp-codebox commands'` so the diagnostic stays accurate.
- Updated the `wp-codebox-recipe-helper-smoke.sh` resolver fixture so the "valid" fake binary responds to `commands` (exit 0) and fails everything else (exit 1), faithfully modeling real wp-codebox behavior and keeping the test meaningful against the new contract.

### Out of scope (intentionally left alone)

- `agent-runtimes/wp-codebox/wp-codebox.json` `version_command: ["--version"]` (and its boundary-test assertion) is the **generic runtime_bin executor readiness descriptor** consumed by Homeboy core's executor runner — a separate probe mechanism from this bash self-probe, mirrored across runtimes (e.g. `opencode`, which *does* support `--version`). Changing it would alter a cross-component contract and is a distinct concern from #1978.
- Genuinely-unrelated `--version` calls (`_homeboy_command_version` generic helper in `validation-dependencies.sh`, package.json `version` reads in `wp-codebox-resolver.js`) were left untouched.

## Files changed

- `wordpress/scripts/lib/wp-codebox-paths.sh` — probe + error message
- `wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh` — resolver fixture

## Verification

- `bash -n wordpress/scripts/lib/wp-codebox-paths.sh` — passed
- `bash -n wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh` — passed
- `bash wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh` — "WP Codebox recipe helper smoke passed." (exit 0)
- On the host: `wp-codebox commands >/dev/null 2>&1; echo $?` → `0`; `wp-codebox --version >/dev/null 2>&1; echo $?` → `1`.

Fixes #1978