### PR TITLE
fix(wp-codebox): forward full secret-env-plan aggregation into sandbox

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1861,8 +1861,15 @@ function secretEnvNamesFromPlan(plan) {
   if (!plan || plan.schema !== 'homeboy/secret-env-plan/v1') {
     return [];
   }
+  // Mirror core's authoritative SecretEnvPlan::secret_env_names() aggregation
+  // (homeboy src/core/secret_env_plan.rs): fold direct names, requirement-derived
+  // names, provider-credential names, and mapped env names so every declared
+  // secret is forwarded into the sandbox. Re-deriving only secret_env_names +
+  // env_name_mapping silently dropped requirement and provider-credential names.
   return uniquePaths([
     ...normalizeArray(plan.secret_env_names),
+    ...normalizeArray(plan.requirements).map((requirement) => requirement && requirement.name),
+    ...Object.values(plan.provider_credentials || {}).flatMap((mapping) => normalizeArray(mapping && mapping.secret_env)),
     ...Object.values(plan.env_name_mapping || {}).flatMap(normalizeArray),
   ]);
 }

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -1514,6 +1514,62 @@ assert.deepEqual(plannedSecretEnvTaskInput.secret_env, [
   'EXPLICIT_CODEBOX_SECRET',
 ]);
 
+// Regression: the consumer must honor the FULL authoritative aggregation that
+// core's SecretEnvPlan::secret_env_names() folds (secret_env_plan.rs:214-235) —
+// provider-credential names and requirement-derived names were previously
+// dropped, so those declared secrets silently never reached the sandbox.
+const previousFullPlan = process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON;
+process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = JSON.stringify({
+  schema: 'homeboy/secret-env-plan/v1',
+  secret_env_names: ['HOMEBOY_PLANNED_CODEBOX_SECRET'],
+  requirements: [
+    { name: 'HOMEBOY_REQUIRED_CODEBOX_SECRET', required: true },
+    { name: 'HOMEBOY_OPTIONAL_CODEBOX_SECRET', required: false },
+  ],
+  provider_credentials: {
+    codex: {
+      secret_env: ['AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN', 'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
+    },
+  },
+  env_name_mapping: {
+    'wordpress.codebox-agent-task-executor': ['HOMEBOY_MAPPED_CODEBOX_SECRET'],
+  },
+  status: [{ name: 'HOMEBOY_PLANNED_CODEBOX_SECRET', configured: true, source: 'env' }],
+});
+let fullPlanSecretEnvTaskInput;
+try {
+  fullPlanSecretEnvTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+    schema: 'homeboy/agent-task-request/v1',
+    task_id: 'full-plan-secret-env-codebox-task-1',
+    executor: {
+      backend: 'codebox',
+      config: { provider: 'codex' },
+    },
+    instructions: 'Run a Codex-backed Codebox task with a fully aggregated secret env plan.',
+    inputs: {},
+  });
+} finally {
+  if (previousFullPlan === undefined) {
+    delete process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON;
+  } else {
+    process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = previousFullPlan;
+  }
+}
+for (const declaredSecret of [
+  'HOMEBOY_PLANNED_CODEBOX_SECRET',
+  'HOMEBOY_REQUIRED_CODEBOX_SECRET',
+  'HOMEBOY_OPTIONAL_CODEBOX_SECRET',
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'HOMEBOY_MAPPED_CODEBOX_SECRET',
+]) {
+  assert.equal(
+    fullPlanSecretEnvTaskInput.secret_env.includes(declaredSecret),
+    true,
+    `expected forwarded secret_env to include ${declaredSecret}`,
+  );
+}
+
 const claudeCodeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'claude-code-codebox-task-1',


### PR DESCRIPTION
## Summary

The wp-codebox agent-task executor consumes the published `homeboy/secret-env-plan/v1` payload (`HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON`) but re-derived only a **partial** name set — merging `secret_env_names` + `env_name_mapping` only. It silently dropped:

- `requirements[].name` (requirement-derived secrets)
- `provider_credentials[].secret_env` (provider-credential secrets)

Both are folded and deduped by core's authoritative `SecretEnvPlan::secret_env_names()` (`homeboy` `src/core/secret_env_plan.rs:214-235`). The result: some declared secrets — notably provider credentials — never reached the Codebox sandbox.

## Fix

`secretEnvNamesFromPlan()` now aggregates identically to core, folding all four sources through the existing dedup:

1. `secret_env_names`
2. `requirements[].name`
3. `provider_credentials[].secret_env`
4. `env_name_mapping` values

The v1 payload already carries every field core aggregates (verified against the publisher `provider_secret_env_plan_with_status` in `homeboy` `src/core/agent_task_provider/secrets.rs`), so **no upstream contract change is required** — this is a pure consumer-side aggregation bug.

## Verification

- `npm run test:codebox-agent-task-executor-boundary` passes with the fix and **fails without it** (`ERR_ASSERTION` on the forwarded provider-credential secret), proving the regression is caught.
- Added a boundary test asserting every declared secret name — including the previously-dropped provider-credential (`AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN` / `_REFRESH_TOKEN`) and requirement (`required` + `optional`) cases — is forwarded into `secret_env`.
- The pre-existing `test:codebox-agent-task-executor` smoke failure (a local `fake-wp-cli` path-resolution issue) reproduces on clean `main` and is unrelated to this change.

Refs Extra-Chill/homeboy#6676

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Tracing the core vs. consumer aggregation gap, implementing the consumer fix, and authoring the regression test.