### PR TITLE
Stabilize OpenCode runtime identity and artifacts

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -316,18 +316,19 @@ function collectOpenCodeArtifacts(context = {}) {
 	const artifacts = [];
 	const evidence_refs = [];
 	const addArtifact = (requirement, filename, content, fallbackKind) => {
-		if (content === undefined || content === null || content === '') {
+		if (content === undefined || content === null) {
 			return;
 		}
+		const artifactContent = String(content);
 		const filePath = path.join(artifactDir, filename);
 		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, content);
+		fs.writeFileSync(filePath, artifactContent);
 		const artifact = {
 			id: requirement.name,
 			name: requirement.name,
 			kind: requirement.kind || fallbackKind,
 			path: filePath,
-			bytes: Buffer.byteLength(content),
+			bytes: Buffer.byteLength(artifactContent),
 		};
 		artifacts.push(artifact);
 		evidence_refs.push({ kind: artifact.kind, label: requirement.name, path: filePath });

--- a/agent-runtimes/opencode/package.json
+++ b/agent-runtimes/opencode/package.json
@@ -7,6 +7,9 @@
     ".": "./index.js",
     "./opencode-agent-task-executor": "./lib/opencode-agent-task-executor.js"
   },
+  "homeboy": {
+    "agent_runtime_manifest": "opencode.json"
+  },
   "bin": {
     "homeboy-opencode-agent-task-executor": "./scripts/agent/homeboy-opencode-agent-task-executor.cjs"
   },

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -63,6 +63,11 @@ assert.equal(manifest.name, 'OpenCode');
 assert.equal(manifest.agent_task_executors.length, 1);
 assert.equal(manifest.agent_task_executors[0].capabilities.includes('nested_orchestrator'), true);
 assert.deepEqual(manifest.agent_task_executors[0], providerContract());
+const packageJson = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'package.json'), 'utf8'));
+assert.equal(packageJson.name, 'homeboy-agent-runtime-opencode');
+assert.equal(packageJson.homeboy.agent_runtime_manifest, 'opencode.json');
+assert.equal(JSON.stringify({ manifest, packageJson }).includes('wp-codebox'), false);
+assert.equal(JSON.stringify({ manifest, packageJson }).includes('WP Codebox'), false);
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-opencode-provider-contract-'));
 try {
@@ -201,6 +206,50 @@ process.exit(0);
 	const agentResult = JSON.parse(fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
 	assert.equal(agentResult.opencode_session.status, 'not_discovered');
 	assert.equal(artifactResult.metadata.missing_declared_artifacts, undefined);
+
+	const quietWorkspace = path.join(root, 'quiet-workspace');
+	fs.mkdirSync(quietWorkspace, { recursive: true });
+	spawnSync('git', ['init'], { cwd: quietWorkspace, encoding: 'utf8' });
+	fs.writeFileSync(path.join(quietWorkspace, 'README.md'), 'unchanged\n');
+	spawnSync('git', ['add', 'README.md'], { cwd: quietWorkspace, encoding: 'utf8' });
+	spawnSync('git', ['commit', '-m', 'initial'], {
+		cwd: quietWorkspace,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Homeboy Test',
+			GIT_AUTHOR_EMAIL: 'homeboy@example.test',
+			GIT_COMMITTER_NAME: 'Homeboy Test',
+			GIT_COMMITTER_EMAIL: 'homeboy@example.test',
+		},
+	});
+
+	const quietCliPath = path.join(root, 'mock-opencode-quiet.cjs');
+	fs.writeFileSync(quietCliPath, `#!/usr/bin/env node
+process.exit(0);
+`);
+	const quietArtifactDir = path.join(root, 'quiet-artifacts');
+	const quietResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-quiet-no-diff-artifacts',
+		workspace_path: quietWorkspace,
+		artifacts_path: quietArtifactDir,
+		expected_artifacts: ['patch', 'transcript', 'agent_result'],
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				command_args: [quietCliPath],
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(quietResult.status, 'succeeded');
+	assert.deepEqual(quietResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'patch', 'transcript']);
+	assert.equal(quietResult.metadata.missing_declared_artifacts, undefined);
+	assert.equal(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'patch').path, 'utf8'), '');
+	assert.equal(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'transcript').path, 'utf8'), '');
+	const quietAgentResult = JSON.parse(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
+	assert.deepEqual(quietAgentResult.artifacts, { patch: false, transcript: false });
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }

--- a/agent-task-contracts/agent-task-runner-contract.js
+++ b/agent-task-contracts/agent-task-runner-contract.js
@@ -10,9 +10,9 @@ function agentTaskRunnerSpec(options = {}) {
 
   const backend = requiredString(options.backend, 'backend');
   const runtime = options.runtime || options.runtime_id;
-  const taskTimeoutSeconds = options.task_timeout_seconds;
+  const taskTimeoutSeconds = options.task_timeout_seconds || options.taskTimeoutSeconds;
   const timeoutMs = options.timeout_ms || secondsToMs(taskTimeoutSeconds);
-  const maxRuntimeMs = options.max_runtime_ms;
+  const maxRuntimeMs = options.max_runtime_ms || options.maxRuntimeMs;
   const limits = stripUndefined({
     ...(options.limits || {}),
     ...(timeoutMs ? { timeout_ms: timeoutMs } : {}),
@@ -20,16 +20,16 @@ function agentTaskRunnerSpec(options = {}) {
     // Compatibility for existing runtime adapters that still read seconds.
     ...(taskTimeoutSeconds ? { task_timeout_seconds: taskTimeoutSeconds } : {}),
   });
-  const artifactDeclarations = normalizeArray(options.artifact_declarations);
-  const expectedArtifacts = normalizeArray(options.expected_artifacts);
+  const artifactDeclarations = normalizeArray(options.artifact_declarations || options.artifactDeclarations);
+  const expectedArtifacts = normalizeArray(options.expected_artifacts || options.expectedArtifacts);
 
   const spec = stripUndefined({
     schema: AGENT_TASK_RUNNER_SPEC_SCHEMA,
     executor: stripUndefined({
       backend,
       ...(runtime ? { runtime } : {}),
-      ...(normalizeArray(options.secret_env).length > 0
-        ? { secret_env: normalizeArray(options.secret_env) }
+      ...(normalizeArray(options.secret_env || options.secretEnv).length > 0
+        ? { secret_env: normalizeArray(options.secret_env || options.secretEnv) }
         : {}),
       config: executorConfig,
     }),

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -85,6 +85,9 @@ assert.equal(opencodeRuntime.executor.backend, 'opencode');
 assert.equal(opencodeRuntime.executor.path, path.join(rootDir, 'agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs'));
 assert.equal(opencodeRuntime.manifest.agent_task_executors[0].status, 'active');
 assert.equal(opencodeRuntime.manifest.agent_task_executors[0].capabilities.includes('nested_orchestrator'), true);
+assert.equal(opencodeRuntime.manifest.name, 'OpenCode');
+assert.equal(JSON.stringify(opencodeRuntime.manifest).includes('wp-codebox'), false);
+assert.equal(JSON.stringify(opencodeRuntime.manifest).includes('WP Codebox'), false);
 
 const tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-provider-')));
 const externalRuntimeDir = path.join(tempDir, 'external-runtime');


### PR DESCRIPTION
## Summary
- materialize required OpenCode artifacts even when patch/transcript content is empty
- add OpenCode runtime package metadata and tests that keep WP Codebox identity out of OpenCode runtime output
- accept camelCase runner spec aliases exposed by provider contract smoke coverage

Fixes #2041.

## Tests
- node tests/agent-task-provider-contract-smoke.mjs
- npm --prefix agent-runtimes/opencode run test:opencode-agent-task-executor-boundary
- node tests/runtime-provider-resolver-smoke.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode native subagents
- **Used for:** Investigating the OpenCode runtime executor/artifact path, drafting the code/test changes, and verifying focused tests. Chris remains responsible for review and landing.