### PR TITLE
fix(wp-codebox): run native agents/chat for the wp-codebox/run-agent-task self-call

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -88,6 +88,21 @@ const RUNTIME_PACKAGE_ABILITY_ALIASES = new Set([
 ]);
 const LEGACY_RUNTIME_PACKAGE_ABILITY_QUARANTINE = 'legacy-runtime-package-ability-alias';
 
+// The wp-codebox native agent-run ability is the OUTER invocation the runner
+// drives via the `run-agent-task` CLI command; it is not a delegated ability
+// that runs inside the sandbox. A profile must still declare it as
+// runtime_task_ability to satisfy the runner contract, but when it surfaces as
+// the resolved inner runtime task we suppress the sandbox-side runtime_task so
+// the sandbox runs its native agents/chat loop with the agent + goal already
+// present in the task input. A non-empty inner runtime_task would otherwise make
+// the sandbox self-delegate wp-codebox/run-agent-task with an input that lacks
+// goal. This mirrors how studio-native invokes run-agent-task with no inner
+// runtime_task.
+const WP_CODEBOX_NATIVE_AGENT_RUN_ABILITIES = new Set([
+  'wp-codebox/run-agent-task',
+  'wp-codebox/agent-task-run',
+]);
+
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
   'bundle_host_path',
@@ -382,7 +397,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     ],
   });
   components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
-  const runtimeTaskAbilityNormalization = runtimeTaskAbilityNormalizationEvidence(runtimeTask);
+  const sandboxRuntimeTask = sandboxRuntimeTaskForNativeAgentRun(runtimeTask);
+  const runtimeTaskAbilityNormalization = runtimeTaskAbilityNormalizationEvidence(sandboxRuntimeTask);
   const context = {
     ...clientContext,
     ...(clientInputs.context || {}),
@@ -407,7 +423,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     context,
     recipe,
     sandbox_tool_policy: sandboxToolPolicy,
-    runtime_task: runtimeTask,
+    ...(sandboxRuntimeTask ? { runtime_task: sandboxRuntimeTask } : {}),
     ...(runtimeTaskAbilityNormalization ? { runtime_task_ability_normalization: runtimeTaskAbilityNormalization } : {}),
     ability_requirements: abilityRequirements,
     callback_data: firstDefined(inputs.callback_data, inputs.callbackData, config.callback_data, config.callbackData, runtimeOptions.callbackData),
@@ -491,7 +507,8 @@ function codeboxFanoutRequestFromAgentTaskRequest(request, config = {}, inputs =
   const workers = normalizeArray(source.workers).map((worker, index) => {
     const metadata = firstObject(worker.metadata) || {};
     const runtimeTask = fanoutWorkerRuntimeTask(worker, request, config, runtimeOptions);
-    const runtimeTaskAbilityNormalization = runtimeTaskAbilityNormalizationEvidence(runtimeTask);
+    const sandboxRuntimeTask = sandboxRuntimeTaskForNativeAgentRun(runtimeTask);
+    const runtimeTaskAbilityNormalization = runtimeTaskAbilityNormalizationEvidence(sandboxRuntimeTask);
     return withoutUndefinedValues({
       ...worker,
       id: firstValue(worker.id, worker.worker_id, `${request.task_id}-worker-${index + 1}`),
@@ -499,7 +516,7 @@ function codeboxFanoutRequestFromAgentTaskRequest(request, config = {}, inputs =
       agent: firstValue(worker.agent, source.agent, config.agent, runtimeOptions.agent),
       dependsOn: normalizeArray(firstValue(worker.dependsOn, worker.depends_on)),
       artifactNamespace: firstValue(worker.artifactNamespace, worker.artifact_namespace, `${request.task_id}/${index + 1}`),
-      ...(runtimeTask ? { runtime_task: runtimeTask } : {}),
+      ...(sandboxRuntimeTask ? { runtime_task: sandboxRuntimeTask } : {}),
       ...(runtimeTaskAbilityNormalization ? { runtime_task_ability_normalization: runtimeTaskAbilityNormalization } : {}),
       ability_requirements: runtimeTask?.ability ? uniqueStrings([runtimeTask.ability, ...normalizeArray(worker.ability_requirements), ...normalizeArray(worker.abilityRequirements)]) : firstDefined(worker.ability_requirements, worker.abilityRequirements),
       metadata: {
@@ -1019,6 +1036,25 @@ function genericAbilityRuntimeTask(request, config, inputs) {
 
 function normalizeRuntimeTaskAbilityForCodebox(ability) {
   return RUNTIME_PACKAGE_ABILITY_ALIASES.has(ability) ? WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY : ability;
+}
+
+function isNativeWpCodeboxAgentRunAbility(ability) {
+  return typeof ability === 'string' && WP_CODEBOX_NATIVE_AGENT_RUN_ABILITIES.has(ability.trim());
+}
+
+function isNativeWpCodeboxAgentRunRuntimeTask(runtimeTask) {
+  return Boolean(runtimeTask)
+    && typeof runtimeTask === 'object'
+    && !Array.isArray(runtimeTask)
+    && isNativeWpCodeboxAgentRunAbility(runtimeTask.ability);
+}
+
+// Suppress the inner sandbox runtime_task for the native wp-codebox/run-agent-task
+// self-call so the sandbox runs its native agents/chat loop instead of delegating
+// the runtime's own outer invocation back to itself. Genuine delegated abilities
+// and the runtime-package path are preserved.
+function sandboxRuntimeTaskForNativeAgentRun(runtimeTask) {
+  return isNativeWpCodeboxAgentRunRuntimeTask(runtimeTask) ? undefined : runtimeTask;
 }
 
 function runtimePackageTaskInputForCodebox(input, options = {}) {

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -164,6 +164,7 @@
     "test:codebox-runtime-overlay-defaults": "node tests/codebox-runtime-overlay-defaults.test.js",
     "test:provider-outcome-normalizer": "node tests/provider-outcome-normalizer.test.js",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",
+    "test:codebox-native-run-agent-task": "node tests/codebox-native-run-agent-task-smoke.js",
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
     "test:wordpress-runtime-task-planner": "node tests/wordpress-runtime-task-planner-smoke.js",
     "test:wordpress-hook-surface-discovery": "node tests/wordpress-hook-surface-discovery-smoke.js",

--- a/wordpress/tests/codebox-native-run-agent-task-smoke.js
+++ b/wordpress/tests/codebox-native-run-agent-task-smoke.js
@@ -1,0 +1,141 @@
+'use strict';
+
+/**
+ * Native wp-codebox/run-agent-task self-call suppression.
+ *
+ * The runtime-agent-ci runner contract requires every runtime profile to
+ * declare a non-empty runtime_task_ability, so the native wp-codebox profile
+ * declares its own `wp-codebox/run-agent-task` ability. That ability is the
+ * OUTER invocation the runner drives via the `run-agent-task` CLI command, not
+ * a delegated ability that runs inside the sandbox.
+ *
+ * The wp-codebox sandbox agent-code only runs its native `agents/chat` default
+ * handler when the inner task_input.runtime_task is empty; a non-empty
+ * runtime_task is executed as a delegated ability. Propagating the runtime's own
+ * `wp-codebox/run-agent-task` ability into the inner runtime_task made the
+ * sandbox self-delegate run-agent-task with an input that lacks `goal`
+ * ("goal is a required property of input").
+ *
+ * The executor must treat its own native agent-run ability as the OUTER native
+ * invocation and leave the inner sandbox runtime_task empty, so the sandbox runs
+ * native agents/chat with the agent + goal already present in the task input.
+ * This mirrors how studio-native invokes run-agent-task with no inner
+ * runtime_task. Genuine delegated abilities and the runtime-package path are
+ * preserved.
+ */
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(__dirname, '..', '..', 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
+
+const { codeboxTaskRequestFromAgentTaskRequest } = require('../../agent-runtimes/wp-codebox');
+const runtimeAgentCi = require('../../runtime-agent-ci');
+
+const workspaceRoot = path.join(__dirname, 'fixtures');
+
+// Build the executor config exactly the way the runner does from a wp-codebox
+// runtime profile that declares its own native run-agent-task ability.
+const nativeAgentRunExecutorConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+  runtimeProfile: 'codebox-agent-runtime',
+  runtimeProfiles: {
+    'codebox-agent-runtime': {
+      schema: 'wp-codebox/runtime-profile/v1',
+      id: 'codebox-agent-runtime',
+      runtime_task_ability: 'wp-codebox/run-agent-task',
+    },
+  },
+  provider: 'openai',
+});
+
+// The runner still resolves a runtime_task from the declared profile ability, so
+// the profile contract (runtime_task_ability declared) stays satisfied.
+assert.deepEqual(nativeAgentRunExecutorConfig.runtime_task, {
+  ability: 'wp-codebox/run-agent-task',
+  input: {},
+});
+
+const nativeAgentRunTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'codebox-native-run-agent-task-1',
+  executor: {
+    backend: 'wp-codebox',
+    config: {
+      ...nativeAgentRunExecutorConfig,
+      agent: 'technical-docs-bootstrap-agent',
+      agent_bundles: [
+        { source: '/workspace/bundles/technical-docs-bootstrap-agent.agent.json', on_conflict: 'skip' },
+      ],
+    },
+  },
+  instructions: 'Generate the developer docs flow natively in the sandbox.',
+  workspace: { root: workspaceRoot, mode: 'readwrite' },
+});
+
+// The inner sandbox runtime_task is suppressed for the native self-call so the
+// sandbox runs native agents/chat instead of self-delegating run-agent-task.
+assert.equal(Object.hasOwn(nativeAgentRunTaskInput, 'runtime_task'), false);
+
+// The goal + agent + agent_bundles reach the sandbox natively, so agents/chat
+// has everything it needs without an inner runtime_task.
+assert.equal(nativeAgentRunTaskInput.goal, 'Generate the developer docs flow natively in the sandbox.');
+assert.equal(nativeAgentRunTaskInput.agent, 'technical-docs-bootstrap-agent');
+assert.deepEqual(nativeAgentRunTaskInput.agent_bundles, [
+  { source: '/workspace/bundles/technical-docs-bootstrap-agent.agent.json', on_conflict: 'skip' },
+]);
+
+// The legacy native alias is suppressed the same way.
+const legacyNativeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'codebox-native-agent-task-run-1',
+  executor: {
+    backend: 'wp-codebox',
+    config: {
+      provider: 'openai',
+      agent: 'technical-docs-bootstrap-agent',
+      agent_bundles: [{ source: '/workspace/bundles/x.agent.json', on_conflict: 'skip' }],
+      runtime_task: { ability: 'wp-codebox/agent-task-run', input: {} },
+    },
+  },
+  instructions: 'Run the legacy native agent-task-run alias.',
+  workspace: { root: workspaceRoot, mode: 'readwrite' },
+});
+assert.equal(Object.hasOwn(legacyNativeTaskInput, 'runtime_task'), false);
+assert.equal(legacyNativeTaskInput.goal, 'Run the legacy native agent-task-run alias.');
+
+// A genuine delegated ability is still propagated as the inner runtime_task.
+const delegatedAbilityTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'codebox-delegated-ability-1',
+  executor: {
+    backend: 'wp-codebox',
+    config: {
+      provider: 'openai',
+      runtime_task: { ability: 'wordpress/site-health', input: { include_debug: true } },
+    },
+  },
+  instructions: 'Run a delegated WordPress ability inside the sandbox.',
+  workspace: { root: workspaceRoot, mode: 'readwrite' },
+});
+assert.deepEqual(delegatedAbilityTaskInput.runtime_task, {
+  ability: 'wordpress/site-health',
+  input: { include_debug: true },
+});
+
+// The runtime-package path is still propagated as the inner runtime_task.
+const runtimePackageContrastTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'codebox-runtime-package-contrast-1',
+  executor: {
+    backend: 'wp-codebox',
+    config: {
+      provider: 'openai',
+      runtime_task: { ability: 'homeboy/run-runtime-package', input: { source: '/workspace/bundles/example' } },
+    },
+  },
+  instructions: 'Run a runtime package inside the sandbox.',
+  workspace: { root: workspaceRoot, mode: 'readwrite' },
+});
+assert.equal(runtimePackageContrastTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+
+console.log('Codebox native run-agent-task suppression smoke passed');


### PR DESCRIPTION
## Summary

Fixes the last structural blocker stopping a Data-Machine-free runner (e.g. build-with-wordpress's docs agent) from running on wp-codebox's native path.

The runtime-agent-ci runner requires every runtime profile to declare a non-empty `runtime_task_ability`, so a native wp-codebox profile declares its own `wp-codebox/run-agent-task` ability. That ability is the **OUTER** invocation the runner drives via the `run-agent-task` CLI command — not a delegated ability that runs *inside* the sandbox.

The wp-codebox executor was propagating that ability into the inner sandbox `task_input.runtime_task`. The sandbox `agent-code` only runs its native `agents/chat` default handler when `runtime_task` is empty; a non-empty `runtime_task` is executed as a delegated ability. So `wp-codebox/run-agent-task` self-delegated with an input lacking `goal`, failing with `Ability "wp-codebox/run-agent-task" has invalid input. Reason: goal is a required property of input.`

## Change

`agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js`: when the resolved runtime task ability is the wp-codebox native agent-run ability (`wp-codebox/run-agent-task`, plus its legacy `wp-codebox/agent-task-run` alias), treat it as the OUTER native invocation and leave the inner sandbox `task_input.runtime_task` empty, so the sandbox runs native `agents/chat` with the agent + goal already present in the task input. This mirrors how studio-native invokes `run-agent-task` with no inner `runtime_task`.

- Applied to both the single-task path (`codeboxTaskRequestFromAgentTaskRequest`) and the fanout worker path (`codeboxFanoutRequestFromAgentTaskRequest`).
- The outer profile requirement (`runtime_task_ability` declared) stays satisfied; only the inner delegated `runtime_task` is suppressed for the native self-call.
- Genuine delegated abilities and the runtime-package path are unchanged.
- Confirmed via `wp-codebox` `agent-code.ts` that the native branch reads `goal`/`agent`/`agent_bundles` from the task input (not from `runtime_task`): empty `runtime_task` → `agents/chat` executed with `$decoded_agent_input`.

## Test

New `wordpress/tests/codebox-native-run-agent-task-smoke.js` (wired as `test:codebox-native-run-agent-task`) proves, through the real executor entry point and the real runner config builder:

- a profile/ability of `wp-codebox/run-agent-task` → built sandbox `task_input` has **no** inner `runtime_task`, while `goal` + `agent` + `agent_bundles` are present;
- the legacy `wp-codebox/agent-task-run` alias is suppressed the same way;
- a non-native delegated ability (`wordpress/site-health`) **still** sets `runtime_task`;
- the runtime-package path (`homeboy/run-runtime-package` → `wp-codebox/run-runtime-package`) **still** sets `runtime_task`.

```
$ node wordpress/tests/codebox-native-run-agent-task-smoke.js
Codebox native run-agent-task suppression smoke passed
```

Verified the test catches the bug: run against the pre-fix executor it fails at `Object.hasOwn(taskInput, 'runtime_task') === false` (actual `true`); with the fix it passes.

## Note (out of scope)

On `origin/main`, three pre-existing wp-codebox executor tests already fail independent of this change (verified by running them on pristine `main`): `codebox-agent-task-executor-boundary.test.js` (`required_typed_artifacts_missing` vs expected `required_typed_artifacts_invalid`), `codebox-agent-task-executor-smoke.js`, and `codebox-agent-task-matrix-smoke.js`. These are unrelated subsystems (typed-artifact diagnostics / runtime-contract-source) and are not touched here; the focused smoke test avoids coupling the proof to those broken files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Tracing the executor → sandbox runtime_task flow, implementing the native run-agent-task self-call suppression, and writing the proof smoke test.