### PR TITLE
Adopt Homeboy fanout and publication contracts

### DIFF
--- a/runtime-agent-ci/lib/fanout-reconcile-runner.js
+++ b/runtime-agent-ci/lib/fanout-reconcile-runner.js
@@ -10,6 +10,10 @@ const { normalizeHostRecordStatus, normalizeHostRunStatus } = require('./runtime
 
 const PLAN_SCHEMA = 'homeboy/fanout-reconcile-plan/v1';
 const RUN_SCHEMA = 'homeboy/fanout-reconcile-run/v1';
+const AGENT_TASK_FANOUT_PLAN_SCHEMA = 'homeboy/agent-task-fanout-plan/v1';
+const AGENT_TASK_FANOUT_AGGREGATE_SCHEMA = 'homeboy/agent-task-fanout-aggregate/v1';
+const AGENT_TASK_FANOUT_CANONICAL_PATH = 'homeboy-durable-scheduler-to-runtime-executor';
+const AGENT_TASK_FANOUT_RUNTIME_BOUNDARY = 'manifest_declared_runtime_executor';
 const FANOUT_RECONCILE_RECORD_STATUSES = ['completed', 'failed', 'missing_record'];
 const FANOUT_RECONCILE_RUN_STATUSES = ['incomplete', 'completed', 'failed'];
 const FANOUT_RECONCILE_SUCCESS_STATUSES = ['completed', 'succeeded', 'no_op', 'success', 'passed', 'accepted'];
@@ -74,7 +78,7 @@ function createFanoutReconcilePlan(input) {
 }
 
 async function executeFanoutReconcileRun(input) {
-  const plan = input.plan || createFanoutReconcilePlan(input);
+  const plan = normalizeFanoutReconcilePlan(input.plan || createFanoutReconcilePlan(input));
   const executeTaskRequest = requiredFunction(input.execute_task_request, 'execute_task_request');
   const classifyOutcome = typeof input.classify_outcome === 'function' ? input.classify_outcome : (record) => record.outcome;
   const reconcile = typeof input.reconcile === 'function' ? input.reconcile : () => ({});
@@ -182,6 +186,88 @@ async function executeFanoutReconcileRun(input) {
   writeRun(run);
 
   return run;
+}
+
+function normalizeFanoutReconcilePlan(plan) {
+  if (plan?.schema === AGENT_TASK_FANOUT_PLAN_SCHEMA || plan?.inputs?.schema === AGENT_TASK_FANOUT_PLAN_SCHEMA) {
+    return projectHomeboyAgentTaskFanoutPlan(plan);
+  }
+  return plan;
+}
+
+function projectHomeboyAgentTaskFanoutPlan(plan) {
+  const inputs = plan.inputs && typeof plan.inputs === 'object' ? plan.inputs : {};
+  const fanoutId = text(plan.fanout_id || inputs.fanout_id || plan.id);
+  const plane = text(plan.plane || inputs.plane || 'isolated_tasks') || 'isolated_tasks';
+  const groupKey = text(plan.group_key || inputs.group_key || fanoutId);
+  const tasks = Array.isArray(plan.tasks)
+    ? plan.tasks
+    : Array.isArray(plan.steps)
+      ? plan.steps.map((step) => step?.inputs?.request || step?.request || step).filter(Boolean)
+      : [];
+  if (!fanoutId) {
+    throw new Error('Homeboy agent-task fanout plan requires fanout_id');
+  }
+  if (tasks.length === 0) {
+    throw new Error('Homeboy agent-task fanout plan requires at least one task');
+  }
+  const taskRequests = tasks.map((task, index) => {
+    const taskId = text(task.task_id || task.id || task.name);
+    if (!taskId) {
+      throw new Error(`Homeboy agent-task fanout task at index ${index} requires task_id`);
+    }
+    return {
+      ...task,
+      task_id: taskId,
+      id: task.id || taskId,
+      group_key: text(task.group_key || groupKey || fanoutId),
+      orchestrator: {
+        ...(task.orchestrator || {}),
+        fanout_id: fanoutId,
+        plane,
+        group_index: index,
+      },
+    };
+  });
+
+  return {
+    schema: PLAN_SCHEMA,
+    plan_schema: AGENT_TASK_FANOUT_PLAN_SCHEMA,
+    orchestrator: {
+      ...(plan.orchestrator || {}),
+      fanout_id: fanoutId,
+      plane,
+      group_key: groupKey,
+      canonical_path: text(inputs.canonical_path) || AGENT_TASK_FANOUT_CANONICAL_PATH,
+      runtime_boundary: inputs.runtime_boundary || {
+        boundary: AGENT_TASK_FANOUT_RUNTIME_BOUNDARY,
+        durable_scheduler: 'homeboy',
+        executor: 'declared_by_task_executor',
+        runtime: 'declared_by_task_runtime',
+      },
+    },
+    summary: {
+      fanout_id: fanoutId,
+      plane,
+      task_count: taskRequests.length,
+      group_count: taskRequests.length,
+      item_count: taskRequests.length,
+      source_schema: AGENT_TASK_FANOUT_PLAN_SCHEMA,
+    },
+    groups: taskRequests.map((taskRequest, index) => ({
+      key: taskRequest.group_key,
+      index,
+      item_count: 1,
+    })),
+    task_requests: taskRequests,
+    reconciliation: {
+      schema: AGENT_TASK_FANOUT_AGGREGATE_SCHEMA,
+      fanout_id: fanoutId,
+      plane,
+      status: 'planned',
+    },
+    homeboy_fanout_plan: plan,
+  };
 }
 
 function requiredFunction(value, name) {
@@ -306,6 +392,10 @@ module.exports = {
   PLAN_SCHEMA,
   RUN_SCHEMA,
   FANOUT_RECONCILE_PLAN_SCHEMA: PLAN_SCHEMA,
+  AGENT_TASK_FANOUT_PLAN_SCHEMA,
+  AGENT_TASK_FANOUT_AGGREGATE_SCHEMA,
+  AGENT_TASK_FANOUT_CANONICAL_PATH,
+  AGENT_TASK_FANOUT_RUNTIME_BOUNDARY,
   FANOUT_RECONCILE_RECORD_STATUSES,
   FANOUT_RECONCILE_SUCCESS_STATUSES,
   FANOUT_RECONCILE_RUN_SCHEMA: RUN_SCHEMA,
@@ -314,5 +404,7 @@ module.exports = {
   createFanoutReconcilePlan,
   executeFanoutReconcileRun,
   groupFanoutItems,
+  normalizeFanoutReconcilePlan,
+  projectHomeboyAgentTaskFanoutPlan,
   normalizeConcurrency,
 };

--- a/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
+++ b/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
@@ -780,6 +780,104 @@ function publishRevision(workspace, publication, delta, hooks = {}) {
   };
 }
 
+function finalizationGateArgs(lifecycle = {}) {
+  return [
+    lifecycle.verification?.gate_result,
+    lifecycle.drift?.gate_result,
+    lifecycle.sideEffectPolicy?.gate_result,
+    lifecycle.writablePaths?.gate_result,
+    lifecycle.workspaceContract?.gate_result,
+    ...(Array.isArray(lifecycle.gate_results) ? lifecycle.gate_results : []),
+  ].filter((gate) => gate && gate.enabled !== false && gate.status === 'passed').map((gate) => {
+    const name = String(gate.id || gate.name || gate.label || 'workspace_lifecycle').replace(/[^A-Za-z0-9_.-]+/g, '_');
+    const detail = String(gate.message || gate.reason || '').replace(/\n/g, ' ').trim();
+    return detail ? `${name}=passed:${detail}` : `${name}=passed`;
+  });
+}
+
+function parseHomeboyJsonOutput(stdout) {
+  const text = String(stdout || '').trim();
+  if (!text) {
+    return null;
+  }
+  const parsed = JSON.parse(text);
+  return plainObject(parsed?.data) ? parsed.data : parsed;
+}
+
+function finalizeWorkspaceReview(config, workspace, publication, delta, lifecycle = {}, hooks = {}) {
+  const gateArgs = finalizationGateArgs({
+    ...lifecycle,
+    gate_results: [
+      ...(Array.isArray(lifecycle.gate_results) ? lifecycle.gate_results : []),
+      ...(Array.isArray(config.finalization_gate_results) ? config.finalization_gate_results : []),
+    ],
+  });
+  if (gateArgs.length === 0) {
+    throw new Error('Homeboy agent-task finalize-pr requires at least one passed deterministic gate_result; no eligible lifecycle gates were available');
+  }
+
+  const adapter = lifecycleHooks(hooks);
+  const homeboyBin = config.homeboy_bin || config.homeboyBin || adapter.env.HOMEBOY_BIN || 'homeboy';
+  const metadata = lifecycle.scenario?.metadata || {};
+  const runId = publication.values.run_id || metadata.run_id || metadata.job_id || 'run';
+  const verificationCommands = commandList(config, 'verification_commands').map((entry) => entry.command);
+  const args = [
+    'agent-task', 'finalize-pr',
+    '--run-id', runId,
+    '--path', workspace,
+    '--base', publication.base,
+    '--head', publication.branch,
+    '--title', publication.templates.title,
+    '--commit-message', publication.templates.commitMessage,
+    '--attempt-summary', lifecycle.gateSummary?.reason || 'green deterministic workspace lifecycle gates completed',
+    '--ai-tool', config.ai_tool || config.aiTool || 'OpenCode',
+    '--ai-model', config.ai_model || config.aiModel || 'not recorded',
+    '--ci-expected', config.ci_expected || config.ciExpected || 'Homeboy CI after push',
+    '--ai-used-for', config.ai_used_for || config.aiUsedFor || 'Drafted implementation and tests; Chris reviews and owns the change.',
+  ];
+  for (const gateArg of gateArgs) {
+    args.push('--gate-result', gateArg);
+  }
+  for (const file of delta.staged) {
+    args.push('--changed-file', file);
+  }
+  for (const command of verificationCommands) {
+    args.push('--targeted-check-run', command);
+  }
+  for (const ref of config.source_refs || config.sourceRefs || []) {
+    args.push('--source-ref', ref);
+  }
+  for (const ref of config.artifact_refs || config.artifactRefs || []) {
+    args.push('--artifact-ref', ref);
+  }
+  for (const branch of config.protected_branches || config.protectedBranches || []) {
+    args.push('--protected-branch', branch);
+  }
+
+  const result = adapter.run(homeboyBin, args, { cwd: workspace });
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || 'homeboy agent-task finalize-pr failed').trim());
+  }
+  const report = parseHomeboyJsonOutput(result.stdout) || {};
+  const publicationProof = plainObject(report.publication_proof) ? report.publication_proof : {};
+  const target = plainObject(publicationProof.target) ? publicationProof.target : {};
+  const url = report.pr_url || publicationProof.adapter_ref || target.url || '';
+  const action = report.pr_action || publicationProof.adapter_action || '';
+  return {
+    report,
+    changed: Array.isArray(report.changed_files) ? report.changed_files.length > 0 : delta.changed,
+    head: report.head || publication.branch,
+    base: report.base || publication.base,
+    url,
+    action,
+    pr_number: report.pr_number ?? null,
+    pr_state: url ? 'OPEN' : '',
+    files: Array.isArray(report.changed_files) ? report.changed_files : delta.staged,
+    publication_intent: report.publication_intent || null,
+    publication_proof: report.publication_proof || null,
+  };
+}
+
 function updateReviewSummary(workspace, review, templates, hooks = {}) {
   if (!review?.number) {
     return { updated: false };
@@ -830,7 +928,7 @@ function ensurePullRequest(workspace, branch, templates, hooks = {}) {
   return ensureReviewRequest(workspace, branch, templates, hooks);
 }
 
-function publishWorkspace(config, results, scenario, workspace, files, hooks = {}) {
+function publishWorkspace(config, results, scenario, workspace, files, hooks = {}, lifecycle = {}) {
   if (files.length === 0) {
     return { opened: false, changed: false };
   }
@@ -845,18 +943,17 @@ function publishWorkspace(config, results, scenario, workspace, files, hooks = {
     return { opened: false, changed: false, head: publication.branch, files: [], publication_evidence_ref: delta.publication_evidence_ref };
   }
 
-  const revision = publishRevision(workspace, publication, delta, hooks);
-  const pullRequest = ensureReviewRequest(workspace, publication.branch, publication.templates, hooks);
-  const url = pullRequest.url;
+  const finalization = finalizeWorkspaceReview(config, workspace, publication, delta, { ...lifecycle, scenario }, hooks);
+  const url = finalization.url;
   const evidenceRef = publicationEvidenceRef({
     repo: publication.repo,
-    head: pullRequest.head || revision.head,
+    head: finalization.head,
     base: publication.base,
     url,
-    action: pullRequest.action,
-    number: pullRequest.number,
-    state: pullRequest.state,
-    files: revision.files,
+    action: finalization.action,
+    number: finalization.pr_number,
+    state: finalization.pr_state,
+    files: finalization.files,
   });
 
 
@@ -867,17 +964,17 @@ function publishWorkspace(config, results, scenario, workspace, files, hooks = {
     source: 'host_runner_lifecycle',
     success: Boolean(url),
     repo: publication.repo,
-    head: pullRequest.head || revision.head,
+    head: finalization.head,
     base: publication.base,
     url,
-    action: pullRequest.action,
-    pr_number: pullRequest.number,
-    pr_state: pullRequest.state,
-    closed_pr_number: pullRequest.closed_pr_number,
-    closed_pr_url: pullRequest.closed_pr_url,
-    reopen_error: pullRequest.reopen_error,
-    files: revision.files,
+    action: finalization.action,
+    pr_number: finalization.pr_number,
+    pr_state: finalization.pr_state,
+    files: finalization.files,
     publication_evidence_ref: evidenceRef,
+    finalization: finalization.report,
+    publication_intent: finalization.publication_intent,
+    publication_proof: finalization.publication_proof,
   };
 }
 
@@ -995,7 +1092,15 @@ function runDeterministicWorkspaceLifecycle(config, results, scenario, workspace
     }
   } else {
     try {
-      publication = publishWorkspace(config, results, scenario, workspace, files, hooks);
+      publication = publishWorkspace(config, results, scenario, workspace, files, hooks, {
+        verification,
+        drift,
+        sideEffectPolicy,
+        writablePaths,
+        workspaceContract,
+        gateSummary,
+        scenario,
+      });
       if (capture.changed && !publication.opened && !publication.dry_run) {
         success = false;
         error = 'Agent wrote files without opening a pull request';
@@ -1030,6 +1135,7 @@ module.exports = {
   evaluateWorkspaceContract,
   ensurePullRequest,
   ensureReviewRequest,
+  finalizeWorkspaceReview,
   lifecycleHooks,
   preparePublication,
   publicationBase,

--- a/runtime-agent-ci/tests/generic-fanout-reconcile-workflow.test.js
+++ b/runtime-agent-ci/tests/generic-fanout-reconcile-workflow.test.js
@@ -9,7 +9,12 @@ const {
   createGenericFanoutReconcilePlan,
   createGenericFanoutReconcileResult,
 } = require('../lib/generic-fanout-reconcile-workflow');
-const { executeFanoutReconcileRun } = require('../lib/fanout-reconcile-runner');
+const {
+  AGENT_TASK_FANOUT_CANONICAL_PATH,
+  AGENT_TASK_FANOUT_PLAN_SCHEMA,
+  executeFanoutReconcileRun,
+  projectHomeboyAgentTaskFanoutPlan,
+} = require('../lib/fanout-reconcile-runner');
 
 async function observedConcurrency(options = {}) {
   const plan = createGenericFanoutReconcilePlan({
@@ -92,6 +97,39 @@ async function observedConcurrency(options = {}) {
   assert.equal(providerStatusRun.status, 'completed');
   assert.deepEqual(providerStatusRun.records.map((record) => record.status), ['completed', 'completed']);
   assert.deepEqual(providerStatusRun.records.map((record) => record.outcome.status), ['succeeded', 'no_op']);
+
+  const homeboyFanoutPlan = {
+    id: 'fanout/site-workflow',
+    inputs: {
+      schema: AGENT_TASK_FANOUT_PLAN_SCHEMA,
+      fanout_id: 'fanout/site-workflow',
+      plane: 'workflow',
+      group_key: 'site-workflow',
+      canonical_path: AGENT_TASK_FANOUT_CANONICAL_PATH,
+      runtime_boundary: {
+        boundary: 'manifest_declared_runtime_executor',
+        durable_scheduler: 'homeboy',
+        executor: 'declared_by_task_executor',
+        runtime: 'declared_by_task_runtime',
+      },
+    },
+    steps: [
+      { id: 'generate', inputs: { request: { task_id: 'generate', instructions: 'Generate' } } },
+      { id: 'diagnose', inputs: { request: { task_id: 'diagnose', instructions: 'Diagnose' } } },
+    ],
+  };
+  const projected = projectHomeboyAgentTaskFanoutPlan(homeboyFanoutPlan);
+  assert.equal(projected.plan_schema, AGENT_TASK_FANOUT_PLAN_SCHEMA);
+  assert.equal(projected.orchestrator.canonical_path, AGENT_TASK_FANOUT_CANONICAL_PATH);
+  assert.deepEqual(projected.task_requests.map((request) => request.task_id), ['generate', 'diagnose']);
+
+  const homeboyProjectedRun = await executeFanoutReconcileRun({
+    plan: homeboyFanoutPlan,
+    execute_task_request: (request) => ({ id: request.task_id, group_key: request.group_key, status: 'completed' }),
+  });
+  assert.equal(homeboyProjectedRun.plan_schema, 'homeboy/fanout-reconcile-plan/v1');
+  assert.equal(homeboyProjectedRun.orchestrator.fanout_id, 'fanout/site-workflow');
+  assert.deepEqual(homeboyProjectedRun.records.map((record) => record.id), ['generate', 'diagnose']);
 
   console.log('Generic fanout reconcile workflow test passed');
 })().catch((error) => {

--- a/runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
+++ b/runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
@@ -191,11 +191,39 @@ try {
     if (command === 'git' && args[0] === 'diff' && args[1] === '--cached') {
       return { status: 0, stdout: 'docs/generated.md\n', stderr: '' };
     }
-    if (command === 'gh' && args[0] === 'pr' && args[1] === 'view') {
-      return { status: 1, stdout: '', stderr: 'not found' };
-    }
-    if (command === 'gh' && args[0] === 'pr' && args[1] === 'create') {
-      return { status: 0, stdout: 'https://github.com/owner/repo/pull/1291\n', stderr: '' };
+    if (command === 'homeboy' && args[0] === 'agent-task' && args[1] === 'finalize-pr') {
+      return {
+        status: 0,
+        stdout: `${JSON.stringify({
+          schema: 'homeboy/agent-task-pr-finalization/v1',
+          run_id: '12345',
+          status: 'review_ready',
+          path: workspace,
+          base: 'trunk',
+          head: 'agent-artifacts/fixture-agent-12345',
+          pr_action: 'created',
+          pr_number: 1291,
+          pr_url: 'https://github.com/owner/repo/pull/1291',
+          changed_files: ['docs/generated.md'],
+          publication_intent: {
+            schema: 'homeboy/agent-task-publication-intent/v1',
+            run_id: '12345',
+            action: 'review_request',
+            target: { kind: 'code_review', adapter: 'github_pull_request', base: 'trunk', head: 'agent-artifacts/fixture-agent-12345' },
+            changed_files: ['docs/generated.md'],
+          },
+          publication_proof: {
+            schema: 'homeboy/agent-task-publication-proof/v1',
+            run_id: '12345',
+            status: 'review_ready',
+            intent_schema: 'homeboy/agent-task-publication-intent/v1',
+            target: { kind: 'code_review', adapter: 'github_pull_request', base: 'trunk', head: 'agent-artifacts/fixture-agent-12345', url: 'https://github.com/owner/repo/pull/1291' },
+            adapter_action: 'created',
+            adapter_ref: 'https://github.com/owner/repo/pull/1291',
+          },
+        })}\n`,
+        stderr: '',
+      };
     }
     return { status: 0, stdout: '', stderr: '' };
   };
@@ -206,6 +234,7 @@ try {
     provider: 'openai',
     model: 'gpt-5.5',
     workload_id: 'fixture-workload',
+    finalization_gate_results: [{ id: 'verification_commands', status: 'passed' }],
     runner_workspace: { branch: 'agent-artifacts/{agent_slug}-{run_id}', from: 'origin/trunk' },
     artifact_export: {
       commit_message_template: 'chore: persist {task_id}',
@@ -228,7 +257,11 @@ try {
   assert.equal(publication.base, 'trunk');
   assert.equal(publication.url, 'https://github.com/owner/repo/pull/1291');
   assert.equal(publication.action, 'created');
+  assert.equal(publication.pr_number, 1291);
   assert.deepEqual(publication.files, ['docs/generated.md']);
+  assert.equal(publication.finalization.schema, 'homeboy/agent-task-pr-finalization/v1');
+  assert.equal(publication.publication_intent.schema, 'homeboy/agent-task-publication-intent/v1');
+  assert.equal(publication.publication_proof.schema, 'homeboy/agent-task-publication-proof/v1');
   assert.deepEqual(publication.publication_evidence_ref, {
     type: 'pull_request',
     provider: 'github',
@@ -237,16 +270,19 @@ try {
     base: 'trunk',
     url: 'https://github.com/owner/repo/pull/1291',
     action: 'created',
-    pr_number: null,
+    pr_number: 1291,
     pr_state: 'OPEN',
     files: ['docs/generated.md'],
   });
-  assert.deepEqual(calls.filter((call) => call.command === 'gh').map((call) => call.args.slice(0, 2)), [
-    ['pr', 'view'],
-    ['pr', 'create'],
-  ]);
-  assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'push'), true);
-  assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'commit'), true);
+  const finalizationCall = calls.find((call) => call.command === 'homeboy' && call.args[0] === 'agent-task' && call.args[1] === 'finalize-pr');
+  assert.ok(finalizationCall, 'publication delegates review finalization to Homeboy');
+  assert.equal(finalizationCall.args.includes('--gate-result'), true);
+  assert.equal(finalizationCall.args.includes('verification_commands=passed'), true);
+  assert.equal(finalizationCall.args.includes('--changed-file'), true);
+  assert.equal(finalizationCall.args.includes('docs/generated.md'), true);
+  assert.equal(calls.some((call) => call.command === 'gh'), false);
+  assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'push'), false);
+  assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'commit'), false);
 } finally {
   fs.rmSync(tmp, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Project upstream Homeboy agent-task fanout plans into the runtime fanout/reconcile runner while preserving Homeboy fanout identity and boundary metadata.
- Delegate workspace PR finalization to `homeboy agent-task finalize-pr` so Homeboy owns commit/push/PR publication, publication intent, and publication proof payloads.
- Update targeted runtime-agent-ci tests to assert the upstream contracts and delegated finalization command.

## Tests
- `node tests/generic-fanout-reconcile-workflow.test.js`
- `node tests/workspace-publication-lifecycle.test.js`
- `node tests/package-boundary.test.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Audited the downstream runtime-agent-ci orchestration, implemented the contract adoption changes, and ran targeted verification.
