### PR TITLE
fix(wordpress): wp-codebox-recipe-helper honors AbortSignal/timeoutMs to kill+reap wedged recipe-run

### DIFF
--- a/wordpress/lib/wp-codebox-recipe-helper.js
+++ b/wordpress/lib/wp-codebox-recipe-helper.js
@@ -12,6 +12,11 @@ const WP_CODEBOX_RECIPE_RUN_CLI_COMMAND = 'recipe-run';
 const DEFAULT_MAX_BUFFER = 1024 * 1024 * 50;
 const DEFAULT_EVENT_SOURCE = 'wp_codebox';
 const DEFAULT_EVENT_PREFIX = 'recipe';
+// Grace period between SIGTERM and the SIGKILL escalation when killing a wedged
+// recipe-run child. Long enough for a cooperating child to flush + exit cleanly,
+// short enough that a truly wedged child (the 28-min orphan scenario) is reaped
+// promptly rather than abandoned.
+const DEFAULT_KILL_GRACE_MS = 5000;
 
 /**
  * Internal dependencies
@@ -60,26 +65,114 @@ function appendBounded(chunks, currentSize, chunk, maxBuffer, streamName) {
   return nextSize;
 }
 
-async function runCommandStreaming(command, args, { cwd, env, maxBuffer, outputFile }) {
+// Send a signal to the child's entire process group so any sub-processes it
+// spawned (a wedged sandbox can fork WP/PHP/node helpers) die with it, not just
+// the immediate child. The child is spawned `detached`, so it leads its own
+// group and `process.kill(-pid, …)` targets the whole group. Falls back to a
+// direct child kill if the group is already gone (ESRCH) or the platform refuses
+// the negative-pid form.
+function killChildGroup(child, signal) {
+  if (!child || typeof child.pid !== 'number') {
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch (groupError) {
+    if (groupError && groupError.code === 'ESRCH') {
+      return;
+    }
+    try {
+      child.kill(signal);
+    } catch {
+      // Child already reaped — nothing left to signal.
+    }
+  }
+}
+
+async function runCommandStreaming(command, args, { cwd, env, maxBuffer, outputFile, signal, timeoutMs, killGraceMs = DEFAULT_KILL_GRACE_MS }) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+    // `detached: true` puts the child in its own process group so a SIGTERM/
+    // SIGKILL can reach the whole group (see killChildGroup). stdio stays piped
+    // so output capture is unchanged.
+    const child = spawn(command, args, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'], detached: true });
     const stdoutChunks = [];
     const stderrChunks = [];
     let stdoutSize = 0;
     let stderrSize = 0;
     let settled = false;
     let stdoutWriter = null;
+    let killReason = null;
+    let killGraceTimer = null;
+    let watchdogTimer = null;
+
+    // Note: the kill-grace (SIGKILL escalation) timer is intentionally NOT
+    // cleared here. Once a kill is in progress the group SIGKILL must always run
+    // to completion — the process-group leader can exit on SIGTERM while a
+    // sub-process ignores it, and only the escalated group SIGKILL reaps that
+    // straggler. The timer is unref'd, so leaving it pending never keeps the
+    // process alive on its own, and a SIGKILL to an already-empty group is a
+    // harmless ESRCH no-op.
+    const clearTimers = () => {
+      if (watchdogTimer) {
+        clearTimeout(watchdogTimer);
+        watchdogTimer = null;
+      }
+      if (signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
+    };
+
+    // Begin the cooperative SIGTERM -> SIGKILL kill of the child (and its group).
+    // The promise stays pending until the OS reaps the child and fires 'close',
+    // so an aborted/timed-out run can never leave an orphaned recipe-run process.
+    const killChild = (reason) => {
+      if (killReason) {
+        return;
+      }
+      killReason = reason;
+      killChildGroup(child, 'SIGTERM');
+      killGraceTimer = setTimeout(() => {
+        killGraceTimer = null;
+        killChildGroup(child, 'SIGKILL');
+      }, killGraceMs);
+      if (typeof killGraceTimer.unref === 'function') {
+        killGraceTimer.unref();
+      }
+    };
+
+    function onAbort() {
+      killChild('abort');
+    }
 
     const fail = (error) => {
       if (settled) {
         return;
       }
       settled = true;
+      clearTimers();
       if (child.exitCode === null && !child.killed) {
-        child.kill('SIGTERM');
+        killChildGroup(child, 'SIGTERM');
       }
       reject(error);
     };
+
+    if (signal) {
+      if (signal.aborted) {
+        // Already aborted before spawn — kill immediately; 'close' still reaps.
+        killChild('abort');
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+
+    if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+      watchdogTimer = setTimeout(() => {
+        killChild('timeout');
+      }, timeoutMs);
+      if (typeof watchdogTimer.unref === 'function') {
+        watchdogTimer.unref();
+      }
+    }
 
     if (outputFile) {
       stdoutWriter = fsSync.createWriteStream(outputFile, { encoding: 'utf8' });
@@ -111,21 +204,42 @@ async function runCommandStreaming(command, args, { cwd, env, maxBuffer, outputF
     });
 
     child.on('error', fail);
-    child.on('close', (code, signal) => {
+    child.on('close', (code, closeSignal) => {
       const finish = () => {
         if (settled) {
           return;
         }
         settled = true;
+        clearTimers();
         const stdout = outputFile ? '' : Buffer.concat(stdoutChunks).toString('utf8');
         const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        // The child has now exited and been reaped by the OS — when we initiated
+        // the kill, surface a clear killed/timeout rejection instead of a bare
+        // "Command failed" so the watchdog cause propagates.
+        if (killReason) {
+          const reasonLabel = killReason === 'timeout'
+            ? `timed out after ${timeoutMs}ms`
+            : 'was aborted';
+          const error = new Error(`WP Codebox recipe-run ${reasonLabel} and was killed: ${command} ${args.join(' ')}`);
+          error.code = code;
+          error.signal = closeSignal;
+          error.killed = true;
+          error.killReason = killReason;
+          if (killReason === 'timeout') {
+            error.timeout_ms = timeoutMs;
+          }
+          error.stdout = stdout;
+          error.stderr = stderr;
+          reject(error);
+          return;
+        }
         if (code === 0) {
           resolve({ stdout, stderr });
           return;
         }
         const error = new Error(`Command failed: ${command} ${args.join(' ')}`);
         error.code = code;
-        error.signal = signal;
+        error.signal = closeSignal;
         error.stdout = stdout;
         error.stderr = stderr;
         reject(error);
@@ -194,6 +308,9 @@ async function runWpCodeboxRecipe({
   cwd,
   eventSource,
   eventPrefix,
+  signal,
+  timeoutMs,
+  killGraceMs,
 } = {}) {
   if (!recipeFile) {
     throw new Error('runWpCodeboxRecipe requires recipeFile.');
@@ -224,7 +341,7 @@ async function runWpCodeboxRecipe({
   emitRecipeEvent(event, 'start', { recipe_file: recipeFile, artifacts_dir: artifactsDir }, eventOptions);
 
   try {
-    const result = await runCommandStreaming(command, commandArgs, { cwd, env, maxBuffer, outputFile });
+    const result = await runCommandStreaming(command, commandArgs, { cwd, env, maxBuffer, outputFile, signal, timeoutMs, killGraceMs });
     const stdout = outputFile ? await fs.readFile(outputFile, 'utf8') : result.stdout;
     const json = parseWpCodeboxJson(stdout);
     emitRecipeEvent(event, 'done', { output_file: outputFile || null, artifacts_dir: artifactsDir }, eventOptions);

--- a/wordpress/tests/wp-codebox-recipe-helper-smoke.js
+++ b/wordpress/tests/wp-codebox-recipe-helper-smoke.js
@@ -34,9 +34,44 @@ if (process.env.FIXTURE_LARGE_STDOUT) {
   process.stdout.write(JSON.stringify({ ok: true, payload: 'x'.repeat(4096) }));
   process.exit(0);
 }
+if (process.env.FIXTURE_HANG) {
+  // Simulate a wedged recipe-run: spawn a sub-process (to prove group-kill) and
+  // then hang forever. Optionally ignore SIGTERM to force the SIGKILL escalation.
+  const { spawn } = require('node:child_process');
+  const grandchild = spawn(process.execPath, ['-e', 'process.on(\\'SIGTERM\\', () => {}); setInterval(() => {}, 1e9);']);
+  fs.writeFileSync(process.env.FIXTURE_PIDS_PATH, JSON.stringify({ child: process.pid, grandchild: grandchild.pid }));
+  if (process.env.FIXTURE_IGNORE_SIGTERM) {
+    process.on('SIGTERM', () => {});
+  }
+  setInterval(() => {}, 1e9);
+  return;
+}
 process.stdout.write(JSON.stringify({ ok: true, artifacts: { directory: process.argv[process.argv.indexOf('--artifacts') + 1] } }));
 `);
 fs.chmodSync(fixtureBin, 0o755);
+
+function pidAlive(pid) {
+  if (typeof pid !== 'number') {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === 'EPERM';
+  }
+}
+
+async function waitForReaped(pids, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pids.some(pidAlive)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return false;
+}
 
 (async () => {
   assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_BIN: fixtureBin } }), fixtureBin);
@@ -104,6 +139,65 @@ fs.chmodSync(fixtureBin, 0o755);
   assert.equal(largeResult.json.ok, true);
   assert.equal(largeResult.json.payload.length, 4096);
   assert.equal(JSON.parse(fs.readFileSync(largeOutputFile, 'utf8')).payload.length, 4096);
+
+  // Abort: a wedged child (and its sub-process group) must be SIGTERM'd and
+  // reaped, and the helper must reject with a clear killed error — no orphan.
+  {
+    const pidsPath = path.join(root, 'abort-pids.json');
+    const controller = new AbortController();
+    const runPromise = runWpCodeboxRecipe({
+      recipeFile,
+      artifactsDir,
+      outputFile: path.join(root, 'output', 'abort-output.json'),
+      wpCodeboxBin: fixtureBin,
+      signal: controller.signal,
+      killGraceMs: 100,
+      env: { ...process.env, FIXTURE_CAPTURE_PATH: capturePath, FIXTURE_HANG: '1', FIXTURE_PIDS_PATH: pidsPath },
+    });
+    let pids = null;
+    for (let i = 0; i < 200 && !pids; i += 1) {
+      if (fs.existsSync(pidsPath)) {
+        pids = JSON.parse(fs.readFileSync(pidsPath, 'utf8'));
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+    assert.ok(pids && typeof pids.child === 'number', 'fixture should report its pid');
+    assert.ok(pidAlive(pids.child), 'child should be running before abort');
+    controller.abort();
+    const abortError = await runPromise.then(
+      () => { throw new Error('expected aborted recipe-run to reject'); },
+      (error) => error
+    );
+    assert.match(abortError.message, /was aborted and was killed/);
+    assert.equal(abortError.killed, true);
+    assert.equal(abortError.killReason, 'abort');
+    assert.equal(await waitForReaped([pids.child, pids.grandchild]), true, 'child + grandchild must be reaped after abort');
+  }
+
+  // Timeout: honoring timeoutMs alone (no external signal) must kill+reap, and a
+  // child that ignores SIGTERM must still be SIGKILL'd after the grace window.
+  {
+    const pidsPath = path.join(root, 'timeout-pids.json');
+    const timeoutError = await runWpCodeboxRecipe({
+      recipeFile,
+      artifactsDir,
+      outputFile: path.join(root, 'output', 'timeout-output.json'),
+      wpCodeboxBin: fixtureBin,
+      timeoutMs: 150,
+      killGraceMs: 100,
+      env: { ...process.env, FIXTURE_CAPTURE_PATH: capturePath, FIXTURE_HANG: '1', FIXTURE_IGNORE_SIGTERM: '1', FIXTURE_PIDS_PATH: pidsPath },
+    }).then(
+      () => { throw new Error('expected timed-out recipe-run to reject'); },
+      (error) => error
+    );
+    assert.match(timeoutError.message, /timed out after 150ms and was killed/);
+    assert.equal(timeoutError.killed, true);
+    assert.equal(timeoutError.killReason, 'timeout');
+    assert.equal(timeoutError.timeout_ms, 150);
+    const pids = JSON.parse(fs.readFileSync(pidsPath, 'utf8'));
+    assert.equal(await waitForReaped([pids.child, pids.grandchild]), true, 'SIGTERM-ignoring child must be SIGKILL-reaped after grace');
+  }
 
   console.log('wp-codebox recipe helper smoke passed');
 })().catch((error) => {


### PR DESCRIPTION
Closes #1995

## Problem
homeboy-rigs #561 added a watchdog in `runWpCodeboxRecipe` (`shared/wp-codebox/recipe.mjs`) that, on timeout, aborts the `AbortSignal` it hands to this helper and fails the batch — so the bench no longer *hangs*. But `wp-codebox-recipe-helper.js` (in `homeboy-extension-wordpress`) **ignored** both `signal` and `timeoutMs`. The spawned `node … recipe-run …` OS child was therefore **abandoned, not killed or reaped** — the 28-min orphaned/duplicate recipe-run that kept running on the runner and held the rig lock.

## Fix
`runCommandStreaming` / `runWpCodeboxRecipe` now honor the cooperative-kill contract the rigs watchdog already passes (`signal`, `timeoutMs`):

- **Honor the AbortSignal.** On abort the helper kills the child and the returned promise stays pending until the OS reaps it (the `close` event), so an aborted run can never leave an orphan. If the signal is already aborted before spawn, it kills immediately.
- **SIGTERM → SIGKILL + reap.** On abort/timeout it sends `SIGTERM`, then escalates to `SIGKILL` after a short grace window (default 5s, overridable via `killGraceMs`). The escalation always runs to completion — a process-group leader can exit on `SIGTERM` while a sub-process ignores it, and only the escalated group `SIGKILL` reaps that straggler.
- **Group-kill.** The child is spawned `detached` so it leads its own process group; kills target the whole group via `process.kill(-pid, …)` (with a direct-child fallback on `ESRCH` / unsupported negative-pid). A wedged sandbox that forked WP/PHP/node sub-processes dies fully. `stdio` stays piped, so output capture is unchanged.
- **Honor `timeoutMs` independently.** Even without an external signal, `timeoutMs` triggers the same kill+reap path.
- **Clear error.** Aborted/timed-out runs reject with a clear message (`was aborted and was killed` / `timed out after Nms and was killed`) and `killed` / `killReason` / `timeout_ms` fields, while normal success and command-failure behavior are unchanged.

Together with the rigs watchdog this fully closes the wedged-recipe-run hole: the watchdog stops the bench hanging, and the helper now actually kills + reaps the underlying child so it can no longer hold resources or the rig lock.

## Tests
Extended `tests/wp-codebox-recipe-helper-smoke.js` (no real wp-codebox sandbox required — a stub fixture child that spawns a sub-process and hangs):
- **Abort:** child + its sub-process group are `SIGTERM`'d and reaped (no lingering pid), helper rejects with `was aborted and was killed`.
- **Timeout + SIGTERM-ignoring child:** `timeoutMs` alone triggers the kill; the child ignores `SIGTERM`, so the `SIGKILL` escalation reaps the whole group; helper rejects with `timed out … and was killed` and `timeout_ms`.
- Existing success / command-failure / maxBuffer cases still pass.

Verified green across repeated runs with a post-run process-leak check (no orphaned fixture processes). `eslint` clean on the changed lib file.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (claude-opus-4-8) via Claude Code
- **Used for:** Diagnosing the signal contract, implementing the kill/reap + group-kill logic, and writing the tests.