### PR TITLE
Surface failed runtime-agent outcome diagnostics on hard failure

### DIFF
--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -698,6 +698,7 @@ jobs:
             ${{ runner.temp }}/runtime-agent-run/events.json
             ${{ runner.temp }}/runtime-agent-run/loop-result.json
             ${{ runner.temp }}/runtime-agent-run/loop-policy.json
+            ${{ runner.temp }}/runtime-agent-run/*-runtime-stderr.txt
           if-no-files-found: warn
 
       - name: Upload replay bundle artifact

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -352,7 +352,63 @@ function executeRuntimeProvider(options = {}) {
     };
   }
   const outcome = JSON.parse(stdout);
-  return captureInvocationResult(outcome, invocation, result, { stderrArtifact });
+  const failureArtifact = surfaceFailedRuntimeOutcome(outcome, { ...options, invocation, result, stderrArtifact });
+  return captureInvocationResult(outcome, invocation, result, { stderrArtifact: failureArtifact || stderrArtifact });
+}
+
+function isFailedRuntimeOutcome(outcome) {
+  if (!outcome || typeof outcome !== 'object' || Array.isArray(outcome)) {
+    return false;
+  }
+  if (outcome.success === false) {
+    return true;
+  }
+  return ['failed', 'error'].includes(String(outcome.status || '').toLowerCase());
+}
+
+function failedRuntimeOutcomeDetail(outcome) {
+  const lines = [];
+  if (outcome.summary) {
+    lines.push(`summary: ${outcome.summary}`);
+  }
+  for (const diagnostic of normalizeArray(outcome.diagnostics)) {
+    const diagnosticClass = diagnostic.class || diagnostic.kind || diagnostic.code || '';
+    lines.push(`diagnostic${diagnosticClass ? ` [${diagnosticClass}]` : ''}: ${diagnostic.message || ''}`);
+    const detail = diagnostic.data && typeof diagnostic.data === 'object'
+      ? (diagnostic.data.stderr || diagnostic.data.error || '')
+      : '';
+    if (detail) {
+      lines.push(String(detail));
+    }
+  }
+  return lines.join('\n').trim();
+}
+
+// Surface the real failure reason from a failed runtime outcome to the job's
+// stderr (so it lands in CI logs) and persist it as the runtime stderr artifact.
+// The runtime executor routes the underlying agent/CLI stderr into the outcome's
+// diagnostics rather than its own stderr, so without this the only thing a hard
+// failure leaves behind is a later generic assertion message — the actual crash
+// reason is lost because results.json is never written once the loop throws.
+function surfaceFailedRuntimeOutcome(outcome, options = {}) {
+  if (!isFailedRuntimeOutcome(outcome)) {
+    return options.stderrArtifact || null;
+  }
+  const detail = failedRuntimeOutcomeDetail(outcome);
+  if (!detail) {
+    return options.stderrArtifact || null;
+  }
+  if (options.stderr !== false) {
+    process.stderr.write(`${boundedText(detail, options.stderrMaxBytes || options.stderr_max_bytes || DEFAULT_STDIO_SUMMARY_BYTES)}\n`);
+  }
+  if (options.stderrArtifact) {
+    return options.stderrArtifact;
+  }
+  const artifact = persistRuntimeInvocationStderr(detail, options);
+  if (artifact && options.stderr !== false) {
+    process.stderr.write(`Runtime failure detail artifact: ${artifact.path}\n`);
+  }
+  return artifact;
 }
 
 function runtimeInvocationEnv(options = {}) {

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -444,4 +444,77 @@ function proofOutcome(request, evidenceRefs) {
   };
 }
 
+// A hard runtime failure routes the underlying agent/CLI stderr into the outcome
+// diagnostics (not its own stderr). Surface that detail to the job's stderr and
+// persist it as the runtime stderr artifact so the real crash reason is visible
+// even when a later assertion throws a generic message and results.json is never
+// written.
+(() => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runtime-agent-stderr-surface-'));
+  const executorScript = path.join(runDir, 'failing-executor.cjs');
+  fs.writeFileSync(executorScript, `'use strict';
+const outcome = {
+  schema: 'homeboy/agent-task-outcome/v1',
+  task_id: 'technical-docs-bootstrap-flow',
+  status: 'failed',
+  summary: 'WP Codebox agent-task-run failed.',
+  diagnostics: [{
+    class: 'wp-codebox.agent_task_run_failed',
+    message: 'WP Codebox agent-task-run failed.',
+    data: { status: 1, stderr: 'PLAYGROUND_BOOT_FATAL: sandbox could not start' },
+  }],
+};
+process.stdout.write(JSON.stringify(outcome));
+process.exitCode = 1;
+`);
+
+  const runtime = {
+    id: 'wp-codebox',
+    executor: {
+      backend: 'wp-codebox',
+      invocation: { command: process.execPath, argv: [executorScript], stderr: 'inherit_on_failure' },
+    },
+  };
+  const request = {
+    schema: 'homeboy/agent-task-request/v1',
+    task_id: 'technical-docs-bootstrap-flow',
+    instructions: 'run',
+    executor: { backend: 'wp-codebox' },
+  };
+
+  const captured = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = (chunk, ...rest) => {
+    captured.push(String(chunk));
+    return originalWrite.call(process.stderr, chunk, ...rest);
+  };
+  let result;
+  try {
+    result = genericLoopRunner.runGenericAgentLoop({
+      runtime,
+      request,
+      validate: false,
+      run_dir: runDir,
+    });
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+
+  const stderrText = captured.join('');
+  assert.ok(
+    stderrText.includes('PLAYGROUND_BOOT_FATAL: sandbox could not start'),
+    'failed runtime outcome diagnostics must be surfaced to stderr'
+  );
+
+  const stderrFile = path.join(runDir, 'technical-docs-bootstrap-flow-runtime-stderr.txt');
+  assert.ok(fs.existsSync(stderrFile), 'runtime stderr artifact file must be written on failure');
+  assert.ok(
+    fs.readFileSync(stderrFile, 'utf8').includes('PLAYGROUND_BOOT_FATAL: sandbox could not start'),
+    'runtime stderr artifact must contain the underlying failure detail'
+  );
+  assert.equal(result.outcome.status, 'failed');
+
+  fs.rmSync(runDir, { recursive: true, force: true });
+})();
+
 process.stdout.write('Generic agent loop runner behavior checks passed\n');


### PR DESCRIPTION
## Problem

In a `runtime-agent-full-run` (e.g. Build With WordPress Developer Docs Agent, run `28338245996`), the agent executes inside the wp-codebox sandbox, the run fails, and the actual crash reason is **swallowed**. The job only surfaces a generic assertion message:

```
scenario technical-docs-bootstrap-flow expected opened PR, satisfied completion outcome,
or allowed no-changes result, got job_status=failed success_status=failed ...
```

and `results.json` is never written (`ERROR: results file missing or empty`).

## Root cause of the swallow

The runtime executor (`homeboy-wp-codebox-task-runner.cjs`) routes the underlying wp-codebox CLI stderr into a JSON `commandFailurePayload` on **stdout** (in `diagnostics[].data.stderr`), not to its own stderr. So in `generic-agent-loop-runner.js#executeRuntimeProvider`, the spawned executor's `result.stderr` is empty, no `*-runtime-stderr.txt` is written, and the parsed *failed* outcome — which holds the real diagnostic — is discarded when `assertLoopSuccess` throws before `writeHeadlessDeterministicLoopArtifacts` runs. The full-run's transcript/stderr artifact is resolved *from* `results.json`, which never exists, so nothing uploads.

## Fix (diagnostics only)

`executeRuntimeProvider` now detects a failed runtime outcome and surfaces its `summary` + `diagnostics` (including the embedded CLI stderr) to the job's stderr **and** persists it as the runtime stderr artifact, regardless of whether the executor emitted raw stderr. This makes the real crash reason visible in CI logs even when the loop later throws the generic assertion. The full-run results-upload step also now captures `*-runtime-stderr.txt`.

No behavior change to successful runs; failure outcomes are unchanged except that their detail is now printed/persisted.

## Tests

Added a focused case in `generic-agent-loop-runner.test.js`: a runtime executor that emits a failed outcome JSON (with `diagnostics[].data.stderr`) and nothing on stderr; asserts the embedded detail is written to `process.stderr` and to `<run_dir>/<task>-runtime-stderr.txt`. Full `runtime-agent-ci` suite passes (the pre-existing `runtime-provider-boundary.test.js` `wp-codebox` vs `codebox` failure is unrelated to this change).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** Tracing the swallow across the spawn layers, the diagnostics change, and the test.