### PR TITLE
Stream raw runtime-agent subprocess output live to the job log

### DIFF
--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -573,6 +573,10 @@ jobs:
           PROVIDER_SECRET_4: ${{ secrets.PROVIDER_SECRET_4 }}
           PROVIDER_SECRET_5: ${{ secrets.PROVIDER_SECRET_5 }}
           HOMEBOY_RUNTIME_AGENT_RUN_DIR: ${{ runner.temp }}/runtime-agent-run
+          # Stream raw subprocess stdout/stderr live to the job log so a hard
+          # crash or timeout inside the runtime agent is visible even when no
+          # structured outcome is produced. Defaulted on for diagnostics.
+          HOMEBOY_RUNTIME_AGENT_DEBUG: '1'
           HOMEBOY_RUNTIME_AGENT_RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
           HOMEBOY_AGENT_TASK_OUTCOME_FILE: ${{ runner.temp }}/runtime-agent-run/outcome.json
           HOMEBOY_RUNTIME_AGENT_EVENTS_FILE: ${{ runner.temp }}/runtime-agent-run/events.json
@@ -699,6 +703,7 @@ jobs:
             ${{ runner.temp }}/runtime-agent-run/loop-result.json
             ${{ runner.temp }}/runtime-agent-run/loop-policy.json
             ${{ runner.temp }}/runtime-agent-run/*-runtime-stderr.txt
+            ${{ runner.temp }}/runtime-agent-run/*-runtime-stdout.txt
           if-no-files-found: warn
 
       - name: Upload replay bundle artifact

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -63,6 +63,13 @@ function requireWpCodeboxCoreLoader() {
 }
 
 const DEFAULT_TASK_RUNNER = path.resolve(__dirname, 'homeboy-wp-codebox-task-runner.cjs');
+
+// Diagnostics mode. When enabled, the task-runner subprocess stderr is
+// fd-inherited so the deeper wp-codebox CLI stderr streams live to the job log.
+function runtimeAgentDebugEnabled(env = process.env) {
+  return ['1', 'true', 'yes', 'on'].includes(String(env.HOMEBOY_RUNTIME_AGENT_DEBUG || '').trim().toLowerCase());
+}
+
 function argValue(name) {
   const index = process.argv.indexOf(name);
   return index >= 0 ? process.argv[index + 1] : '';
@@ -613,12 +620,16 @@ async function runTaskRunner(request) {
     }
     return true;
   });
+  const debug = runtimeAgentDebugEnabled();
   const result = spawnSync(process.execPath, [runner, ...args, ...configArgs], {
     encoding: 'utf8',
     input: JSON.stringify(taskInput),
     env: { ...process.env, ...providerAuthEnv(taskInput) },
     maxBuffer: 1024 * 1024 * 20,
     timeout: requestTimeoutMs(request),
+    // In debug mode inherit the task-runner stderr so the wp-codebox CLI
+    // stderr streams live to this process's stderr (and onward to the job log).
+    ...(debug ? { stdio: ['pipe', 'pipe', 'inherit'] } : {}),
   });
 
   if (result.stderr) {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -41,6 +41,40 @@ const {
 } = require('../../lib/wp-codebox-adapter-descriptor');
 
 
+// Diagnostics mode. When enabled, the wp-codebox CLI subprocess stderr is
+// streamed (fd-inherited) straight to this process's stderr in real time
+// instead of being buffered into structured payloads, so a hard crash or
+// timeout inside the sandbox still surfaces its raw output in the job log.
+// Raw stdout/stderr files are written for every run regardless of this flag.
+function runtimeAgentDebugEnabled(env = process.env) {
+  return ['1', 'true', 'yes', 'on'].includes(String(env.HOMEBOY_RUNTIME_AGENT_DEBUG || '').trim().toLowerCase());
+}
+
+function safeRuntimeFileSegment(value) {
+  return String(value || 'wp-codebox-task').replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'wp-codebox-task';
+}
+
+// Persist the wp-codebox CLI's raw stdout/stderr to the runtime-agent run
+// directory so they are always retrievable as CI artifacts, independent of
+// whether a structured outcome was produced. In debug mode stderr is inherited
+// (live in the log) so result.stderr is null and only stdout is written here.
+function writeRuntimeRawOutputFiles(result, request) {
+  const runDir = process.env.HOMEBOY_RUNTIME_AGENT_RUN_DIR || '';
+  if (!runDir) {
+    return;
+  }
+  try {
+    fs.mkdirSync(runDir, { recursive: true });
+    const taskId = safeRuntimeFileSegment(request?.orchestrator?.agent_task_id || request?.task_id);
+    fs.writeFileSync(path.join(runDir, `${taskId}-wp-codebox-runtime-stdout.txt`), String(result.stdout || ''));
+    if (result.stderr != null) {
+      fs.writeFileSync(path.join(runDir, `${taskId}-wp-codebox-runtime-stderr.txt`), String(result.stderr || ''));
+    }
+  } catch (error) {
+    process.stderr.write(`Failed to persist wp-codebox raw runtime output: ${error && error.message ? error.message : String(error)}\n`);
+  }
+}
+
 function argValue(name) {
   const index = process.argv.indexOf(name);
   return index >= 0 ? process.argv[index + 1] : '';
@@ -2134,6 +2168,7 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
     console.error(JSON.stringify({ command: resolved.command, args: resolved.args, input }, null, 2));
   }
 
+  const debug = runtimeAgentDebugEnabled();
   let result;
   try {
     result = spawnSync(resolved.command, resolved.args, {
@@ -2144,9 +2179,19 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
       },
       maxBuffer: 1024 * 1024 * 20,
       timeout: timeoutMs,
+      // In debug mode inherit the CLI's stderr so it streams live to the job
+      // log (crash/timeout-proof); stdout stays piped to capture the JSON
+      // outcome. Stdin stays an empty pipe as before (CLI reads --input-file).
+      ...(debug ? { stdio: ['pipe', 'pipe', 'inherit'] } : {}),
     });
   } finally {
     stopHomeboyRuntimeToolBridge(bridgeServer);
+  }
+  writeRuntimeRawOutputFiles(result, request);
+  if (debug && result.stdout) {
+    // stdout is the JSON return channel for this process, so the captured
+    // CLI stdout is not otherwise visible; mirror it to stderr for the log.
+    process.stderr.write(`[wp-codebox-cli stdout]\n${String(result.stdout)}\n`);
   }
   const shouldPreserveEvidence = Boolean(result.error) || result.status !== 0;
   const failureEvidence = shouldPreserveEvidence ? preserveWpCodeboxFailureEvidence({

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -20,6 +20,8 @@ const DEFAULT_STDIO_SUMMARY_BYTES = 8192;
 const DEFAULT_RUNTIME_ENV_ALLOWLIST = [
   'CI',
   'HOME',
+  'HOMEBOY_RUNTIME_AGENT_DEBUG',
+  'HOMEBOY_RUNTIME_AGENT_RUN_DIR',
   'LANG',
   'LC_ALL',
   'LOGNAME',
@@ -30,6 +32,16 @@ const DEFAULT_RUNTIME_ENV_ALLOWLIST = [
   'TMPDIR',
   'USER',
 ];
+
+// Diagnostics mode. When enabled, the runtime executor subprocess stderr is
+// fd-inherited so the full spawn chain (executor -> task-runner -> wp-codebox
+// CLI) streams raw stderr straight to this process's stderr — which, since this
+// runner shares the process that the CI step launches, lands directly in the
+// job log in real time, even on a hard crash or timeout that produces no
+// structured outcome.
+function runtimeAgentDebugEnabled(env = process.env) {
+  return ['1', 'true', 'yes', 'on'].includes(String(env.HOMEBOY_RUNTIME_AGENT_DEBUG || '').trim().toLowerCase());
+}
 
 function buildGenericAgentLoopRequest(options = {}) {
   const plan = requiredObject(options.plan, 'plan');
@@ -328,12 +340,18 @@ function executeRuntimeProvider(options = {}) {
     throw new Error(`Runtime ${runtime.id || '(unknown)'} does not declare an executor command.`);
   }
   const spawn = options.spawnSync || spawnSync;
+  const debug = runtimeAgentDebugEnabled(options.env) || runtimeAgentDebugEnabled(process.env);
   const result = spawn(invocation.command, invocation.argv || [], {
     encoding: 'utf8',
     cwd: invocation.cwd || process.cwd(),
     input: invocationStdin(invocation, options.request),
     env: runtimeInvocationEnv({ ...options, invocation }),
     maxBuffer: 1024 * 1024 * 20,
+    // In debug mode inherit the executor stderr so the entire spawn chain's
+    // raw stderr streams live to the job log, independent of any structured
+    // outcome (which is never produced on a hard crash). stdout stays piped to
+    // capture the JSON outcome.
+    ...(debug ? { stdio: ['pipe', 'pipe', 'inherit'] } : {}),
   });
   const stderrArtifact = handleRuntimeInvocationStderr(result.stderr, { ...options, invocation, result });
   const stdout = String(result.stdout || '');


### PR DESCRIPTION
## Problem

The wp-codebox runtime agent dies silently in CI: it executes ~45s, then the generic `scenario ... got job_status=failed` assertion prints with **zero** stdout/stderr in the "Run runtime agent" step, no `results.json`, and no artifacts. The agent IS executing, but its output is swallowed.

The spawn chain captures each child's stdout/stderr into structured JSON payloads / diagnostics rather than streaming them:

`generic-agent-loop-runner.js#executeRuntimeProvider` -> `homeboy-codebox-agent-task-executor.cjs` -> `homeboy-wp-codebox-task-runner.cjs#runWpCodeboxParentTask` -> wp-codebox CLI

PR #2011 only surfaces a *structured failed outcome's* diagnostics. This crash produces no structured outcome, so nothing reaches the job log.

## Change

Add a diagnostics mode gated by `HOMEBOY_RUNTIME_AGENT_DEBUG`. When set, each of the three spawn layers `fd`-inherits the child's **stderr**, so the deepest wp-codebox CLI's raw stderr streams straight to the job log in real time. Because `executeRuntimeProvider` runs in the same process the CI step launches, an inherited fd chain bypasses all intermediate buffering and survives a hard crash or timeout. **stdout** stays piped to preserve the JSON outcome channel; in debug mode the captured CLI stdout is mirrored to stderr so it is visible too.

Also: the wp-codebox CLI raw stdout (and stderr when captured) is persisted for **every** run to the runtime-agent run dir as `*-wp-codebox-runtime-stdout.txt` / `*-wp-codebox-runtime-stderr.txt`, added to the results artifact upload glob (`if-no-files-found: warn`).

`HOMEBOY_RUNTIME_AGENT_DEBUG=1` is defaulted on in the `Run runtime agent` step of `runtime-agent-full-run.yml`, so consumers pinned to `@main` get live raw output with no changes. Generic; no per-consumer hardcoding.

## Validation

- `node -c` on all three edited scripts; YAML validated.
- `runtime-agent-ci/tests/generic-agent-loop-runner.test.js` passes. (The pre-existing `runtime-provider-boundary.test.js` failure on `main` is unrelated to this change.)
- Real-runner validation: re-run the Build With WordPress Developer Docs Agent against `fix/developer-docs-execute-via-full-run` once this is on `main`, and read the raw CLI output in the step log to identify the actual crash.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Mapping the spawn chain, implementing the fd-inherit diagnostics mode and raw-output artifacts, and wiring the workflow default.