### PR TITLE
feat(build): declared local-workspace dependency overrides with peer dedup

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -66,6 +66,13 @@
       "type": "object",
       "default": {},
       "description": "Additional non-secret environment values consumed by Node.js bench workloads."
+    },
+    {
+      "id": "local_workspace_dependencies",
+      "label": "Local workspace dependency overrides",
+      "type": "array",
+      "default": [],
+      "description": "Declared local (unpublished) workspace package dependencies to build from source, pack, and install into the consumer as a self-contained built tarball before the build runs. Installing a built tarball (not a file: symlink) lets peer dependencies such as React dedupe to the consumer's single copy. Each entry is an object: name (required package name), path (required source path relative to the component, may reference sibling repos), and optional package_dir (monorepo subpackage to pack), build (explicit build command run in path; defaults to install + run build script), and package_manager (npm|pnpm|yarn, auto-detected by default)."
     }
   ],
   "ci": {

--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -32,9 +32,20 @@ homeboy_runner_init --bash 4 --failure-trap
 source "$COMMAND_CAPTURE_HELPER"
 # shellcheck source=../lib/node-helpers.sh
 source "${SCRIPT_DIR}/../lib/node-helpers.sh"
+# shellcheck source=../lib/local-workspace-deps.sh
+source "${HOMEBOY_RUNTIME_LOCAL_WORKSPACE_DEPS:-${SCRIPT_DIR}/../lib/local-workspace-deps.sh}"
 homeboy_require_package_json
 homeboy_detect_package_manager
 homeboy_ensure_node_dependencies
+
+# Apply declared local-workspace-dependency overrides (no-op unless declared in
+# HOMEBOY_SETTINGS_JSON). Runs after deps are installed and before the build so
+# the built, deduped tarball is resolvable during the consumer build.
+if ! homeboy_apply_local_workspace_dependencies "${PROJECT_PATH}"; then
+    FAILED_STEP="Local workspace dependency override failed"
+    FAILURE_OUTPUT="A declared local_workspace_dependencies override failed to build/pack/install. See output above."
+    exit 1
+fi
 
 # Resolve the build command.
 BUILD_CMD=""

--- a/nodejs/scripts/lib/local-workspace-deps.sh
+++ b/nodejs/scripts/lib/local-workspace-deps.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+
+# Local workspace dependency overrides for Node.js builds.
+#
+# Problem this solves
+# -------------------
+# A component can depend on a sibling workspace package that is intentionally
+# NOT published to a registry — it is "cooked locally" on a branch (e.g. an
+# `@scope/ui` package living in a sibling pnpm monorepo built on `trunk`).
+# There is no clean way to make a build consume it:
+#
+#   * An npm `file:` install symlinks the dependency's own node_modules into the
+#     consumer. The dependency's peer deps (React, etc.) then resolve to a
+#     SECOND copy → "Invalid hook call" → a blank app.
+#   * A hand-rolled tarball is manual and fragile.
+#
+# The fix is a declared, config-driven override that:
+#   1. BUILDS the dependency from its local source (its own build), then
+#   2. packs it into a self-contained tarball (`npm pack` / `pnpm pack`), then
+#   3. installs that tarball into the consumer as a real, built package.
+#
+# Installing a built tarball (not a live symlink) lets the package manager
+# dedupe peer dependencies against the consumer's single copy — React resolves
+# once, so hooks work.
+#
+# Declaring overrides
+# -------------------
+# Overrides are read from `HOMEBOY_SETTINGS_JSON` (the same channel the
+# WordPress build uses for `package_artifacts`) under the key
+# `local_workspace_dependencies`, an array of objects:
+#
+#   {
+#     "local_workspace_dependencies": [
+#       {
+#         "name": "@automattic/agenttic-ui",        // required: package name
+#         "path": "../agenttic",                     // required: source path,
+#                                                    //   relative to the
+#                                                    //   consumer (or absolute)
+#         "package_dir": "packages/agenttic-ui",     // optional: subdir within
+#                                                    //   `path` to pack (monorepo)
+#         "build": "pnpm install --frozen-lockfile && pnpm --filter @automattic/agenttic-ui build",
+#                                                    // optional: explicit build
+#                                                    //   command run in `path`.
+#                                                    //   Defaults to auto:
+#                                                    //   install + run `build`.
+#         "package_manager": "pnpm"                  // optional: override
+#                                                    //   auto-detection
+#       }
+#     ]
+#   }
+#
+# This helper is generic: it carries no WordPress/Studio knowledge. The
+# WordPress build sources it; the generic Node.js build runner uses it too.
+
+# Apply all declared local workspace dependency overrides for a consumer.
+#
+# Usage: homeboy_apply_local_workspace_dependencies <consumer_dir>
+#
+# Reads HOMEBOY_SETTINGS_JSON. A no-op (returns 0) when no overrides are
+# declared, so callers can always invoke it unconditionally. Returns non-zero
+# when a declared override is invalid or fails to build/pack/install — a
+# misconfigured override is a hard build failure, not a silent skip, because the
+# resulting bundle would be broken.
+#
+# Optional env:
+#   HOMEBOY_LOCAL_WORKSPACE_DEP_NPM_FLAGS  Extra flags for the consumer-side
+#       `npm install <tarball>` (e.g. "--no-audit --no-fund --legacy-peer-deps").
+#       `--no-save` is always added so the consumer's committed package.json and
+#       lockfile are never mutated by the build.
+homeboy_apply_local_workspace_dependencies() {
+    local consumer_dir="$1"
+
+    if [ -z "$consumer_dir" ]; then
+        echo "[local-workspace-deps] consumer directory is required" >&2
+        return 1
+    fi
+    if [ ! -d "$consumer_dir" ]; then
+        echo "[local-workspace-deps] consumer directory does not exist: $consumer_dir" >&2
+        return 1
+    fi
+
+    # No settings at all → nothing declared → no-op.
+    case "${HOMEBOY_SETTINGS_JSON:-}" in
+        ""|"{}") return 0 ;;
+    esac
+
+    if ! command -v node >/dev/null 2>&1; then
+        echo "[local-workspace-deps] node is required to parse local_workspace_dependencies" >&2
+        return 1
+    fi
+
+    local consumer_abs
+    consumer_abs="$(cd "$consumer_dir" && pwd)"
+
+    # Emit one tab-separated record per declared override:
+    #   name<TAB>path<TAB>package_dir<TAB>package_manager<TAB>base64(build)
+    # build is base64-encoded so embedded spaces/newlines survive transport.
+    # Validation happens inside node; a non-zero exit aborts the build.
+    local records
+    if ! records="$(node <<'NODE'
+const raw = process.env.HOMEBOY_SETTINGS_JSON || '{}';
+let settings;
+try {
+  settings = JSON.parse(raw);
+} catch (e) {
+  process.stderr.write('[local-workspace-deps] HOMEBOY_SETTINGS_JSON is not valid JSON.\n');
+  process.exit(1);
+}
+if (settings === null || typeof settings !== 'object' || Array.isArray(settings)) {
+  process.stderr.write('[local-workspace-deps] HOMEBOY_SETTINGS_JSON must be a JSON object.\n');
+  process.exit(1);
+}
+const entries = settings.local_workspace_dependencies;
+if (entries === undefined) {
+  process.exit(0);
+}
+if (!Array.isArray(entries)) {
+  process.stderr.write('[local-workspace-deps] local_workspace_dependencies must be an array.\n');
+  process.exit(1);
+}
+const cleanField = (value, field, index) => {
+  if (typeof value !== 'string' || value === '') {
+    process.stderr.write(`[local-workspace-deps] entry ${index}: "${field}" must be a non-empty string.\n`);
+    process.exit(1);
+  }
+  if (/[\t\n]/.test(value)) {
+    process.stderr.write(`[local-workspace-deps] entry ${index}: "${field}" cannot contain tabs or newlines.\n`);
+    process.exit(1);
+  }
+  return value;
+};
+const optionalField = (value, field, index) => {
+  if (value === undefined || value === null || value === '') return '';
+  if (typeof value !== 'string') {
+    process.stderr.write(`[local-workspace-deps] entry ${index}: "${field}" must be a string when set.\n`);
+    process.exit(1);
+  }
+  return value;
+};
+entries.forEach((entry, index) => {
+  if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+    process.stderr.write(`[local-workspace-deps] entry ${index} must be an object.\n`);
+    process.exit(1);
+  }
+  const name = cleanField(entry.name, 'name', index);
+  const sourcePath = cleanField(entry.path, 'path', index);
+  const packageDir = optionalField(entry.package_dir, 'package_dir', index);
+  const packageManager = optionalField(entry.package_manager, 'package_manager', index);
+  if (/[\t\n]/.test(packageDir) || /[\t\n]/.test(packageManager)) {
+    process.stderr.write(`[local-workspace-deps] entry ${index}: package_dir/package_manager cannot contain tabs or newlines.\n`);
+    process.exit(1);
+  }
+  if (packageManager && !['npm', 'pnpm', 'yarn'].includes(packageManager)) {
+    process.stderr.write(`[local-workspace-deps] entry ${index}: package_manager must be npm, pnpm, or yarn.\n`);
+    process.exit(1);
+  }
+  const build = optionalField(entry.build, 'build', index);
+  const buildB64 = Buffer.from(build, 'utf8').toString('base64');
+  process.stdout.write([name, sourcePath, packageDir, packageManager, buildB64].join('\t') + '\n');
+});
+NODE
+)"; then
+        return 1
+    fi
+
+    if [ -z "$records" ]; then
+        return 0
+    fi
+
+    local name source_path package_dir package_manager build_b64
+    while IFS=$'\t' read -r name source_path package_dir package_manager build_b64; do
+        [ -n "$name" ] || continue
+        if ! _homeboy_local_workspace_dep_one \
+            "$consumer_abs" "$name" "$source_path" "$package_dir" "$package_manager" "$build_b64"; then
+            return 1
+        fi
+    done <<EOF
+$records
+EOF
+
+    return 0
+}
+
+# Build + pack + install a single declared override. Internal helper.
+_homeboy_local_workspace_dep_one() {
+    local consumer_abs="$1"
+    local name="$2"
+    local source_path="$3"
+    local package_dir="$4"
+    local package_manager="$5"
+    local build_b64="$6"
+
+    echo "[local-workspace-deps] Resolving '$name' from '$source_path'"
+
+    # Resolve source directory relative to the consumer (or accept absolute).
+    local source_abs
+    case "$source_path" in
+        /*) source_abs="$source_path" ;;
+        *)  source_abs="$consumer_abs/$source_path" ;;
+    esac
+    if [ ! -d "$source_abs" ]; then
+        echo "[local-workspace-deps] '$name': source directory not found: $source_abs" >&2
+        return 1
+    fi
+    source_abs="$(cd "$source_abs" && pwd)"
+
+    # The directory whose package we pack (monorepo subpackage support).
+    local pack_abs="$source_abs"
+    if [ -n "$package_dir" ]; then
+        pack_abs="$source_abs/$package_dir"
+    fi
+    if [ ! -f "$pack_abs/package.json" ]; then
+        echo "[local-workspace-deps] '$name': no package.json found at: $pack_abs" >&2
+        return 1
+    fi
+    pack_abs="$(cd "$pack_abs" && pwd)"
+
+    # Validate the package name matches what was declared, so a misconfigured
+    # path can't silently install the wrong package.
+    local packed_name
+    packed_name="$(HOMEBOY_LWD_PKG="$pack_abs/package.json" node -e 'process.stdout.write(String(require(process.env.HOMEBOY_LWD_PKG).name || ""))' 2>/dev/null || true)"
+    if [ "$packed_name" != "$name" ]; then
+        echo "[local-workspace-deps] '$name': package at $pack_abs is named '${packed_name:-<none>}', expected '$name'" >&2
+        return 1
+    fi
+
+    # Detect the dependency's package manager unless overridden.
+    local pm="$package_manager"
+    if [ -z "$pm" ]; then
+        if [ -f "$source_abs/pnpm-lock.yaml" ]; then
+            pm="pnpm"
+        elif [ -f "$source_abs/yarn.lock" ]; then
+            pm="yarn"
+        else
+            pm="npm"
+        fi
+    fi
+    if ! command -v "$pm" >/dev/null 2>&1; then
+        echo "[local-workspace-deps] '$name': package manager '$pm' is not available" >&2
+        return 1
+    fi
+
+    # Build the dependency from source.
+    local build_cmd=""
+    if [ -n "$build_b64" ]; then
+        build_cmd="$(printf '%s' "$build_b64" | base64 --decode 2>/dev/null || printf '%s' "$build_b64" | base64 -d)"
+    fi
+
+    if [ -n "$build_cmd" ]; then
+        echo "[local-workspace-deps] '$name': building via declared command"
+        if ! ( cd "$source_abs" && bash -c "$build_cmd" ); then
+            echo "[local-workspace-deps] '$name': declared build command failed" >&2
+            return 1
+        fi
+    else
+        # Install where dependencies are actually declared: the source root for
+        # a monorepo (so workspaces resolve), otherwise the packed package dir.
+        local install_dir="$source_abs"
+        if [ ! -f "$source_abs/package.json" ]; then
+            install_dir="$pack_abs"
+        fi
+        echo "[local-workspace-deps] '$name': installing dependency sources ($pm) in $install_dir"
+        if ! _homeboy_local_workspace_dep_install "$pm" "$install_dir"; then
+            echo "[local-workspace-deps] '$name': dependency install failed" >&2
+            return 1
+        fi
+        # Prefer a build script in the packed package; fall back to source root.
+        local build_dir=""
+        if _homeboy_local_workspace_dep_has_build_script "$pack_abs"; then
+            build_dir="$pack_abs"
+        elif _homeboy_local_workspace_dep_has_build_script "$source_abs"; then
+            build_dir="$source_abs"
+        else
+            echo "[local-workspace-deps] '$name': no build command declared and no 'build' script found in $pack_abs or $source_abs" >&2
+            return 1
+        fi
+        echo "[local-workspace-deps] '$name': running build script in $build_dir"
+        if ! ( cd "$build_dir" && _homeboy_local_workspace_dep_run_build "$pm" ); then
+            echo "[local-workspace-deps] '$name': build script failed" >&2
+            return 1
+        fi
+    fi
+
+    # Pack the built package into a self-contained tarball.
+    local pack_dest
+    pack_dest="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-lwd.XXXXXX")"
+    echo "[local-workspace-deps] '$name': packing built artifact"
+    if ! ( cd "$pack_abs" && _homeboy_local_workspace_dep_pack "$pm" "$pack_dest" ); then
+        echo "[local-workspace-deps] '$name': pack failed" >&2
+        rm -rf "$pack_dest"
+        return 1
+    fi
+
+    local tarball
+    tarball="$(find "$pack_dest" -maxdepth 1 -name '*.tgz' -type f 2>/dev/null | head -1)"
+    if [ -z "$tarball" ] || [ ! -f "$tarball" ]; then
+        echo "[local-workspace-deps] '$name': no tarball produced in $pack_dest" >&2
+        rm -rf "$pack_dest"
+        return 1
+    fi
+
+    # Install the built tarball into the consumer as a real package. Peer deps
+    # (React, etc.) dedupe against the consumer's already-installed copy, which
+    # is the whole point — a live symlink would not dedupe.
+    local install_flags="--no-save ${HOMEBOY_LOCAL_WORKSPACE_DEP_NPM_FLAGS:---no-audit --no-fund}"
+    echo "[local-workspace-deps] '$name': installing built tarball into consumer (npm install $install_flags)"
+    if ! ( cd "$consumer_abs" && npm install "$tarball" $install_flags ); then
+        echo "[local-workspace-deps] '$name': consumer install of built tarball failed" >&2
+        rm -rf "$pack_dest"
+        return 1
+    fi
+
+    # Structured evidence line (mirrors the package_artifacts manifest style).
+    local sha256=""
+    if command -v shasum >/dev/null 2>&1; then
+        sha256="$(shasum -a 256 "$tarball" | awk '{print $1}')"
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256="$(sha256sum "$tarball" | awk '{print $1}')"
+    fi
+    printf '{"type":"nodejs.local_workspace_dependency","name":"%s","source":"%s","pack_dir":"%s","tarball":"%s","sha256":"%s"}\n' \
+        "$name" "$source_abs" "$pack_abs" "$(basename "$tarball")" "$sha256"
+
+    rm -rf "$pack_dest"
+    return 0
+}
+
+_homeboy_local_workspace_dep_install() {
+    local pm="$1"
+    local dir="$2"
+    case "$pm" in
+        pnpm)
+            if [ -f "$dir/pnpm-lock.yaml" ]; then
+                ( cd "$dir" && pnpm install --frozen-lockfile )
+            else
+                ( cd "$dir" && pnpm install )
+            fi
+            ;;
+        yarn)
+            ( cd "$dir" && yarn install --frozen-lockfile )
+            ;;
+        npm|*)
+            if [ -f "$dir/package-lock.json" ]; then
+                ( cd "$dir" && npm ci --no-audit --no-fund )
+            else
+                ( cd "$dir" && npm install --no-audit --no-fund )
+            fi
+            ;;
+    esac
+}
+
+_homeboy_local_workspace_dep_has_build_script() {
+    local dir="$1"
+    [ -f "$dir/package.json" ] || return 1
+    HOMEBOY_LWD_PKG="$dir/package.json" node -e '
+        const pkg = require(process.env.HOMEBOY_LWD_PKG);
+        process.exit(pkg.scripts && pkg.scripts.build ? 0 : 1);
+    ' 2>/dev/null
+}
+
+_homeboy_local_workspace_dep_run_build() {
+    local pm="$1"
+    case "$pm" in
+        pnpm) pnpm run build ;;
+        yarn) yarn run build ;;
+        npm|*) npm run build ;;
+    esac
+}
+
+_homeboy_local_workspace_dep_pack() {
+    local pm="$1"
+    local dest="$2"
+    case "$pm" in
+        pnpm) pnpm pack --pack-destination "$dest" ;;
+        # yarn classic writes to the cwd with --filename; pack there then move.
+        yarn)
+            yarn pack --filename "$dest/package.tgz"
+            ;;
+        npm|*) npm pack --pack-destination "$dest" ;;
+    esac
+}

--- a/nodejs/tests/local-workspace-deps-smoke.sh
+++ b/nodejs/tests/local-workspace-deps-smoke.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+
+set -euo pipefail
+
+# Smoke test for the generic local-workspace-dependency override helper.
+#
+# Proves the real mechanism with real npm:
+#   1. A locally "cooked" (unpublished) sibling package is BUILT from source.
+#   2. It is packed into a self-contained tarball and installed into a consumer.
+#   3. The consumer ends up with the BUILT dependency and a single, deduped copy
+#      of the peer dependency (React) — NOT a nested second copy that a `file:`
+#      symlink would produce.
+# Also exercises config validation error paths.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HELPER="${EXTENSION_DIR}/scripts/lib/local-workspace-deps.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-lwd-smoke.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if ! command -v npm >/dev/null 2>&1; then
+    echo "npm is required for the local workspace deps smoke" >&2
+    exit 1
+fi
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# --- Fixture: peer dependency (fake React) -------------------------------------
+react_dir="${TMP_DIR}/react-fake"
+mkdir -p "$react_dir"
+cat > "${react_dir}/package.json" <<'JSON'
+{ "name": "react", "version": "18.3.0", "main": "index.js" }
+JSON
+printf 'module.exports = { version: "18.3.0" };\n' > "${react_dir}/index.js"
+
+# --- Fixture: local workspace dependency (a monorepo subpackage) ---------------
+# Source lives under monorepo/packages/widget; it declares React as a PEER dep,
+# has a real build step that emits dist/, and is unpublished.
+monorepo_dir="${TMP_DIR}/monorepo"
+widget_dir="${monorepo_dir}/packages/widget"
+mkdir -p "${widget_dir}/src"
+cat > "${widget_dir}/package.json" <<'JSON'
+{
+  "name": "@scope/widget",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "files": ["dist", "package.json"],
+  "scripts": { "build": "node build.js" },
+  "peerDependencies": { "react": "*" }
+}
+JSON
+printf 'export const widget = "src";\n' > "${widget_dir}/src/index.js"
+cat > "${widget_dir}/build.js" <<'JS'
+const fs = require('fs');
+fs.mkdirSync('dist', { recursive: true });
+fs.writeFileSync('dist/index.js', 'module.exports = { widget: "built" };\n');
+JS
+
+# --- Fixture: consumer ---------------------------------------------------------
+consumer_dir="${TMP_DIR}/consumer"
+mkdir -p "$consumer_dir"
+cat > "${consumer_dir}/package.json" <<JSON
+{
+  "name": "consumer",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": { "react": "file:${react_dir}" }
+}
+JSON
+
+# Install the consumer's own deps first (React must exist to dedupe against).
+( cd "$consumer_dir" && npm install --no-audit --no-fund >/dev/null 2>&1 ) \
+    || fail "consumer npm install failed"
+[ -f "${consumer_dir}/node_modules/react/index.js" ] || fail "consumer React not installed"
+
+# --- Apply the override --------------------------------------------------------
+settings_json="$(node -e '
+  process.stdout.write(JSON.stringify({
+    local_workspace_dependencies: [
+      { name: "@scope/widget", path: "'"${monorepo_dir}"'", package_dir: "packages/widget" }
+    ]
+  }));
+')"
+
+out_file="${TMP_DIR}/apply.out"
+(
+    HOMEBOY_SETTINGS_JSON="$settings_json" \
+        bash -c 'source "$1"; homeboy_apply_local_workspace_dependencies "$2"' \
+        _ "$HELPER" "$consumer_dir"
+) > "$out_file" 2>&1 || { sed 's/^/  /' "$out_file" >&2; fail "override application failed"; }
+
+# The BUILT dependency must be installed in the consumer.
+dep_built="${consumer_dir}/node_modules/@scope/widget/dist/index.js"
+[ -f "$dep_built" ] || { sed 's/^/  /' "$out_file" >&2; fail "built dependency not installed into consumer"; }
+grep -Fq 'built' "$dep_built" || fail "installed dependency is not the BUILT artifact"
+
+# It must be a real installed package, NOT a live symlink into the source tree.
+if [ -L "${consumer_dir}/node_modules/@scope/widget" ]; then
+    fail "dependency installed as a symlink — peer deps would NOT dedupe"
+fi
+
+# Peer dedup: there must be NO second React nested under the dependency.
+if [ -e "${consumer_dir}/node_modules/@scope/widget/node_modules/react" ]; then
+    fail "duplicate React under dependency — peer dedup failed (Invalid hook call risk)"
+fi
+
+# Structured evidence line emitted.
+grep -Fq '"type":"nodejs.local_workspace_dependency"' "$out_file" \
+    || fail "missing structured evidence line"
+grep -Fq '"name":"@scope/widget"' "$out_file" || fail "evidence missing dependency name"
+
+echo "ok: real build + pack + install with peer dedup"
+
+# --- No-op cases ---------------------------------------------------------------
+run_helper() {
+    local settings="$1"
+    local consumer="$2"
+    HOMEBOY_SETTINGS_JSON="$settings" \
+        bash -c 'source "$1"; homeboy_apply_local_workspace_dependencies "$2"' \
+        _ "$HELPER" "$consumer" 2>&1
+}
+
+run_helper "" "$consumer_dir" >/dev/null || fail "empty settings should be a no-op"
+run_helper "{}" "$consumer_dir" >/dev/null || fail "empty object should be a no-op"
+run_helper '{"package_artifacts":["x"]}' "$consumer_dir" >/dev/null \
+    || fail "unrelated settings should be a no-op"
+echo "ok: no-op when no overrides declared"
+
+# --- Validation error cases ----------------------------------------------------
+expect_failure() {
+    local label="$1"
+    local settings="$2"
+    local needle="$3"
+    local result
+    if result="$(run_helper "$settings" "$consumer_dir")"; then
+        echo "$result" | sed 's/^/  /' >&2
+        fail "expected failure: $label"
+    fi
+    grep -Fq "$needle" <<<"$result" || {
+        echo "$result" | sed 's/^/  /' >&2
+        fail "expected error message for $label to contain: $needle"
+    }
+}
+
+expect_failure "missing name" \
+    '{"local_workspace_dependencies":[{"path":"../x"}]}' \
+    '"name" must be a non-empty string'
+
+expect_failure "non-array" \
+    '{"local_workspace_dependencies":{"name":"x"}}' \
+    'local_workspace_dependencies must be an array'
+
+expect_failure "missing source path" \
+    '{"local_workspace_dependencies":[{"name":"@scope/widget","path":"./does-not-exist"}]}' \
+    'source directory not found'
+
+expect_failure "name mismatch" \
+    "$(node -e 'process.stdout.write(JSON.stringify({local_workspace_dependencies:[{name:"@scope/WRONG",path:"'"${monorepo_dir}"'",package_dir:"packages/widget"}]}))')" \
+    "expected '@scope/WRONG'"
+
+echo "ok: config validation rejects malformed overrides"
+
+echo "local workspace deps smoke passed."

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -337,6 +337,44 @@ least one file. Included package artifacts are copied into the staging directory
 after the default rsync excludes and reported with SHA-256 values in the build
 output.
 
+### Local workspace dependency overrides
+
+A component can depend on a sibling workspace package that is intentionally not
+published — "cooked locally" on a branch (e.g. an `@scope/ui` package in a
+sibling pnpm monorepo built on `trunk`). An npm `file:` install symlinks the
+dependency's own `node_modules`, so its peer deps (React) resolve to a *second*
+copy → "Invalid hook call" → a blank app. Declare the dependency instead and the
+build will build it from source, pack it, and install the built tarball so peer
+deps dedupe to the consumer's single copy:
+
+```json
+{
+	"extensions": {
+		"wordpress": {
+			"local_workspace_dependencies": [
+				{
+					"name": "@automattic/agenttic-ui",
+					"path": "../agenttic",
+					"package_dir": "packages/agenttic-ui",
+					"build": "pnpm install --frozen-lockfile && pnpm --filter @automattic/agenttic-ui build",
+					"package_manager": "pnpm"
+				}
+			]
+		}
+	}
+}
+```
+
+Only `name` and `path` are required. `path` is resolved relative to the
+component (sibling repos via `..` are allowed) and `name` is validated against
+the resolved package. When `build` is omitted the dependency's own `build`
+script is run after installing its dependencies. The override runs after the
+consumer's own dependencies are installed and before the consumer build, and a
+declared override that fails is a fatal build error. The mechanism is generic
+Node.js behavior shared with the `nodejs` build runner
+(`nodejs/scripts/lib/local-workspace-deps.sh`); it carries no WordPress
+specifics.
+
 ## Bench runner
 
 Bench workloads run through WP Codebox. WP Codebox owns the disposable WordPress

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -57,6 +57,13 @@ RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:?HOMEBOY_RUNTIME_RESOL
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context --component-alias PLUGIN_PATH
 
+# Generic local-workspace-dependency override helper. The mechanism (build a
+# local sibling package, pack it, install the built tarball so peer deps dedupe)
+# is generic Node.js behavior and lives in the nodejs extension, which is
+# installed alongside this one. Resolve via an explicit runtime override first,
+# then the sibling extension path.
+LOCAL_WORKSPACE_DEPS_HELPER="${HOMEBOY_RUNTIME_LOCAL_WORKSPACE_DEPS:-${EXTENSION_PATH}/../nodejs/scripts/lib/local-workspace-deps.sh}"
+
 # Output functions
 print_status() {
     echo -e "${BLUE}[BUILD]${NC} $1"
@@ -407,6 +414,43 @@ install_frontend_dependencies() {
     fi
 }
 
+# Apply declared local-workspace-dependency overrides for the current directory.
+#
+# No-op unless `local_workspace_dependencies` is declared in HOMEBOY_SETTINGS_JSON.
+# When declared, the generic nodejs helper builds each local dependency from
+# source, packs it, and installs the built tarball into this consumer so peer
+# deps (React) dedupe to the consumer's single copy — the fix for the
+# "Invalid hook call" blank-app failure caused by `file:` symlink dupes.
+apply_local_workspace_overrides() {
+    case "${HOMEBOY_SETTINGS_JSON:-}" in
+        ""|"{}") return 0 ;;
+    esac
+
+    # Cheap pre-check: only engage the helper when overrides are actually
+    # declared. The helper does full validation; this just avoids requiring it
+    # for the common case where nothing is declared.
+    if ! printf '%s' "$HOMEBOY_SETTINGS_JSON" | grep -q 'local_workspace_dependencies'; then
+        return 0
+    fi
+
+    if [ ! -f "$LOCAL_WORKSPACE_DEPS_HELPER" ]; then
+        print_error "local_workspace_dependencies declared but helper not found: $LOCAL_WORKSPACE_DEPS_HELPER"
+        return 1
+    fi
+
+    # Match the consumer install's peer-dep handling for the tarball install.
+    local npm_flags=()
+    while IFS= read -r flag; do
+        npm_flags+=("$flag")
+    done < <(npm_install_flags)
+
+    print_status "Applying local workspace dependency overrides..."
+    # shellcheck source=/dev/null
+    HOMEBOY_LOCAL_WORKSPACE_DEP_NPM_FLAGS="${npm_flags[*]}" \
+        bash -c 'source "$1"; homeboy_apply_local_workspace_dependencies "$2"' \
+        _ "$LOCAL_WORKSPACE_DEPS_HELPER" "$(pwd)"
+}
+
 # Build frontend assets (Gutenberg blocks via @wordpress/scripts, Vite, or generic npm build)
 #
 # Frontend builds are non-fatal for PHP-primary plugins. If node/npm is
@@ -453,6 +497,18 @@ build_frontend_assets() {
 
     # Ensure dependencies exist and expected local build binary is present.
     install_frontend_dependencies "$build_tool" ""
+
+    # Apply any declared local-workspace-dependency overrides after the
+    # consumer's own deps are installed (so peer deps exist to dedupe against)
+    # and before the consumer build runs (so the built artifact is resolvable).
+    #
+    # A declared override is explicit intent that the dependency matters, so a
+    # failure here is fatal rather than silently shipping a bundle missing the
+    # dependency — even for otherwise PHP-primary plugins.
+    if ! apply_local_workspace_overrides; then
+        print_error "Local workspace dependency override failed"
+        exit 1
+    fi
 
     # Run the build command
     print_status "Building frontend assets..."

--- a/wordpress/scripts/build/local-workspace-dep-build-smoke.sh
+++ b/wordpress/scripts/build/local-workspace-dep-build-smoke.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end smoke for the WordPress build's local-workspace-dependency override.
+#
+# Runs the real build.sh against a plugin that declares a local_workspace_dependencies
+# override consuming a locally "cooked" (unpublished) sibling package. Proves:
+#   * build.sh builds + packs + installs the local dependency before the consumer build
+#   * the consumer build can resolve the BUILT dependency
+#   * peer deps (React) dedupe (no nested second copy)
+#   * a declared override with a missing helper fails the build loudly
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ROOT_DIR="$(cd "${EXTENSION_DIR}/.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RESOLVE_CONTEXT_CORE_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-lwd.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if ! command -v npm >/dev/null 2>&1; then
+    echo "npm is required for the WordPress local workspace deps smoke" >&2
+    exit 1
+fi
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# --- Fixture: peer dependency (fake React) -------------------------------------
+react_dir="${TMP_DIR}/react-fake"
+mkdir -p "$react_dir"
+cat > "${react_dir}/package.json" <<'JSON'
+{ "name": "react", "version": "18.3.0", "main": "index.js" }
+JSON
+printf 'module.exports = { version: "18.3.0" };\n' > "${react_dir}/index.js"
+
+# --- Fixture: locally cooked dependency (monorepo subpackage) -------------------
+monorepo_dir="${TMP_DIR}/monorepo"
+widget_dir="${monorepo_dir}/packages/widget"
+mkdir -p "${widget_dir}"
+cat > "${widget_dir}/package.json" <<'JSON'
+{
+  "name": "@scope/widget",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "files": ["dist", "package.json"],
+  "scripts": { "build": "node build.js" },
+  "peerDependencies": { "react": "*" }
+}
+JSON
+cat > "${widget_dir}/build.js" <<'JS'
+const fs = require('fs');
+fs.mkdirSync('dist', { recursive: true });
+fs.writeFileSync('dist/index.js', 'module.exports = { widget: "built" };\n');
+JS
+
+# --- Fixture: the WordPress plugin (consumer) ----------------------------------
+component_dir="${TMP_DIR}/lwd-plugin"
+mkdir -p "$component_dir"
+cat > "${component_dir}/lwd-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: LWD Plugin
+ * Version: 1.0.0
+ */
+PHP
+
+# The consumer "build" verifies the BUILT dependency resolved and that React was
+# deduped (no nested copy), then writes a marker that lands in build/.
+cat > "${component_dir}/verify-build.js" <<'JS'
+const fs = require('fs');
+const built = require('@scope/widget');
+if (built.widget !== 'built') {
+  console.error('dependency is not the built artifact');
+  process.exit(1);
+}
+if (fs.existsSync('node_modules/@scope/widget/node_modules/react')) {
+  console.error('duplicate React under dependency — peer dedup failed');
+  process.exit(1);
+}
+fs.mkdirSync('build', { recursive: true });
+fs.writeFileSync('build/ok.txt', 'built+deduped\n');
+JS
+
+cat > "${component_dir}/package.json" <<JSON
+{
+  "name": "lwd-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": { "build": "node verify-build.js" },
+  "dependencies": { "react": "file:${react_dir}" }
+}
+JSON
+
+settings_json="$(node -e '
+  process.stdout.write(JSON.stringify({
+    local_workspace_dependencies: [
+      { name: "@scope/widget", path: "'"${monorepo_dir}"'", package_dir: "packages/widget" }
+    ]
+  }));
+')"
+
+# --- Run the real build --------------------------------------------------------
+build_out="${TMP_DIR}/build.out"
+(
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="lwd-plugin" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_CORE_HELPER" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_REQUIRE_FRONTEND=1 \
+    HOMEBOY_SETTINGS_JSON="$settings_json" \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "$build_out" 2>&1
+) || { sed 's/^/  /' "$build_out" >&2; fail "build with local workspace override failed"; }
+
+grep -Fq '[local-workspace-deps]' "$build_out" || {
+    sed 's/^/  /' "$build_out" >&2
+    fail "override helper did not run during build"
+}
+
+zip_file="${component_dir}/build/lwd-plugin.zip"
+[ -f "$zip_file" ] || fail "build artifact missing: $zip_file"
+unzip -l "$zip_file" | grep -Fq 'lwd-plugin/build/ok.txt' \
+    || { unzip -l "$zip_file" >&2; fail "consumer build output (proving resolved+deduped dependency) missing from zip"; }
+
+echo "ok: build.sh built, packed, installed and deduped the local workspace dependency"
+
+# --- Declared override but helper missing must fail loudly ---------------------
+missing_out="${TMP_DIR}/missing.out"
+if (
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="lwd-plugin" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_CORE_HELPER" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_SETTINGS_JSON="$settings_json" \
+    HOMEBOY_RUNTIME_LOCAL_WORKSPACE_DEPS="${TMP_DIR}/does-not-exist.sh" \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "$missing_out" 2>&1
+); then
+    sed 's/^/  /' "$missing_out" >&2
+    fail "build should fail when a declared override's helper is missing"
+fi
+grep -Fq 'helper not found' "$missing_out" \
+    || { sed 's/^/  /' "$missing_out" >&2; fail "expected 'helper not found' error"; }
+
+echo "ok: declared override with missing helper fails the build"
+
+echo "WordPress local workspace dependency build smoke passed."

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1142,6 +1142,13 @@
       "type": "array",
       "default": [],
       "description": "Component-relative glob patterns for intentional package ZIP artifacts that should be included in the production build even though arbitrary *.zip files are excluded by default. Each declared pattern must match at least one file."
+    },
+    {
+      "id": "local_workspace_dependencies",
+      "label": "Local workspace dependency overrides",
+      "type": "array",
+      "default": [],
+      "description": "Declared local (unpublished) workspace package dependencies to build from source, pack, and install into the consumer as a self-contained built tarball before the consumer build runs. Installing a built tarball (not a file: symlink) lets peer dependencies such as React dedupe to the consumer's single copy. Each entry is an object: name (required package name), path (required source path relative to the component, may reference sibling repos), and optional package_dir (monorepo subpackage to pack), build (explicit build command run in path; defaults to install + run build script), and package_manager (npm|pnpm|yarn, auto-detected by default)."
     }
   ],
   "release_preflights": [


### PR DESCRIPTION
## Summary

Adds a config-driven mechanism for consuming an **unreleased local sibling workspace package** (e.g. an `@scope/ui` package "cooked locally" on a branch and intentionally unpublished) during a build/deploy, without the fragile symlink/tarball bypass surgery described in Extra-Chill/homeboy#6863.

The concrete case in #6863: `frontend-agent-chat` (a `wp-scripts`/webpack WordPress plugin) needs `@automattic/agenttic-ui` / `@automattic/agenttic-client` at an unreleased version living on the `agenttic` pnpm monorepo's `trunk`. The two manual bypasses both broke the runtime:
- an npm `file:` symlink → webpack resolved a **second** React from the dependency's own `node_modules` → "Invalid hook call" → blank app;
- a hand-rolled `pnpm pack` tarball → fragile asset wiring → stale/404 assets.

This PR makes that a first-class, declarative capability.

### How it works
- The generic mechanism lives in the **nodejs** extension (`nodejs/scripts/lib/local-workspace-deps.sh`) and carries no WordPress/Studio specifics. Given a declared dependency it: (1) builds the dependency from its own source, (2) packs it into a self-contained tarball (`npm`/`pnpm pack`), (3) installs that **built tarball** into the consumer.
- Installing a built tarball — not a `file:` symlink — lets the package manager dedupe peer dependencies (React) to the consumer's single copy. That is the fix for the "Invalid hook call" failure.
- It runs **after** the consumer's own deps are installed (so peers exist to dedupe against) and **before** the consumer build (so the built dependency resolves and its assets get bundled).
- Both the WordPress build (`wordpress/scripts/build/build.sh`) and the generic Node.js build runner (`nodejs/scripts/build/build-runner.sh`) consume the same helper. A declared override that fails is a **fatal** build error rather than a silently broken bundle.

### How a consumer declares the override
Via the existing `HOMEBOY_SETTINGS_JSON` channel (same one `package_artifacts` uses), under `local_workspace_dependencies`:

```json
{
  "extensions": {
    "wordpress": {
      "local_workspace_dependencies": [
        {
          "name": "@automattic/agenttic-ui",
          "path": "../agenttic",
          "package_dir": "packages/agenttic-ui",
          "build": "pnpm install --frozen-lockfile && pnpm --filter @automattic/agenttic-ui build",
          "package_manager": "pnpm"
        }
      ]
    }
  }
}
```

Only `name` and `path` are required (`path` is component-relative and may reference sibling repos via `..`; `name` is validated against the resolved package). When `build` is omitted, the dependency's own `build` script runs after installing its deps. The same key is available for the generic `nodejs` build runner.

### Tests
- `nodejs/tests/local-workspace-deps-smoke.sh` — real-npm end-to-end: builds a locally cooked monorepo subpackage, packs it, installs into a consumer, and asserts the **built** artifact is installed with a **single, deduped** React (no nested second copy). Also covers no-op and config-validation error paths.
- `wordpress/scripts/build/local-workspace-dep-build-smoke.sh` — runs the real `build.sh` end-to-end: proves the override is wired, the consumer build resolves the built+deduped dependency, the output lands in the ZIP, and a declared override with a missing helper fails the build loudly.

All existing build smokes remain green (`build-helper-smoke.sh`, `build-package-artifacts-smoke.sh`, `wordpress-build-staging-syntax-smoke.sh`, `build-runner-shell-smoke.sh`).

### Follow-ups (not in this PR)
- Nested-package consumers (`build_nested_packages`) are not yet covered; only the top-level consumer build applies overrides.
- Consumer-side tarball install standardizes on `npm` (the dedup tool for the reported bug); native pnpm/yarn consumer `add` could be added later.

Refs Extra-Chill/homeboy#6863

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Codebase recon, designing and implementing the mechanism, and writing the smoke tests. Every line reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)