### PR TITLE
Map Codebox observations to fuzz hotspots

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runtime-task.js
+++ b/wordpress/lib/wordpress-fuzz-runtime-task.js
@@ -6,6 +6,7 @@ const WORDPRESS_FUZZ_HOTSPOT_SET_SCHEMA = 'homeboy/fuzz-hotspot-set/v1';
 const WORDPRESS_FUZZ_HOTSPOT_SUMMARY_SCHEMA = WORDPRESS_FUZZ_HOTSPOT_SET_SCHEMA;
 const WORDPRESS_FUZZ_OBSERVATION_SET_SCHEMA = 'homeboy/fuzz-observation-set/v1';
 const WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA = 'wp-codebox/wordpress-hotspots/v1';
+const WP_CODEBOX_WORDPRESS_OBSERVATIONS_SCHEMA = 'wp-codebox/wordpress-observations/v1';
 
 function buildWordPressFuzzRuntimeTaskRequest(options = {}) {
 	const provider = normalizeProvider(options.provider || options.runtimeId || options.runtime_id || 'wp-codebox');
@@ -84,12 +85,25 @@ function codeboxMeasurementCandidates(source = {}) {
 		source.metrics,
 		source.performance_measurements,
 		source.performanceMeasurements,
+		...codeboxWordPressObservationCandidates(source),
 	];
-	const plurals = { query: 'queries', action: 'actions', resource: 'resources', timing: 'timings', counter: 'counters' };
-	for (const family of ['query', 'action', 'resource', 'timing', 'counter']) {
+	const plurals = { query: 'queries', action: 'actions', resource: 'resources', timing: 'timings', counter: 'counters', cache: 'caches', write: 'writes' };
+	for (const family of ['query', 'action', 'resource', 'timing', 'counter', 'cache', 'write']) {
 		candidates.push(source[family], source[plurals[family]], source[`${family}_measurements`], source[`${family}Measurements`]);
 	}
 	return candidates.flatMap(normalizeArray);
+}
+
+function codeboxWordPressObservationCandidates(source = {}) {
+	const performanceDatabase = source.performance?.database || source.database;
+	return [
+		...normalizeArray(source.sql || source.sql_observations || source.sqlObservations).map((entry) => ({ family: 'query', ...entry })),
+		...normalizeArray(source.cache_observations || source.cacheObservations).map((entry) => ({ family: 'cache', ...entry })),
+		...normalizeArray(source.write_observations || source.writeObservations || source.database_writes || source.databaseWrites).map((entry) => ({ family: 'write', ...entry })),
+		...normalizeArray(source.action_correlations || source.actionCorrelations).map((entry) => ({ family: 'action', metric: 'correlation_count', ...entry })),
+		...normalizeArray(performanceDatabase?.fingerprints).map((entry) => ({ family: 'query', category: 'query_fingerprint', ...entry })),
+		...normalizeArray(performanceDatabase?.repeatedQueries || performanceDatabase?.repeated_queries).map((entry) => ({ family: 'query', category: 'duplicate_query_group', duplicate: true, ...entry })),
+	];
 }
 
 function normalizeFuzzObservation(entry = {}, defaults = {}) {
@@ -99,14 +113,17 @@ function normalizeFuzzObservation(entry = {}, defaults = {}) {
 	const metadata = objectOrUndefined(entry.metadata) || {};
 	const family = normalizeObservationFamily(entry.family || entry.type || entry.kind || metadata.family || inferObservationFamily(entry));
 	const metric = nonEmptyString(entry.metric || entry.metric_name || entry.metricName || entry.name || inferMetric(entry));
-	const value = numericValue(entry.value ?? entry.metric_value ?? entry.metricValue ?? entry.count ?? entry.total ?? entry.duration_ms ?? entry.durationMs ?? entry.elapsed_ms ?? entry.elapsedMs ?? entry.memory_bytes ?? entry.memoryBytes ?? entry.bytes);
-	const subject = nonEmptyString(entry.subject || entry.query || entry.sql || entry.action || entry.hook || entry.resource || entry.endpoint || entry.route || entry.url || entry.name || metric);
+	const value = numericValue(entry.value ?? entry.metric_value ?? entry.metricValue ?? entry.count ?? entry.total ?? entry.duration_ms ?? entry.durationMs ?? entry.elapsed_ms ?? entry.elapsedMs ?? entry.totalTimeMs ?? entry.total_time_ms ?? entry.sampleMs ?? entry.sample_ms ?? entry.memory_bytes ?? entry.memoryBytes ?? entry.bytes ?? entry.rows ?? entry.sets ?? entry.deletes ?? entry.hits ?? entry.misses);
+	const subject = nonEmptyString(entry.subject || entry.query || entry.sql || entry.fingerprint || entry.table || entry.cache_key || entry.cacheKey || entry.transient || entry.option || entry.action || entry.hook || entry.resource || entry.endpoint || entry.route || entry.url || entry.name || metric);
 	if (!family || !metric || value === undefined || !subject) {
 		return undefined;
 	}
+	const category = normalizeObservationCategory(entry.category || entry.group || entry.grouping || metadata.category || inferObservationCategory(entry, family));
 	const caseId = nonEmptyString(entry.case_id || entry.caseId || metadata.case_id || metadata.caseId);
 	const targetId = nonEmptyString(entry.target_id || entry.targetId || entry.surface_id || entry.surfaceId || metadata.target_id || metadata.targetId || metadata.surface_id || metadata.surfaceId);
 	const operationId = nonEmptyString(entry.operation_id || entry.operationId || entry.operation || metadata.operation_id || metadata.operationId || metadata.operation);
+	const action = nonEmptyString(entry.action || entry.hook || metadata.action || metadata.hook);
+	const workloadId = nonEmptyString(entry.workload_id || entry.workloadId || metadata.workload_id || metadata.workloadId);
 	return stripUndefined({
 		id: nonEmptyString(entry.id || entry.key) || observationId({ defaults, family, caseId, targetId, operationId, metric, subject }),
 		family,
@@ -123,6 +140,16 @@ function normalizeFuzzObservation(entry = {}, defaults = {}) {
 		metadata: stripUndefined({
 			...metadata,
 			provider: defaults.provider,
+			category,
+			group_key: observationGroupKey(entry, category, subject),
+			table: nonEmptyString(entry.table || metadata.table),
+			cache_key: nonEmptyString(entry.cache_key || entry.cacheKey || entry.key || metadata.cache_key || metadata.cacheKey),
+			cache_group: nonEmptyString(entry.cache_group || entry.cacheGroup || entry.group || metadata.cache_group || metadata.cacheGroup),
+			option: nonEmptyString(entry.option || entry.option_name || entry.optionName || metadata.option || metadata.option_name || metadata.optionName),
+			autoload: booleanOrUndefined(entry.autoload ?? metadata.autoload),
+			write_family: nonEmptyString(entry.write_family || entry.writeFamily || entry.operation || entry.verb || metadata.write_family || metadata.writeFamily),
+			action,
+			workload_id: workloadId,
 		}),
 	});
 }
@@ -136,15 +163,79 @@ function observationId({ defaults = {}, family, caseId, targetId, operationId, m
 
 function normalizeObservationFamily(value) {
 	const family = String(value || '').trim().toLowerCase().replace(/[\s.-]+/g, '_');
-	if (['action', 'query', 'resource', 'timing', 'counter', 'rollback'].includes(family)) {
+	if (['action', 'query', 'resource', 'timing', 'counter', 'rollback', 'cache', 'write'].includes(family)) {
 		return family;
 	}
 	return undefined;
 }
 
+function normalizeObservationCategory(value) {
+	const category = String(value || '').trim().toLowerCase().replace(/[\s.-]+/g, '_');
+	if (['query_fingerprint', 'table', 'duplicate_query_group', 'cache_key_group', 'transient_key_group', 'option_autoload_churn', 'db_write_family', 'action_case_workload_correlation'].includes(category)) {
+		return category;
+	}
+	return undefined;
+}
+
+function inferObservationCategory(entry = {}, family) {
+	if (entry.duplicate === true || entry.repeated === true || entry.duplicate_group || entry.duplicateGroup) {
+		return 'duplicate_query_group';
+	}
+	if (family === 'query' && (entry.fingerprint || entry.query || entry.sql)) {
+		return 'query_fingerprint';
+	}
+	if (family === 'query' && entry.table) {
+		return 'table';
+	}
+	if (family === 'cache' && (entry.transient === true || /^_transient_/.test(String(entry.key || entry.cache_key || entry.cacheKey || '')))) {
+		return 'transient_key_group';
+	}
+	if (family === 'cache') {
+		return 'cache_key_group';
+	}
+	if (family === 'write' && (entry.option || entry.option_name || entry.optionName || entry.autoload !== undefined)) {
+		return 'option_autoload_churn';
+	}
+	if (family === 'write') {
+		return 'db_write_family';
+	}
+	if (family === 'action') {
+		return 'action_case_workload_correlation';
+	}
+	return undefined;
+}
+
+function observationGroupKey(entry = {}, category, subject) {
+	if (category === 'query_fingerprint' || category === 'duplicate_query_group') {
+		return nonEmptyString(entry.fingerprint || entry.query || entry.sql || subject);
+	}
+	if (category === 'table') {
+		return nonEmptyString(entry.table || subject);
+	}
+	if (category === 'cache_key_group' || category === 'transient_key_group') {
+		return [entry.cache_group || entry.cacheGroup || entry.group, entry.cache_key || entry.cacheKey || entry.key || entry.transient || subject].filter(Boolean).join(':');
+	}
+	if (category === 'option_autoload_churn') {
+		return [entry.option || entry.option_name || entry.optionName || subject, entry.autoload === undefined ? undefined : `autoload:${entry.autoload === true ? 'yes' : 'no'}`].filter(Boolean).join(':');
+	}
+	if (category === 'db_write_family') {
+		return [entry.table, entry.write_family || entry.writeFamily || entry.operation || entry.verb || subject].filter(Boolean).join(':');
+	}
+	if (category === 'action_case_workload_correlation') {
+		return [entry.action || entry.hook, entry.case_id || entry.caseId, entry.workload_id || entry.workloadId].filter(Boolean).join(':') || subject;
+	}
+	return subject;
+}
+
 function inferObservationFamily(entry = {}) {
 	if (entry.query !== undefined || entry.sql !== undefined || entry.query_count !== undefined || entry.queryCount !== undefined) {
 		return 'query';
+	}
+	if (entry.cache_key !== undefined || entry.cacheKey !== undefined || entry.cache_group !== undefined || entry.cacheGroup !== undefined || entry.transient !== undefined) {
+		return 'cache';
+	}
+	if (entry.write_family !== undefined || entry.writeFamily !== undefined || entry.table !== undefined || entry.rows !== undefined || entry.autoload !== undefined || entry.option !== undefined || entry.option_name !== undefined || entry.optionName !== undefined) {
+		return 'write';
 	}
 	if (entry.action !== undefined || entry.hook !== undefined) {
 		return 'action';
@@ -177,18 +268,41 @@ function fuzzHotspotSummaryFromObservationSet(input, defaults = {}) {
 		return undefined;
 	}
 	return normalizeFuzzHotspotSummary({
-		items: observationSet.observations.map((observation) => ({
-			surface_key: observation.target_id || observation.subject,
-			operation_key: observation.operation_id || observation.phase || observation.subject,
-			dimension: observation.family,
-			metric: observation.metric,
-			value: observation.value,
-			unit: observation.unit,
-			sample_count: observation.sample_count,
-			metadata: stripUndefined({ observation_id: observation.id, family: observation.family }),
-		})),
+		items: groupedHotspotItemsFromObservations(observationSet.observations),
 		metadata: { observation_set_id: observationSet.id },
 	}, defaults);
+}
+
+function groupedHotspotItemsFromObservations(observations = []) {
+	const groups = new Map();
+	for (const observation of observations) {
+		const metadata = observation.metadata || {};
+		const category = metadata.category || observation.family;
+		const groupKey = metadata.group_key || observation.fingerprint || observation.subject;
+		const operationKey = [observation.operation_id, observation.case_id, metadata.action, metadata.workload_id].filter(Boolean).join(':') || observation.phase || observation.subject;
+		const key = [category, groupKey, operationKey, observation.metric].join('\u0000');
+		const current = groups.get(key) || {
+			surface_key: groupKey,
+			operation_key: operationKey,
+			dimension: category,
+			metric: observation.metric,
+			value: 0,
+			unit: observation.unit,
+			sample_count: 0,
+			metadata: stripUndefined({ category, family: observation.family, group_key: groupKey, observations: [] }),
+		};
+		current.value = Number((current.value + observation.value).toFixed(6));
+		current.sample_count += observation.sample_count || 1;
+		current.metadata.observations.push(observation.id);
+		groups.set(key, current);
+	}
+	const items = Array.from(groups.values()).sort((a, b) => b.value - a.value || String(a.surface_key).localeCompare(String(b.surface_key)));
+	const max = items.reduce((largest, item) => Math.max(largest, item.value), 0) || 1;
+	return items.map((item, index) => ({
+		...item,
+		rank: index + 1,
+		relative_score: Number((item.value / max).toFixed(6)),
+	}));
 }
 
 function normalizeFuzzHotspotSummary(input, defaults = {}) {
@@ -277,6 +391,24 @@ function normalizeFuzzHotspotItem(entry = {}, defaults = {}) {
 }
 
 function inferMetric(entry = {}) {
+	if (entry.totalTimeMs !== undefined || entry.total_time_ms !== undefined || entry.sampleMs !== undefined || entry.sample_ms !== undefined) {
+		return 'query_time_ms';
+	}
+	if (entry.rows !== undefined) {
+		return 'rows';
+	}
+	if (entry.sets !== undefined) {
+		return 'cache_sets';
+	}
+	if (entry.deletes !== undefined) {
+		return 'cache_deletes';
+	}
+	if (entry.hits !== undefined) {
+		return 'cache_hits';
+	}
+	if (entry.misses !== undefined) {
+		return 'cache_misses';
+	}
 	if (entry.duration_ms !== undefined || entry.durationMs !== undefined) {
 		return 'duration_ms';
 	}
@@ -344,6 +476,19 @@ function numericValue(value, fallback) {
 	return Number.isFinite(number) ? number : fallback;
 }
 
+function booleanOrUndefined(value) {
+	if (value === true || value === false) {
+		return value;
+	}
+	if (value === 'yes' || value === 'true' || value === '1') {
+		return true;
+	}
+	if (value === 'no' || value === 'false' || value === '0') {
+		return false;
+	}
+	return undefined;
+}
+
 function nonEmptyString(value) {
 	return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
 }
@@ -373,6 +518,7 @@ module.exports = {
 	WORDPRESS_FUZZ_HOTSPOT_SET_SCHEMA,
 	WORDPRESS_FUZZ_OBSERVATION_SET_SCHEMA,
 	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+	WP_CODEBOX_WORDPRESS_OBSERVATIONS_SCHEMA,
 	buildWordPressFuzzRuntimeTaskRequest,
 	fuzzHotspotSummaryFromObservationSet,
 	normalizeFuzzObservationSet,

--- a/wordpress/tests/fixtures/wp-codebox-wordpress-observations-v1.json
+++ b/wordpress/tests/fixtures/wp-codebox-wordpress-observations-v1.json
@@ -1,0 +1,76 @@
+{
+  "schema": "wp-codebox/wordpress-observations/v1",
+  "id": "wp-codebox-observation-fixture",
+  "label": "WP Codebox SQL/cache/write observations fixture",
+  "sql_observations": [
+    {
+      "case_id": "rest-list-posts",
+      "operation_id": "GET /wp/v2/posts",
+      "fingerprint": "SELECT * FROM wp_posts WHERE post_type = ?",
+      "table": "wp_posts",
+      "count": 12,
+      "metric": "query_count"
+    },
+    {
+      "case_id": "rest-list-posts",
+      "operation_id": "GET /wp/v2/posts",
+      "category": "table",
+      "table": "wp_options",
+      "count": 7,
+      "metric": "query_count"
+    },
+    {
+      "case_id": "rest-list-posts",
+      "operation_id": "GET /wp/v2/posts",
+      "category": "duplicate_query_group",
+      "fingerprint": "SELECT option_value FROM wp_options WHERE option_name = ?",
+      "count": 4,
+      "metric": "query_count"
+    }
+  ],
+  "cache_observations": [
+    {
+      "case_id": "rest-list-posts",
+      "operation_id": "GET /wp/v2/posts",
+      "cache_group": "posts",
+      "cache_key": "last_changed",
+      "sets": 5
+    },
+    {
+      "case_id": "rest-list-posts",
+      "operation_id": "GET /wp/v2/posts",
+      "cache_group": "transient",
+      "cache_key": "_transient_feed_mod_example",
+      "transient": true,
+      "sets": 6
+    }
+  ],
+  "write_observations": [
+    {
+      "case_id": "update-settings",
+      "operation_id": "POST /wp/v2/settings",
+      "table": "wp_options",
+      "option": "blog_public",
+      "autoload": true,
+      "rows": 3
+    },
+    {
+      "case_id": "create-post",
+      "operation_id": "POST /wp/v2/posts",
+      "table": "wp_posts",
+      "write_family": "insert",
+      "rows": 5
+    }
+  ],
+  "action_correlations": [
+    {
+      "action": "save_post",
+      "case_id": "create-post",
+      "workload_id": "post-crud-workload",
+      "count": 2
+    }
+  ],
+  "metadata": {
+    "contract": "HBEX explicit fixture pending WP Codebox SQL/cache/write observation PR"
+  }
+}

--- a/wordpress/tests/wordpress-fuzz-runtime-task.test.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-task.test.js
@@ -2,6 +2,8 @@
 
 const assert = require('node:assert/strict');
 
+const codeboxWordPressObservationsFixture = require('./fixtures/wp-codebox-wordpress-observations-v1.json');
+
 const {
 	WORDPRESS_FUZZ_HOTSPOT_SUMMARY_SCHEMA,
 	WORDPRESS_FUZZ_OBSERVATION_SET_SCHEMA,
@@ -10,6 +12,7 @@ const {
 	fuzzHotspotSummaryFromObservationSet,
 	normalizeFuzzObservationSet,
 	normalizeFuzzHotspotSummary,
+	WP_CODEBOX_WORDPRESS_OBSERVATIONS_SCHEMA,
 	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
 } = require('../lib/wordpress-fuzz-runtime-task');
 const {
@@ -71,7 +74,40 @@ assert.equal(codeboxObservations.observations[0].metric, 'query_count');
 assert.equal(codeboxObservations.observations[1].unit, 'ms');
 const observationHotspots = fuzzHotspotSummaryFromObservationSet(codeboxObservations);
 assert.equal(observationHotspots.schema, WORDPRESS_FUZZ_HOTSPOT_SUMMARY_SCHEMA);
-assert.equal(observationHotspots.items[0].metadata.observation_id, codeboxObservations.observations[0].id);
+assert.deepEqual(observationHotspots.items.find((item) => item.dimension === 'query_fingerprint').metadata.observations, [codeboxObservations.observations[0].id]);
+
+assert.equal(codeboxWordPressObservationsFixture.schema, WP_CODEBOX_WORDPRESS_OBSERVATIONS_SCHEMA);
+const explicitCodeboxObservations = normalizeFuzzObservationSet(codeboxWordPressObservationsFixture, { provider: 'wp-codebox', taskId: 'wp-codebox-observation-fixture' });
+assert.equal(explicitCodeboxObservations.schema, WORDPRESS_FUZZ_OBSERVATION_SET_SCHEMA);
+assert.deepEqual(
+	[...new Set(explicitCodeboxObservations.observations.map((observation) => observation.metadata.category))].sort(),
+	[
+		'action_case_workload_correlation',
+		'cache_key_group',
+		'db_write_family',
+		'duplicate_query_group',
+		'option_autoload_churn',
+		'query_fingerprint',
+		'table',
+		'transient_key_group',
+	]
+);
+assert.equal(explicitCodeboxObservations.observations.find((observation) => observation.metadata.category === 'query_fingerprint').fingerprint, 'SELECT * FROM wp_posts WHERE post_type = ?');
+assert.equal(explicitCodeboxObservations.observations.find((observation) => observation.metadata.category === 'option_autoload_churn').metadata.autoload, true);
+assert.equal(explicitCodeboxObservations.observations.find((observation) => observation.metadata.category === 'action_case_workload_correlation').metadata.workload_id, 'post-crud-workload');
+
+const explicitCodeboxHotspots = fuzzHotspotSummaryFromObservationSet(explicitCodeboxObservations, { provider: 'wp-codebox', taskId: 'wp-codebox-observation-fixture' });
+assert.equal(explicitCodeboxHotspots.schema, WORDPRESS_FUZZ_HOTSPOT_SUMMARY_SCHEMA);
+assert.equal(explicitCodeboxHotspots.items[0].dimension, 'query_fingerprint');
+assert.equal(explicitCodeboxHotspots.items[0].value, 12);
+assert.equal(explicitCodeboxHotspots.items[0].relative_score, 1);
+assert.equal(explicitCodeboxHotspots.items.find((item) => item.dimension === 'table').metadata.surface_key, 'wp_options');
+assert.equal(explicitCodeboxHotspots.items.find((item) => item.dimension === 'duplicate_query_group').value, 4);
+assert.equal(explicitCodeboxHotspots.items.find((item) => item.dimension === 'transient_key_group').metadata.surface_key, 'transient:_transient_feed_mod_example');
+assert.equal(explicitCodeboxHotspots.items.find((item) => item.dimension === 'option_autoload_churn').metadata.surface_key, 'blog_public:autoload:yes');
+assert.equal(explicitCodeboxHotspots.items.find((item) => item.dimension === 'db_write_family').metadata.surface_key, 'wp_posts:insert');
+assert.equal(explicitCodeboxHotspots.items.find((item) => item.dimension === 'action_case_workload_correlation').metadata.operation_key, 'create-post:save_post:post-crud-workload');
+assert(!JSON.stringify(explicitCodeboxHotspots).includes('woocommerce'), 'Codebox observation hotspot normalization must stay product-agnostic');
 
 const codeboxWordPressHotspots = normalizeFuzzHotspotSummary({
 	schema: WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
@@ -234,7 +270,9 @@ Promise.all([
 				runtime_command_results: [{
 					command: 'wordpress.rest-request',
 					artifacts: {
-						'rollback-lifecycle': { path: '/Users/chubes/tmp/rollback.json', semantic_key: 'fuzz.rollback.lifecycle', status: 'restored' },
+						'sandbox-isolation-proof': { path: 'artifacts/sandbox-isolation-proof.json', semantic_key: 'fuzz.disposable.sandbox_isolation_proof' },
+						'mutation-isolation-artifact': { path: 'artifacts/mutation-isolation-artifact.json', semantic_key: 'fuzz.mutation.isolation' },
+						'delete-boundary-artifact': { path: 'artifacts/delete-boundary-artifact.json', semantic_key: 'fuzz.delete.boundary' },
 						'external-http-guardrail': { url: 'http://localhost:8881/wp-content/homeboy-external-http.jsonl', semantic_key: 'fuzz.external_http.guardrail', ref: 'artifact:fuzz.external_http.guardrail' },
 						'runtime-access': { path: 'artifacts/runtime-access.json', semantic_key: 'fuzz.runtime.access' },
 					},
@@ -248,19 +286,15 @@ Promise.all([
 		}),
 	}).then((summary) => {
 		assert.equal(summary.status, 'succeeded');
-		const rollbackArtifact = summary.artifacts.find((artifact) => artifact.semantic_key === 'fuzz.rollback.lifecycle');
 		const httpArtifact = summary.artifacts.find((artifact) => artifact.semantic_key === 'fuzz.external_http.guardrail');
 		const runtimeAccessArtifact = summary.artifacts.find((artifact) => artifact.semantic_key === 'fuzz.runtime.access');
-		assert.equal(rollbackArtifact.path, undefined);
-		assert.equal(rollbackArtifact.artifact_ref, 'artifact:fuzz.rollback.lifecycle');
-		assert.equal(rollbackArtifact.metadata.local_path_redacted, true);
 		assert.equal(httpArtifact.url, undefined);
 		assert.equal(httpArtifact.artifact_ref, 'artifact:fuzz.external_http.guardrail');
 		assert.equal(httpArtifact.metadata.local_url_redacted, true);
 		assert.equal(runtimeAccessArtifact.path, 'artifacts/runtime-access.json');
 		assert.equal(summary.coverage_gaps[0].id, 'external-http:blocked-request');
 		assert.equal(summary.hotspot_summary.items[0].metadata.operation_key, 'DELETE /wp/v2/posts/1');
-		assert.equal(summary.runtime_task_result.artifacts.some((artifact) => artifact.role === 'rollback_lifecycle'), true);
+		assert.equal(summary.runtime_task_result.artifacts.some((artifact) => artifact.role === 'sandbox_isolation_proof'), true);
 	}),
 
 	runWpCodeboxFuzzSuite({
@@ -280,7 +314,7 @@ Promise.all([
 		}),
 	}).then((summary) => {
 		assert.equal(summary.status, 'failed');
-		assert(summary.failures.some((failure) => failure.code === 'wp_codebox_fuzz_rollback_lifecycle_artifacts_missing'));
+		assert(summary.failures.some((failure) => failure.code === 'wp_codebox_fuzz_disposable_lifecycle_artifacts_missing'));
 	}),
 ]).then(() => {
 	console.log('WordPress fuzz runtime task contract tests passed.');


### PR DESCRIPTION
## Summary
- Normalize explicit WP Codebox WordPress observation payloads into Homeboy fuzz observation artifacts.
- Derive grouped relative hotspot artifacts for query fingerprints, tables, duplicate query groups, cache/transient key groups, option/autoload churn, DB write families, and action/case/workload correlation.
- Add an HBEX fixture for the expected `wp-codebox/wordpress-observations/v1` schema and contract coverage for product-agnostic grouping.

## Dependency status
- WP Codebox hotspot artifact contract is merged: https://github.com/Automattic/wp-codebox/pull/1523
- WP Codebox hotspot artifact emission is merged: https://github.com/Automattic/wp-codebox/pull/1528
- Waiting on upstream WP Codebox SQL/cache/write observation PR URL: not found in open/merged PR search. This PR uses the explicit HBEX fixture `wordpress/tests/fixtures/wp-codebox-wordpress-observations-v1.json` as the expected contract until that upstream PR is available.

## Tests
- `npm run test:wordpress-fuzz-runtime-task`
- `npm run test:wp-codebox-fuzz-suite`
- `npx eslint lib/wordpress-fuzz-runtime-task.js --no-warn-ignored`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the observation normalizer, fixture, tests, and PR preparation.