### PR TITLE
Stream OpenCode agent task telemetry

### DIFF
--- a/agent-runtimes/lib/cli-agent-task-executor-bin.js
+++ b/agent-runtimes/lib/cli-agent-task-executor-bin.js
@@ -19,7 +19,7 @@ const fs = require('node:fs');
  *
  * @param {{execute: Function, outcome: Function, providerContract: Function}} executor Provider executor surface.
  */
-function runCliAgentTaskExecutorBin({ execute, outcome, providerContract }) {
+async function runCliAgentTaskExecutorBin({ execute, outcome, providerContract }) {
 	if (process.argv.includes('--provider-contract')) {
 		process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
 		process.exit(0);
@@ -42,7 +42,7 @@ function runCliAgentTaskExecutorBin({ execute, outcome, providerContract }) {
 		}
 	}
 
-	process.stdout.write(`${JSON.stringify(execute(request), null, 2)}\n`);
+	process.stdout.write(`${JSON.stringify(await execute(request), null, 2)}\n`);
 	process.exit(0);
 }
 

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -11,9 +11,10 @@ const {
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
 	createCliAgentTaskExecutor,
+	timeoutSecondsFromLimits,
 } = require('../../lib/cli-agent-task-executor');
 
-const { spawnSync } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -154,6 +155,11 @@ const OPENCODE_PROVIDER_DEFAULTS = {
 	},
 };
 
+const OPENCODE_SESSION_METADATA_ABSENT = {
+	status: 'not_discovered',
+	reason: 'OpenCode did not expose stable session or transcript metadata through the executor process contract.',
+};
+
 const OPENCODE_PROVIDER_PREFLIGHT = {
 	codex: {
 		label: 'Codex',
@@ -280,7 +286,26 @@ function opencodeSuccessOutcome(context) {
 		status: 'succeeded',
 		summary: 'OpenCode completed successfully.',
 		diagnostics: [{ classification: 'provider', message: 'OpenCode CLI exited with status 0.' }],
-		metadata: { exit_code: 0 },
+		metadata: {
+			exit_code: 0,
+			opencode_session: sessionMetadata(context),
+		},
+		...collectOpenCodeArtifacts(context),
+	};
+}
+
+function opencodeFailureOutcome(context) {
+	return {
+		status: 'failed',
+		failure_classification: 'execution_failed',
+		failure_code: 'agent_task.opencode_failed',
+		summary: 'OpenCode execution failed.',
+		diagnostics: [{ classification: 'execution_failed', message: `OpenCode CLI exited with status ${context.spawnResult.status}.` }],
+		metadata: {
+			exit_code: context.spawnResult.status,
+			...(context.spawnResult.signal ? { signal: context.spawnResult.signal } : {}),
+			opencode_session: sessionMetadata(context),
+		},
 		...collectOpenCodeArtifacts(context),
 	};
 }
@@ -334,6 +359,7 @@ function collectOpenCodeArtifacts(context = {}) {
 			patch: patch !== '',
 			transcript: transcript !== '',
 		},
+		opencode_session: sessionMetadata(context),
 	}, null, 2);
 
 	for (const requirement of requirements) {
@@ -347,6 +373,51 @@ function collectOpenCodeArtifacts(context = {}) {
 	}
 
 	return { artifacts, evidence_refs };
+}
+
+function collectOpenCodeRuntimeLogs(context = {}) {
+	const request = context.request || {};
+	const config = context.config || {};
+	const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
+	if (!artifactDir) {
+		return {};
+	}
+
+	const artifacts = [];
+	const evidence_refs = [];
+	for (const stream of ['stdout', 'stderr']) {
+		const filePath = context.runtimeLogPaths?.[stream];
+		if (!filePath || !fs.existsSync(filePath)) {
+			continue;
+		}
+		const bytes = fs.statSync(filePath).size;
+		if (bytes === 0) {
+			continue;
+		}
+		const artifact = {
+			id: `opencode-runtime-${stream}`,
+			name: `opencode-runtime-${stream}`,
+			kind: 'opencode-runtime-log',
+			stream,
+			path: filePath,
+			bytes,
+		};
+		artifacts.push(artifact);
+		evidence_refs.push({ kind: artifact.kind, label: `OpenCode ${stream}`, path: filePath });
+	}
+	return { artifacts, evidence_refs };
+}
+
+function mergeEvidence(primary = {}, secondary = {}) {
+	return {
+		artifacts: [...arrayValue(primary.artifacts), ...arrayValue(secondary.artifacts)],
+		evidence_refs: [...arrayValue(primary.evidence_refs), ...arrayValue(secondary.evidence_refs)],
+	};
+}
+
+function sessionMetadata(context = {}) {
+	const explicit = context.spawnResult?.opencode_session || context.spawnResult?.opencodeSession;
+	return explicit && typeof explicit === 'object' && !Array.isArray(explicit) ? explicit : OPENCODE_SESSION_METADATA_ABSENT;
 }
 
 function gitDiff(cwd) {
@@ -407,6 +478,173 @@ function resolveCommandSpec(config = {}, options = {}) {
 	return { command: configuredCommand.trim(), args: configuredArgs };
 }
 
+async function executeOpenCodeAgentTask(request = {}, options = {}) {
+	const validationError = validateOpenCodeRequest(request);
+	if (validationError) {
+		return validationFailure(request, validationError);
+	}
+
+	const config = request.executor.config || {};
+	const commandSpec = resolveCommandSpec(config, options);
+	if (commandSpec.error) {
+		return outcome(request, {
+			status: 'provider_error',
+			failure_classification: commandSpec.classification || 'provider',
+			failure_code: commandSpec.code || 'agent_task.invalid_opencode_command',
+			summary: commandSpec.summary || 'OpenCode command configuration is invalid.',
+			diagnostics: [{ classification: 'provider_setup', message: commandSpec.error }],
+		});
+	}
+
+	const cwd = config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
+	const args = [
+		...commandSpec.args,
+		'run',
+		...(config.model ? ['--model', config.model] : []),
+		...(config.agent ? ['--agent', config.agent] : []),
+		...(config.variant ? ['--variant', config.variant] : []),
+		...(config.title ? ['--title', config.title] : []),
+		request.instructions,
+	];
+	const spawnExtra = { env: opencodeSpawnEnv(request, options) };
+	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
+	const runtimeLogPaths = openCodeRuntimeLogPaths(request, config);
+	const spawnResult = await spawnOpenCodeStreaming(commandSpec.command, args, {
+		cwd,
+		env: spawnExtra.env,
+		timeoutMs: timeoutSeconds > 0 ? timeoutSeconds * 1000 : 0,
+		runtimeLogPaths,
+	});
+	const context = { request, config, commandSpec, cwd, spawnResult, spawnExtra, runtimeLogPaths };
+	const runtimeLogs = collectOpenCodeRuntimeLogs(context);
+
+	if (spawnResult.error?.code === 'ENOENT') {
+		return outcome(request, {
+			status: 'provider_error',
+			failure_classification: 'provider',
+			failure_code: 'agent_task.opencode_command_not_found',
+			summary: 'OpenCode command was not found.',
+			diagnostics: [{ classification: 'provider_setup', message: 'Install opencode or configure executor.config.command.' }],
+			...runtimeLogs,
+		});
+	}
+
+	if (spawnResult.error) {
+		const timedOut = spawnResult.error.code === 'ETIMEDOUT';
+		return outcome(request, {
+			status: timedOut ? 'timeout' : 'provider_error',
+			failure_classification: timedOut ? 'timeout' : 'provider',
+			failure_code: timedOut ? 'agent_task.opencode_timeout' : 'agent_task.opencode_spawn_failed',
+			summary: timedOut ? 'OpenCode execution timed out.' : 'OpenCode process failed to start or complete.',
+			diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: spawnResult.error.message }],
+			metadata: { opencode_session: sessionMetadata(context) },
+			...runtimeLogs,
+		});
+	}
+
+	const terminal = spawnResult.status === 0 ? opencodeSuccessOutcome(context) : opencodeFailureOutcome(context);
+	return outcome(request, { ...terminal, ...mergeEvidence(terminal, runtimeLogs) });
+}
+
+function validateOpenCodeRequest(request) {
+	if (!request || typeof request !== 'object' || Array.isArray(request)) {
+		return 'Request must be a JSON object.';
+	}
+	if (request.schema !== 'homeboy/agent-task-request/v1') {
+		return 'Request schema must be homeboy/agent-task-request/v1.';
+	}
+	if (!request.task_id || typeof request.task_id !== 'string') {
+		return 'Request task_id is required.';
+	}
+	if (request.executor?.backend !== 'opencode') {
+		return 'Request executor.backend must be opencode.';
+	}
+	if (!request.executor.config || typeof request.executor.config !== 'object' || Array.isArray(request.executor.config)) {
+		return 'Request executor.config is required.';
+	}
+	if (!request.instructions || typeof request.instructions !== 'string') {
+		return 'Request instructions are required.';
+	}
+	return null;
+}
+
+function openCodeRuntimeLogPaths(request = {}, config = {}) {
+	const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
+	if (!artifactDir) {
+		return {};
+	}
+	return {
+		stdout: path.join(artifactDir, `${safeFileSegment(request.task_id)}-opencode-runtime-stdout.log`),
+		stderr: path.join(artifactDir, `${safeFileSegment(request.task_id)}-opencode-runtime-stderr.log`),
+	};
+}
+
+function spawnOpenCodeStreaming(command, args, options = {}) {
+	return new Promise((resolve) => {
+		const stdoutChunks = [];
+		const stderrChunks = [];
+		let settled = false;
+		let timedOut = false;
+		let child;
+
+		for (const filePath of Object.values(options.runtimeLogPaths || {})) {
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, '');
+		}
+
+		const append = (stream, chunk) => {
+			const content = redactKnownSecrets(chunk.toString('utf8'), options.env);
+			if (stream === 'stdout') {
+				stdoutChunks.push(content);
+			} else {
+				stderrChunks.push(content);
+			}
+			const filePath = options.runtimeLogPaths?.[stream];
+			if (filePath) {
+				fs.appendFileSync(filePath, content);
+			}
+		};
+
+		const finish = (result) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			resolve({
+				stdout: stdoutChunks.join(''),
+				stderr: stderrChunks.join(''),
+				...result,
+			});
+		};
+
+		try {
+			child = spawn(command, args, { cwd: options.cwd, env: options.env, stdio: ['ignore', 'pipe', 'pipe'] });
+		} catch (error) {
+			finish({ error });
+			return;
+		}
+
+		const timer = options.timeoutMs > 0 ? setTimeout(() => {
+			timedOut = true;
+			child.kill('SIGTERM');
+		}, options.timeoutMs) : null;
+
+		child.stdout.on('data', (chunk) => append('stdout', chunk));
+		child.stderr.on('data', (chunk) => append('stderr', chunk));
+		child.on('error', (error) => finish({ error }));
+		child.on('close', (status, signal) => {
+			if (timer) {
+				clearTimeout(timer);
+			}
+			finish({
+				status,
+				signal,
+				...(timedOut ? { error: Object.assign(new Error('OpenCode execution timed out.'), { code: 'ETIMEDOUT' }) } : {}),
+			});
+		});
+	});
+}
+
 function parseEnvCommandArgs() {
 	if (!process.env.HOMEBOY_OPENCODE_COMMAND_ARGS) {
 		return [];
@@ -419,7 +657,7 @@ function parseEnvCommandArgs() {
 	}
 }
 
-const { execute: executeOpenCodeAgentTask, outcome, validationFailure } = createCliAgentTaskExecutor({
+const { outcome, validationFailure } = createCliAgentTaskExecutor({
 	backend: 'opencode',
 	providerId: OPENCODE_PROVIDER_ID,
 	providerLabel: 'OpenCode agent',
@@ -428,6 +666,7 @@ const { execute: executeOpenCodeAgentTask, outcome, validationFailure } = create
 	finalizeOutcome: withDeclaredArtifactDiagnostics,
 	resolveCommandSpec,
 	successOutcome: opencodeSuccessOutcome,
+	failureOutcome: opencodeFailureOutcome,
 	buildArgs: (request, config, commandSpec) => [
 		...commandSpec.args,
 		'run',

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -33,6 +33,7 @@ function secretEnvRequirementForProvider(contract, provider) {
 	));
 }
 
+(async () => {
 const provider = providerContract();
 assert.equal(provider.id, 'opencode.agent-task-executor');
 assert.equal(provider.backend, 'opencode');
@@ -131,11 +132,11 @@ process.exit(0);
 		AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-must-not-leak',
 		UNDECLARED_SECRET: 'must-not-reach-opencode',
 	};
-	assert.deepEqual(JSON.parse(runResult.stdout), executeOpenCodeAgentTask(request, { env: fixtureEnv }));
+	assert.deepEqual(JSON.parse(runResult.stdout), await executeOpenCodeAgentTask(request, { env: fixtureEnv }));
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('refresh-token-must-not-leak'), false);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('access-token-must-not-leak'), false);
 
-	const missingArtifactResult = executeOpenCodeAgentTask({
+	const missingArtifactResult = await executeOpenCodeAgentTask({
 		...request,
 		task_id: 'opencode-missing-artifact',
 		expected_artifacts: ['opencode-report'],
@@ -170,7 +171,7 @@ fs.writeFileSync('README.md', 'after\\n');
 process.stdout.write('transcript output ' + process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN);
 process.exit(0);
 `);
-	const artifactResult = executeOpenCodeAgentTask({
+	const artifactResult = await executeOpenCodeAgentTask({
 		...request,
 		task_id: 'opencode-artifacts',
 		workspace_path: workspace,
@@ -185,15 +186,27 @@ process.exit(0);
 		},
 	}, { env: fixtureEnv });
 	assert.equal(artifactResult.status, 'succeeded');
-	assert.deepEqual(artifactResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'patch', 'transcript']);
+	assert.deepEqual(artifactResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stdout', 'patch', 'transcript']);
 	assert.match(fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'patch').path, 'utf8'), /after/);
 	const transcript = fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'transcript').path, 'utf8');
 	assert.match(transcript, /transcript output/);
 	assert.equal(transcript.includes('refresh-token-must-not-leak'), false);
 	assert.match(transcript, /\[redacted\]/);
+	assert.equal(artifactResult.artifacts.some((artifact) => artifact.name === 'opencode-runtime-stdout'), true);
+	const runtimeStdout = fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'opencode-runtime-stdout').path, 'utf8');
+	assert.match(runtimeStdout, /transcript output/);
+	assert.equal(runtimeStdout.includes('refresh-token-must-not-leak'), false);
+	assert.match(runtimeStdout, /\[redacted\]/);
+	assert.equal(artifactResult.metadata.opencode_session.status, 'not_discovered');
+	const agentResult = JSON.parse(fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
+	assert.equal(agentResult.opencode_session.status, 'not_discovered');
 	assert.equal(artifactResult.metadata.missing_declared_artifacts, undefined);
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }
 
 process.stdout.write('OpenCode agent task executor boundary passed\n');
+})().catch((error) => {
+	process.stderr.write(`${error.stack || error.message}\n`);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add an OpenCode-specific streaming child process path for agent-task execution
- capture redacted stdout/stderr incrementally into runtime log artifacts
- keep declared terminal artifacts for patch, transcript, and agent_result, including session metadata absence evidence
- allow the shared CLI executor bin to await async provider executors

Fixes #2033

## Tests
- `npm run test:opencode-agent-task-executor`
- `npm run test:codex-agent-task-executor-boundary`
- `npm run test:claude-code-agent-task-executor-boundary`
- `npm run test:pi-agent-task-executor-boundary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the streaming OpenCode telemetry slice, updating focused boundary tests, and preparing this PR.