### PR TITLE
Harden WP Codebox runtime mount contracts

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -41,6 +41,8 @@ function readWordPressFuzzRunnerEnv(env = process.env) {
 		wpCodeboxFuzzWorkloadRoot: env.WP_CODEBOX_FUZZ_WORKLOAD_ROOT,
 		wpCodeboxBin: env.HOMEBOY_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN,
 		wpCliBin: env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN,
+		componentPathOverrides: componentPathOverridesFromEnv(env, 'HOMEBOY_RIG_COMPONENT_PATH__'),
+		componentCheckoutRootOverrides: componentPathOverridesFromEnv(env, 'HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__'),
 	});
 }
 
@@ -248,13 +250,14 @@ function buildWpCodeboxFuzzRuntimeRequirements({ workload = {}, env = {} } = {})
 		|| workload.metadata?.fixture?.component
 		|| workload.metadata?.fixture?.plugin
 		|| workload.target?.slug;
-	const component = componentId && components ? objectOrUndefined(components[componentId]) : undefined;
-	const source = component?.path || component?.source;
+	const component = componentId && components ? componentFromContext(components, componentId) : undefined;
+	const source = component?.path || component?.source || componentPathOverride(env.componentPathOverrides, componentId);
 	if ((!componentId || typeof source !== 'string' || source.trim() === '') && !workloadRoot) {
 		return undefined;
 	}
 	const activation = workload.metadata?.fixture?.activation || firstCasePluginActivation(workload);
-	const pluginRequirement = buildWpCodeboxFuzzPluginRequirement({ workload, componentId, source, activation, context });
+	const checkoutRoot = component?.checkout_root || component?.checkoutRoot || component?.extensions?.wordpress?.checkout_root || component?.extensions?.wordpress?.checkoutRoot || componentPathOverride(env.componentCheckoutRootOverrides, componentId);
+	const pluginRequirement = buildWpCodeboxFuzzPluginRequirement({ workload, componentId, source, activation, context, checkoutRoot });
 	return {
 		extra_plugins: pluginRequirement ? [pluginRequirement.extraPlugin] : undefined,
 		component_contracts: pluginRequirement ? [pluginRequirement.componentContract] : undefined,
@@ -267,15 +270,15 @@ function buildWpCodeboxFuzzRuntimeRequirements({ workload = {}, env = {} } = {})
 	};
 }
 
-function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, source, activation, context = {} } = {}) {
+function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, source, activation, context = {}, checkoutRoot } = {}) {
 	if (!componentId || typeof source !== 'string' || source.trim() === '') {
 		return undefined;
 	}
 	const slug = workload.target?.slug || componentId;
-	const component = objectOrUndefined(context.components?.[componentId]);
+	const component = componentFromContext(context.components, componentId);
 	const wordpressExtension = objectOrUndefined(component?.extensions?.wordpress);
 	const sourceSubpath = nonEmptyString(wordpressExtension?.wp_codebox_source_subpath || wordpressExtension?.wpCodeboxSourceSubpath);
-	const sourceLayout = wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension });
+	const sourceLayout = wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot });
 	return {
 		extraPlugin: stripUndefined({
 			slug,
@@ -302,12 +305,19 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 	};
 }
 
-function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension } = {}) {
+function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot } = {}) {
 	const normalizedSubpath = nonEmptyString(sourceSubpath);
 	if (normalizedSubpath && source.endsWith(`/${normalizedSubpath}`)) {
 		return {
 			sourceRoot: source.slice(0, -normalizedSubpath.length - 1),
 			sourceSubpath: normalizedSubpath,
+		};
+	}
+	const normalizedCheckoutRoot = nonEmptyString(checkoutRoot);
+	if (normalizedCheckoutRoot && source.startsWith(`${normalizedCheckoutRoot}/`)) {
+		return {
+			sourceRoot: normalizedCheckoutRoot,
+			sourceSubpath: source.slice(normalizedCheckoutRoot.length + 1),
 		};
 	}
 
@@ -324,6 +334,40 @@ function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension } = {
 	}
 
 	return {};
+}
+
+function componentPathOverridesFromEnv(env = {}, prefix = '') {
+	const overrides = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (!key.startsWith(prefix) || typeof value !== 'string' || value.trim() === '') {
+			continue;
+		}
+		const suffix = key.slice(prefix.length);
+		const normalizedKey = normalizedComponentId(suffix);
+		if (!normalizedKey) {
+			continue;
+		}
+		overrides[normalizedKey] = value.trim();
+	}
+	return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
+function componentFromContext(components = {}, componentId) {
+	const normalizedId = normalizedComponentId(componentId);
+	for (const [key, value] of Object.entries(objectOrUndefined(components) || {})) {
+		if (key === componentId || normalizedComponentId(key) === normalizedId) {
+			return objectOrUndefined(value);
+		}
+	}
+	return undefined;
+}
+
+function componentPathOverride(overrides = {}, componentId) {
+	return objectOrUndefined(overrides)?.[normalizedComponentId(componentId)];
+}
+
+function normalizedComponentId(value) {
+	return nonEmptyString(value)?.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
 function nonEmptyString(value) {

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -992,6 +992,7 @@ async function runWpCodeboxPublicFuzzOperation(options = {}) {
 
 function wpCodeboxPublicCliInput(request = {}, options = {}) {
 	const runtimeRequirements = objectOrUndefined(wpCodeboxFuzzRequestRuntimeRequirements(request));
+	validateWpCodeboxRuntimeRequirementMounts(runtimeRequirements, options);
 	const input = stageArtifactPostprocessHelpers(wpCodeboxFuzzRequestInput(request, options), runtimeRequirements, options);
 	return {
 		...input,
@@ -1001,6 +1002,33 @@ function wpCodeboxPublicCliInput(request = {}, options = {}) {
 			homeboy_wp_codebox_fuzz_execution: request,
 		},
 	};
+}
+
+function validateWpCodeboxRuntimeRequirementMounts(runtimeRequirements = {}, options = {}) {
+	if (options.validateRuntimeMounts === false || options.validate_runtime_mounts === false) {
+		return;
+	}
+	for (const [collection, entries] of Object.entries({
+		runtime_mounts: runtimeRequirements.runtime_mounts,
+		extra_plugins: runtimeRequirements.extra_plugins,
+		component_contracts: runtimeRequirements.component_contracts,
+	})) {
+		for (const [index, entry] of normalizeArray(entries).entries()) {
+			const requirement = objectOrUndefined(entry);
+			if (!requirement) {
+				continue;
+			}
+			const source = requirement.sourceRoot || requirement.source || requirement.path;
+			if (!isLocalAbsolutePath(source) || fs.existsSync(source)) {
+				continue;
+			}
+			throw new Error(`WP Codebox runtime requirement ${collection}[${index}] source does not exist: ${source}`);
+		}
+	}
+}
+
+function isLocalAbsolutePath(value) {
+	return typeof value === 'string' && path.isAbsolute(value) && !value.includes('${') && !value.includes('{{');
 }
 
 function stageArtifactPostprocessHelpers(input = {}, runtimeRequirements = {}, options = {}) {
@@ -2551,7 +2579,9 @@ module.exports = {
 	publicFuzzCliRunnerModeForRequest,
 	runWpCodeboxFuzzSuite,
 	runWpCodeboxPublicFuzzOperation,
+	validateWpCodeboxRuntimeRequirementMounts,
 	wpCodeboxFuzzExecutionRequest,
+	wpCodeboxPublicCliInput,
 	wpCodeboxFuzzSuiteAbility,
 	wpCodeboxFuzzSuiteResultSchema,
 	wpCodeboxFuzzSuiteSchema,

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -31,6 +31,7 @@ const {
 	HOMEBOY_FUZZ_RESULT_ENVELOPE_SCHEMA,
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
+	readWordPressFuzzRunnerEnv,
 	runWordPressFuzzRunnerResult,
 	writeHomeboyFuzzArtifactFiles,
 } = require('../lib/wordpress-fuzz-runner');
@@ -315,6 +316,37 @@ assert.equal(remappedPlugin.sourceSubpath, undefined);
 assert.equal(remappedPlugin.pluginFile, 'jetpack/jetpack.php');
 assert.equal(remappedPluginRootResult.wp_codebox_runtime_requirements.component_contracts[0].sourceRoot, undefined);
 assert.equal(remappedPluginRootResult.wp_codebox_runtime_requirements.component_contracts[0].sourceSubpath, undefined);
+
+const envMountedPluginRoot = path.join(os.tmpdir(), 'homeboy-wordpress-component-checkout');
+const envMountedPluginPath = path.join(envMountedPluginRoot, 'plugins', 'sample-plugin');
+const envMountedPluginResult = buildWordPressFuzzRunnerResult({
+	env: readWordPressFuzzRunnerEnv({
+		HOMEBOY_FUZZ_WORKLOAD_PATH: '/unused/in-unit-test.json',
+		HOMEBOY_FUZZ_WORKLOAD_ID: 'env-mounted-plugin',
+		HOMEBOY_FUZZ_RUN_ID: 'env-mounted-plugin-run',
+		HOMEBOY_RIG_COMPONENT_PATH__SAMPLE_PLUGIN: envMountedPluginPath,
+		HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__SAMPLE_PLUGIN: envMountedPluginRoot,
+	}),
+	workload: {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: 'env-mounted-plugin',
+		target: { type: 'wordpress-plugin', slug: 'sample-plugin', component: 'sample-plugin' },
+		metadata: { fixture: { component: 'sample-plugin', activation: 'sample-plugin/sample-plugin.php' } },
+		cases: [{ id: 'env-mounted-plugin:default', intent: { plugin: { activation: 'sample-plugin/sample-plugin.php' } } }],
+	},
+});
+assert.deepEqual(envMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0], {
+	slug: 'sample-plugin',
+	source: envMountedPluginPath,
+	sourceRoot: envMountedPluginRoot,
+	sourceSubpath: 'plugins/sample-plugin',
+	path: envMountedPluginPath,
+	pluginFile: 'sample-plugin/sample-plugin.php',
+	loadAs: 'plugin',
+	metadata: { component: 'sample-plugin', activation: 'fuzz-suite-setup-step' },
+});
+assert.equal(envMountedPluginResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceRoot, envMountedPluginRoot);
+assert.equal(envMountedPluginResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceSubpath, 'plugins/sample-plugin');
 
 const genericPrimitiveResult = buildWordPressFuzzRunnerResult({
 	env: {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -32,8 +32,10 @@ const {
 	publicFuzzCliRunnerModeForRequest,
 	runWpCodeboxPublicFuzzOperation,
 	runWpCodeboxFuzzSuite,
+	validateWpCodeboxRuntimeRequirementMounts,
 	wordpressFuzzPostprocessBinding,
 	wpCodeboxFuzzExecutionRequest,
+	wpCodeboxPublicCliInput,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
 	wpCodeboxRuntimeContractManifest,
@@ -210,6 +212,38 @@ assert.equal(executionRequest.command, 'run-fuzz-suite');
 assert.equal(executionRequest.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 assert.equal(executionRequest.metadata.executor, 'wp-codebox-direct-fuzz');
 assert.equal(executionRequest.executor, undefined);
+
+const runtimeRequirementRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-runtime-requirements-'));
+const runtimePluginRoot = path.join(runtimeRequirementRoot, 'sample-checkout');
+const runtimePluginPath = path.join(runtimePluginRoot, 'plugins', 'sample-plugin');
+const runtimeWorkloadRoot = path.join(runtimeRequirementRoot, 'workloads');
+fs.mkdirSync(runtimePluginPath, { recursive: true });
+fs.mkdirSync(runtimeWorkloadRoot, { recursive: true });
+const runtimeRequirementRequest = wpCodeboxFuzzExecutionRequest({
+	taskId: 'runtime-requirement-suite-task',
+	input,
+	runtimeRequirements: {
+		extra_plugins: [{ slug: 'sample-plugin', source: runtimePluginPath, sourceRoot: runtimePluginRoot, sourceSubpath: 'plugins/sample-plugin' }],
+		component_contracts: [{ slug: 'sample-plugin', path: runtimePluginPath, sourceRoot: runtimePluginRoot, sourceSubpath: 'plugins/sample-plugin' }],
+		runtime_mounts: [{ source: runtimeWorkloadRoot, target: runtimeWorkloadRoot, mode: 'readonly' }],
+	},
+});
+const publicCliInput = wpCodeboxPublicCliInput(runtimeRequirementRequest);
+assert.equal(publicCliInput.metadata.runtime_requirements.extra_plugins[0].sourceRoot, runtimePluginRoot);
+assert.equal(publicCliInput.metadata.runtime_requirements.component_contracts[0].sourceSubpath, 'plugins/sample-plugin');
+assert.deepEqual(publicCliInput.metadata.runtime_requirements.runtime_mounts, [{ source: runtimeWorkloadRoot, target: runtimeWorkloadRoot, mode: 'readonly' }]);
+assert.throws(
+	() => validateWpCodeboxRuntimeRequirementMounts({ runtime_mounts: [{ source: path.join(runtimeRequirementRoot, 'missing-workloads'), target: '/tmp/missing-workloads' }] }),
+	/WP Codebox runtime requirement runtime_mounts\[0\] source does not exist/
+);
+assert.throws(
+	() => wpCodeboxPublicCliInput(wpCodeboxFuzzExecutionRequest({
+		taskId: 'missing-plugin-suite-task',
+		input,
+		runtimeRequirements: { extra_plugins: [{ slug: 'missing-plugin', source: path.join(runtimeRequirementRoot, 'missing-plugin') }] },
+	})),
+	/WP Codebox runtime requirement extra_plugins\[0\] source does not exist/
+);
 
 const preflightMissingCommand = preflightWpCodeboxFuzzCapabilityContract({
 	request: taskRequest,
@@ -1146,8 +1180,8 @@ runWpCodeboxFuzzSuite({
 		runtimeContractManifest: manifest,
 		wpCodeboxBin: '/custom/direct-wp-codebox',
 		runtimeRequirements: {
-			extra_plugins: [{ slug: 'sample-plugin', source: '/runner/components/sample-plugin', loadAs: 'plugin' }],
-			runtime_env: { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: '/runner/workloads' },
+			extra_plugins: [{ slug: 'sample-plugin', source: runtimePluginPath, loadAs: 'plugin' }],
+			runtime_env: { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: runtimeWorkloadRoot },
 		},
 		runPublicCli: ({ command, args, stdin }) => {
 			assert.equal(command, '/custom/direct-wp-codebox');
@@ -1166,8 +1200,8 @@ runWpCodeboxFuzzSuite({
 			assert.equal(stdin, undefined);
 			const publicCliInput = JSON.parse(fs.readFileSync(args[2], 'utf8'));
 			assert.equal(publicCliInput.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
-			assert.equal(publicCliInput.metadata.runtime_requirements.extra_plugins[0].source, '/runner/components/sample-plugin');
-			assert.equal(publicCliInput.metadata.runtime_requirements.runtime_env.WP_CODEBOX_FUZZ_WORKLOAD_ROOT, '/runner/workloads');
+			assert.equal(publicCliInput.metadata.runtime_requirements.extra_plugins[0].source, runtimePluginPath);
+			assert.equal(publicCliInput.metadata.runtime_requirements.runtime_env.WP_CODEBOX_FUZZ_WORKLOAD_ROOT, runtimeWorkloadRoot);
 			assert.equal(publicCliInput.metadata.homeboy_wp_codebox_fuzz_execution.schema, WP_CODEBOX_FUZZ_EXECUTION_SCHEMA);
 			assert.equal(publicCliInput.metadata.homeboy_wp_codebox_fuzz_execution.expected_artifacts.includes('case-log'), true);
 			assert.equal(publicCliInput.metadata.homeboy_agent_task_request, undefined);


### PR DESCRIPTION
## Summary
- Resolve runtime requirement component paths from metadata and normalized env overrides.
- Validate local absolute runtime mount/plugin/contract sources before WP Codebox dispatch.
- Add smoke coverage for env-derived component paths and missing source failures.

## Verification
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting the implementation, tests, and verification workflow.