### PR TITLE
Exclude runner .ci materialization from captured workspace patch

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -74,6 +74,13 @@ const {
 } = require('./provider-credential-boundary');
 
 const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
+// The full-run runner materializes its dependency checkouts into `.ci/` inside
+// the target repo working tree (see materialize-dependencies.cjs). Those clones
+// are untracked relative to the target repo's HEAD, so the sandbox workspace
+// diff would otherwise report every materialized file as an agent change. The
+// runner owns that directory, so it excludes its own materialization from the
+// captured workspace patch; genuine agent changes outside `.ci/` are retained.
+const RUNNER_MATERIALIZATION_EXCLUDE_PATHS = Object.freeze(['.ci/**']);
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
 const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 const AGENT_TASK_EVENT_SCHEMA = 'homeboy/agent-task-event/v1';
@@ -2252,7 +2259,12 @@ function defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options)
       source: workspaceRoot,
       target: workspaceTarget,
       mode: workspaceMode(request, config, inputs),
-      metadata: { kind: WP_CODEBOX_WORKSPACE_MOUNT_KIND, workspace_slug: workspaceSlug(workspaceRoot), workspaceRef: path.basename(workspaceRoot) },
+      metadata: {
+        kind: WP_CODEBOX_WORKSPACE_MOUNT_KIND,
+        workspace_slug: workspaceSlug(workspaceRoot),
+        workspaceRef: path.basename(workspaceRoot),
+        artifactExcludePaths: [...RUNNER_MATERIALIZATION_EXCLUDE_PATHS],
+      },
     },
   ];
 }

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -1403,7 +1403,12 @@ assert.deepEqual(repoLoopWorkspaceMount.metadata, {
   kind: 'homeboy-runtime-workspace',
   workspace_slug: 'wp-site-generator',
   workspaceRef: 'wp-site-generator@wpsg-lab-proof-20260622-2102',
+  artifactExcludePaths: ['.ci/**'],
 });
+// The runner materializes its dependency checkouts into `.ci/` inside the target
+// repo working tree; the workspace mount must exclude that directory from the
+// captured sandbox patch so dependency clones do not masquerade as agent changes.
+assert.deepEqual(repoLoopWorkspaceMount.metadata.artifactExcludePaths, ['.ci/**']);
 assert.equal(repoLoopWorkspaceTaskInput.allowed_tools.includes('workspace_apply_patch'), true);
 assert.deepEqual(repoLoopWorkspaceTaskInput.workspace_materialization, {
   repo: 'example-repo@example-loop-main-20260616',


### PR DESCRIPTION
## Problem

The full-run runtime-agent runner materializes its dependency checkouts into `.ci/` **inside the target repo working tree** (`materialize-dependencies.cjs` clones `.ci/homeboy-extensions`, `.ci/wp-codebox`, `.ci/agents-api`, etc.). Those clones are untracked relative to the target repo's committed HEAD, so the wp-codebox sandbox workspace diff (`gitWorkingTreeDiff` → `directoryDiff`) reports every materialized file as an "added" agent change.

A live native run (`Automattic/build-with-wordpress` run 28374330671) produced:

> `Agent sandbox produced 11130 changed files and a 74270363-byte patch.`

with `completion_tokens: 0` — the agent did no real work; the entire 74 MB / 11130-file patch was `.ci/` dependency-checkout pollution (~123k path hits under `.ci/homeboy-extensions` alone), which would bury any real docs change.

## Fix

The runner owns `.ci/`, so it now excludes its own materialization from the captured agent change set. `defaultWorkspaceMounts` sets `metadata.artifactExcludePaths = ['.ci/**']` on the workspace mount it dispatches. wp-codebox already honors that generic per-mount exclude in both its changed-file capture and diff capture (`mountArtifactExcludePaths` → `relativePathExcluded`), so no sandbox change is required and every consumer of the full-run benefits. Genuine agent changes outside `.ci/` (e.g. `docs/**`) are still captured.

## Tests

- Boundary test updated to assert the workspace mount carries `artifactExcludePaths: ['.ci/**']`.
- End-to-end proof of the capture honoring this contract lives in the companion wp-codebox PR (the diff capture is wp-codebox code): with the exclude, a `.ci/**` materialization is dropped while a real `docs/README.md` edit is retained; without it, `.ci/**` files leak.

Note: `wordpress/tests/codebox-agent-task-executor-boundary.test.js` has a **pre-existing**, unrelated failure at line ~1186 (`required_typed_artifacts_missing` vs `_invalid`, a fixture/env skew present on clean `main`); the runner-emits-`.ci/**` assertion was verified in isolation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Tracing the `.ci/` pollution path and implementing the runner-side workspace-patch exclusion + test.
