### PR TITLE
Translate provider credential and app-token into sandbox secret env

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const {
   buildConfig,
+  buildSecretEnvFallbacks,
   loopPolicyFromEnv,
   projectRuntimeConfig,
   providerBenchEnvFromManifest,
@@ -29,4 +30,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired };
+module.exports = { buildConfig, buildSecretEnvFallbacks, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired };

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -46,10 +46,17 @@ function buildConfig(env) {
     throw new Error(`Runtime CLI build missing at ${runtimeBin || 'runtime.paths.runtime_bin'}`);
   }
 
+  const githubTokenEnv = 'HOMEBOY_GITHUB_APP_TOKEN';
+  const githubRepositoryTokenEnv = 'GITHUB_TOKEN';
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', true);
   const validationDependencies = validationPaths(workspace, providerPlugin, env.PROVIDER || '');
   const providerSecretEnvMapping = providerPlugin.provider_secret_env || {};
   const providerBenchEnvNames = providerBenchEnvFromManifest(runtime, env.PROVIDER || '', env);
+  // Provider-canonical secret env names advertised by the runtime manifest (e.g.
+  // OPENAI_API_KEY for the openai provider). Captured before folding in the
+  // caller's generic credential source names so the two roles stay distinct.
+  const providerCanonicalSecretEnvNames = Array.from(providerBenchEnvNames);
+  const providerCredentialSourceEnvNames = [];
   for (const providerEnvName of Object.values(providerSecretEnvMapping)) {
     if (typeof providerEnvName !== 'string' || providerEnvName.length === 0) {
       continue;
@@ -58,7 +65,14 @@ function buildConfig(env) {
       throw new Error(`Invalid provider credential env name: ${providerEnvName}`);
     }
     providerBenchEnvNames.add(providerEnvName);
+    providerCredentialSourceEnvNames.push(providerEnvName);
   }
+  const secretEnvFallbacks = buildSecretEnvFallbacks({
+    githubTokenEnv,
+    githubRepositoryTokenEnv,
+    providerCanonicalSecretEnvNames,
+    providerCredentialSourceEnvNames,
+  });
 
   const runtimeTask = runtimeTaskFromEnv(env);
   const runtimeExecution = parseJsonInput('runtime_execution', env.RUNTIME_EXECUTION || '{}', 'object', {});
@@ -156,14 +170,20 @@ function buildConfig(env) {
     runtime_component_paths: runtimeComponents,
     provider_plugin_paths: providerPluginPaths,
     runtime_requirements: effectiveRuntimeProfile,
-    github_token_env: 'HOMEBOY_GITHUB_APP_TOKEN',
-    github_repository_token_env: 'GITHUB_TOKEN',
+    github_token_env: githubTokenEnv,
+    github_repository_token_env: githubRepositoryTokenEnv,
     secret_env: uniqueStrings([
       ...normalizeStringArray(runtimeConfig.secret_env),
-      'GITHUB_TOKEN',
-      'HOMEBOY_GITHUB_APP_TOKEN',
+      githubRepositoryTokenEnv,
+      githubTokenEnv,
       ...Array.from(providerBenchEnvNames),
     ]),
+    // Fill a target secret env from a fallback source before the sandbox
+    // preflight runs: the provider's canonical key (e.g. OPENAI_API_KEY) from
+    // the caller's generic credential secret (PROVIDER_SECRET_n), and the
+    // Homeboy app token from the repository GITHUB_TOKEN when no app token is
+    // available. The run step applies these against its own environment.
+    ...(Object.keys(secretEnvFallbacks).length > 0 ? { secret_env_fallbacks: secretEnvFallbacks } : {}),
     github_profile_id: env.GITHUB_PROFILE_ID || `${workloadId}-ci`,
     target_repo: targetRepo,
     context_repositories: normalizeContextRepositories(env.CONTEXT_REPOSITORIES || '[]'),
@@ -280,6 +300,37 @@ function normalizeStringArray(value) {
 
 function uniqueStrings(values) {
   return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
+}
+
+// Build the declarative secret-env fallback map consumed by the run step. Each
+// entry maps a target secret env name to an ordered list of source env names;
+// the run step sets target = first non-empty source when target is unset. This
+// keeps the translation generic (driven by the runtime manifest + caller
+// credential mapping) with no per-consumer or per-provider hardcoding.
+function buildSecretEnvFallbacks({
+  githubTokenEnv,
+  githubRepositoryTokenEnv,
+  providerCanonicalSecretEnvNames = [],
+  providerCredentialSourceEnvNames = [],
+} = {}) {
+  const fallbacks = {};
+  // The Homeboy app token falls back to the repository GITHUB_TOKEN for
+  // consumers that run with require_homeboy_app_token=false and no app creds.
+  if (githubTokenEnv && githubRepositoryTokenEnv && githubTokenEnv !== githubRepositoryTokenEnv) {
+    fallbacks[githubTokenEnv] = [githubRepositoryTokenEnv];
+  }
+  // When the caller maps provider credentials to generic secret env names, the
+  // provider plugin still reads the runtime's canonical name (e.g.
+  // OPENAI_API_KEY), so source the canonical name from the mapped secret.
+  if (providerCredentialSourceEnvNames.length > 0) {
+    for (const canonical of providerCanonicalSecretEnvNames) {
+      const sources = providerCredentialSourceEnvNames.filter((name) => name !== canonical);
+      if (sources.length > 0) {
+        fallbacks[canonical] = uniqueStrings([...(fallbacks[canonical] || []), ...sources]);
+      }
+    }
+  }
+  return fallbacks;
 }
 
 function runtimeWorkloadFromEnv(env, fallbackId) {
@@ -461,4 +512,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys };
+module.exports = { buildConfig, buildSecretEnvFallbacks, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys };

--- a/runtime-agent-ci/scripts/run-headless-loop.cjs
+++ b/runtime-agent-ci/scripts/run-headless-loop.cjs
@@ -21,7 +21,15 @@ try {
     throw new Error('Pass --spec <path>, --config <path>, or HOMEBOY_RUNTIME_AGENT_CONFIG_PATH.');
   }
   const repoRoot = path.resolve(__dirname, '..', '..');
-  const spec = materializeHeadlessProductionLoopSpec(JSON.parse(fs.readFileSync(specPath, 'utf8')), {
+  const rawSpec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
+  // Fill required secret env names from declared fallbacks before any preflight
+  // runs. The provider's canonical key (e.g. OPENAI_API_KEY) is sourced from the
+  // caller's generic credential secret, and the Homeboy app token falls back to
+  // the repository GITHUB_TOKEN when no app token is present. Forwarding still
+  // happens through the secret-env-names-only boundary; only this process's env
+  // is populated so the names resolve.
+  applySecretEnvFallbacks(rawSpec.secret_env_fallbacks);
+  const spec = materializeHeadlessProductionLoopSpec(rawSpec, {
     revolutions: args.revolutions || args.max_revolutions || process.env.HOMEBOY_HEADLESS_LOOP_REVOLUTIONS,
     runtime_id: args.runtime_id || process.env.HOMEBOY_AGENT_RUNTIME,
     runtime_profile: args.runtime_profile || process.env.HOMEBOY_AGENT_RUNTIME_PROFILE,
@@ -83,4 +91,26 @@ function parseArgs(argv) {
 
 function listArg(value) {
   return String(value || '').split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function applySecretEnvFallbacks(fallbacks) {
+  if (!fallbacks || typeof fallbacks !== 'object' || Array.isArray(fallbacks)) {
+    return;
+  }
+  for (const [target, sources] of Object.entries(fallbacks)) {
+    if (typeof target !== 'string' || target === '') {
+      continue;
+    }
+    if (typeof process.env[target] === 'string' && process.env[target] !== '') {
+      continue;
+    }
+    const sourceList = Array.isArray(sources) ? sources : [sources];
+    for (const source of sourceList) {
+      const value = typeof source === 'string' ? process.env[source] : undefined;
+      if (typeof value === 'string' && value !== '') {
+        process.env[target] = value;
+        break;
+      }
+    }
+  }
 }

--- a/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
+++ b/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const { dependencyEntries, resolvePlan } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs'));
-const { buildConfig, providerBenchEnvFromManifest } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
+const { buildConfig, buildSecretEnvFallbacks, providerBenchEnvFromManifest } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
 const { normalizeProviderPlugin } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/lib/common.cjs'));
 const { resolveRuntimeProvider } = require(path.join(repoRoot, 'runtime-agent-ci/lib/runtime-provider-resolver.cjs'));
 
@@ -126,5 +126,42 @@ const neutralConfig = buildConfig({
 assert.deepEqual(neutralConfig.provider_secret_env_mapping, {});
 assert.equal('OPENAI_API_KEY' in neutralConfig.bench_env, false);
 assert.deepEqual(neutralConfig.secret_env, ['GITHUB_TOKEN', 'HOMEBOY_GITHUB_APP_TOKEN']);
+
+// Secret env fallbacks: the provider's canonical key is sourced from the mapped
+// generic credential secret, and the Homeboy app token falls back to GITHUB_TOKEN.
+assert.deepEqual(
+  buildSecretEnvFallbacks({
+    githubTokenEnv: 'HOMEBOY_GITHUB_APP_TOKEN',
+    githubRepositoryTokenEnv: 'GITHUB_TOKEN',
+    providerCanonicalSecretEnvNames: ['OPENAI_API_KEY'],
+    providerCredentialSourceEnvNames: ['PROVIDER_SECRET_1'],
+  }),
+  {
+    HOMEBOY_GITHUB_APP_TOKEN: ['GITHUB_TOKEN'],
+    OPENAI_API_KEY: ['PROVIDER_SECRET_1'],
+  }
+);
+
+// Without a caller credential mapping, only the GitHub token fallback applies.
+assert.deepEqual(
+  buildSecretEnvFallbacks({
+    githubTokenEnv: 'HOMEBOY_GITHUB_APP_TOKEN',
+    githubRepositoryTokenEnv: 'GITHUB_TOKEN',
+    providerCanonicalSecretEnvNames: ['OPENAI_API_KEY'],
+    providerCredentialSourceEnvNames: [],
+  }),
+  { HOMEBOY_GITHUB_APP_TOKEN: ['GITHUB_TOKEN'] }
+);
+
+// A canonical name that equals its own mapped source is not aliased to itself.
+assert.deepEqual(
+  buildSecretEnvFallbacks({
+    githubTokenEnv: 'HOMEBOY_GITHUB_APP_TOKEN',
+    githubRepositoryTokenEnv: 'GITHUB_TOKEN',
+    providerCanonicalSecretEnvNames: ['OPENAI_API_KEY'],
+    providerCredentialSourceEnvNames: ['OPENAI_API_KEY'],
+  }),
+  { HOMEBOY_GITHUB_APP_TOKEN: ['GITHUB_TOKEN'] }
+);
 
 console.log('runtime agent full-run provider-neutral smoke passed');


### PR DESCRIPTION
## Problem

Offloaded `runtime-agent-full-run` runs (e.g. build-with-wordpress developer-docs) died in the `Run runtime agent` step before the agent ever started:

```
Required WP Codebox secret environment variable missing: HOMEBOY_GITHUB_APP_TOKEN, OPENAI_API_KEY
```

At that point the run env has `PROVIDER_SECRET_1=***` (the OpenAI key, forwarded by `runtime-agent-full-run.yml`) and `GITHUB_TOKEN`, but **not** `OPENAI_API_KEY` and **not** `HOMEBOY_GITHUB_APP_TOKEN`.

## Root cause

`full-run-config.cjs` builds the required `secret_env` list from:
- the runtime manifest's provider defaults → `OPENAI_API_KEY` (the openai provider's canonical key), and
- two hardcoded GitHub names → `GITHUB_TOKEN`, `HOMEBOY_GITHUB_APP_TOKEN`.

But:
- The caller maps its provider credential to a generic secret name (`provider_plugin.credentials = { connectors_ai_openai_api_key: PROVIDER_SECRET_1 }`), so the key value only exists under `PROVIDER_SECRET_1`. Nothing ever translated `PROVIDER_SECRET_1` into the canonical `OPENAI_API_KEY` that Data Machine actually reads (env `OPENAI_API_KEY` is its highest-precedence source). The `provider_secret_env_mapping` was written into config and consumed by nothing.
- `HOMEBOY_GITHUB_APP_TOKEN` was required unconditionally even for `require_homeboy_app_token: false` consumers that intentionally fall back to `GITHUB_TOKEN`.

## Fix

Emit a declarative `secret_env_fallbacks` map from `full-run-config.cjs` — the only layer that holds both the runtime-manifest provider-canonical names and the caller credential mapping — and apply it in `run-headless-loop.cjs` before any preflight:

- provider canonical key (e.g. `OPENAI_API_KEY`) ← mapped generic secret (`PROVIDER_SECRET_1`)
- `HOMEBOY_GITHUB_APP_TOKEN` ← repository `GITHUB_TOKEN` when no app token is present

A target is only filled when it is unset, so explicit app tokens and direct keys still win. Forwarding still flows through the secret-env-names-only boundary; only the run step's own process env is populated so the declared names resolve and forward into the sandbox. Generic and provider-neutral — no per-consumer or per-provider hardcoding.

## Tests

Extended `runtime-agent-full-run-provider-neutral-smoke.mjs` with `buildSecretEnvFallbacks` coverage (provider+github, github-only, and self-alias guard). Validated end to end via a live consumer re-run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** secret_env contract trace, the fix, and tests