### PR TITLE
Adopt lab artifact and env contracts

### DIFF
--- a/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
+++ b/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
@@ -10,6 +10,7 @@ const {
 	providerSecretEnvRequirement,
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
+	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
 } = require('../../lib/cli-agent-task-executor');
 
@@ -138,7 +139,13 @@ const { execute: executeClaudeCodeAgentTask, outcome, validationFailure } = crea
 		return null;
 	},
 	buildArgs: (request, config, commandSpec) => commandSpec.args,
-	buildSpawn: (request) => ({ env: process.env, input: JSON.stringify(request) }),
+	buildSpawn: (request, config, options) => ({
+		env: cliAgentTaskSpawnEnv(request, options, {
+			allowlist: ['HOMEBOY_CLAUDE_CODE_AGENT_TASK_COMMAND', 'HOMEBOY_CLAUDE_CODE_AGENT_TASK_COMMAND_ARGS'],
+			secretEnv: CLAUDE_CODE_SECRET_ENV,
+		}),
+		input: JSON.stringify(request),
+	}),
 	messages: {
 		invalidRequest: { code: 'agent_task.invalid_claude_code_request', summary: 'Claude Code request validation failed.' },
 		invalidCommand: { code: 'agent_task.invalid_claude_code_command', summary: 'Claude Code command configuration is invalid.' },

--- a/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
@@ -80,6 +80,7 @@ process.stdin.on('end', () => {
   assert.equal(request.executor.backend, 'claude-code');
   assert.equal(request.executor.runtime, 'claude-code');
   assert.equal(request.instructions, 'Prove the Claude Code provider boundary without leaking secrets.');
+  assert.equal(process.env.UNDECLARED_SECRET, undefined);
   process.stdout.write(process.env.AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN || 'missing secret');
   process.stderr.write(process.env.AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN || 'missing secret');
   process.exit(0);
@@ -112,6 +113,7 @@ process.stdin.on('end', () => {
 			AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN: 'refresh-token-must-not-leak',
 			AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN: 'access-token-must-not-leak',
 			AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT: 'expires-at-must-not-leak',
+			UNDECLARED_SECRET: 'must-not-reach-claude-code',
 		},
 		input: JSON.stringify(runRequest),
 	});

--- a/agent-runtimes/codex/lib/codex-agent-task-executor.js
+++ b/agent-runtimes/codex/lib/codex-agent-task-executor.js
@@ -10,6 +10,7 @@ const {
 	providerSecretEnvRequirement,
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
+	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
 } = require('../../lib/cli-agent-task-executor');
 
@@ -116,7 +117,12 @@ const { execute: executeCodexAgentTask, outcome, validationFailure } = createCli
 		...(config.model ? ['--model', config.model] : []),
 		request.instructions,
 	],
-	buildSpawn: () => ({ env: process.env }),
+	buildSpawn: (request, config, options) => ({
+		env: cliAgentTaskSpawnEnv(request, options, {
+			allowlist: ['HOMEBOY_CODEX_COMMAND', 'HOMEBOY_CODEX_COMMAND_ARGS'],
+			secretEnv: CODEX_SECRET_ENV,
+		}),
+	}),
 	messages: {
 		invalidRequest: { code: 'agent_task.invalid_codex_request', summary: 'Codex request validation failed.' },
 		invalidCommand: { code: 'agent_task.invalid_codex_command', summary: 'Codex command configuration is invalid.' },

--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -91,6 +91,7 @@ assert.equal(process.argv[2], 'exec');
 assert.equal(process.argv[3], '--model');
 assert.equal(process.argv[4], 'gpt-5.5');
 assert.equal(process.argv.at(-1), 'Prove the Codex runtime boundary without leaking secrets.');
+assert.equal(process.env.UNDECLARED_SECRET, undefined);
 process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
 process.stderr.write(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN || 'missing secret');
 process.exit(0);
@@ -122,6 +123,7 @@ process.exit(0);
 			...process.env,
 			AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-must-not-leak',
 			AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-must-not-leak',
+			UNDECLARED_SECRET: 'must-not-reach-codex',
 		},
 		input: JSON.stringify(request),
 	});

--- a/agent-runtimes/lib/cli-agent-task-executor.js
+++ b/agent-runtimes/lib/cli-agent-task-executor.js
@@ -18,6 +18,19 @@ const {
 } = require('../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
 
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+const DEFAULT_PROCESS_ENV_ALLOWLIST = [
+	'CI',
+	'HOME',
+	'LANG',
+	'LC_ALL',
+	'LOGNAME',
+	'NODE_OPTIONS',
+	'PATH',
+	'PWD',
+	'SHELL',
+	'TMPDIR',
+	'USER',
+];
 
 /**
  * Build a CLI agent-task executor from a per-provider configuration.
@@ -156,6 +169,9 @@ function createCliAgentTaskExecutor(spec) {
 		if (!request.instructions || typeof request.instructions !== 'string') {
 			return 'Request instructions are required.';
 		}
+		if (request.executor?.config?.inherit_env === true || request.executor?.config?.inheritEnv === true) {
+			return 'executor.config.inherit_env is not supported; declare env_allowlist, runtime_env, and secret_env explicitly.';
+		}
 		return null;
 	}
 
@@ -264,7 +280,42 @@ function redactSecrets(content, secretEnvNames) {
 	return redacted;
 }
 
+function cliAgentTaskSpawnEnv(request = {}, options = {}, envOptions = {}) {
+	const ambient = options.env && typeof options.env === 'object' && !Array.isArray(options.env) ? options.env : process.env;
+	const config = request.executor?.config || {};
+	const names = new Set([
+		...DEFAULT_PROCESS_ENV_ALLOWLIST,
+		...arrayValue(envOptions.allowlist),
+		...arrayValue(config.env_allowlist || config.envAllowlist),
+		...arrayValue(config.runtime_env_allowlist || config.runtimeEnvAllowlist),
+		...arrayValue(envOptions.secretEnv),
+		...arrayValue(config.secret_env),
+		...arrayValue(request.executor?.secret_env),
+	]);
+	const env = {};
+	for (const name of names) {
+		if (typeof name === 'string' && name && ambient[name] !== undefined) {
+			env[name] = ambient[name];
+		}
+	}
+	return {
+		...env,
+		...objectValue(config.runtime_env),
+		...objectValue(options.envOverrides || options.env_overrides),
+	};
+}
+
+function arrayValue(value) {
+	return Array.isArray(value) ? value : [];
+}
+
+function objectValue(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
 module.exports = {
+	DEFAULT_PROCESS_ENV_ALLOWLIST,
+	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
 	timeoutSecondsFromLimits,
 	resolveCwd,

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -10,6 +10,7 @@ const {
 	providerSecretEnvRequirement,
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
+	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
 	timeoutSecondsFromLimits,
 } = require('../../lib/cli-agent-task-executor');
@@ -213,25 +214,14 @@ function providerContract(options = {}) {
 }
 
 function opencodeSpawnEnv(request = {}, options = {}) {
-	const ambient = options.env && typeof options.env === 'object' && !Array.isArray(options.env) ? options.env : process.env;
 	const config = request.executor?.config || {};
 	if (config.inherit_env === true || config.inheritEnv === true) {
-		return { ...ambient, ...objectValue(config.runtime_env), ...objectValue(options.envOverrides || options.env_overrides) };
+		throw new Error('OpenCode ambient env inheritance is not supported; declare env_allowlist, runtime_env, and secret_env explicitly.');
 	}
-	const names = new Set([
-		...OPENCODE_PROCESS_ENV_ALLOWLIST,
-		...arrayValue(config.env_allowlist || config.envAllowlist),
-		...arrayValue(config.runtime_env_allowlist || config.runtimeEnvAllowlist),
-		...arrayValue(config.secret_env),
-		...arrayValue(request.executor?.secret_env),
-	]);
-	const env = {};
-	for (const name of names) {
-		if (typeof name === 'string' && name && ambient[name] !== undefined) {
-			env[name] = ambient[name];
-		}
-	}
-	return { ...env, ...objectValue(config.runtime_env), ...objectValue(options.envOverrides || options.env_overrides) };
+	return cliAgentTaskSpawnEnv(request, options, {
+		allowlist: OPENCODE_PROCESS_ENV_ALLOWLIST,
+		secretEnv: OPENCODE_SECRET_ENV,
+	});
 }
 
 function withDeclaredArtifactDiagnostics(request = {}, normalized = {}) {
@@ -564,6 +554,9 @@ function validateOpenCodeRequest(request) {
 	}
 	if (!request.instructions || typeof request.instructions !== 'string') {
 		return 'Request instructions are required.';
+	}
+	if (request.executor.config.inherit_env === true || request.executor.config.inheritEnv === true) {
+		return 'executor.config.inherit_env is not supported; declare env_allowlist, runtime_env, and secret_env explicitly.';
 	}
 	return null;
 }

--- a/agent-runtimes/pi/lib/pi-agent-task-executor.js
+++ b/agent-runtimes/pi/lib/pi-agent-task-executor.js
@@ -8,6 +8,7 @@ const {
 	agentTaskProviderContractFields,
 } = require('../../../agent-task-contracts/agent-task-provider-contract');
 const {
+	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
 } = require('../../lib/cli-agent-task-executor');
 
@@ -91,13 +92,17 @@ const { execute: executePiAgentTask, outcome, validationFailure } = createCliAge
 	timeoutFallback: (config) => config.timeout_seconds || DEFAULT_TIMEOUT_SECONDS,
 	resolveCommandSpec,
 	buildArgs: (request, config, commandSpec) => commandSpec.args,
-	buildSpawn: (request) => {
+	buildSpawn: (request, config, options) => {
 		const requestJson = JSON.stringify(request);
 		return {
-			env: {
-				...process.env,
+			env: cliAgentTaskSpawnEnv(request, {
+				...options,
+				env_overrides: {
+					...options.env_overrides,
+					...options.envOverrides,
 				HOMEBOY_AGENT_TASK_REQUEST: requestJson,
 			},
+			}, { allowlist: ['HOMEBOY_PI_COMMAND', 'HOMEBOY_PI_COMMAND_ARGS'] }),
 			input: requestJson,
 		};
 	},

--- a/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
@@ -89,6 +89,7 @@ process.stdin.on('end', () => {
   const envRequest = JSON.parse(process.env.HOMEBOY_AGENT_TASK_REQUEST);
   assert.equal(stdinRequest.task_id, 'pi-real-executor');
   assert.equal(envRequest.instructions, 'Validate the Pi provider boundary through a configured command.');
+  assert.equal(process.env.UNDECLARED_SECRET, undefined);
   process.exit(0);
 });
 `);
@@ -108,6 +109,7 @@ process.stdin.on('end', () => {
 	};
 	const runResult = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
+		env: { ...process.env, UNDECLARED_SECRET: 'must-not-reach-pi' },
 		input: JSON.stringify(configuredRequest),
 	});
 	assert.equal(runResult.status, 0, runResult.stderr);

--- a/runtime-agent-ci/lib/artifact-paths.cjs
+++ b/runtime-agent-ci/lib/artifact-paths.cjs
@@ -3,6 +3,9 @@
 const path = require('node:path');
 
 const ARTIFACT_PATHS_SCHEMA = 'homeboy/runtime-agent-artifact-paths/v1';
+const ARTIFACT_MANIFEST_SCHEMA = 'homeboy/artifact-manifest/v1';
+const ARTIFACT_MANIFEST_FILE = 'homeboy-artifact-manifest.json';
+const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = 'homeboy/runner-artifact-manifest-ref/v1';
 const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
   events: 'events.json',
   status: 'status.json',
@@ -44,7 +47,71 @@ function runtimeAgentArtifactPaths(options = {}) {
     fanout_run: firstString(provided.fanout_run, provided.fanoutRun, options.fanoutRunFile, options.fanout_run_file, options.runsOutputPath, options.runs_output_path, options.env?.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, process.env.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, runArtifactPath(runDir, 'fanout_run')),
     loop_result: firstString(provided.loop_result, provided.loopResult, options.loopResultFile, options.loop_result_file, options.resultFile, options.result_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, runArtifactPath(runDir, 'loop_result')),
     loop_policy: firstString(provided.loop_policy, provided.loopPolicy, options.loopPolicyFile, options.loop_policy_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, runArtifactPath(runDir, 'loop_policy')),
+    artifact_manifest: firstString(provided.artifact_manifest, provided.artifactManifest, options.artifactManifestFile, options.artifact_manifest_file, options.env?.HOMEBOY_RUNTIME_AGENT_ARTIFACT_MANIFEST_FILE, process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACT_MANIFEST_FILE, runDir ? path.join(runDir, ARTIFACT_MANIFEST_FILE) : ''),
   });
+}
+
+function artifactManifestRef(artifactPaths = runtimeAgentArtifactPaths()) {
+  const manifestPath = artifactPaths.artifact_manifest || '';
+  return manifestPath ? {
+    schema: RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+    manifest_schema: ARTIFACT_MANIFEST_SCHEMA,
+    path: manifestPath,
+  } : null;
+}
+
+function artifactManifestForFiles(artifactPaths = {}, files = []) {
+  const root = artifactPaths.run_dir || '';
+  return {
+    schema: ARTIFACT_MANIFEST_SCHEMA,
+    artifacts: normalizeManifestFiles(files)
+      .map((file) => manifestEntryForFile(root, file))
+      .filter(Boolean),
+  };
+}
+
+function normalizeManifestFiles(files) {
+  return files
+    .map((file) => typeof file === 'string' ? { path: file } : file)
+    .filter((file) => file && typeof file === 'object' && typeof file.path === 'string' && file.path.trim() !== '');
+}
+
+function manifestEntryForFile(root, file) {
+  const relative = relativeArtifactPath(root, file.path);
+  if (!relative) {
+    return null;
+  }
+  return stripUndefined({
+    id: firstString(file.id, file.name, file.role, path.basename(relative)),
+    path: relative,
+    kind: firstString(file.kind, file.type, 'file'),
+    role: firstString(file.role),
+    label: firstString(file.label, file.name),
+    semantic_key: firstString(file.semantic_key, file.semanticKey),
+    content_type: firstString(file.content_type, file.contentType),
+    public_url: firstString(file.public_url, file.publicUrl),
+    size_bytes: Number.isFinite(file.size_bytes) ? file.size_bytes : Number.isFinite(file.bytes) ? file.bytes : undefined,
+    sha256: firstString(file.sha256),
+    metadata: file.metadata && typeof file.metadata === 'object' && !Array.isArray(file.metadata) ? file.metadata : {},
+  });
+}
+
+function relativeArtifactPath(root, filePath) {
+  const absolute = path.resolve(filePath);
+  if (!root) {
+    return safeRelativePath(filePath);
+  }
+  const rootAbsolute = path.resolve(root);
+  const relative = path.relative(rootAbsolute, absolute);
+  return safeRelativePath(relative);
+}
+
+function safeRelativePath(value) {
+  const normalized = String(value || '').replaceAll(path.sep, '/');
+  if (!normalized || normalized.startsWith('../') || normalized === '..' || normalized.startsWith('/') || normalized.includes('/../') || normalized === '.') {
+    return '';
+  }
+  return normalized;
 }
 
 function runArtifactPath(runDir, key) {
@@ -65,7 +132,12 @@ function stripUndefined(value) {
 }
 
 module.exports = {
+  ARTIFACT_MANIFEST_FILE,
+  ARTIFACT_MANIFEST_SCHEMA,
   ARTIFACT_PATHS_SCHEMA,
   CANONICAL_RUN_ARTIFACT_FILES,
+  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+  artifactManifestForFiles,
+  artifactManifestRef,
   runtimeAgentArtifactPaths,
 };

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -123,6 +123,13 @@ function buildConfig(env) {
     runnerWorkspaceGuestCheckout,
   });
 
+  const secretEnv = uniqueStrings([
+    ...normalizeStringArray(runtimeConfig.secret_env),
+    githubRepositoryTokenEnv,
+    githubTokenEnv,
+    ...Array.from(providerBenchEnvNames),
+  ]);
+
   return {
     ...runtimeConfig,
     _configPath: path.join(runnerTemp, 'runtime-agent-full-run-config.json'),
@@ -164,12 +171,13 @@ function buildConfig(env) {
     runtime_requirements: effectiveRuntimeProfile,
     github_token_env: githubTokenEnv,
     github_repository_token_env: githubRepositoryTokenEnv,
-    secret_env: uniqueStrings([
-      ...normalizeStringArray(runtimeConfig.secret_env),
-      githubRepositoryTokenEnv,
-      githubTokenEnv,
-      ...Array.from(providerBenchEnvNames),
-    ]),
+    secret_env: secretEnv,
+    secret_env_plan: buildSecretEnvPlan({
+      secretEnv,
+      runtimeEnv,
+      providerSecretEnvMapping,
+      secretEnvFallbacks,
+    }),
     // Fill a target secret env from a fallback source before the sandbox
     // preflight runs: the provider's canonical key (e.g. OPENAI_API_KEY) from
     // the caller's generic credential secret (PROVIDER_SECRET_n), and the
@@ -323,6 +331,23 @@ function buildSecretEnvFallbacks({
     }
   }
   return fallbacks;
+}
+
+function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvFallbacks = {} } = {}) {
+  return {
+    schema: 'homeboy/secret-env-plan/v1',
+    public_env: Object.fromEntries(Object.entries(runtimeEnv).filter(([, value]) => typeof value === 'string')),
+    secret_env_names: uniqueStrings(secretEnv),
+    requirements: uniqueStrings(secretEnv).map((name) => ({ name, required: true })),
+    env_name_mapping: Object.fromEntries(Object.entries({
+      provider_secret_env: Object.values(providerSecretEnvMapping).filter((value) => typeof value === 'string' && value.length > 0),
+      secret_env_fallbacks: Object.values(secretEnvFallbacks).flat().filter((value) => typeof value === 'string' && value.length > 0),
+    }).filter(([, names]) => names.length > 0)),
+    inheritance: {
+      require_declaration: true,
+      allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
+    },
+  };
 }
 
 function runtimeWorkloadFromEnv(env, fallbackId) {

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -14,7 +14,7 @@ const {
 const { runtimeAgentCiTaskExecutorConfig } = require('./runtime-agent-ci-plan');
 const { evaluateGatePlan } = require('./gate-plan-evaluator');
 const { assertLoopSuccess, loopEvidence, loopIteration, loopRun } = require('./loop-lifecycle.cjs');
-const { runtimeAgentArtifactPaths } = require('./artifact-paths.cjs');
+const { artifactManifestForFiles, runtimeAgentArtifactPaths } = require('./artifact-paths.cjs');
 
 const DEFAULT_STDIO_SUMMARY_BYTES = 8192;
 const DEFAULT_RUNTIME_ENV_ALLOWLIST = [
@@ -435,9 +435,7 @@ function runtimeInvocationEnv(options = {}) {
   const executor = optionalObject(request.executor);
   const config = optionalObject(executor.config);
   const invocation = optionalObject(options.invocation);
-  if (invocation.inherit_env === true || invocation.inheritEnv === true || config.inherit_env === true || config.inheritEnv === true) {
-    return { ...ambient, ...optionalObject(config.runtime_env), ...optionalObject(invocation.env) };
-  }
+  assertNoAmbientEnvInheritance(invocation, config);
 
   const names = new Set([
     ...DEFAULT_RUNTIME_ENV_ALLOWLIST,
@@ -517,6 +515,7 @@ function runtimeExecutorInvocation(runtime = {}) {
       stdin: executor.invocation.stdin || 'request_json',
       stdout: executor.invocation.stdout || 'outcome_json',
       stderr: executor.invocation.stderr || 'inherit_on_failure',
+      inherit_env: executor.invocation.inherit_env === true || executor.invocation.inheritEnv === true,
       env_allowlist: normalizeArray(executor.invocation.env_allowlist || executor.invocation.envAllowlist),
       artifacts: executor.invocation.artifacts || {},
       results: executor.invocation.results || {},
@@ -536,6 +535,12 @@ function runtimeExecutorInvocation(runtime = {}) {
     };
   }
   return {};
+}
+
+function assertNoAmbientEnvInheritance(invocation = {}, config = {}) {
+  if (invocation.inherit_env === true || invocation.inheritEnv === true || config.inherit_env === true || config.inheritEnv === true) {
+    throw new Error('Runtime executor ambient env inheritance is not supported; declare env_allowlist, runtime_env, and secret_env explicitly.');
+  }
 }
 
 function invocationStdin(invocation, request) {
@@ -856,11 +861,14 @@ function validateGenericAgentLoopOutcomeContract(options = {}) {
 
 function writeGenericAgentLoopArtifacts(options = {}) {
   const artifactPaths = runtimeAgentArtifactPaths(options);
+  const manifestFiles = [];
   if (artifactPaths.outcome) {
     writeJsonFile(artifactPaths.outcome, options.outcome);
+    manifestFiles.push({ id: 'outcome', kind: 'agent-task-outcome', role: 'outcome', label: 'Agent task outcome', path: artifactPaths.outcome, content_type: 'application/json' });
   }
   if (artifactPaths.results) {
     writeJsonFile(artifactPaths.results, options.results);
+    manifestFiles.push({ id: 'results', kind: 'runtime-agent-results', role: 'results', label: 'Runtime agent results', path: artifactPaths.results, content_type: 'application/json' });
   }
   if (artifactPaths.status) {
     writeJsonFile(artifactPaths.status, {
@@ -869,6 +877,19 @@ function writeGenericAgentLoopArtifacts(options = {}) {
       status: options.outcome?.status || 'failed',
       success: ['succeeded', 'no_op'].includes(options.outcome?.status),
     });
+    manifestFiles.push({ id: 'status', kind: 'runtime-agent-status', role: 'status', label: 'Runtime agent status', path: artifactPaths.status, content_type: 'application/json' });
+  }
+  for (const artifact of normalizeArray(options.outcome?.artifacts)) {
+    if (artifact?.path) {
+      manifestFiles.push(artifact);
+    }
+  }
+  const stderrArtifact = options.outcome?.metadata?.runtime_invocation_result?.stderr_artifact || options.outcome?.metadata?.runtime_invocation_stderr_artifact;
+  if (stderrArtifact?.path) {
+    manifestFiles.push({ id: 'runtime_stderr', role: 'stderr', label: 'Runtime stderr', ...stderrArtifact });
+  }
+  if (artifactPaths.artifact_manifest) {
+    writeJsonFile(artifactPaths.artifact_manifest, artifactManifestForFiles(artifactPaths, manifestFiles));
   }
 }
 

--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -16,7 +16,7 @@ const {
 } = require('./loop-policy');
 const { executeFanoutReconcileRun } = require('./fanout-reconcile-runner');
 const { resolveRuntimeProvider, runtimeIdFromOptions } = require('./runtime-provider-resolver.cjs');
-const { runtimeAgentArtifactPaths } = require('./artifact-paths.cjs');
+const { artifactManifestForFiles, artifactManifestRef, runtimeAgentArtifactPaths } = require('./artifact-paths.cjs');
 
 async function runHeadlessDeterministicLoop(options = {}) {
   const spec = requiredObject(options.spec || options.config || options.plan, 'spec');
@@ -424,23 +424,41 @@ function readJsonOrNull(filePath) {
 
 function writeHeadlessDeterministicLoopArtifacts(options = {}) {
   const artifactPaths = runtimeAgentArtifactPaths(options);
+  const manifestFiles = [];
   if (artifactPaths.loop_result) {
     writeJsonFile(artifactPaths.loop_result, options.result);
+    manifestFiles.push({ id: 'loop_result', kind: 'headless-loop-result', role: 'loop_result', label: 'Headless loop result', path: artifactPaths.loop_result, content_type: 'application/json' });
   }
   if (artifactPaths.events) {
     writeJsonFile(artifactPaths.events, options.result?.events || []);
+    manifestFiles.push({ id: 'events', kind: 'runtime-agent-events', role: 'events', label: 'Runtime agent events', path: artifactPaths.events, content_type: 'application/json' });
   }
   if (artifactPaths.loop_policy) {
     writeJsonFile(artifactPaths.loop_policy, policyArtifact(options.result));
+    manifestFiles.push({ id: 'loop_policy', kind: 'runtime-agent-loop-policy', role: 'loop_policy', label: 'Runtime agent loop policy', path: artifactPaths.loop_policy, content_type: 'application/json' });
   }
   if (artifactPaths.status) {
     writeJsonFile(artifactPaths.status, statusArtifact(options.result));
+    manifestFiles.push({ id: 'status', kind: 'runtime-agent-status', role: 'status', label: 'Runtime agent status', path: artifactPaths.status, content_type: 'application/json' });
   }
   writeGenericAgentLoopArtifacts({
     outcome: options.result?.outcome,
     results: options.result?.results,
     artifact_paths: { ...artifactPaths, status: '' },
   });
+  for (const key of ['outcome', 'results']) {
+    if (artifactPaths[key]) {
+      manifestFiles.push({ id: key, kind: key === 'outcome' ? 'agent-task-outcome' : 'runtime-agent-results', role: key, path: artifactPaths[key], content_type: 'application/json' });
+    }
+  }
+  for (const artifact of normalizeArray(options.result?.outcome?.artifacts)) {
+    if (artifact?.path) {
+      manifestFiles.push(artifact);
+    }
+  }
+  if (artifactPaths.artifact_manifest) {
+    writeJsonFile(artifactPaths.artifact_manifest, artifactManifestForFiles(artifactPaths, manifestFiles));
+  }
 }
 
 function runHeadlessPolicyLoop(options = {}) {
@@ -848,6 +866,7 @@ function taskLoopResultEnvelope({ loop, loopPolicy, policyStatus, startedAt, sta
     max_revolutions: loopPolicy.max_revolutions,
     max_synchronous_revolutions: loopPolicy.max_synchronous_revolutions,
     artifact_paths: artifactPaths,
+    artifact_manifest: artifactManifestRef(artifactPaths),
   };
 }
 
@@ -864,6 +883,7 @@ function aggregateLoopResultEnvelope({ loopId, status, startedAt, completedAt, t
     duration_ms: tasks.at(-1)?.loop_policy?.duration_ms || 0,
     deadline_at: tasks.at(-1)?.loop_policy?.deadline_at || 0,
     artifact_paths: artifactPaths,
+    artifact_manifest: artifactManifestRef(artifactPaths),
   };
 }
 

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -52,6 +52,12 @@ try {
 
   assert.equal(config.execution_kind, 'runtime_execution');
   assert.deepEqual(config.secret_env.slice(0, 2), ['GITHUB_TOKEN', 'HOMEBOY_GITHUB_APP_TOKEN']);
+  assert.equal(config.secret_env_plan.schema, 'homeboy/secret-env-plan/v1');
+  assert.deepEqual(config.secret_env_plan.inheritance, {
+    require_declaration: true,
+    allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
+  });
+  assert.deepEqual(config.secret_env_plan.secret_env_names, config.secret_env);
 } finally {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 }

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -353,6 +353,20 @@ process.stdout.write(JSON.stringify({
     artifact_paths: { run_dir: sharedArtifactDir },
   });
   assert.equal(sharedArtifactsRun.outcome.metadata.runtime_invocation_result.stderr_artifact.path, path.join(sharedArtifactDir, 'shared-artifact-paths-runtime-stderr.txt'));
+  genericLoopRunner.writeGenericAgentLoopArtifacts({
+    outcome: sharedArtifactsRun.outcome,
+    results: sharedArtifactsRun.results,
+    artifact_paths: { run_dir: sharedArtifactDir },
+  });
+  const sharedManifest = JSON.parse(fs.readFileSync(path.join(sharedArtifactDir, 'homeboy-artifact-manifest.json'), 'utf8'));
+  assert.equal(sharedManifest.schema, 'homeboy/artifact-manifest/v1');
+  assert.deepEqual(sharedManifest.artifacts.map((artifact) => artifact.path).sort(), [
+    'outcome.json',
+    'results.json',
+    'shared-artifact-paths-runtime-stderr.txt',
+    'status.json',
+  ]);
+  assert.equal(sharedManifest.artifacts.every((artifact) => !path.isAbsolute(artifact.path)), true);
 
   let capturedEnv = null;
   genericLoopRunner.runGenericAgentLoop({
@@ -394,6 +408,24 @@ process.stdout.write(JSON.stringify({
     },
   });
   assert.equal(capturedEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE, '/tmp/wp-codebox-core/contracts.js');
+  const inheritEnvRun = genericLoopRunner.runGenericAgentLoop({
+    runtime: {
+      id: 'env-inherit-runtime',
+      executor: { backend: 'fixture', invocation: { command: 'node', inherit_env: true } },
+    },
+    request: {
+      schema: 'homeboy/agent-task-request/v1',
+      task_id: 'env-inherit-runtime',
+      instructions: 'Exercise runtime inherit_env rejection.',
+      executor: { backend: 'fixture', config: {} },
+    },
+    plan: { ...plan, workload_id: 'env-inherit-runtime' },
+    validationPolicy: { success_completion_outcomes: ['done'] },
+    validate: false,
+    spawnSync: () => ({ status: 0, stdout: '{}', stderr: '' }),
+  });
+  assert.equal(inheritEnvRun.outcome.status, 'failed');
+  assert.match(inheritEnvRun.outcome.summary, /ambient env inheritance is not supported/);
 
   const hugePayloadSentinel = 'WHOLESALE_RESULT_PAYLOAD_SENTINEL';
   const stdoutSummary = genericLoopRunner.genericAgentLoopStdoutSummary({

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -29,6 +29,7 @@ const baseSpec = {
 
 (async () => {
 const executedTaskIds = [];
+const loopArtifactRefDir = path.join(os.tmpdir(), `headless-loop-ref-${process.pid}`);
 const twoRevolution = await runHeadlessDeterministicLoop({
   spec: {
     ...baseSpec,
@@ -49,6 +50,7 @@ const twoRevolution = await runHeadlessDeterministicLoop({
     },
   },
   runtime,
+  artifact_paths: { run_dir: loopArtifactRefDir },
   validate: false,
   execute: ({ request }) => {
     executedTaskIds.push(request.task_id);
@@ -75,8 +77,11 @@ assert.equal(twoRevolution.tasks[0].loop_policy.iterations[1].accepted, true);
 assert.equal(twoRevolution.tasks[0].loop_result.schema, 'homeboy/headless-loop-result-envelope/v1');
 assert.equal(twoRevolution.tasks[0].loop_result.mode, 'count');
 assert.equal(twoRevolution.tasks[0].loop_result.revolutions, 2);
+assert.equal(twoRevolution.tasks[0].loop_result.artifact_manifest.schema, 'homeboy/runner-artifact-manifest-ref/v1');
+assert.equal(twoRevolution.tasks[0].loop_result.artifact_manifest.manifest_schema, 'homeboy/artifact-manifest/v1');
 assert.equal(twoRevolution.loop_result.schema, 'homeboy/headless-loop-result-envelope/v1');
 assert.equal(twoRevolution.loop_result.revolutions, 2);
+assert.equal(twoRevolution.loop_result.artifact_manifest.schema, 'homeboy/runner-artifact-manifest-ref/v1');
 assert.equal(twoRevolution.tasks[0].outcome.metadata.headless_loop_policy_status.iteration_count, 2);
 assert.equal(twoRevolution.tasks[0].results.scenarios[0].metadata.completion_outcome_satisfied, true);
 assert.equal(twoRevolution.fanout.records[0].status, 'completed');
@@ -191,6 +196,18 @@ assert.equal(expiredHeadlessCalls, 0);
 assert.equal(expiredDeadline.status, 'failed');
 assert.equal(expiredDeadline.tasks[0].loop_policy.stop_reason, 'deadline_reached');
 assert.equal(expiredDeadline.tasks[0].loop_policy.iteration_count, 0);
+
+const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headless-loop-artifact-manifest-'));
+try {
+  writeHeadlessDeterministicLoopArtifacts({ result: twoRevolution, artifact_paths: { run_dir: artifactDir } });
+  const manifest = JSON.parse(fs.readFileSync(path.join(artifactDir, 'homeboy-artifact-manifest.json'), 'utf8'));
+  assert.equal(manifest.schema, 'homeboy/artifact-manifest/v1');
+  assert.equal(manifest.artifacts.some((artifact) => artifact.path === 'loop-result.json'), true);
+  assert.equal(manifest.artifacts.some((artifact) => artifact.path === 'events.json'), true);
+  assert.equal(manifest.artifacts.every((artifact) => !path.isAbsolute(artifact.path)), true);
+} finally {
+  fs.rmSync(artifactDir, { recursive: true, force: true });
+}
 
 await assert.rejects(
   () => runHeadlessDeterministicLoop({


### PR DESCRIPTION
## Summary
- emit Homeboy artifact manifest files and runner artifact manifest refs from runtime-agent loop artifact paths
- materialize a typed secret env plan in runtime-agent-full-run config with explicit inherited-env policy
- remove ambient env inheritance from generic runtime invocations and OpenCode/Codex/Claude Code/Pi provider spawn envs, keeping only allowlisted public env plus declared secret env

## Tests
- node runtime-agent-ci/tests/generic-agent-loop-runner.test.js
- node runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
- node runtime-agent-ci/tests/build-runner-config.test.js
- node agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
- node agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
- node agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
- node agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js

## Blockers / upstream gaps
- None for this coherent adoption slice. HBX can emit the upstream manifest/ref and secret-env-plan shapes locally; deeper Homeboy-side manifest import behavior remains owned by Extra-Chill/homeboy#7021.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Scoped implementation, test updates, verification, and PR description.