### PR TITLE
wordpress: release.update_dependency composer custom-package repin (cascade hook)

### DIFF
--- a/wordpress/scripts/release/update-dependency.sh
+++ b/wordpress/scripts/release/update-dependency.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repin a Composer custom-package dependency to a just-released upstream version.
+#
+# Invoked by homeboy's dependency-aware release cascade
+# (`release.update_dependency` action) against a DEPENDENT component's checkout.
+# It rewrites the dependent's Composer custom-package entry to point at the
+# released upstream tag/sha and regenerates the lockfile, replacing the manual
+# composer-pin spelunking operators do by hand.
+#
+# Working directory: the dependent component's checkout (HOMEBOY_COMPONENT_PATH).
+#
+# Input (HOMEBOY_SETTINGS_JSON), generic dependency coordinates from core:
+#   .dependency.released_id  - upstream component id (informational)
+#   .dependency.package      - composer package name to repin (e.g. chubes/php-transformer)
+#   .dependency.version      - released upstream version (e.g. 1.4.0)
+#   .dependency.tag          - released upstream tag (e.g. v1.4.0)
+#   .dependency.sha          - released upstream commit sha
+#
+# What it rewrites, deterministically, in composer.json:
+#   repositories[] (type=="package", package.name==<package>):
+#     .package.version           = <version>
+#     .package.dist.url          = <repo>/archive/refs/tags/<tag>.zip
+#     .package.dist.reference    = <sha>
+#     .package.source.reference  = <sha> (when a source block exists)
+#   require[<package]] / require-dev[<package>] constraint = <version>
+# The same package coordinates are mirrored into composer.lock when present.
+#
+# Lockfile content-hash refresh runs `composer update <package>` when composer
+# is available (and HOMEBOY_SKIP_COMPOSER_UPDATE is unset). The deterministic
+# JSON rewrite above always runs so the pin is correct even offline.
+#
+# Output (stdout): one JSON object describing what changed.
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required to repin composer dependencies" >&2
+  exit 1
+fi
+
+PAYLOAD="${HOMEBOY_SETTINGS_JSON:-}"
+read_field() {
+  printf '%s' "${PAYLOAD}" | jq -r --arg key "$1" '
+    (.dependency[$key] // empty)
+  ' 2>/dev/null || printf ''
+}
+
+PACKAGE="$(read_field package)"
+VERSION="$(read_field version)"
+TAG="$(read_field tag)"
+SHA="$(read_field sha)"
+
+if [[ -z "${PACKAGE}" || -z "${VERSION}" || -z "${TAG}" ]]; then
+  echo "Error: dependency.package, dependency.version and dependency.tag are required" >&2
+  echo "Received payload: ${PAYLOAD}" >&2
+  exit 1
+fi
+
+if [[ ! -f composer.json ]]; then
+  echo "Error: no composer.json in $(pwd); cannot repin ${PACKAGE}" >&2
+  exit 1
+fi
+
+# Rewrite composer.json. Fails (exit nonzero) if the package is not declared as
+# a custom-package repository, so a misconfigured cascade surfaces loudly rather
+# than silently shipping an unchanged pin.
+UPDATED_JSON="$(jq \
+  --arg package "${PACKAGE}" \
+  --arg version "${VERSION}" \
+  --arg tag "${TAG}" \
+  --arg sha "${SHA}" \
+  '
+  def repo_base($p):
+    ($p.dist.url // "") as $d
+    | if ($d | test("/archive/refs/tags/")) then ($d | sub("/archive/refs/tags/.*$"; ""))
+      elif (($p.source.url // "") | length) > 0 then ($p.source.url | sub("\\.git$"; ""))
+      else "" end;
+
+  def repin_pkg:
+    .package.version = $version
+    | .package.dist.type = (.package.dist.type // "zip")
+    | .package.dist.url = (repo_base(.package) + "/archive/refs/tags/" + $tag + ".zip")
+    | .package.dist.reference = $sha
+    | (if .package.source then .package.source.reference = $sha else . end);
+
+  ((.repositories // []) | map(select(.type == "package" and .package.name == $package)) | length) as $matches
+  | if $matches == 0 then
+      error("composer package \($package) is not declared as a custom-package repository")
+    else . end
+  | .repositories |= map(if (.type == "package" and .package.name == $package) then repin_pkg else . end)
+  | (if (.require // {}) | has($package) then .require[$package] = $version else . end)
+  | (if (."require-dev" // {}) | has($package) then ."require-dev"[$package] = $version else . end)
+  ' composer.json)"
+
+printf '%s\n' "${UPDATED_JSON}" >composer.json
+echo "Repinned ${PACKAGE} -> ${VERSION} (${TAG} @ ${SHA:-no-sha}) in composer.json" >&2
+
+LOCK_UPDATED="false"
+if [[ -f composer.lock ]]; then
+  UPDATED_LOCK="$(jq \
+    --arg package "${PACKAGE}" \
+    --arg version "${VERSION}" \
+    --arg tag "${TAG}" \
+    --arg sha "${SHA}" \
+    '
+    def repo_base($p):
+      ($p.dist.url // "") as $d
+      | if ($d | test("/archive/refs/tags/")) then ($d | sub("/archive/refs/tags/.*$"; ""))
+        elif (($p.source.url // "") | length) > 0 then ($p.source.url | sub("\\.git$"; ""))
+        else "" end;
+
+    def repin:
+      .version = $version
+      | .dist.type = (.dist.type // "zip")
+      | .dist.url = (repo_base(.) + "/archive/refs/tags/" + $tag + ".zip")
+      | .dist.reference = $sha
+      | (if .source then .source.reference = $sha else . end);
+
+    (.packages // []) |= map(if .name == $package then repin else . end)
+    | (."packages-dev" // []) |= map(if .name == $package then repin else . end)
+    ' composer.lock)"
+  printf '%s\n' "${UPDATED_LOCK}" >composer.lock
+  LOCK_UPDATED="true"
+  echo "Mirrored ${PACKAGE} coordinates into composer.lock" >&2
+fi
+
+COMPOSER_REFRESHED="false"
+if [[ -z "${HOMEBOY_SKIP_COMPOSER_UPDATE:-}" ]] && command -v composer >/dev/null 2>&1; then
+  echo "Refreshing lockfile via composer update ${PACKAGE}..." >&2
+  if composer update "${PACKAGE}" --no-interaction --no-scripts --no-audit >&2; then
+    COMPOSER_REFRESHED="true"
+  else
+    echo "Warning: composer update ${PACKAGE} failed; the dependent's build step will reconcile the lockfile" >&2
+  fi
+fi
+
+jq -cn \
+  --arg package "${PACKAGE}" \
+  --arg version "${VERSION}" \
+  --arg tag "${TAG}" \
+  --arg sha "${SHA}" \
+  --argjson lock "${LOCK_UPDATED}" \
+  --argjson composer "${COMPOSER_REFRESHED}" \
+  '{
+    success: true,
+    package: $package,
+    version: $version,
+    tag: $tag,
+    sha: $sha,
+    composer_json_updated: true,
+    composer_lock_updated: $lock,
+    composer_refreshed: $composer
+  }'

--- a/wordpress/tests/release-scripts-smoke.sh
+++ b/wordpress/tests/release-scripts-smoke.sh
@@ -26,6 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PACKAGE_SH="${EXTENSION_PATH}/scripts/release/package.sh"
 PUBLISH_SH="${EXTENSION_PATH}/scripts/release/publish.sh"
+UPDATE_DEP_SH="${EXTENSION_PATH}/scripts/release/update-dependency.sh"
 
 if [[ ! -x "${PACKAGE_SH}" ]]; then
   echo "FAIL: package.sh is not executable" >&2
@@ -34,6 +35,11 @@ fi
 
 if [[ ! -x "${PUBLISH_SH}" ]]; then
   echo "FAIL: publish.sh is not executable" >&2
+  exit 1
+fi
+
+if [[ ! -x "${UPDATE_DEP_SH}" ]]; then
+  echo "FAIL: update-dependency.sh is not executable" >&2
   exit 1
 fi
 
@@ -304,6 +310,162 @@ else
   else
     echo "OK: publish.sh force-pushes release-latest branch when configured"
   fi
+fi
+
+# ---------------------------------------------------------------------------
+# update-dependency.sh: repins a Composer custom-package to a released upstream
+# and mirrors the coordinates into composer.lock. Asserts the EXACT rewrite
+# shape (version, dist.url archive tag, dist/source reference, require
+# constraint). composer is skipped so the deterministic JSON rewrite is what is
+# under test.
+# ---------------------------------------------------------------------------
+UPDATE_DIR="$(mktemp -d -t homeboy-wp-update-dep.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}" "${STUB_BIN_DIR}" "${HAPPY_DIR}" "${BRANCH_DIR}" "${UPDATE_DIR}"' EXIT
+
+cat > "${UPDATE_DIR}/composer.json" <<'JSON'
+{
+  "name": "chubes/static-site-importer",
+  "require": {
+    "php": ">=8.1",
+    "chubes/php-transformer": "1.3.0"
+  },
+  "repositories": [
+    {
+      "type": "package",
+      "package": {
+        "name": "chubes/php-transformer",
+        "version": "1.3.0",
+        "dist": {
+          "type": "zip",
+          "url": "https://github.com/chubes4/php-transformer/archive/refs/tags/v1.3.0.zip",
+          "reference": "oldsha111"
+        },
+        "source": {
+          "type": "git",
+          "url": "https://github.com/chubes4/php-transformer.git",
+          "reference": "oldsha111"
+        }
+      }
+    }
+  ]
+}
+JSON
+
+cat > "${UPDATE_DIR}/composer.lock" <<'JSON'
+{
+  "content-hash": "stale000",
+  "packages": [
+    {
+      "name": "chubes/php-transformer",
+      "version": "1.3.0",
+      "dist": {
+        "type": "zip",
+        "url": "https://github.com/chubes4/php-transformer/archive/refs/tags/v1.3.0.zip",
+        "reference": "oldsha111"
+      },
+      "source": {
+        "type": "git",
+        "url": "https://github.com/chubes4/php-transformer.git",
+        "reference": "oldsha111"
+      }
+    }
+  ],
+  "packages-dev": []
+}
+JSON
+
+UPDATE_PAYLOAD='{"release":{"component_id":"static-site-importer","local_path":"'"${UPDATE_DIR}"'"},"dependency":{"released_id":"php-transformer","package":"chubes/php-transformer","version":"1.4.0","tag":"v1.4.0","sha":"newsha999"}}'
+
+set +e
+update_out="$(
+  cd "${UPDATE_DIR}" && \
+  HOMEBOY_SKIP_COMPOSER_UPDATE=1 \
+  HOMEBOY_COMPONENT_ID="static-site-importer" \
+  HOMEBOY_SETTINGS_JSON="${UPDATE_PAYLOAD}" \
+  "${UPDATE_DEP_SH}" 2>/dev/null
+)"
+update_status=$?
+set -e
+
+if [[ ${update_status} -ne 0 ]]; then
+  echo "FAIL: update-dependency.sh exited ${update_status}" >&2
+  failures=$((failures + 1))
+else
+  cj="${UPDATE_DIR}/composer.json"
+  expected_url="https://github.com/chubes4/php-transformer/archive/refs/tags/v1.4.0.zip"
+  if ! jq -e --arg u "${expected_url}" '
+        (.repositories[0].package.version == "1.4.0")
+        and (.repositories[0].package.dist.url == $u)
+        and (.repositories[0].package.dist.reference == "newsha999")
+        and (.repositories[0].package.source.reference == "newsha999")
+        and (.require["chubes/php-transformer"] == "1.4.0")
+      ' "${cj}" >/dev/null 2>&1; then
+    echo "FAIL: update-dependency.sh composer.json rewrite shape wrong; got: $(cat "${cj}")" >&2
+    failures=$((failures + 1))
+  elif ! echo "${update_out}" | jq -e '.success == true and .composer_lock_updated == true and .composer_refreshed == false' >/dev/null 2>&1; then
+    echo "FAIL: update-dependency.sh receipt unexpected; got: ${update_out}" >&2
+    failures=$((failures + 1))
+  elif ! jq -e --arg u "${expected_url}" '
+        (.packages[0].version == "1.4.0")
+        and (.packages[0].dist.url == $u)
+        and (.packages[0].dist.reference == "newsha999")
+        and (.packages[0].source.reference == "newsha999")
+      ' "${UPDATE_DIR}/composer.lock" >/dev/null 2>&1; then
+    echo "FAIL: update-dependency.sh composer.lock mirror wrong; got: $(cat "${UPDATE_DIR}/composer.lock")" >&2
+    failures=$((failures + 1))
+  else
+    echo "OK: update-dependency.sh repins custom-package version/dist/source/constraint + lock mirror"
+  fi
+fi
+
+# update-dependency.sh: a package not declared as a custom-package repository
+# must fail loudly rather than ship an unchanged pin.
+NOPKG_DIR="$(mktemp -d -t homeboy-wp-update-nopkg.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}" "${STUB_BIN_DIR}" "${HAPPY_DIR}" "${BRANCH_DIR}" "${UPDATE_DIR}" "${NOPKG_DIR}"' EXIT
+cat > "${NOPKG_DIR}/composer.json" <<'JSON'
+{
+  "name": "chubes/static-site-importer",
+  "require": { "php": ">=8.1" },
+  "repositories": []
+}
+JSON
+
+set +e
+nopkg_err="$(
+  cd "${NOPKG_DIR}" && \
+  HOMEBOY_SKIP_COMPOSER_UPDATE=1 \
+  HOMEBOY_SETTINGS_JSON='{"dependency":{"package":"chubes/php-transformer","version":"1.4.0","tag":"v1.4.0","sha":"x"}}' \
+  "${UPDATE_DEP_SH}" 2>&1 >/dev/null
+)"
+nopkg_status=$?
+set -e
+
+if [[ ${nopkg_status} -eq 0 ]]; then
+  echo "FAIL: update-dependency.sh exited 0 when package is not a custom-package repository" >&2
+  failures=$((failures + 1))
+elif ! echo "${nopkg_err}" | grep -q "custom-package repository"; then
+  echo "FAIL: update-dependency.sh did not surface the missing custom-package error; got: ${nopkg_err}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: update-dependency.sh fails loudly when package is not a custom-package repository"
+fi
+
+# update-dependency.sh: missing required dependency coordinates must fail.
+set +e
+missing_err="$(
+  cd "${UPDATE_DIR}" && \
+  HOMEBOY_SKIP_COMPOSER_UPDATE=1 \
+  HOMEBOY_SETTINGS_JSON='{"dependency":{"package":"chubes/php-transformer"}}' \
+  "${UPDATE_DEP_SH}" 2>&1 >/dev/null
+)"
+missing_status=$?
+set -e
+
+if [[ ${missing_status} -eq 0 ]]; then
+  echo "FAIL: update-dependency.sh exited 0 with missing version/tag" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: update-dependency.sh rejects missing dependency coordinates"
 fi
 
 if [[ ${failures} -gt 0 ]]; then

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1189,6 +1189,16 @@
         "release": "{{payload.release}}",
         "config": "{{payload.config}}"
       }
+    },
+    {
+      "id": "release.update_dependency",
+      "label": "Repin Composer custom-package to a released upstream",
+      "type": "command",
+      "command": "bash \"{{extension_path}}/scripts/release/update-dependency.sh\"",
+      "payload": {
+        "release": "{{payload.release}}",
+        "dependency": "{{payload.dependency}}"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Extension side of homeboy's dependency-aware release cascade (Extra-Chill/homeboy#6938). When core releases an upstream and cascades to a dependent, it invokes the generic `release.update_dependency` action with the released coordinates (`package`, `version`, `tag`, `sha`) in the payload's `dependency` block. This PR is where the Composer-specific knowledge lives — core stays generic.

## What it does

`scripts/release/update-dependency.sh` runs against the **dependent's** checkout (`HOMEBOY_COMPONENT_PATH`) and repins the Composer custom-package, replacing the manual edit operators do by hand:

- `composer.json` `repositories[]` (type `package`, matching name):
  - `package.version` = released version
  - `package.dist.url` = `<repo>/archive/refs/tags/<tag>.zip`
  - `package.dist.reference` = released sha
  - `package.source.reference` = released sha
- `composer.json` `require` / `require-dev` constraint for the package = version
- `composer.lock` package coordinates mirrored to match

If the package is not declared as a custom-package repository the script **fails loudly** rather than shipping an unchanged pin. Lockfile content-hash refresh runs `composer update <package>` when composer is available (`HOMEBOY_SKIP_COMPOSER_UPDATE` bypasses it); the deterministic JSON rewrite always runs so the pin is correct offline.

A new manifest action `release.update_dependency` wires the script in (payload carries `release` + `dependency`).

## Tests

Extends `tests/release-scripts-smoke.sh` with high-signal assertions on the **exact** rewrite shape (version / dist.url archive tag / dist.reference / source.reference / require constraint + composer.lock mirror), plus the missing-custom-package and missing-coordinate failure paths. `bash wordpress/tests/release-scripts-smoke.sh` → `PASS`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Investigation, the script + manifest action, and shell tests.

Pairs with Extra-Chill/homeboy#6938 cascade core. DO NOT MERGE without review.