### PR TITLE
Require explicit Codebox fuzz contracts

### DIFF
--- a/tests/fixtures/wp-codebox-core-runtime-contract.cjs
+++ b/tests/fixtures/wp-codebox-core-runtime-contract.cjs
@@ -52,6 +52,27 @@ const manifest = {
       runFuzzSuite: 'wp-codebox/run-fuzz-suite',
     },
   },
+  commands: {
+    wordpressRuntime: {
+      runWorkload: 'run-wordpress-workload',
+      runFuzzSuite: 'run-fuzz-suite',
+    },
+  },
+  capabilities: {
+    wordpressRuntime: {
+      commands: ['run-fuzz-suite', 'run-wordpress-workload'],
+      capabilities: ['rest', 'disposable-runtime', 'runtime-isolation', 'artifact-export'],
+      runner_modes: { 'runtime-backed': true },
+    },
+  },
+  readiness: {
+    wordpressRuntime: {
+      schema: 'wp-codebox/fuzz-runner-readiness/v1',
+      status: 'ready',
+      mode: 'runtime-backed',
+      command_available: true,
+    },
+  },
   providerRuntime: {
     schema: 'wp-codebox/provider-runtime-invocation-contract/v1',
     version: 1,

--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -197,10 +197,6 @@ function buildWordPressFuzzRunnerSummary({
 }
 
 async function resolveCodeboxResult(context, options = {}) {
-	if (hasPrecomputedCodeboxResult(context.workload)) {
-		return normalizeCodeboxResult(context.workload, { runId: context.runId, fixtureOnly: precomputedCodeboxResultIsFixtureOnly(context.workload) });
-	}
-
 	const runner = options.runFuzzSuite || options.runRuntimeTask || options.runTask;
 	return runWpCodeboxFuzzSuite({
 		...options,
@@ -487,10 +483,6 @@ function normalizeCodeboxResult(workload, context = {}) {
 			},
 		],
 	});
-}
-
-function hasPrecomputedCodeboxResult(workload = {}) {
-	return Boolean(precomputedCodeboxResult(workload));
 }
 
 function precomputedCodeboxResult(workload = {}) {

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -37,7 +37,6 @@ const {
 } = require('./wp-codebox-resolver');
 const {
 	createCodeboxClient,
-	normalizeCliResult,
 } = require('./codebox-client');
 const {
 	WP_CODEBOX_FUZZ_PUBLIC_ABILITIES,
@@ -226,6 +225,8 @@ const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 const REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS = [
 	'abilities.wordpressRuntime.runFuzzSuite',
 	'abilities.wordpressRuntime.runWorkload',
+	'commands.wordpressRuntime.runFuzzSuite',
+	'commands.wordpressRuntime.runWorkload',
 	'schemas.wordpressRuntime.fuzzSuite',
 	'schemas.wordpressRuntime.fuzzSuiteResult',
 	'schemas.wordpressRuntime.workloadRun',
@@ -245,6 +246,7 @@ function wpCodeboxWordPressRuntimeContracts(options = {}) {
 	return {
 		manifest,
 		abilities: objectOrUndefined(manifest?.abilities?.wordpressRuntime) || {},
+		commands: objectOrUndefined(manifest?.commands?.wordpressRuntime) || {},
 		schemas: objectOrUndefined(manifest?.schemas?.wordpressRuntime) || {},
 	};
 }
@@ -295,6 +297,14 @@ function wpCodeboxFuzzSuiteResultSchema(options = {}) {
 
 function wpCodeboxWordPressWorkloadRunSchema(options = {}) {
 	return wpCodeboxWordPressRuntimeContracts(options).schemas.workloadRun || DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA;
+}
+
+function wpCodeboxFuzzSuiteCommand(options = {}) {
+	return wpCodeboxWordPressRuntimeContracts(options).commands.runFuzzSuite;
+}
+
+function wpCodeboxWordPressWorkloadRunCommand(options = {}) {
+	return wpCodeboxWordPressRuntimeContracts(options).commands.runWorkload;
 }
 
 function wpCodeboxFuzzSuiteInput(options = {}) {
@@ -441,7 +451,7 @@ function normalizeWpCodeboxFuzzSuiteCases(source = {}, context = {}) {
 	}
 	const planCases = homeboyFuzzWorkloadPlanCases(source);
 	if (planCases.length > 0) {
-		return planCases.map((entry, index) => homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry, source, index, context));
+		return planCases.map((entry, index) => homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry, source, index));
 	}
 	if (directCases.length === 0) {
 		const defaultCase = homeboyFuzzWorkloadDefaultCase(source);
@@ -502,7 +512,7 @@ function homeboyFuzzWorkloadPlanCases(manifest = {}) {
 	));
 }
 
-function homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry = {}, manifest = {}, index = 0, context = {}) {
+function homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry = {}, manifest = {}, index = 0) {
 	const caseId = entry.case_id || entry.caseId || entry.id || `${manifest.id || 'fuzz-workload'}:${index}`;
 	const artifacts = normalizeHomeboyFuzzCaseArtifacts(entry, manifest);
 	const target = homeboyFuzzPlanCaseTarget(entry);
@@ -985,12 +995,13 @@ function wpCodeboxFuzzExecutionRequest(options = {}) {
 	const input = wpCodeboxFuzzSuiteInput(options.input || options.abilityInput || options.ability_input || options);
 	const taskId = requiredString(options.taskId || options.task_id || input.id, 'taskId');
 	const ability = options.ability || wpCodeboxFuzzSuiteAbility(options);
+	const command = wpCodeboxCommandFromFuzzAbility(ability, options);
 	const runtimeRequirements = options.runtimeRequirements || options.runtime_requirements;
 	return stripUndefined({
 		schema: WP_CODEBOX_FUZZ_EXECUTION_SCHEMA,
 		task_id: taskId,
 		ability,
-		command: wpCodeboxCommandFromFuzzAbility(ability, options),
+		command,
 		input,
 		runtime_requirements: objectOrUndefined(runtimeRequirements),
 		artifact_declarations: options.artifactDeclarations || options.artifact_declarations || DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
@@ -1315,9 +1326,9 @@ function detectWpCodeboxPublicFuzzCapabilities(options = {}) {
 		return normalizeWpCodeboxPublicFuzzCapabilities(options.capabilities.public_cli || options.capabilities.publicCli);
 	}
 
-	const readiness = runWpCodeboxPublicFuzzReadiness(options);
-	if (readiness.status === 0) {
-		return normalizeWpCodeboxPublicFuzzCapabilitiesFromReadiness(parseWpCodeboxPublicCliJson(readiness.stdout, { command: 'fuzz readiness' }));
+	const manifestDescriptor = wpCodeboxPublicFuzzCapabilitiesFromRuntimeContract(options);
+	if (manifestDescriptor) {
+		return manifestDescriptor;
 	}
 
 	return normalizeWpCodeboxPublicFuzzCapabilities({
@@ -1328,12 +1339,29 @@ function detectWpCodeboxPublicFuzzCapabilities(options = {}) {
 			command_available: false,
 			diagnostics: [{
 				severity: 'error',
-				code: 'wp_codebox_fuzz_readiness_command_unavailable',
-				message: 'WP Codebox public CLI must expose `fuzz readiness --format=json` before Homeboy dispatches WordPress fuzz workloads.',
-				stderr: readiness.stderr || undefined,
-				stdout: readiness.stdout || undefined,
+				code: 'wp_codebox_fuzz_explicit_public_descriptor_missing',
+				message: 'WP Codebox public fuzz dispatch requires explicit runtime contract fields; Homeboy does not probe production runtimes for fuzz capabilities.',
 			}],
 		},
+	});
+}
+
+function wpCodeboxPublicFuzzCapabilitiesFromRuntimeContract(options = {}) {
+	const manifest = wpCodeboxRuntimeContractManifest(options);
+	const commands = objectOrUndefined(manifest?.commands?.wordpressRuntime);
+	const wordpressCapabilities = objectOrUndefined(manifest?.capabilities?.wordpressRuntime || manifest?.wordpressRuntime?.capabilities);
+	const readiness = objectOrUndefined(manifest?.readiness?.wordpressRuntime || manifest?.wordpressRuntime?.readiness);
+	if (!commands || !wordpressCapabilities || !readiness) {
+		return null;
+	}
+	return normalizeWpCodeboxPublicFuzzCapabilities({
+		commands: stripUndefined({
+			[commands?.runFuzzSuite]: Boolean(commands?.runFuzzSuite),
+			[commands?.runWorkload]: Boolean(commands?.runWorkload),
+		}),
+		capabilities: wordpressCapabilities?.capabilities || wordpressCapabilities?.runtime_capabilities || wordpressCapabilities?.runtimeCapabilities || wordpressCapabilities?.supports,
+		runner_modes: wordpressCapabilities?.runner_modes || wordpressCapabilities?.runnerModes,
+		readiness,
 	});
 }
 
@@ -1350,6 +1378,7 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 	const requiredPlanContracts = requiredWpCodeboxContractsForFuzzPlan(plan);
 	const destructiveReadiness = normalizeWpCodeboxDestructiveReadiness(capabilities.readiness, { request, suiteInput, plan });
 	const requiredAbilities = { ...WP_CODEBOX_FUZZ_PUBLIC_ABILITIES };
+	const requiredCommandMap = wpCodeboxWordPressRuntimeContracts({ runtimeContractManifest: manifest }).commands;
 	const requiredCommands = requiredPublicCommandsForRequest(request, requiredPlanContracts);
 	const missingContracts = [];
 	const readinessStatus = capabilities.readiness?.status;
@@ -1358,9 +1387,8 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 		&& capabilities.readiness?.mode === 'runtime-backed';
 	if (capabilities.readiness?.command_available === false) {
 		missingContracts.push({
-			type: 'public_cli_readiness_command',
-			command: 'fuzz readiness',
-			message: 'WP Codebox public CLI must expose `fuzz readiness --format=json` before Homeboy dispatches WordPress fuzz workloads.',
+			type: 'explicit_public_descriptor',
+			message: 'WP Codebox public fuzz dispatch requires explicit runtime contract fields; Homeboy does not probe production runtimes for fuzz capabilities.',
 			readiness: capabilities.readiness,
 		});
 	}
@@ -1399,11 +1427,11 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 	}
 
 	for (const command of requiredCommands) {
-		if (capabilities.commands?.[command] !== true) {
+		if (!Object.values(requiredCommandMap).includes(command) || capabilities.commands?.[command] !== true) {
 			missingContracts.push({
 				type: 'public_cli_command',
 				command,
-				message: `WP Codebox public CLI must expose \`${command}\` before Homeboy dispatches WordPress fuzz workloads.`,
+				message: `WP Codebox runtime contract must explicitly declare public command \`${command}\` before Homeboy dispatches WordPress fuzz workloads.`,
 			});
 		}
 	}
@@ -1463,15 +1491,15 @@ function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
 function requiredPublicCommandsForRequest(request = {}, requiredPlanContracts = {}) {
 	const ability = wpCodeboxFuzzRequestAbility(request);
 	if (ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY) {
-		return ['run-wordpress-workload'];
+		return [request.command].filter(Boolean);
 	}
 	if (ability === DEFAULT_FUZZ_SUITE_ABILITY) {
 		const input = wpCodeboxFuzzRequestInput(request);
 		const runnerMode = publicFuzzCliRunnerModeForRequest(request, { requiredPlanContracts });
 		return unique([
-			'run-fuzz-suite',
+			request.command,
 			...normalizeArray(requiredPlanContracts.commands).filter((command) => runnerMode === 'runtime-backed' ? command !== 'run-wordpress-workload' : true),
-			...(runnerMode === 'runtime-backed' || !suiteInputRequiresWorkloadCommand(input) ? [] : ['run-wordpress-workload']),
+			...(runnerMode === 'runtime-backed' || !suiteInputRequiresWorkloadCommand(input) ? [] : [wpCodeboxWordPressWorkloadRunCommand({ runtimeContractManifest: request.metadata?.runtime_contract_manifest })]),
 		]);
 	}
 	return requiredPlanContracts.commands?.length > 0 ? unique(requiredPlanContracts.commands) : [...WP_CODEBOX_PUBLIC_CLI_COMMANDS];
@@ -1735,23 +1763,9 @@ function wordpressRuntimeCapabilitiesFromFuzzReadiness(readiness = {}) {
 	]);
 }
 
-function runWpCodeboxPublicFuzzReadiness(options = {}) {
-	return runWpCodeboxPublicCliCommand(['fuzz', 'readiness', '--format=json'], options);
-}
-
 function publicFuzzCliCommandForRequest(request = {}, capabilities = {}) {
 	if (request.command && capabilities.commands?.[request.command]) {
 		return request.command;
-	}
-	const ability = wpCodeboxFuzzRequestAbility(request);
-	if (ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY && capabilities.commands?.['run-wordpress-workload']) {
-		return 'run-wordpress-workload';
-	}
-	if (capabilities.commands?.['run-fuzz-suite']) {
-		return 'run-fuzz-suite';
-	}
-	if (capabilities.commands?.['run-wordpress-workload']) {
-		return 'run-wordpress-workload';
 	}
 	return undefined;
 }
@@ -1788,22 +1802,14 @@ async function runWpCodeboxPublicCli(command, input, options = {}) {
 	return createCodeboxClient(options).runPublicJsonCommand(command, input, options);
 }
 
-function runWpCodeboxPublicCliCommand(args, options = {}) {
-	if (typeof options.runPublicCli === 'function') {
-		return normalizeCliResult(options.runPublicCli({ command: wpCodeboxPublicCliBin(options), args, stdin: options.stdin }, options));
-	}
-	if (typeof options.runCli === 'function') {
-		return normalizeCliResult(options.runCli({ command: wpCodeboxPublicCliBin(options), args, stdin: options.stdin }, options));
-	}
-
-	return createCodeboxClient(options).runPublicCliCommand(args, options);
-}
-
 function wpCodeboxCommandFromFuzzAbility(ability, options = {}) {
-	if (ability === wpCodeboxWordPressWorkloadRunAbility(options) || ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY) {
-		return 'run-wordpress-workload';
+	if (ability === wpCodeboxWordPressWorkloadRunAbility(options)) {
+		return wpCodeboxWordPressWorkloadRunCommand(options);
 	}
-	return 'run-fuzz-suite';
+	if (ability === wpCodeboxFuzzSuiteAbility(options)) {
+		return wpCodeboxFuzzSuiteCommand(options);
+	}
+	return undefined;
 }
 
 function wpCodeboxPublicCliBin(options = {}) {
@@ -3065,12 +3071,14 @@ module.exports = {
 	wpCodeboxFuzzExecutionRequest,
 	wpCodeboxPublicCliInput,
 	wpCodeboxFuzzSuiteAbility,
+	wpCodeboxFuzzSuiteCommand,
 	wpCodeboxFuzzSuiteResultSchema,
 	wpCodeboxFuzzSuiteSchema,
 	wpCodeboxFuzzRuntimeTaskRequest,
 	wpCodeboxRuntimeContractManifest,
 	wpCodeboxWordPressRuntimeContracts,
 	wpCodeboxWordPressWorkloadRunAbility,
+	wpCodeboxWordPressWorkloadRunCommand,
 	wpCodeboxWordPressWorkloadRunInput,
 	wpCodeboxWordPressWorkloadRunSchema,
 	wpCodeboxFuzzSuiteInput,

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -23,7 +23,10 @@ const { loadWpCodeboxCoreFunction } = require('../../lib/wp-codebox-core-loader'
 const {
 	publicFuzzCliRunnerModeForRequest,
 	wpCodeboxFuzzSuiteAbility,
+	wpCodeboxFuzzSuiteCommand,
 	wpCodeboxRuntimeContractManifest,
+	wpCodeboxWordPressWorkloadRunAbility,
+	wpCodeboxWordPressWorkloadRunCommand,
 } = require('../../lib/wp-codebox-fuzz-run');
 
 const WP_CODEBOX_FUZZ_EXECUTION_SCHEMA = 'homeboy/wp-codebox-fuzz-execution/v1';
@@ -199,16 +202,13 @@ function requiresCodeboxTaskAdapter(request) {
 
 function wpCodeboxCommandFromPublicAbility(ability, options = {}) {
 	const contracts = wpCodeboxRuntimeContractManifest(options)?.abilities?.wordpressRuntime || {};
-	const publicAbilities = new Set([
-		contracts.runWorkload,
-		contracts.runFuzzSuite,
-		'wp-codebox/run-wordpress-workload',
-		'wp-codebox/run-fuzz-suite',
-	].filter(Boolean));
-	if (!publicAbilities.has(ability)) {
-		return '';
+	if (ability === contracts.runFuzzSuite || ability === wpCodeboxFuzzSuiteAbility(options)) {
+		return wpCodeboxFuzzSuiteCommand(options) || '';
 	}
-	return String(ability).replace(/^wp-codebox\//, '');
+	if (ability === contracts.runWorkload || ability === wpCodeboxWordPressWorkloadRunAbility(options)) {
+		return wpCodeboxWordPressWorkloadRunCommand(options) || '';
+	}
+	return '';
 }
 
 async function runWpCodeboxPublicRuntimeCommand(command, invocation, tempDir, options = {}) {

--- a/wordpress/tests/wordpress-fuzz-destructive-codebox-readiness-gate.test.js
+++ b/wordpress/tests/wordpress-fuzz-destructive-codebox-readiness-gate.test.js
@@ -44,6 +44,12 @@ const runtimeContractManifest = {
 			runFuzzSuite: 'wp-codebox/run-fuzz-suite',
 		},
 	},
+	commands: {
+		wordpressRuntime: {
+			runWorkload: 'run-wordpress-workload',
+			runFuzzSuite: 'run-fuzz-suite',
+		},
+	},
 };
 
 const destructivePlan = {
@@ -113,17 +119,16 @@ const missingReadinessPreflight = preflightWpCodeboxFuzzCapabilityContract({
 	runtimeContractManifest,
 	runPublicCli: ({ args }) => {
 		missingReadinessCliCalls.push(args);
-		assert.deepEqual(args, ['fuzz', 'readiness', '--format=json']);
-		return { status: 1, stdout: '', stderr: 'readiness unavailable' };
+		throw new Error('production dispatch must not probe fuzz readiness');
 	},
 });
 
 assert.equal(missingReadinessPreflight.ok, false);
-assert.deepEqual(missingReadinessCliCalls, [['fuzz', 'readiness', '--format=json']]);
+assert.deepEqual(missingReadinessCliCalls, []);
 assert.equal(missingReadinessPreflight.capabilities.commands['run-fuzz-suite'], false);
 assert.equal(missingReadinessPreflight.capabilities.commands['run-wordpress-workload'], false);
-assert.equal(missingReadinessPreflight.missing_contracts.some((contract) => contract.type === 'public_cli_readiness_command'), true);
-assert.equal(missingReadinessPreflight.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_public_cli_readiness_command'), true);
+assert.equal(missingReadinessPreflight.missing_contracts.some((contract) => contract.type === 'explicit_public_descriptor'), true);
+assert.equal(missingReadinessPreflight.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_explicit_public_descriptor'), true);
 
 const missingManifestPreflight = preflightWpCodeboxFuzzCapabilityContract({
 	request: destructiveRequest,
@@ -191,6 +196,7 @@ assert.deepEqual(normalizeWpCodeboxDestructiveReadiness(completeReadiness, {
 	assert.equal(result.homeboy_fuzz_campaign.metadata.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_destructive_readiness'), true);
 	assert.equal(result.homeboy_fuzz_result_envelope.gates.failures.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_destructive_readiness'), true);
 
+	let precomputedDispatchCalls = 0;
 	const blockedPrecomputed = await runWordPressFuzzRunnerResult({
 		env: {
 			workloadPath: '/unused/precomputed-destructive-workload.json',
@@ -206,33 +212,21 @@ assert.deepEqual(normalizeWpCodeboxDestructiveReadiness(completeReadiness, {
 				status: 'succeeded',
 			},
 		},
-	});
-
-	assert.equal(blockedPrecomputed.status, 'unsupported');
-	assert.equal(blockedPrecomputed.succeeded, false);
-	assert.equal(blockedPrecomputed.wp_codebox_result.metadata.precomputed_result_blocked, true);
-	assert.equal(blockedPrecomputed.wp_codebox_result.failures.some((diagnostic) => diagnostic.code === 'wp_codebox_precomputed_fuzz_result_not_fixture_only'), true);
-
-	const fixturePrecomputed = await runWordPressFuzzRunnerResult({
-		env: {
-			workloadPath: '/unused/fixture-only-destructive-workload.json',
-			workloadId: 'fixture-only-destructive-workload',
-			runId: 'fixture-only-destructive-run',
-		},
-		workload: {
-			id: 'fixture-only-destructive-workload',
-			fixture_only: true,
-			plan: destructivePlan,
-			wp_codebox_suite_result: {
+		runFuzzSuite: async () => {
+			precomputedDispatchCalls += 1;
+			return {
 				schema: 'wp-codebox/fuzz-suite-result/v1',
-				request_id: 'fixture-only-destructive-run',
-				status: 'succeeded',
-			},
+				request_id: 'precomputed-destructive-run',
+				status: 'skipped',
+				diagnostics: [{ severity: 'error', code: 'runner-called', message: 'production dispatch called Codebox' }],
+			};
 		},
 	});
 
-	assert.equal(fixturePrecomputed.status, 'succeeded');
-	assert.equal(fixturePrecomputed.succeeded, true);
+	assert.equal(blockedPrecomputed.status, 'skipped');
+	assert.equal(blockedPrecomputed.succeeded, false);
+	assert.equal(precomputedDispatchCalls, 1);
+	assert.equal(blockedPrecomputed.wp_codebox_result.failures.some((diagnostic) => diagnostic.code === 'runner-called'), true);
 })().catch((error) => {
 	process.nextTick(() => {
 		throw error;

--- a/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
+++ b/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
@@ -55,6 +55,9 @@ fs.writeFileSync(fakeCodeboxCoreModule, `module.exports.runtimeContractManifest 
   schema: 'wp-codebox/runtime-contract-manifest/v1',
   version: 1,
   abilities: { wordpressRuntime: { runFuzzSuite: 'wp-codebox/run-fuzz-suite', runWorkload: 'wp-codebox/run-wordpress-workload' } },
+  commands: { wordpressRuntime: { runFuzzSuite: 'run-fuzz-suite', runWorkload: 'run-wordpress-workload' } },
+  capabilities: { wordpressRuntime: { commands: ['run-fuzz-suite', 'run-wordpress-workload'], capabilities: ['rest', 'disposable-runtime', 'runtime-isolation', 'artifact-export'], runner_modes: { 'runtime-backed': true } } },
+  readiness: { wordpressRuntime: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'ready', mode: 'runtime-backed', command_available: true } },
   schemas: { wordpressRuntime: { fuzzSuite: 'wp-codebox/fuzz-suite/v1', fuzzSuiteResult: 'wp-codebox/fuzz-suite-result/v1', workloadRun: 'wp-codebox/wordpress-workload-run/v1' } }
 });\n`);
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
@@ -63,30 +66,16 @@ const fs = require('node:fs');
 const command = process.argv[2];
 const inputFileIndex = process.argv.indexOf('--input-file');
 if (command === 'fuzz' && process.argv[3] === 'readiness' && process.argv.includes('--format=json')) {
-  process.stdout.write(JSON.stringify({
-    schema: 'wp-codebox/fuzz-runner-readiness/v1',
-    status: 'ready',
-    mode: 'runtime-backed',
-    commands: ['run-fuzz-suite', 'run-wordpress-workload'],
-    capabilities: {
-      commands: ['wordpress.rest-request', 'wordpress.run-workload'],
-      runtimeActionTypes: ['rest_request'],
-      capabilities: ['rest', 'disposable-runtime', 'runtime-isolation', 'artifact-export']
-    },
-    disposable: true,
-    isolation: { runtime_backed: true, disposable: true },
-    artifacts: { export: true },
-    unsupportedRequiredCapabilities: []
-  }));
-  process.exit(0);
+  process.stderr.write('production dispatch must not probe fuzz readiness');
+  process.exit(2);
 }
 if (command === 'run-fuzz-suite' && process.argv.includes('--help')) {
-	process.stdout.write('usage: wp-codebox run-fuzz-suite');
-	process.exit(0);
+	process.stderr.write('production dispatch must not probe run-fuzz-suite help');
+	process.exit(2);
 }
 if (command === 'run-wordpress-workload' && process.argv.includes('--help')) {
-	process.stdout.write('usage: wp-codebox run-wordpress-workload');
-	process.exit(0);
+	process.stderr.write('production dispatch must not probe run-wordpress-workload help');
+	process.exit(2);
 }
 if (command !== 'run-fuzz-suite' || inputFileIndex < 0 || !process.argv.includes('--format=json')) {
 	process.stderr.write('expected public run-fuzz-suite --input-file <file> --format=json invocation');

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -162,6 +162,43 @@ assert.deepEqual(executedResult.homeboy_fuzz_result_envelope.dispatch_identity, 
 });
 assert.equal(executedResult.observation.status, 'succeeded');
 
+let productionCodeboxCalls = 0;
+runWordPressFuzzRunnerResult({
+	env: {
+		workloadPath: '/unused/in-unit-test.json',
+		runId: 'production-dispatch-run',
+	},
+	workload: {
+		...workload,
+		fixture_only: true,
+		wp_codebox_suite_result: {
+			schema: 'wp-codebox/fuzz-suite-result/v1',
+			request_id: 'embedded-result-that-must-not-run',
+			status: 'succeeded',
+		},
+	},
+	runFuzzSuite: async () => {
+		productionCodeboxCalls += 1;
+		return {
+			schema: 'wp-codebox/fuzz-suite-result/v1',
+			request_id: 'production-dispatch-run',
+			status: 'succeeded',
+			summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+			artifactRefs: [{ name: 'result-envelope', content: { status: 'succeeded' } }],
+			wordpress_fuzz_result: {
+				schema: 'wordpress-fuzz-result/v1',
+				id: 'production-dispatch-result',
+				status: 'passed',
+				cases: [{ id: 'get-posts', status: 'passed' }],
+			},
+		};
+	},
+}).then((productionDispatchResult) => {
+	assert.equal(productionCodeboxCalls, 1);
+	assert.equal(productionDispatchResult.wp_codebox_result.request_id, 'production-dispatch-run');
+	assert.equal(productionDispatchResult.wp_codebox_result.wordpress_fuzz_result.id, 'production-dispatch-result');
+});
+
 const mutatingPlanResult = buildWordPressFuzzRunnerResult({
 	env: {
 		workloadPath: '/unused/in-unit-test.json',
@@ -613,31 +650,16 @@ fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const subcommand = process.argv[2];
 if (subcommand === 'fuzz' && process.argv[3] === 'readiness' && process.argv.includes('--format=json')) {
-  process.stdout.write(JSON.stringify({
-    schema: 'wp-codebox/fuzz-runner-readiness/v1',
-    status: 'ready',
-    mode: 'runtime-backed',
-    entrypoint: 'run-fuzz-suite --runner-mode=runtime-backed',
-    capabilities: {
-      schema: 'wp-codebox/fuzz-runner-capabilities/v1',
-      mode: 'runtime-backed',
-      capabilities: ['target:runtime', 'runtime'],
-      targetKinds: ['runtime'],
-      operationKinds: ['read'],
-      commands: ['run-fuzz-suite', 'wordpress.run-workload'],
-      unsupportedRequiredCapabilities: []
-    },
-    unsupportedRequiredCapabilities: []
-  }));
-  process.exit(0);
+	process.stderr.write('production dispatch must not probe fuzz readiness');
+	process.exit(2);
 }
 if (subcommand === 'run-fuzz-suite' && process.argv.includes('--help')) {
-  process.stdout.write('usage: wp-codebox run-fuzz-suite');
-  process.exit(0);
+	process.stderr.write('production dispatch must not probe run-fuzz-suite help');
+	process.exit(2);
 }
 if (subcommand === 'run-wordpress-workload' && process.argv.includes('--help')) {
-  process.stderr.write('unknown command');
-  process.exit(1);
+	process.stderr.write('production dispatch must not probe run-wordpress-workload help');
+	process.exit(2);
 }
 const inputFileIndex = process.argv.indexOf('--input-file');
 const request = inputFileIndex === -1 ? undefined : JSON.parse(fs.readFileSync(process.argv[inputFileIndex + 1], 'utf8'));
@@ -727,12 +749,12 @@ fs.writeFileSync(taskAdapterCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const command = process.argv[2];
 if (command === 'run-fuzz-suite' && process.argv.includes('--help')) {
-  process.stdout.write('usage: wp-codebox run-fuzz-suite');
-  process.exit(0);
+	process.stderr.write('production dispatch must not probe run-fuzz-suite help');
+	process.exit(2);
 }
 if (command === 'run-wordpress-workload' && process.argv.includes('--help')) {
-  process.stdout.write('usage: wp-codebox run-wordpress-workload');
-  process.exit(0);
+	process.stderr.write('production dispatch must not probe run-wordpress-workload help');
+	process.exit(2);
 }
 const inputFile = process.argv[process.argv.indexOf('--input-file') + 1];
 const request = JSON.parse(fs.readFileSync(inputFile, 'utf8'));

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -105,6 +105,27 @@ const manifest = {
 			runFuzzSuite: 'wp-codebox/run-fuzz-suite',
 		},
 	},
+	commands: {
+		wordpressRuntime: {
+			runWorkload: 'run-wordpress-workload',
+			runFuzzSuite: 'run-fuzz-suite',
+		},
+	},
+	capabilities: {
+		wordpressRuntime: {
+			commands: ['run-fuzz-suite', 'run-wordpress-workload'],
+			capabilities: ['rest', 'disposable-runtime', 'runtime-isolation', 'artifact-export'],
+			runner_modes: { 'runtime-backed': true },
+		},
+	},
+	readiness: {
+		wordpressRuntime: {
+			schema: 'wp-codebox/fuzz-runner-readiness/v1',
+			status: 'ready',
+			mode: 'runtime-backed',
+			command_available: true,
+		},
+	},
 };
 
 assert.equal(wpCodeboxFuzzSuiteAbility({ runtimeContractManifest: manifest }), DEFAULT_FUZZ_SUITE_ABILITY);
@@ -114,6 +135,8 @@ assert.equal(wpCodeboxWordPressWorkloadRunSchema({ runtimeContractManifest: mani
 assert.deepEqual(REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS, [
 	'abilities.wordpressRuntime.runFuzzSuite',
 	'abilities.wordpressRuntime.runWorkload',
+	'commands.wordpressRuntime.runFuzzSuite',
+	'commands.wordpressRuntime.runWorkload',
 	'schemas.wordpressRuntime.fuzzSuite',
 	'schemas.wordpressRuntime.fuzzSuiteResult',
 	'schemas.wordpressRuntime.workloadRun',
@@ -219,7 +242,7 @@ const destructiveTaskRequest = wpCodeboxFuzzSuiteTaskRequest({
 assert.equal(destructiveTaskRequest.artifact_declarations.find((artifact) => artifact.name === 'rollback-lifecycle').required, true);
 assert(destructiveTaskRequest.expected_artifacts.includes('rollback-lifecycle'));
 
-const executionRequest = wpCodeboxFuzzExecutionRequest({ taskId: 'direct-suite-task', input, wpCodeboxBin: '/custom/wp-codebox' });
+const executionRequest = wpCodeboxFuzzExecutionRequest({ taskId: 'direct-suite-task', input, wpCodeboxBin: '/custom/wp-codebox', runtimeContractManifest: manifest });
 assert.equal(executionRequest.schema, WP_CODEBOX_FUZZ_EXECUTION_SCHEMA);
 assert.equal(executionRequest.task_id, 'direct-suite-task');
 assert.equal(executionRequest.command, 'run-fuzz-suite');
@@ -236,6 +259,7 @@ fs.mkdirSync(runtimeWorkloadRoot, { recursive: true });
 const runtimeRequirementRequest = wpCodeboxFuzzExecutionRequest({
 	taskId: 'runtime-requirement-suite-task',
 	input,
+	runtimeContractManifest: manifest,
 	runtimeRequirements: {
 		extra_plugins: [{ slug: 'sample-plugin', source: runtimePluginPath, sourceRoot: runtimePluginRoot, sourceSubpath: 'plugins/sample-plugin' }],
 		component_contracts: [{ slug: 'sample-plugin', path: runtimePluginPath, sourceRoot: runtimePluginRoot, sourceSubpath: 'plugins/sample-plugin' }],
@@ -254,6 +278,7 @@ assert.throws(
 	() => wpCodeboxPublicCliInput(wpCodeboxFuzzExecutionRequest({
 		taskId: 'missing-plugin-suite-task',
 		input,
+		runtimeContractManifest: manifest,
 		runtimeRequirements: { extra_plugins: [{ slug: 'missing-plugin', source: path.join(runtimeRequirementRoot, 'missing-plugin') }] },
 	})),
 	/WP Codebox runtime requirement extra_plugins\[0\] source does not exist/
@@ -321,28 +346,29 @@ const readinessContract = {
 	unsupportedRequiredCapabilities: [],
 };
 const readinessCapabilities = detectWpCodeboxPublicFuzzCapabilities({
-	runPublicCli: ({ args }) => args.join(' ') === 'fuzz readiness --format=json'
-		? { status: 0, stdout: JSON.stringify(readinessContract) }
-		: { status: 1, stderr: 'unexpected command' },
+	runtimeContractManifest: manifest,
+	runPublicCli: () => {
+		throw new Error('production dispatch must not probe fuzz readiness');
+	},
 });
 assert.equal(readinessCapabilities.readiness.schema, 'wp-codebox/fuzz-runner-readiness/v1');
 assert.equal(readinessCapabilities.commands['run-fuzz-suite'], true);
 assert.equal(readinessCapabilities.commands['run-wordpress-workload'], true);
-assert.deepEqual(readinessCapabilities.capabilities, ['crud', 'database', 'query-observation', 'rest', 'sequence']);
+assert.deepEqual(readinessCapabilities.capabilities, ['artifact-export', 'disposable-runtime', 'rest', 'runtime-isolation']);
 const preflightReadinessPassed = preflightWpCodeboxFuzzCapabilityContract({
 	request: taskRequest,
 	runtimeContractManifest: manifest,
-	runPublicCli: ({ args }) => args.join(' ') === 'fuzz readiness --format=json'
-		? { status: 0, stdout: JSON.stringify(readinessContract) }
-		: { status: 1, stderr: 'unexpected command' },
+	runPublicCli: () => {
+		throw new Error('production dispatch must not probe fuzz readiness');
+	},
 });
 assert.equal(preflightReadinessPassed.ok, true);
 const preflightReadinessOnlyPassed = preflightWpCodeboxFuzzCapabilityContract({
 	request: taskRequest,
 	loadRuntimeContractSource: () => null,
-	runPublicCli: ({ args }) => args.join(' ') === 'fuzz readiness --format=json'
-		? { status: 0, stdout: JSON.stringify(readinessContract) }
-		: { status: 1, stderr: 'unexpected command' },
+	runPublicCli: () => {
+		throw new Error('production dispatch must not probe fuzz readiness');
+	},
 });
 assert.equal(preflightReadinessOnlyPassed.ok, false);
 assert.equal(
@@ -366,14 +392,18 @@ assert.equal(preflightUnsupportedReadiness.diagnostics.some((diagnostic) => diag
 
 const preflightMissingReadinessCommand = preflightWpCodeboxFuzzCapabilityContract({
 	request: taskRequest,
-	runtimeContractManifest: manifest,
-	runPublicCli: ({ args }) => args.join(' ') === 'fuzz readiness --format=json'
-		? { status: 1, stderr: 'unknown command: fuzz readiness' }
-		: { status: 0, stdout: 'legacy help' },
+	runtimeContractManifest: {
+		...manifest,
+		capabilities: undefined,
+		readiness: undefined,
+	},
+	runPublicCli: () => {
+		throw new Error('production dispatch must not probe fuzz readiness');
+	},
 });
 assert.equal(preflightMissingReadinessCommand.ok, false);
-assert.equal(preflightMissingReadinessCommand.missing_contracts.some((contract) => contract.type === 'public_cli_readiness_command'), true);
-assert.equal(preflightMissingReadinessCommand.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_public_cli_readiness_command'), true);
+assert.equal(preflightMissingReadinessCommand.missing_contracts.some((contract) => contract.type === 'explicit_public_descriptor'), true);
+assert.equal(preflightMissingReadinessCommand.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_explicit_public_descriptor'), true);
 
 const rollbackRestPlanRequest = wpCodeboxFuzzSuiteTaskRequest({
 	taskId: 'rollback-rest-plan-task',
@@ -1324,12 +1354,14 @@ process.stdout.write(JSON.stringify({
 	return runWpCodeboxFuzzSuite({
 		taskId: 'public-cli-unsupported-run',
 		input,
-		runtimeContractManifest: manifest,
-		runPublicCli: () => ({ status: 1, stderr: 'unknown command' }),
+		runtimeContractManifest: { ...manifest, capabilities: undefined, readiness: undefined },
+		runPublicCli: () => {
+			throw new Error('production dispatch must not probe or execute without explicit descriptors');
+		},
 	});
 }).then((summary) => {
 	assert.equal(summary.succeeded, false);
-	assert.equal(summary.failures[0].code, 'wp_codebox_fuzz_missing_public_cli_readiness_command');
+	assert.equal(summary.failures[0].code, 'wp_codebox_fuzz_missing_explicit_public_descriptor');
 	assert.equal(summary.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_artifacts_missing'), false);
 
 	console.log('wp-codebox fuzz-run smoke passed');


### PR DESCRIPTION
## Summary
- Require explicit WP Codebox fuzz command descriptors in the runtime contract manifest before production dispatch.
- Remove production fuzz readiness probing and command-name fallback selection.
- Ensure production WordPress fuzz runner calls Codebox execution even when workload JSON embeds precomputed Codebox results.
- Update fuzz contract fixtures and tests to prove missing descriptors fail and dispatch does not call readiness/help probes.

## Tests
- `npx eslint lib/wp-codebox-fuzz-run.js lib/wordpress-fuzz-runner.js scripts/fuzz/fuzz-runner.cjs`
- `node tests/wp-codebox-fuzz-run-smoke.js`
- `node tests/wordpress-fuzz-runner-smoke.js`
- `node tests/wordpress-fuzz-runner-codebox-contract-canary.js`
- `node tests/wordpress-fuzz-destructive-codebox-readiness-gate.test.js`
- `node tests/wordpress-fuzz-runtime-task.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the production fuzz dispatch contract cleanup, updating tests, running verification, and drafting this PR description.