### PR TITLE
Expose built wp-codebox CLI to runtime-agent-full-run (fixes 'Runtime CLI build missing')

### DIFF
--- a/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
+++ b/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
@@ -1,8 +1,18 @@
 'use strict';
 
+const fs = require('node:fs');
 const path = require('node:path');
 
 function setupRuntime({ phase, workspace, env = process.env, run, installCheckedOutPhpDependencies }) {
+  // After the runtime's build commands run, the wp-codebox CLI exists in the
+  // checkout (packages/cli/dist/index.js, made executable by the build) but is
+  // not on PATH and HOMEBOY_WP_CODEBOX_BIN is unset, so the downstream
+  // "Build runner config" step reports the bin as missing. Point the env var at
+  // the built CLI so subsequent steps resolve runtime.paths.runtime_bin. Runs
+  // for the wp-codebox runtime regardless of the WordPress-dependency gate.
+  if (phase === 'after_commands') {
+    exportRuntimeBin(workspace, env);
+  }
   if (!requiresWordPressDependencies(env)) {
     return;
   }
@@ -13,6 +23,23 @@ function setupRuntime({ phase, workspace, env = process.env, run, installChecked
   }
   if (phase === 'after_commands') {
     installCheckedOutPhpDependencies(workspace);
+  }
+}
+
+function exportRuntimeBin(workspace, env = process.env) {
+  // Already provided by the caller/env — don't override an explicit bin.
+  if (env.HOMEBOY_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN) {
+    return;
+  }
+  const binPath = path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js');
+  if (!fs.existsSync(binPath)) {
+    // Build did not produce the CLI; let the downstream check surface a clear,
+    // accurate "Runtime CLI build missing" error rather than a wrong path.
+    return;
+  }
+  const githubEnv = env.GITHUB_ENV;
+  if (githubEnv) {
+    fs.appendFileSync(githubEnv, `HOMEBOY_WP_CODEBOX_BIN=${binPath}\n`);
   }
 }
 


### PR DESCRIPTION
## Problem

After the runtime deps build succeeds, `Build runner config` fails with `Runtime CLI build missing at wp-codebox`. The wp-codebox build DOES produce an executable CLI at `.ci/wp-codebox/packages/cli/dist/index.js` (shebang + chmod via `ensure-cli-bin-executable.mjs`), but homeboy-extensions never points at it: the bin isn't on PATH and `HOMEBOY_WP_CODEBOX_BIN` is unset, so `runtime.paths.runtime_bin` resolves to the bare `wp-codebox` default and `runtimeExecutableAvailable` (a PATH lookup) fails.

This is a homeboy-side wiring gap, not a wp-codebox build problem.

## Fix

The wp-codebox runtime adapter now exports `HOMEBOY_WP_CODEBOX_BIN` to the built CLI path via `$GITHUB_ENV` in the `after_commands` phase (after the build), so the downstream `Build runner config` step resolves the runtime bin. Honors an explicit `HOMEBOY_WP_CODEBOX_BIN`/`WP_CODEBOX_BIN` if already provided; no-ops if the build did not produce the CLI (so a genuine missing build still surfaces accurately).

Latent since the pipeline couldn't run (Jun 23); exposed after the parse (#2001) and runtime-provider-checkout (#2004) fixes advanced the run to this step.

## Verification

`node --check` passes; unit test confirms the adapter writes `HOMEBOY_WP_CODEBOX_BIN=<workspace>/.ci/wp-codebox/packages/cli/dist/index.js` to GITHUB_ENV when the CLI exists. End-to-end validated by re-running a consumer (build-with-wordpress).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Diagnosis (confirming a homeboy wiring gap, not a wp-codebox build issue) and the fix.