### PR TITLE
fix(runtime-agent-ci): materialize runtime checkout when only RUNTIME_PROVIDER/BACKEND is set

### DIFF
--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -259,6 +259,8 @@ function runtimeIdFromOptions(options = {}, env = process.env) {
 		options.runtime,
 		env.RUNTIME_ID,
 		env.RUNTIME,
+		env.RUNTIME_PROVIDER,
+		env.BACKEND,
 		DEFAULT_RUNTIME_ID
 	);
 }

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict');
 
-const { DEFAULT_RUNTIME_ID } = require('../lib/runtime-provider-resolver.cjs');
+const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider, runtimeIdFromOptions } = require('../lib/runtime-provider-resolver.cjs');
 const { runtimeAgentCiRunnerSpec } = require('..');
 const { runRuntimeSetup, runtimeSetupAdapter } = require('../../.github/scripts/runtime-agent-full-run/setup-runtime.cjs');
 const { requiresWordPressDependencies, setupRuntime } = require('../../agent-runtimes/wp-codebox/lib/runtime-setup.cjs');
@@ -18,6 +18,29 @@ assert.equal(
   }).executor.backend,
   'wp-codebox'
 );
+
+// Regression guard: materialize-dependencies resolves the runtime id via
+// runtimeIdFromOptions while setup-runtime resolves it via
+// RUNTIME || RUNTIME_PROVIDER || BACKEND. When a consumer sets only
+// RUNTIME_PROVIDER (or BACKEND), both must resolve the SAME runtime so the
+// runtime provider repo is checked out into .ci/<runtime> before its npm
+// setup/build commands run there. Honoring only RUNTIME/RUNTIME_ID here makes
+// materialize fall back to DEFAULT_RUNTIME_ID (local-shell, no checkout), so
+// setup-runtime later spawns `npm install` in a never-created .ci/wp-codebox
+// and fails with a missing-cwd ENOENT.
+for (const env of [{ RUNTIME_PROVIDER: 'wp-codebox' }, { BACKEND: 'wp-codebox' }]) {
+  const materializeRuntimeId = runtimeIdFromOptions({}, env);
+  const setupRuntimeId = env.RUNTIME || env.RUNTIME_PROVIDER || env.BACKEND || DEFAULT_RUNTIME_ID;
+  assert.equal(
+    materializeRuntimeId,
+    setupRuntimeId,
+    `materialize and setup-runtime must resolve the same runtime for ${JSON.stringify(env)}`
+  );
+  assert.equal(materializeRuntimeId, 'wp-codebox');
+  const materializeCheckout = resolveRuntimeProvider(materializeRuntimeId, { env }).checkout;
+  assert.equal(materializeCheckout.repo, 'Automattic/wp-codebox');
+  assert.equal(materializeCheckout.target, '.ci/wp-codebox');
+}
 
 assert.equal(runtimeSetupAdapter({ manifest: { ci_materialization: {} } }), null);
 assert.equal(runtimeSetupAdapter({ manifest: { ci_materialization: { requires_wordpress_dependencies: true } } }), null);


### PR DESCRIPTION
## Problem

The `runtime-agent-full-run` pipeline fails at step 14 (\"Install and build runtime dependencies\") for the wp-codebox runtime with:

```
npm install failed to spawn (cwd: /home/runner/work/build-with-wordpress/build-with-wordpress/.ci/wp-codebox): spawnSync npm ENOENT
```

`actions/setup-node@v4` succeeds earlier in the same job (`node v24.17.0`, `npm 11.13.0`), so npm is on PATH. This is a **missing-cwd ENOENT**: `.ci/wp-codebox` was never created, not a missing binary or dropped PATH.

## Root cause

Two scripts resolve the runtime id differently:

- `materialize-dependencies.cjs` (step \"Checkout runtime dependencies\") decides which provider repo to clone via `runtimeIdFromOptions({}, env)`.
- `setup-runtime.cjs` (step 14) resolves the runtime via `RUNTIME || RUNTIME_PROVIDER || BACKEND`.

PR #2019 (`ee9d79e0`, \"Remove legacy contract compatibility\") removed `env.RUNTIME_PROVIDER` and `env.BACKEND` from `runtimeIdFromOptions` in `runtime-agent-ci/lib/runtime-provider-resolver.cjs`, while leaving intact the comment that documents those vars must be honored.

When a consumer (build-with-wordpress) sets only `RUNTIME_PROVIDER=wp-codebox` (not `RUNTIME`):

- `materialize-dependencies` falls back to `DEFAULT_RUNTIME_ID` (`local-shell`, which has no checkout repo) and never clones `Automattic/wp-codebox` into `.ci/wp-codebox`.
- `setup-runtime` still resolves `wp-codebox` and runs `npm install` in the never-created `.ci/wp-codebox` → missing-cwd ENOENT.

Reproduced deterministically: with `{ RUNTIME_PROVIDER: 'wp-codebox' }`, materialize resolved `local-shell` (checkout repo `\"\"`) while setup resolved `wp-codebox` (`.ci/wp-codebox`).

> Note: the original hypothesis was a dropped `PATH`/`process.env` in the spawn `env`. That is **not** the cause — the npm spawn inherits `process.env` and never receives a custom `env`. The real cause is the runtime-id resolution divergence above.

## Fix

Restore `env.RUNTIME_PROVIDER` and `env.BACKEND` to the `runtimeIdFromOptions` precedence so materialize-dependencies and setup-runtime agree on the runtime and the provider repo is materialized before its setup/build commands run. This matches the comment #2019 left in place. No per-consumer hardcoding; no feature reverted (the #2014 component-path provisioning and #2019 contract cleanup are untouched).

## Proof

Extended `runtime-agent-ci/tests/runtime-provider-boundary.test.js` to assert that, for `RUNTIME_PROVIDER`-only and `BACKEND`-only env, materialize and setup-runtime resolve the **same** runtime and that the wp-codebox checkout (`Automattic/wp-codebox` → `.ci/wp-codebox`) is materialized.

```
$ node runtime-agent-ci/tests/runtime-provider-boundary.test.js
Runtime provider boundary passed
```

Verified the assertion is a real regression guard: reintroducing the #2019 removal makes the test fail (`materialize resolves 'local-shell' != 'wp-codebox'`); restoring the fix passes.

## Post-merge end-to-end validation

The consumer pins `runtime-agent-full-run.yml@main`, so end-to-end validation requires this fix on `main`. After merge:

```
gh workflow run "Build With WordPress Developer Docs Agent" --repo Automattic/build-with-wordpress --ref fix/developer-docs-execute-via-full-run
```

Confirm step 14 \"Install and build runtime dependencies\" now passes (npm builds wp-codebox in a materialized `.ci/wp-codebox`) and the run proceeds to the agent step.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.8)
- **Used for:** Root-cause diagnosis (runtime-id resolution divergence from #2019), the resolver fix, and the regression test.