### PR TITLE
Fix runtime-provider checkout skipped (RUNTIME_PROVIDER not honored) — Closes #2003

### DIFF
--- a/runtime-agent-ci/lib/full-run-inputs.cjs
+++ b/runtime-agent-ci/lib/full-run-inputs.cjs
@@ -195,8 +195,16 @@ function getByPath(value, expression) {
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { stdio: 'inherit', ...options });
+  // spawnSync returns status: null both when the process is killed by a signal
+  // and when it cannot be spawned at all (result.error, e.g. a missing cwd).
+  // Surface the real cause instead of a bare "status null".
+  if (result.error) {
+    const cwd = options.cwd ? ` (cwd: ${options.cwd})` : '';
+    throw new Error(`${command} ${args.join(' ')} failed to spawn${cwd}: ${result.error.message}`);
+  }
   if (result.status !== 0) {
-    throw new Error(`${command} ${args.join(' ')} failed with status ${result.status}`);
+    const detail = result.signal ? ` (signal ${result.signal})` : '';
+    throw new Error(`${command} ${args.join(' ')} failed with status ${result.status}${detail}`);
   }
 }
 

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -248,12 +248,20 @@ function normalizeRuntimeId(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 }
 
 function runtimeIdFromOptions(options = {}, env = process.env) {
+	// Mirror the env precedence used by setup-runtime.cjs
+	// (RUNTIME || RUNTIME_PROVIDER || BACKEND). Consumers commonly set only
+	// RUNTIME_PROVIDER; without honoring it here, materialize-dependencies
+	// resolves DEFAULT_RUNTIME_ID instead of the real runtime and never checks
+	// out the runtime provider repo, so its setup_commands later fail on a
+	// missing cwd.
 	return firstString(
 		options.runtimeId,
 		options.runtime_id,
 		options.runtime,
 		env.RUNTIME_ID,
 		env.RUNTIME,
+		env.RUNTIME_PROVIDER,
+		env.BACKEND,
 		DEFAULT_RUNTIME_ID
 	);
 }


### PR DESCRIPTION
## Root cause (corrected from #2003 — not OOM)

`runtime-agent-full-run` runs failed at `setup-runtime.cjs` with `npm install failed with status null` and no output. `Automattic/wp-codebox` is ~8 MB, so OOM was implausible. The real cause:

- `materialize-dependencies.cjs` resolves the runtime via `runtimeIdFromOptions`, which only honored `RUNTIME_ID || RUNTIME`.
- Consumers set only `RUNTIME_PROVIDER=wp-codebox` (RUNTIME/BACKEND empty), so it fell through to `DEFAULT_RUNTIME_ID = 'local-shell'` and **never checked out `Automattic/wp-codebox` into `.ci/wp-codebox`**.
- `setup-runtime.cjs` DOES resolve via `RUNTIME || RUNTIME_PROVIDER || BACKEND` → `wp-codebox` → ran its `setup_commands` (`npm install`, cwd `.ci/wp-codebox`) against a missing directory → `spawnSync` ENOENT → `status: null`.
- `run()` only checked `status !== 0`, so it reported a bare "failed with status null", hiding the missing-cwd cause and making it look like a kill/OOM.

Latent since the runner couldn't parse (Jun 23, fixed in #2001); exposed once parsing was restored.

## Fix

1. `runtimeIdFromOptions` now honors `RUNTIME_PROVIDER` and `BACKEND` (matching `setup-runtime.cjs`), so both scripts resolve the same runtime and the provider repo is checked out.
2. `run()` surfaces `result.error` (with cwd) and `result.signal`, so spawn failures and signal-kills are no longer mislabeled as "status null".

## Verification

`node --check` passes both files. Functional: `runtimeIdFromOptions({}, { RUNTIME_PROVIDER: 'wp-codebox' })` now returns `wp-codebox` (previously `local-shell`). Full end-to-end validated by re-running a consumer (build-with-wordpress) after merge.

Closes #2003.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Root-cause diagnosis (correcting an initial OOM hypothesis) and the fix.