### PR TITLE
Provision Agents API for Codebox agent runtime

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1702,6 +1702,11 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     options.agentRuntimeTools,
     ...componentDiscoveryCandidates('agent_runtime_tools', discovery, settings, workspaceBase),
   );
+  const agentsApiPath = firstExistingPath(
+    options.agentsApi,
+    options.agents_api,
+    ...componentDiscoveryCandidates('agents_api', discovery, settings, workspaceBase),
+  );
   const providerPluginPath = firstExistingPath(
     settings.wp_codebox_provider_plugin_path,
     process.env.HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH,
@@ -1722,7 +1727,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     wpCodeboxBin: wpCodeboxBin({ settings, executable: '' }),
     runtimeOverlayProfiles: defaultRuntimeOverlayProfiles(settings),
     runtimeOverlays: defaultRuntimeOverlays(settings),
-    runtimeRequirements: defaultRuntimeRequirements(),
+    runtimeRequirements: defaultRuntimeRequirements({ agentsApiPath }),
     runtimeEnv: defaultRuntimeEnv(settings),
     runtimeStateMounts: defaultRuntimeStateMounts(settings),
     runtimeConfigMounts: defaultRuntimeConfigMounts(settings),
@@ -1762,8 +1767,19 @@ function defaultRuntimeOverlays(settings) {
   return [];
 }
 
-function defaultRuntimeRequirements() {
-  return {};
+function defaultRuntimeRequirements({ agentsApiPath = '' } = {}) {
+  const componentContracts = [];
+  if (agentsApiPath) {
+    componentContracts.push({
+      slug: 'agents-api',
+      path: agentsApiPath,
+      pluginFile: 'agents-api/agents-api.php',
+      loadAs: 'mu-plugin',
+      activate: false,
+      metadata: { source: 'wp-codebox-agent-runtime-default' },
+    });
+  }
+  return componentContracts.length > 0 ? { component_contracts: componentContracts } : {};
 }
 
 function defaultChatHandlerPluginContracts(settings = {}, options = {}, providerConfig = {}) {

--- a/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
+++ b/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
@@ -25,6 +25,15 @@ const descriptorSource = fs.readFileSync(path.join(runtimeRoot, 'lib', 'wp-codeb
 assert.match(descriptorSource, /runtime', 'descriptor', '--json/);
 assert.doesNotMatch(descriptorSource, /run-agent-task', '--help/);
 
+const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'wp-codebox.json'), 'utf8'));
+assert.deepEqual(manifest.component_path_defaults.contract_slug_map['agents-api'], 'agents_api');
+assert.ok(manifest.component_path_defaults.discovery.agents_api.some((entry) => Array.isArray(entry.env) && entry.env.includes('HOMEBOY_WP_CODEBOX_AGENTS_API_PATH')));
+
+const executorSource = fs.readFileSync(path.join(runtimeRoot, 'lib', 'codebox-agent-task-executor.js'), 'utf8');
+assert.match(executorSource, /function defaultRuntimeRequirements\(\{ agentsApiPath = '' \} = \{\}\)/);
+assert.match(executorSource, /slug: 'agents-api'/);
+assert.match(executorSource, /pluginFile: 'agents-api\/agents-api\.php'/);
+
 assert.deepEqual(wpCodeboxProviderPluginPathsFromEnv({
   WP_CODEBOX_PROVIDER_PLUGIN_PATHS: JSON.stringify(['/tmp/provider-a', '/tmp/provider-b']),
 }), ['/tmp/provider-a', '/tmp/provider-b']);

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -36,6 +36,19 @@
       "export": "scenarioResultsFromOutcome"
     }
   },
+  "component_path_defaults": {
+    "discovery": {
+      "agents_api": [
+        { "env": ["WP_CODEBOX_AGENTS_API_PATH", "HOMEBOY_WP_CODEBOX_AGENTS_API_PATH"] },
+        { "settings": ["wp_codebox_agents_api_path", "agents_api_path"] },
+        { "active_plugin": "agents-api" },
+        { "sibling": "agents-api" }
+      ]
+    },
+    "contract_slug_map": {
+      "agents-api": "agents_api"
+    }
+  },
   "workflow_input_projection": {
     "adapter": {
       "module": "agent-runtimes/wp-codebox/lib/runtime-workflow-input-projection.js",


### PR DESCRIPTION
## Summary
- Add default `agents-api` component discovery for the WP Codebox runtime manifest.
- Inject an `agents-api` component contract into default Codebox runtime requirements when the path resolves.
- Cover the contract in the WP Codebox adapter boundary test.

## Why
The WP Codebox agent runtime needs `agents/chat` and the Agents API registry in the sandbox. A live Codebox cook with a Codex-capable provider plugin mounted reached WP Codebox, but failed with `agents_api_loaded=false`, `agents_registry_class=false`, and `agents/chat` unavailable because the agent-task path did not mount `agents-api`.

Related WP Codebox PR: https://github.com/Automattic/wp-codebox/pull/1629

## Verification
- `node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosis, implementation, focused verification, and PR drafting.
