### PR TITLE
fix: generate agent-task core contract fixture from core's published contract

### DIFF
--- a/agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs
+++ b/agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs
@@ -1,0 +1,191 @@
+'use strict';
+
+// Generator for `homeboy-agent-task-core-contract.json`.
+//
+// The fixture is the cross-repo handoff contract for durable host
+// orchestration (see ../../docs/agent-runtime-package-contract.md). It is the
+// union of two single-source-of-truth surfaces:
+//
+//   1. Homeboy core's authoritative agent-task core contract, published by the
+//      `homeboy agent-task contract --format json` command. This generator
+//      consumes that command output directly so the core region of the fixture
+//      can never silently drift from core's `agent_task_core_contract()`.
+//   2. The extensions-owned fanout/reconcile + orchestration overlay, derived
+//      from the same JS constant modules the runtime uses at execution time.
+//
+// Usage:
+//   node generate-homeboy-agent-task-core-contract.cjs            # write fixture
+//   node generate-homeboy-agent-task-core-contract.cjs --check    # verify only
+//
+// `--check` regenerates from core + overlay and fails (exit 1) when the
+// committed fixture differs, so CI catches drift without hand-maintenance.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+  AGENT_TASK_OUTCOME_STATUSES,
+} = require('../../agent-task-contracts/agent-task-provider-contract');
+const {
+  FANOUT_RECONCILE_PLAN_SCHEMA,
+  FANOUT_RECONCILE_RECORD_STATUSES,
+  FANOUT_RECONCILE_RUN_SCHEMA,
+  FANOUT_RECONCILE_RUN_STATUSES,
+} = require('../../runtime-agent-ci/lib/fanout-reconcile-runner');
+const {
+  GENERIC_FANOUT_RECONCILE_CONFIG_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_RECONCILIATION_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_RESULT_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_SUCCESS_STATUSES,
+  GENERIC_FINDING_PACKET_FANOUT_CONFIG_SCHEMA,
+} = require('../../runtime-agent-ci/lib/generic-fanout-reconcile-workflow');
+
+const FIXTURE_PATH = path.join(__dirname, 'homeboy-agent-task-core-contract.json');
+
+// Outcome statuses that map to a successful host-orchestration record status.
+// Every other agent-task outcome status maps to `failed` (see the bridge table
+// in docs/agent-runtime-package-contract.md).
+const FANOUT_RECORD_SUCCESS_OUTCOME_STATUSES = ['succeeded', 'no_op'];
+
+// Extensions-owned overlay merged on top of the core contract. These keys are
+// additive: the host orchestration runtime owns fanout/reconcile, while the
+// core region remains owned by Homeboy core.
+function extensionsOverlay() {
+  const outcomeToRecordStatus = {};
+  for (const status of AGENT_TASK_OUTCOME_STATUSES) {
+    outcomeToRecordStatus[status] = FANOUT_RECORD_SUCCESS_OUTCOME_STATUSES.includes(status)
+      ? 'completed'
+      : 'failed';
+  }
+
+  return {
+    schemas: {
+      fanout_reconcile_config: GENERIC_FANOUT_RECONCILE_CONFIG_SCHEMA,
+      fanout_reconcile_plan: FANOUT_RECONCILE_PLAN_SCHEMA,
+      fanout_reconcile_run: FANOUT_RECONCILE_RUN_SCHEMA,
+      fanout_reconcile_result: GENERIC_FANOUT_RECONCILE_RESULT_SCHEMA,
+      fanout_reconcile_reconciliation: GENERIC_FANOUT_RECONCILE_RECONCILIATION_SCHEMA,
+      finding_packet_fanout_config: GENERIC_FINDING_PACKET_FANOUT_CONFIG_SCHEMA,
+    },
+    enums: {
+      fanout_record_status: [...FANOUT_RECONCILE_RECORD_STATUSES],
+      fanout_run_status: [...FANOUT_RECONCILE_RUN_STATUSES],
+    },
+    orchestration: {
+      agent_task_outcome_to_fanout_record_status: outcomeToRecordStatus,
+      fanout_success_statuses: [...GENERIC_FANOUT_RECONCILE_SUCCESS_STATUSES],
+    },
+  };
+}
+
+// Run `homeboy agent-task contract --format json` and return the contract body
+// (`.data`). Returns null when the homeboy binary is unavailable so callers can
+// degrade gracefully in environments without a Homeboy install.
+function fetchCoreContractData(options = {}) {
+  const binary = options.binary || process.env.HOMEBOY_BIN || 'homeboy';
+  const result = spawnSync(binary, ['agent-task', 'contract', '--format', 'json'], {
+    encoding: 'utf8',
+  });
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      return null;
+    }
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `\`${binary} agent-task contract --format json\` exited ${result.status}: ${result.stderr || ''}`
+    );
+  }
+  const envelope = JSON.parse(result.stdout);
+  if (!envelope || envelope.success !== true || typeof envelope.data !== 'object') {
+    throw new Error('Unexpected homeboy agent-task contract envelope shape');
+  }
+  return envelope.data;
+}
+
+// Merge the core contract with the extensions overlay. Core keys are
+// authoritative; overlay keys are additive within `schemas`/`enums` and add the
+// top-level `orchestration` section.
+function buildCoreContractFixture(coreData) {
+  assert.ok(coreData && typeof coreData === 'object', 'core contract data is required');
+  const overlay = extensionsOverlay();
+  return {
+    ...coreData,
+    schemas: { ...coreData.schemas, ...overlay.schemas },
+    enums: { ...coreData.enums, ...overlay.enums },
+    orchestration: overlay.orchestration,
+  };
+}
+
+// Deterministic serialization: recursively sort object keys (arrays keep their
+// order, which is semantic), 2-space indent, trailing newline.
+function canonicalJson(value) {
+  return `${JSON.stringify(sortKeysDeep(value), null, 2)}\n`;
+}
+
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value)
+      .sort()
+      .reduce((sorted, key) => {
+        sorted[key] = sortKeysDeep(value[key]);
+        return sorted;
+      }, {});
+  }
+  return value;
+}
+
+function readCommittedFixture() {
+  return fs.readFileSync(FIXTURE_PATH, 'utf8');
+}
+
+function main(argv) {
+  const check = argv.includes('--check');
+  const coreData = fetchCoreContractData();
+  if (coreData === null) {
+    process.stderr.write(
+      'homeboy binary not found; cannot regenerate the agent-task core contract fixture.\n'
+        + 'Install Homeboy or set HOMEBOY_BIN to a Homeboy executable.\n'
+    );
+    process.exit(check ? 0 : 1);
+    return;
+  }
+
+  const generated = canonicalJson(buildCoreContractFixture(coreData));
+
+  if (check) {
+    const committed = readCommittedFixture();
+    if (committed !== generated) {
+      process.stderr.write(
+        'Drift detected: homeboy-agent-task-core-contract.json is out of sync with core.\n'
+          + 'Regenerate with: node agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs\n'
+      );
+      process.exit(1);
+      return;
+    }
+    process.stdout.write('Agent task core contract fixture is in sync with core.\n');
+    return;
+  }
+
+  fs.writeFileSync(FIXTURE_PATH, generated);
+  process.stdout.write(`Wrote ${path.relative(process.cwd(), FIXTURE_PATH)}\n`);
+}
+
+module.exports = {
+  FIXTURE_PATH,
+  buildCoreContractFixture,
+  canonicalJson,
+  extensionsOverlay,
+  fetchCoreContractData,
+  sortKeysDeep,
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
+++ b/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
@@ -1,63 +1,26 @@
 {
-  "schema": "homeboy/agent-task-core-contract/v1",
-  "schemas": {
-    "request": "homeboy/agent-task-request/v1",
-    "outcome": "homeboy/agent-task-outcome/v1",
-    "artifact": "homeboy/agent-task-artifact/v1",
-    "artifact_declaration": "homeboy/agent-task-artifact-declaration/v1",
-    "evidence_ref": "homeboy/agent-task-evidence-ref/v1",
-    "workflow": "homeboy/agent-task-workflow/v1",
-    "plan": "homeboy/agent-task-plan/v1",
-    "aggregate": "homeboy/agent-task-aggregate/v1",
-    "matrix_plan": "homeboy/agent-task-matrix-plan/v1",
-    "matrix_aggregate": "homeboy/agent-task-matrix-aggregate/v1",
-    "provider": "homeboy/agent-task-executor-provider/v1",
-    "provider_capability_contract": "homeboy/agent-task-provider-capability-contract/v1",
-    "tool_request": "homeboy/agent-tool-request/v1",
-    "tool_result": "homeboy/agent-tool-result/v1",
-    "tool_policy": "homeboy/agent-tool-policy/v1",
-    "tool_dispatch_evidence": "homeboy/agent-tool-dispatch-evidence/v1",
-    "gate_report": "homeboy/agent-task-gate-report/v1",
-    "promotion_report": "homeboy/agent-task-promotion-report/v1",
-    "cook_loop_report": "homeboy/agent-task-cook-loop-report/v1",
-    "loop_controller": "homeboy/agent-task-loop-controller/v1",
-    "loop_controller_status": "homeboy/agent-task-loop-controller-status/v1",
-    "loop_definition": "homeboy/agent-task-loop-definition/v1",
-    "secret_env_plan": "homeboy/secret-env-plan/v1",
-    "secret_env_requirement": "homeboy/secret-env-requirement/v1",
-    "command_invocation": "homeboy/command-invocation/v1",
-    "fanout_reconcile_config": "homeboy/generic-fanout-reconcile-config/v1",
-    "fanout_reconcile_plan": "homeboy/fanout-reconcile-plan/v1",
-    "fanout_reconcile_run": "homeboy/fanout-reconcile-run/v1",
-    "fanout_reconcile_result": "homeboy/generic-fanout-reconcile-result/v1",
-    "fanout_reconcile_reconciliation": "homeboy/generic-fanout-reconcile-reconciliation/v1",
-    "finding_packet_fanout_config": "homeboy/generic-finding-packet-fanout-config/v1"
-  },
-  "provider_capability": {
-    "schema": "homeboy/agent-task-provider-capability-contract/v1",
-    "provider_schema": "homeboy/agent-task-executor-provider/v1",
-    "request_schema": "homeboy/agent-task-request/v1",
-    "outcome_schema": "homeboy/agent-task-outcome/v1",
-    "tool_request_schema": "homeboy/agent-tool-request/v1",
-    "tool_result_schema": "homeboy/agent-tool-result/v1",
-    "tool_policy_schema": "homeboy/agent-tool-policy/v1",
-    "request_required_fields": [
-      "schema",
-      "task_id",
-      "executor.backend",
-      "instructions"
-    ],
-    "outcome_statuses": [
+  "enums": {
+    "aggregate_status": [
       "succeeded",
-      "no_op",
-      "unable_to_remediate",
-      "provider_error",
-      "timeout",
+      "partial_failure",
       "failed",
-      "follow_up_issue",
       "cancelled"
     ],
-    "failure_classifications": [
+    "execution_handle_kind": [
+      "queued_record",
+      "local_pid",
+      "runner_job",
+      "provider_run"
+    ],
+    "execution_state": [
+      "queued",
+      "running",
+      "waiting",
+      "succeeded",
+      "failed",
+      "cancelled"
+    ],
+    "failure_classification": [
       "provider",
       "transient",
       "timeout",
@@ -67,24 +30,71 @@
       "execution_failed",
       "unknown"
     ],
-    "redacted_metadata_keys": [
-      "secret_env_values",
-      "secretEnvValues",
-      "secrets"
+    "fanout_record_status": [
+      "completed",
+      "failed",
+      "missing_record"
     ],
-    "provider_capability_fields": [
-      "schema",
-      "provider_schema",
-      "request_schema",
-      "outcome_schema",
-      "request_required_fields",
-      "outcome_statuses",
-      "failure_classifications",
-      "redacted_metadata_keys",
-      "tool_request_schema",
-      "tool_result_schema",
-      "tool_policy_schema"
+    "fanout_run_status": [
+      "incomplete",
+      "completed",
+      "failed"
     ],
+    "outcome_status": [
+      "succeeded",
+      "no_op",
+      "unable_to_remediate",
+      "provider_error",
+      "timeout",
+      "failed",
+      "follow_up_issue",
+      "cancelled"
+    ],
+    "run_state": [
+      "queued",
+      "running",
+      "succeeded",
+      "partial_failure",
+      "failed",
+      "cancelled"
+    ],
+    "task_state": [
+      "queued",
+      "blocked",
+      "skipped",
+      "running",
+      "succeeded",
+      "failed",
+      "cancelled",
+      "timed_out"
+    ],
+    "workflow_step_status": [
+      "pending",
+      "running",
+      "succeeded",
+      "failed",
+      "skipped",
+      "cancelled"
+    ]
+  },
+  "orchestration": {
+    "agent_task_outcome_to_fanout_record_status": {
+      "cancelled": "failed",
+      "failed": "failed",
+      "follow_up_issue": "failed",
+      "no_op": "completed",
+      "provider_error": "failed",
+      "succeeded": "completed",
+      "timeout": "failed",
+      "unable_to_remediate": "failed"
+    },
+    "fanout_success_statuses": [
+      "completed",
+      "success",
+      "passed"
+    ]
+  },
+  "provider_capability": {
     "executor_provider_fields": [
       "schema",
       "id",
@@ -121,52 +131,8 @@
       "runtime_id",
       "runtime_path",
       "extra"
-    ]
-  },
-  "enums": {
-    "execution_state": [
-      "queued",
-      "running",
-      "waiting",
-      "succeeded",
-      "failed",
-      "cancelled"
     ],
-    "task_state": [
-      "queued",
-      "blocked",
-      "skipped",
-      "running",
-      "succeeded",
-      "failed",
-      "cancelled",
-      "timed_out"
-    ],
-    "run_state": [
-      "queued",
-      "running",
-      "succeeded",
-      "partial_failure",
-      "failed",
-      "cancelled"
-    ],
-    "aggregate_status": [
-      "succeeded",
-      "partial_failure",
-      "failed",
-      "cancelled"
-    ],
-    "outcome_status": [
-      "succeeded",
-      "no_op",
-      "unable_to_remediate",
-      "provider_error",
-      "timeout",
-      "failed",
-      "follow_up_issue",
-      "cancelled"
-    ],
-    "failure_classification": [
+    "failure_classifications": [
       "provider",
       "transient",
       "timeout",
@@ -176,62 +142,70 @@
       "execution_failed",
       "unknown"
     ],
-    "workflow_step_status": [
-      "pending",
-      "running",
+    "outcome_schema": "homeboy/agent-task-outcome/v1",
+    "outcome_statuses": [
       "succeeded",
+      "no_op",
+      "unable_to_remediate",
+      "provider_error",
+      "timeout",
       "failed",
-      "skipped",
+      "follow_up_issue",
       "cancelled"
     ],
-    "fanout_record_status": [
-      "completed",
-      "failed",
-      "missing_record"
+    "provider_capability_fields": [
+      "schema",
+      "provider_schema",
+      "request_schema",
+      "outcome_schema",
+      "request_required_fields",
+      "outcome_statuses",
+      "failure_classifications",
+      "redacted_metadata_keys",
+      "tool_request_schema",
+      "tool_result_schema",
+      "tool_policy_schema"
     ],
-    "fanout_run_status": [
-      "incomplete",
-      "completed",
-      "failed"
-    ]
-  },
-  "orchestration": {
-    "agent_task_outcome_to_fanout_record_status": {
-      "succeeded": "completed",
-      "no_op": "completed",
-      "unable_to_remediate": "failed",
-      "provider_error": "failed",
-      "timeout": "failed",
-      "failed": "failed",
-      "follow_up_issue": "failed",
-      "cancelled": "failed"
-    },
-    "fanout_success_statuses": [
-      "completed",
-      "success",
-      "passed"
+    "provider_schema": "homeboy/agent-task-executor-provider/v1",
+    "redacted_metadata_keys": [
+      "secret_env_values",
+      "secretEnvValues",
+      "secrets"
+    ],
+    "request_required_fields": [
+      "schema",
+      "task_id",
+      "executor.backend",
+      "instructions"
+    ],
+    "request_schema": "homeboy/agent-task-request/v1",
+    "schema": "homeboy/agent-task-provider-capability-contract/v1",
+    "tool_policy_schema": "homeboy/agent-tool-policy/v1",
+    "tool_request_schema": "homeboy/agent-tool-request/v1",
+    "tool_result_schema": "homeboy/agent-tool-result/v1",
+    "workspace_materialization_fields": [
+      "cwd",
+      "requires_git",
+      "write_scope",
+      "artifact_paths",
+      "spec",
+      "mounts",
+      "apply_back",
+      "extra"
+    ],
+    "workspace_mount_spec_fields": [
+      "handle",
+      "repo",
+      "host_path",
+      "target_path",
+      "mode",
+      "materialization",
+      "metadata",
+      "extra"
     ]
   },
   "redaction_defaults": {
     "replacement": "[REDACTED]",
-    "sensitive_keys": [
-      "api_key",
-      "apikey",
-      "auth",
-      "authorization",
-      "bearer",
-      "client_secret",
-      "cookie",
-      "key",
-      "nonce",
-      "passwd",
-      "password",
-      "refresh_token",
-      "secret",
-      "session",
-      "sid",
-      "token"
-    ],
     "sensitive_headers": [
       "authorization",
       "cookie",
@@ -241,6 +215,66 @@
       "x-auth-token",
       "x-csrf-token",
       "x-wp-nonce"
+    ],
+    "sensitive_keys": [
+      "api_key",
+      "apikey",
+      "auth",
+      "authorization",
+      "bearer",
+      "client_secret",
+      "cookie",
+      "credential",
+      "key",
+      "nonce",
+      "passwd",
+      "password",
+      "refresh_token",
+      "secret",
+      "session",
+      "sid",
+      "token"
     ]
+  },
+  "schema": "homeboy/agent-task-core-contract/v1",
+  "schemas": {
+    "aggregate": "homeboy/agent-task-aggregate/v1",
+    "artifact": "homeboy/agent-task-artifact/v1",
+    "artifact_declaration": "homeboy/agent-task-artifact-declaration/v1",
+    "artifact_handoff": "homeboy/agent-task-artifact-handoff/v1",
+    "batch_cook_fanout_plan": "homeboy/agent-task-batch-cook-fanout-plan/v1",
+    "batch_cook_fanout_run": "homeboy/agent-task-batch-cook-fanout-run/v1",
+    "batch_cook_fanout_submit": "homeboy/agent-task-batch-cook-fanout-submit/v1",
+    "command_invocation": "homeboy/command-invocation/v1",
+    "cook_feedback_report": "homeboy/agent-task-cook-feedback-report/v1",
+    "diagnostic_ranking": "homeboy/agent-task-diagnostic-ranking/v1",
+    "evidence_ref": "homeboy/agent-task-evidence-ref/v1",
+    "fanout_reconcile_config": "homeboy/generic-fanout-reconcile-config/v1",
+    "fanout_reconcile_plan": "homeboy/fanout-reconcile-plan/v1",
+    "fanout_reconcile_reconciliation": "homeboy/generic-fanout-reconcile-reconciliation/v1",
+    "fanout_reconcile_result": "homeboy/generic-fanout-reconcile-result/v1",
+    "fanout_reconcile_run": "homeboy/fanout-reconcile-run/v1",
+    "finding_packet_fanout_config": "homeboy/generic-finding-packet-fanout-config/v1",
+    "gate_report": "homeboy/agent-task-gate-report/v1",
+    "loop_action": "homeboy/agent-task-loop-action/v1",
+    "loop_controller": "homeboy/agent-task-loop-controller/v1",
+    "loop_controller_status": "homeboy/agent-task-loop-controller-status/v1",
+    "loop_definition": "homeboy/agent-task-loop-definition/v1",
+    "matrix_aggregate": "homeboy/agent-task-matrix-aggregate/v1",
+    "matrix_plan": "homeboy/agent-task-matrix-plan/v1",
+    "outcome": "homeboy/agent-task-outcome/v1",
+    "plan": "homeboy/agent-task-plan/v1",
+    "promotion_report": "homeboy/agent-task-promotion-report/v1",
+    "provider": "homeboy/agent-task-executor-provider/v1",
+    "provider_capability_contract": "homeboy/agent-task-provider-capability-contract/v1",
+    "provider_outcome_contract": "homeboy/agent-task-provider-outcome-contract/v1",
+    "request": "homeboy/agent-task-request/v1",
+    "secret_env_plan": "homeboy/secret-env-plan/v1",
+    "secret_env_requirement": "homeboy/secret-env-requirement/v1",
+    "tool_dispatch_evidence": "homeboy/agent-tool-dispatch-evidence/v1",
+    "tool_policy": "homeboy/agent-tool-policy/v1",
+    "tool_request": "homeboy/agent-tool-request/v1",
+    "tool_result": "homeboy/agent-tool-result/v1",
+    "workflow": "homeboy/agent-task-workflow/v1"
   }
 }

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -159,6 +159,17 @@ execution. Homeboy core owns durable queueing, fanout, progress, retries,
 artifacts, and promotion. Runtime packages own the executor command and backend
 translation behind the provider manifest.
 
+This fixture is a generated artifact, not a hand-maintained mirror. Its core
+region is consumed directly from Homeboy core's published contract via
+`homeboy agent-task contract --format json` (core's `agent_task_core_contract()`),
+and the extensions-owned fanout/reconcile + orchestration overlay below is
+derived from the runtime's own JS constant modules. Regenerate it with
+`node agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs`
+(or `npm run fixture:agent-task-core-contract` from `wordpress/`). The
+`agent-task-core-contract-drift` test asserts byte-for-byte equality between the
+committed fixture and the generator output whenever the homeboy binary is
+available, so the fixture can never silently drift from core.
+
 Generic fanout/reconcile schemas are part of that fixture:
 
 - `homeboy/generic-fanout-reconcile-config/v1`

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -157,6 +157,8 @@
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",
     "test:agent-task-core-contract-drift": "node tests/agent-task-core-contract-drift.test.js",
+    "fixture:agent-task-core-contract": "node ../agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs",
+    "fixture:agent-task-core-contract:check": "node ../agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs --check",
     "test:runtime-agent-host-lifecycle": "node tests/runtime-agent-host-lifecycle-smoke.js",
     "test:codebox-agent-task-executor-boundary": "node tests/codebox-agent-task-executor-boundary.test.js",
     "test:provider-outcome-normalizer": "node tests/provider-outcome-normalizer.test.js",

--- a/wordpress/tests/agent-task-core-contract-drift.test.js
+++ b/wordpress/tests/agent-task-core-contract-drift.test.js
@@ -30,14 +30,15 @@ const {
   GENERIC_FINDING_PACKET_FANOUT_CONFIG_SCHEMA,
 } = require('../../runtime-agent-ci/lib/generic-fanout-reconcile-workflow');
 
-const contract = JSON.parse(fs.readFileSync(path.join(
-  __dirname,
-  '..',
-  '..',
-  'agent-runtimes',
-  'fixtures',
-  'homeboy-agent-task-core-contract.json'
-), 'utf8'));
+const {
+  FIXTURE_PATH,
+  buildCoreContractFixture,
+  canonicalJson,
+  fetchCoreContractData,
+} = require('../../agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs');
+
+const committedFixtureText = fs.readFileSync(FIXTURE_PATH, 'utf8');
+const contract = JSON.parse(committedFixtureText);
 const wpCodeboxManifest = JSON.parse(fs.readFileSync(path.join(
   __dirname,
   '..',
@@ -68,7 +69,12 @@ assert.deepEqual(AGENT_TASK_REDACTED_METADATA_KEYS, providerFields.redacted_meta
 assert.deepEqual(FANOUT_RECONCILE_RECORD_STATUSES, contract.enums.fanout_record_status);
 assert.deepEqual(FANOUT_RECONCILE_RUN_STATUSES, contract.enums.fanout_run_status);
 assert.deepEqual(GENERIC_FANOUT_RECONCILE_SUCCESS_STATUSES, contract.orchestration.fanout_success_statuses);
-assert.deepEqual(Object.keys(contract.orchestration.agent_task_outcome_to_fanout_record_status), AGENT_TASK_OUTCOME_STATUSES);
+// The fixture is canonically serialized with sorted object keys, so compare the
+// mapping's key set to the outcome statuses order-independently.
+assert.deepEqual(
+  Object.keys(contract.orchestration.agent_task_outcome_to_fanout_record_status).slice().sort(),
+  AGENT_TASK_OUTCOME_STATUSES.slice().sort()
+);
 assert.deepEqual(
   Object.values(contract.orchestration.agent_task_outcome_to_fanout_record_status).filter((status) => !FANOUT_RECONCILE_RECORD_STATUSES.includes(status)),
   []
@@ -89,4 +95,33 @@ assert.deepEqual(wpCodeboxProvider.outcome_statuses, providerFields.outcome_stat
 assert.deepEqual(wpCodeboxProvider.failure_classifications, providerFields.failure_classifications);
 assert.deepEqual(wpCodeboxProvider.redacted_metadata_keys, providerFields.redacted_metadata_keys);
 
-process.stdout.write('Agent task core contract drift check passed\n');
+// Strong anti-drift guarantee: the fixture is a generated artifact derived from
+// Homeboy core's published contract (`homeboy agent-task contract --format
+// json`) merged with the extensions-owned fanout/orchestration overlay. When
+// the homeboy binary is available, assert the committed fixture is byte-for-byte
+// what the generator produces from core. This catches any core contract change
+// (added, removed, renamed, or reordered keys) that the static checks above
+// cannot see. Regenerate with:
+//   node agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs
+const coreData = fetchCoreContractData();
+if (coreData === null) {
+  process.stdout.write(
+    'Agent task core contract drift check passed (homeboy binary unavailable; '
+      + 'core-region byte-equality check skipped)\n'
+  );
+} else {
+  const expectedFixture = buildCoreContractFixture(coreData);
+  assert.deepEqual(
+    contract,
+    expectedFixture,
+    'Fixture drifted from core: regenerate with '
+      + 'node agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs'
+  );
+  assert.equal(
+    committedFixtureText,
+    canonicalJson(expectedFixture),
+    'Fixture serialization drifted from the generator: regenerate with '
+      + 'node agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs'
+  );
+  process.stdout.write('Agent task core contract drift check passed (verified against core)\n');
+}


### PR DESCRIPTION
## Summary

`agent-runtimes/fixtures/homeboy-agent-task-core-contract.json` is the cross-repo handoff contract for durable host orchestration. It was a **hand-maintained mirror** of Homeboy core's `agent_task_core_contract()` (`homeboy/src/core/agent_task_contract.rs`) and had **silently drifted** from core. The fixture was only asserted against a sibling JS shape covering a subset of keys, so the drift went uncaught.

### Drift corrected
- Renamed `cook_loop_report` → `cook_feedback_report` (core's actual key).
- Added missing core keys: `artifact_handoff`, `loop_action`, `provider_outcome_contract`, `diagnostic_ranking`, `tool_dispatch_evidence`, `batch_cook_fanout_plan|run|submit`, `enums.execution_handle_kind`, `provider_capability.workspace_materialization_fields`, `provider_capability.workspace_mount_spec_fields`.
- Picked up an additional core drift the generator surfaced: `credential` was missing from `redaction_defaults.sensitive_keys`.

## Path taken: consume (not issue)

Core **already publishes** the contract via `homeboy agent-task contract --format json` (core's `agent_task_core_contract()` exported through `src/commands/agent_task/contract.rs`). So per the contract's fix-upstream-first rule, this consumes that surface directly rather than filing an issue:

- **New generator** `agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs` builds the fixture from `homeboy agent-task contract --format json` (the authoritative core region) merged with the extensions-owned fanout/reconcile + orchestration overlay (derived from the runtime's own JS constant modules — `fanout-reconcile-runner.js`, `generic-fanout-reconcile-workflow.js`, `agent-task-provider-contract.js`). The fixture is now a **generated artifact**, not a hand-maintained mirror. `--check` mode fails on drift.
- **Regenerated** the committed fixture from core.
- **Drift test** `wordpress/tests/agent-task-core-contract-drift.test.js` now asserts **byte-for-byte equality** between the committed fixture and the generator output whenever the `homeboy` binary is available — catching any added/removed/renamed/reordered core key. When the binary is unavailable the existing overlay/provider assertions still run and the byte-equality check is skipped with a clear notice.
- Made the orchestration key-coverage assertion order-independent (the fixture is now canonically serialized with sorted keys).
- Added `fixture:agent-task-core-contract` / `:check` npm scripts and documented the generated-artifact contract in `docs/agent-runtime-package-contract.md`.

## Verification

Run from `wordpress/` (homeboy 0.266.2 present locally; core contract identical between 0.266.2 and ref-main 0.266.3 — no diff in `agent_task_contract.rs`):

- `node tests/agent-task-core-contract-drift.test.js` → `Agent task core contract drift check passed (verified against core)`
- `node ../agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs --check` → `Agent task core contract fixture is in sync with core.`
- `node tests/wordpress-runtime-task-planner-smoke.js` → pass
- `node tests/generic-agent-runtime-contract.test.js` → pass
- `node ../tests/agent-task-provider-contract-smoke.mjs` → pass

Behavior-preserving. No core edits. The pre-existing failure in `wordpress-fuzz-runner-codebox-contract-canary.js` (unrelated fuzz-artifact-kind drift) fails identically on `main` and is out of scope.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Investigating the drift, designing the generator/consume approach, writing the generator + drift-test changes, and verification.