### PR TITLE
Stop requiring removed legacy run-response path in wp-codebox contract loader

### DIFF
--- a/.github/workflows/wp-codebox-test-runtime-canary.yml
+++ b/.github/workflows/wp-codebox-test-runtime-canary.yml
@@ -55,6 +55,11 @@ jobs:
           npm install
           npm run build
 
+      - name: Verify canonical runtime contract manifest loads from built module
+        env:
+          HOMEBOY_WP_CODEBOX_CORE_MODULE: ${{ github.workspace }}/.ci/wp-codebox/packages/runtime-core/dist/contracts.js
+        run: node tests/wp-codebox-runtime-contract-built-module-canary.mjs
+
       - name: Run WP Codebox-backed test runner canary
         env:
           HOMEBOY_WP_CODEBOX_BIN: ${{ github.workspace }}/.ci/wp-codebox/packages/cli/dist/index.js

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -14,7 +14,6 @@ const REQUIRED_RUNTIME_CONTRACT_PATHS = [
   'schemas.providerRuntime.credentialResolution',
   'schemas.agentTask.runRequest',
   'schemas.agentTask.runResult',
-  'schemas.agentTask.legacyRunResponse',
   'schemas.runtimeBoundary.profile',
   'schemas.runtimeBoundary.previewLease',
   'schemas.runtimeBoundary.browserContainedSiteStatus',

--- a/tests/wp-codebox-runtime-contract-built-module-canary.mjs
+++ b/tests/wp-codebox-runtime-contract-built-module-canary.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Loads the canonical wp-codebox runtime contract manifest through the runner's
+// own loader, against the REAL built @automattic/wp-codebox-core module pointed
+// at by HOMEBOY_WP_CODEBOX_CORE_MODULE. Unit smokes exercise a hand-written
+// fixture, which can silently drift from the published contract (as it did when
+// Automattic/wp-codebox#1637 dropped schemas.agentTask.legacyRunResponse). This
+// canary asserts the manifest actually resolves from the built module the same
+// way the "Build runner config" step does, so a contract drift fails CI here
+// instead of in every downstream runtime-agent-full-run.
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const coreModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE;
+assert.ok(coreModule, 'HOMEBOY_WP_CODEBOX_CORE_MODULE (or WP_CODEBOX_CORE_MODULE) must point at the built wp-codebox runtime-core contracts module.');
+assert.ok(fs.existsSync(coreModule), `Built wp-codebox runtime-core module not found at ${coreModule}. Build packages/runtime-core before running the canary.`);
+
+const {
+  loadCanonicalRuntimeContractSource,
+  loadCanonicalRuntimeContractSourceSync,
+  RUNTIME_CONTRACT_MANIFEST_SCHEMA,
+} = await import(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-runtime-contract-source.js'));
+
+// Sync path mirrors build-runner-config.cjs.
+const sync = loadCanonicalRuntimeContractSourceSync({ required: true });
+assert.equal(sync.canonical, true, 'Sync loader must resolve the canonical runtime contract manifest from the built module.');
+assert.equal(sync.manifest.schema, RUNTIME_CONTRACT_MANIFEST_SCHEMA);
+assert.equal(typeof sync.manifest.schemas.agentTask.runResult, 'string', 'Canonical manifest must publish schemas.agentTask.runResult.');
+
+// Async path mirrors the providerRuntime consumers.
+const asyncResult = await loadCanonicalRuntimeContractSource({ required: true });
+assert.equal(asyncResult.canonical, true, 'Async loader must resolve the canonical runtime contract manifest from the built module.');
+assert.deepEqual(asyncResult.manifest, sync.manifest, 'Async and sync loaders must resolve the same canonical manifest.');
+
+console.log(`wp-codebox runtime contract built-module canary passed (schema ${sync.manifest.schema}, source ${sync.source})`);

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -23,7 +23,6 @@ const canonicalManifest = {
     agentTask: {
       runRequest: 'canonical/run-agent-task/v1',
       runResult: 'canonical/agent-task-run-result/v1',
-      legacyRunResponse: 'canonical/agent-task-run/v1',
     },
     runtimeBoundary: {
       profile: 'canonical/runtime-profile/v1',
@@ -115,6 +114,17 @@ const {
 } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
 
 assert.equal(REQUIRED_RUNTIME_CONTRACT_PATHS.includes('schemas.runtimeBoundary.profile'), true);
+// The canonical wp-codebox runtime contract dropped the legacy run-response alias
+// (Automattic/wp-codebox#1637). The loader must not require a manifest path the
+// canonical contract no longer publishes, or every real run fails validation.
+assert.equal(REQUIRED_RUNTIME_CONTRACT_PATHS.includes('schemas.agentTask.legacyRunResponse'), false);
+for (const requiredPath of REQUIRED_RUNTIME_CONTRACT_PATHS) {
+  assert.equal(
+    typeof requiredPath.split('.').reduce((value, key) => (value == null ? value : value[key]), canonicalManifest),
+    'string',
+    `Required runtime contract path ${requiredPath} must resolve in the canonical manifest`
+  );
+}
 assert.deepEqual(runtimeContractManifest(), canonicalManifest);
 assert.deepEqual(providerRuntimeInvocationContract(), canonicalManifest.providerRuntime);
 


### PR DESCRIPTION
## Summary

The runtime-agent-full-run **Build runner config** step (`build-runner-config.cjs`) was failing for every wp-codebox run with:

> WP Codebox canonical runtime contract manifest is unavailable. Install @automattic/wp-codebox-core or configure HOMEBOY_WP_CODEBOX_CORE_MODULE.

even though `HOMEBOY_WP_CODEBOX_CORE_MODULE` was set and pointed at a real, freshly-built `packages/runtime-core/dist/contracts.js`. This blocked the build-with-wordpress developer-docs run (Automattic/build-with-wordpress run 28378263623) at step 15.

## Root cause (verified, not the env var)

The env var was a red herring. The module loaded correctly via `require()` (Node 24 supports `require()` of ESM) and exposed `runtimeContractManifest()`. The failure was in **manifest validation**, not module loading:

- `agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js` validated every manifest against `REQUIRED_RUNTIME_CONTRACT_PATHS`, which still listed `schemas.agentTask.legacyRunResponse`.
- Automattic/wp-codebox#1637 ("Remove legacy contract compatibility", merged between the last good run and the failing run) intentionally removed that legacy alias from the canonical runtime-core manifest. It only duplicated `schemas.agentTask.runResult`, which is still present and still required.
- `loadCanonicalRuntimeContractSourceSync` therefore threw `manifest missing schemas.agentTask.legacyRunResponse`, surfaced as the generic "unavailable" message.

Reproduced by building wp-codebox `origin/main` runtime-core and running the loader against the real `dist/contracts.js`: it threw `missing schemas.agentTask.legacyRunResponse`; after the fix it resolves the canonical manifest. `legacyRunResponse` was the **only** missing required path.

This is the correct layer to fix: wp-codebox#1637 was a deliberate feature (dropping legacy aliases), so the loader — the consumer — must stop demanding a path the canonical contract no longer publishes. No env re-pointing, no revert of the upstream feature.

## Why CI did not catch it

The loader's unit smoke fixture carried the same stale `legacyRunResponse` alias, so homeboy-extensions CI stayed green while every downstream run broke. This PR aligns the fixture with the canonical (legacy-free) manifest and adds a built-module canary so the unit fixture can no longer mask canonical-contract drift.

## Changes

- `agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js` — drop the obsolete `schemas.agentTask.legacyRunResponse` required path.
- `tests/wp-codebox-runtime-contract-source-smoke.mjs` — remove the stale alias from the canonical fixture; assert the loader no longer demands it and that every required path resolves in the canonical manifest.
- `tests/wp-codebox-runtime-contract-built-module-canary.mjs` (new) + `.github/workflows/wp-codebox-test-runtime-canary.yml` — load the manifest through the runner's own loader against the **real built** `runtime-core/dist/contracts.js`, so canonical-contract drift fails in this canary instead of in every consumer.

## Proof

Built wp-codebox `origin/main` runtime-core, then:

- Fixed loader against the real built `dist/contracts.js`: `LOADED OK` (schema `wp-codebox/runtime-contract-manifest/v1`, `canonical=true`).
- Unfixed (origin/main) loader against the same built module: fails with the exact CI error and underlying `missing schemas.agentTask.legacyRunResponse` — proving the canary catches this class of regression.
- `test:wp-codebox-runtime-contract-source` smoke: `passed`.
- New built-module canary: `passed`.
- `test:codebox-agent-task-executor-boundary` (uses the untouched shared fixture): still `passed`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Diagnosing the contract-manifest load failure and implementing the loader fix, fixture alignment, and built-module canary.