### PR TITLE
fix: consume canonical Codebox typed artifacts

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -31,10 +31,8 @@ const {
   artifactNameFromDeclaration,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome: normalizeCodeboxArtifactOutcomeContract,
-  normalizeTypedArtifactEntry: normalizeCodeboxTypedArtifactEntry,
   normalizeTypedArtifacts: normalizeCodeboxTypedArtifacts,
   typedArtifactsFromCodeboxResult,
-  typedArtifactFileRefs: codeboxTypedArtifactFileRefs,
 } = require('./codebox-artifact-contract');
 const {
   codeboxPublicResultEnvelope,
@@ -2684,10 +2682,6 @@ function sanitizePublicMetadata(value) {
   }));
 }
 
-function normalizeTypedArtifactEntry(name, artifact) {
-  return normalizeCodeboxTypedArtifactEntry(name, artifact, { sanitize: sanitizePublicMetadata });
-}
-
 function normalizeTypedArtifacts(value) {
   return normalizeCodeboxTypedArtifacts(value, { sanitize: sanitizePublicMetadata });
 }
@@ -2703,84 +2697,6 @@ function codeboxAgentResultFromResult(result) {
 function codeboxBundleDirectoryFromResult(result) {
   const artifactBundle = codeboxPublicResultEnvelope(result)?.artifact_result?.artifactBundle;
   return artifactBundle?.path || artifactBundle?.uri || '';
-}
-
-function firstTranscriptArtifactRefFromResult(result) {
-  const publicEnvelope = codeboxPublicResultEnvelope(result);
-  const candidates = [
-    ...(publicEnvelope?.artifact_result?.artifactRefs || []),
-    ...(publicEnvelope?.artifact_result?.evidenceRefs || []),
-  ];
-  const transcriptArtifact = candidates
-    .map((artifact) => artifactFromCodeboxArtifact(artifact))
-    .find((artifact) => artifact?.path && /transcript|conversation|messages/i.test(`${artifact.kind || ''} ${artifact.name || ''} ${artifact.path || ''}`));
-  if (transcriptArtifact) {
-    return {
-      kind: transcriptArtifact.kind || 'codebox-transcript',
-      path: transcriptArtifact.path,
-      url: transcriptArtifact.url,
-      mime: transcriptArtifact.mime || 'application/json',
-      metadata: transcriptArtifact.metadata || {},
-      schema: transcriptArtifact.metadata?.schema || transcriptArtifact.metadata?.artifact_schema,
-    };
-  }
-
-  return null;
-}
-
-function isTranscriptArtifactDeclaration(declaration) {
-  const name = typedArtifactNameFromDeclaration(declaration);
-  const type = declaration?.type || declaration?.kind || declaration?.artifact_type || declaration?.artifactType || '';
-  const schema = declaration?.artifact_schema || declaration?.artifactSchema || declaration?.schema || '';
-  return /transcript|conversation|messages/i.test(`${name} ${type} ${schema}`);
-}
-
-function transcriptTypedArtifactsFromCodeboxResult(request, result, existingTypedArtifacts = {}) {
-  if (!request) {
-    return {};
-  }
-  const requiredTranscriptArtifacts = requiredArtifactDeclarationsFromRequest(request).filter(isTranscriptArtifactDeclaration);
-  if (requiredTranscriptArtifacts.length === 0) {
-    return {};
-  }
-  const transcriptRef = firstTranscriptArtifactRefFromResult(result);
-  if (!transcriptRef?.path && !transcriptRef?.url) {
-    return {};
-  }
-  return Object.fromEntries(requiredTranscriptArtifacts
-    .map((declaration) => typedArtifactNameFromDeclaration(declaration))
-    .filter((name) => name && !existingTypedArtifacts[name])
-    .map((name) => [name, normalizeTypedArtifactEntry(name, {
-      name,
-      type: 'transcript',
-      artifact_schema: transcriptRef.schema || 'wp-codebox/agent-transcript/v1',
-      file_refs: [{ kind: transcriptRef.kind || 'codebox-transcript', path: transcriptRef.path, url: transcriptRef.url, mime: transcriptRef.mime || 'application/json' }],
-      metadata: transcriptRef.metadata || {},
-    })])
-    .filter(([, artifact]) => artifact));
-}
-
-function typedArtifactProjectionFromOutputPath(outputPath, value, typedArtifacts) {
-  const match = String(outputPath || '').match(/(?:^|\.)typed_?artifacts\.([^.]+)\.payload$/i);
-  if (!match) {
-    return null;
-  }
-  const artifactName = match[1];
-  const existing = typedArtifacts[artifactName] || {};
-  return normalizeTypedArtifactEntry(artifactName, {
-    ...existing,
-    name: existing.name || artifactName,
-    payload: value,
-  });
-}
-
-function typedArtifactFileRefs(typedArtifact) {
-  const refs = codeboxTypedArtifactFileRefs(typedArtifact);
-  const directRefs = [typedArtifact.path, typedArtifact.url, typedArtifact.file, typedArtifact.directory].filter(Boolean);
-  return [
-    ...directRefs.map((ref) => ({ path: ref })),
-    ...refs,
-  ];
 }
 
 function typedArtifactNameFromDeclaration(declaration) {
@@ -2814,53 +2730,6 @@ function requiredArtifactDeclarationsForResult(request, result) {
     seen.add(key);
     return true;
   });
-}
-
-function isTranscriptArtifactDeclaration(declaration) {
-  const name = typedArtifactNameFromDeclaration(declaration);
-  const type = declaration?.type || declaration?.kind || declaration?.artifact_type || declaration?.artifactType || '';
-  const schema = declaration?.artifact_schema || declaration?.artifactSchema || declaration?.schema || '';
-  return /transcript|conversation|messages/i.test(`${name} ${type} ${schema}`);
-}
-
-function replyTextFromResult(result) {
-  const publicEnvelope = codeboxPublicResultEnvelope(result) || {};
-  const candidates = [
-    publicEnvelope.reply,
-    publicEnvelope.outputs?.reply,
-    publicEnvelope.outputs?.text,
-    publicEnvelope.outputs?.content,
-  ];
-  return candidates.find((candidate) => typeof candidate === 'string' && candidate.trim() !== '') || '';
-}
-
-function replyTypedArtifactsFromResult(request, result, existingTypedArtifacts = {}) {
-  const reply = replyTextFromResult(result);
-  if (!reply) {
-    return {};
-  }
-  return Object.fromEntries(requiredArtifactDeclarationsForResult(request, result)
-    .filter((declaration) => !isTranscriptArtifactDeclaration(declaration))
-    .map((declaration) => {
-      const name = typedArtifactNameFromDeclaration(declaration);
-      if (!name || existingTypedArtifacts[name]) {
-        return null;
-      }
-      return [name, normalizeCodeboxTypedArtifactEntry(name, {
-        name,
-        artifact_id: name,
-        kind: declaration.artifact_schema || declaration.artifactSchema || declaration.schema,
-        type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType || name,
-        artifact_schema: declaration.artifact_schema || declaration.artifactSchema || declaration.schema,
-        payload: {
-          content: reply,
-          format: 'markdown',
-        },
-        provenance: { source: 'agent_reply' },
-      })];
-    })
-    .filter(Boolean)
-    .filter(([, artifact]) => artifact));
 }
 
 function artifactDeclarationsMetadataFromRequest(request) {
@@ -2918,32 +2787,6 @@ function unexecutedWorkspaceToolCallArtifact(artifact) {
   return /^<workspace_[a-z0-9_:-]+(?:\s[^>]*)?\/>$/i.test(content);
 }
 
-function outputsWithInputTypedArtifacts(outputs, request) {
-  const typedArtifacts = outputs?.typed_artifacts && typeof outputs.typed_artifacts === 'object' && !Array.isArray(outputs.typed_artifacts)
-    ? { ...outputs.typed_artifacts }
-    : {};
-  let added = false;
-  for (const declaration of requiredArtifactDeclarationsFromRequest(request)) {
-    const name = typedArtifactNameFromDeclaration(declaration);
-    if (!name || typedArtifacts[name]) {
-      continue;
-    }
-    const value = request.inputs?.[name];
-    if (value === undefined || value === null || value === '') {
-      continue;
-    }
-    typedArtifacts[name] = normalizeTypedArtifactEntry(name, {
-      name,
-      type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType || name,
-      artifact_schema: declaration.artifact_schema || declaration.artifactSchema || declaration.schema,
-      payload: typeof value === 'object' ? value : { content: String(value), format: 'text' },
-      metadata: { normalized_from: 'request_input' },
-    });
-    added = true;
-  }
-  return added ? { ...outputs, typed_artifacts: typedArtifacts } : outputs;
-}
-
 function artifactFromCodeboxArtifact(artifact, index) {
   const normalized = agentTaskArtifactFromRef(
     {
@@ -2978,10 +2821,6 @@ function normalizeOutputs(result, request = null, options = {}) {
     ? publicEnvelope.outputs
     : {};
   const typedArtifacts = typedArtifactsFromResult(result, options);
-  Object.assign(typedArtifacts, transcriptTypedArtifactsFromCodeboxResult(request, result, typedArtifacts));
-  if (request) {
-    Object.assign(typedArtifacts, replyTypedArtifactsFromResult(request, result, typedArtifacts));
-  }
   for (const [name, artifact] of Object.entries(typedArtifacts)) {
     typedArtifacts[name] = controllerVisibleTypedArtifact(artifact);
   }
@@ -3022,10 +2861,6 @@ function normalizeOutputs(result, request = null, options = {}) {
       const value = pathValue(source, outputPath);
       if (value !== undefined && value !== null && value !== '') {
         outputs[name] = value;
-        const typedArtifact = typedArtifactProjectionFromOutputPath(outputPath, value, typedArtifacts);
-        if (typedArtifact) {
-          typedArtifacts[typedArtifact.name] = typedArtifact;
-        }
         break;
       }
     }
@@ -3510,7 +3345,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     status = localStatus;
   }
   const failureClassification = homeboyFailureClassification(result.failure_classification || recipeSummary?.metadata?.failure_classification || runSummary?.failure_classification, status);
-  const outputs = outputsWithInputTypedArtifacts(normalizeOutputs(result, request, envelopeOptions), request);
+  const outputs = normalizeOutputs(result, request, envelopeOptions);
   const missingRequiredTypedArtifacts = missingRequiredTypedArtifactDiagnostic(request, outputs);
   const invalidRequiredTypedArtifacts = invalidRequiredTypedArtifactDiagnostic(request, outputs);
   const runtimeFailureDiagnostic = agentRuntimeFailureDiagnostic(result);

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -659,14 +659,7 @@ async function runTaskRunner(request) {
     payload = stderrFailurePayload(result);
   }
 
-  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, ...coreNormalizers, ...legacyResultCompatibilityOptions(request, payload) });
-}
-
-function legacyResultCompatibilityOptions(request, payload = {}) {
-  const config = request.executor?.config || {};
-  const explicitConfig = config.allowLegacyCodeboxResultCompatibility || config.allow_legacy_codebox_result_compatibility;
-  const explicitRunnerFallback = payload.metadata?.run_agent_task_compatibility?.legacy_result_normalization === true;
-  return explicitConfig || explicitRunnerFallback ? { allowLegacyCodeboxResultCompatibility: true } : {};
+  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, ...coreNormalizers });
 }
 
 (async () => {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1355,52 +1355,6 @@ function mergeTypedArtifactOutputs(outputs, ...candidates) {
   };
 }
 
-function isTranscriptArtifactDeclaration(declaration) {
-  const name = artifactDeclarationName(declaration);
-  const type = declaration?.type || declaration?.kind || declaration?.artifact_type || declaration?.artifactType || '';
-  const schema = declaration?.artifact_schema || declaration?.artifactSchema || declaration?.schema || '';
-  return /transcript|conversation|messages/i.test(`${name} ${type} ${schema}`);
-}
-
-function replyTextFromAgentResult(agentResult) {
-  const candidates = [
-    agentResult?.result?.reply,
-    agentResult?.reply,
-    agentResult?.metadata?.result?.reply,
-    agentResult?.outputs?.reply,
-    agentResult?.outputs?.text,
-    agentResult?.outputs?.content,
-  ];
-  return candidates.find((candidate) => typeof candidate === 'string' && candidate.trim() !== '') || '';
-}
-
-function replyTypedArtifactsFromAgentResult(input, agentResult, config = {}) {
-  const reply = replyTextFromAgentResult(agentResult);
-  if (!reply) {
-    return {};
-  }
-  return Object.fromEntries(requiredArtifactDeclarations(input, config)
-    .filter((declaration) => !isTranscriptArtifactDeclaration(declaration))
-    .map((declaration) => {
-      const name = artifactDeclarationName(declaration);
-      if (!name) {
-        return null;
-      }
-      return [name, normalizeTypedArtifactEntry(name, {
-        name,
-        type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType || name,
-        artifact_schema: declaration.artifact_schema || declaration.artifactSchema || declaration.schema,
-        payload: {
-          content: reply,
-          format: 'markdown',
-        },
-        provenance: { source: 'agent_reply' },
-      })];
-    })
-    .filter(Boolean)
-    .filter(([, artifact]) => artifact));
-}
-
 function sandboxToolPolicy(input, allowedTools) {
   const explicit = input.parent_request?.sandbox_tool_policy
     || input.parent_request?.sandboxToolPolicy
@@ -1570,10 +1524,7 @@ function normalizeAgentTaskRun(input, result) {
   if (plainObject(agentResult)) {
     agentResult = {
       ...agentResult,
-      outputs: mergeTypedArtifactOutputs(
-        plainObject(agentResult.outputs) ? agentResult.outputs : {},
-        replyTypedArtifactsFromAgentResult(input, agentResult, config),
-      ),
+      outputs: plainObject(agentResult.outputs) ? agentResult.outputs : {},
     };
   }
   const bundleValidation = isAgentBundle(input) ? validateAgentRuntimeWorkload(agentResult, config) : validateRuntimeTaskWorkload(agentResult, config);
@@ -1596,22 +1547,13 @@ function normalizeAgentTaskRun(input, result) {
           outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
         },
       }
-    : {
-        schema: 'wp-codebox/artifact-result-envelope/v1',
-        status: success ? 'created' : 'failed',
-        success,
-        result: {
-          status: success ? 'succeeded' : 'failed',
-          success,
-          outputs: plainObject(agentResult.outputs) ? agentResult.outputs : (plainObject(result.outputs) ? result.outputs : {}),
-        },
-      };
+    : undefined;
 
   return {
     ...result,
     success,
     status: success ? 'completed' : result.status,
-    artifact_result: artifactResult,
+    ...(artifactResult ? { artifact_result: artifactResult } : {}),
     outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
     summary: success ? 'WP Codebox agent task succeeded.' : (artifactValidation?.message || bundleValidation?.message || runtimeFailure?.message || result.summary || 'WP Codebox agent task failed.'),
     session: result.session ? {
@@ -2236,8 +2178,7 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
         secretNames: input.secret_env || [],
       }) : null);
       const callbackPayload = withCallbackDataEnvelope(normalizedPayload, readCallbackData(callbackInput.callback_data));
-      const compatibilityPayload = attachRunAgentTaskCompatibilityMetadata(callbackPayload, invocation);
-      const enrichedPayload = payloadEvidence ? attachFailureEvidence(compatibilityPayload, payloadEvidence) : compatibilityPayload;
+      const enrichedPayload = payloadEvidence ? attachFailureEvidence(callbackPayload, payloadEvidence) : callbackPayload;
       process.stdout.write(`${JSON.stringify(enrichedPayload, null, 2)}\n`);
       return callbackPayload.success === false ? 1 : 0;
     } catch {
@@ -2271,22 +2212,6 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
     return 1;
   }
   return result.status ?? 1;
-}
-
-function attachRunAgentTaskCompatibilityMetadata(payload, invocation) {
-  if (!payload || typeof payload !== 'object' || invocation.implementation !== 'legacy-agent-task-run-compat') {
-    return payload;
-  }
-  return {
-    ...payload,
-    metadata: {
-      ...(payload.metadata && typeof payload.metadata === 'object' && !Array.isArray(payload.metadata) ? payload.metadata : {}),
-      run_agent_task_compatibility: {
-        legacy_result_normalization: true,
-        implementation: invocation.implementation,
-      },
-    },
-  };
 }
 
 (async () => {

--- a/tests/wp-codebox-artifact-contract-smoke.mjs
+++ b/tests/wp-codebox-artifact-contract-smoke.mjs
@@ -179,6 +179,60 @@ assert.equal(
   normalizedOutcome.typed_artifacts.find((artifact) => artifact.name === 'runtime_access')?.artifact_schema,
   WP_CODEBOX_RUNTIME_ACCESS_SCHEMA
 );
+
+const conceptPacketRequest = {
+  schema: AGENT_TASK_REQUEST_SCHEMA,
+  task_id: 'task-concept-packet',
+  instructions: 'Generate a concept packet.',
+  executor: { backend: WP_CODEBOX_BACKEND },
+  inputs: {
+    concept_packet: { title: 'input fallback must not satisfy required artifacts' },
+  },
+  artifact_declarations: [{
+    name: 'concept_packet',
+    type: 'concept_packet',
+    artifact_schema: 'wp-site-generator/ConceptPacket/v1',
+    required: true,
+  }],
+};
+const conceptPacketOutcome = agentTaskOutcomeFromCodeboxResult(conceptPacketRequest, {
+  artifact_result: normalizeArtifactResultEnvelope({
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {
+        typed_artifacts: {
+          concept_packet: {
+            name: 'concept_packet',
+            type: 'concept_packet',
+            artifact_schema: 'wp-site-generator/ConceptPacket/v1',
+            payload: { title: 'Canonical typed packet' },
+          },
+        },
+      },
+    },
+  }),
+});
+assert.equal(conceptPacketOutcome.status, 'succeeded');
+assert.equal(conceptPacketOutcome.outputs.typed_artifacts.concept_packet.payload.title, 'Canonical typed packet');
+assert.equal(
+  conceptPacketOutcome.typed_artifacts.find((artifact) => artifact.name === 'concept_packet')?.artifact_schema,
+  'wp-site-generator/ConceptPacket/v1'
+);
+
+const missingConceptPacketOutcome = agentTaskOutcomeFromCodeboxResult(conceptPacketRequest, {
+  artifact_result: normalizeArtifactResultEnvelope({
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: { outputs: {} },
+  }),
+});
+assert.equal(missingConceptPacketOutcome.status, 'failed');
+assert.equal(missingConceptPacketOutcome.outputs.typed_artifacts?.concept_packet, undefined);
+assert.ok(missingConceptPacketOutcome.diagnostics.some((diagnostic) => (
+  diagnostic.class === 'codebox.required_typed_artifacts_missing'
+    && diagnostic.message.includes('concept_packet')
+)));
 assert.deepEqual(typedArtifactsFromCodeboxResult({
   metadata: {
     agent_runtime: {


### PR DESCRIPTION
## Summary
- consume typed artifacts only from canonical WP Codebox public artifact-result envelopes
- remove legacy result normalization/backfill paths from the WP Codebox executor boundary
- remove `run_agent_task_compatibility.legacy_result_normalization` from the executor result path
- add contract coverage for canonical typed artifact DTO consumption

## Verification
- `node tests/wp-codebox-artifact-contract-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** removing legacy WP Codebox result compatibility paths, drafting tests, running verification, and preparing this PR description.
