### PR TITLE
Fix invalid YAML breaking runtime-agent-full-run for all callers

### DIFF
--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -139,7 +139,7 @@ name: Runtime Agent Full Run (reusable)
         type: boolean
         default: true
       proof_profile:
-        description: Controller-loop proof profile: artifact_only, cook_to_pr, or none.
+        description: "Controller-loop proof profile: artifact_only, cook_to_pr, or none."
         type: string
         default: artifact_only
       success_completion_outcomes:


### PR DESCRIPTION
## Problem

`runtime-agent-full-run.yml` fails to parse — **every caller** of this reusable workflow errors before any job runs:

```
error parsing called workflow (...runtime-agent-full-run.yml@main): You have an error in your yaml syntax on line 142
```

Line 142:
```yaml
        description: Controller-loop proof profile: artifact_only, cook_to_pr, or none.
```

The unquoted colon in the description (`proof profile: artifact_only`) is parsed as a YAML mapping separator → `mapping values are not allowed in this context`. Introduced in #1803 (Add runtime proof profiles) on Jun 23; since then **no consumer of this runner has been able to execute** (build-with-wordpress developer-docs, intelligence docs-agent, world-creator, etc. all fail at parse).

## Fix

Quote the description string. Verified with `actionlint` + ruby YAML: the file now parses cleanly. No other lines affected.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Diagnosing the parse failure via branch-dispatch validation and the one-line fix.