### PR TITLE
Fix OpenCode artifacts without explicit artifact dir

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -249,7 +249,7 @@ function withDeclaredArtifactDiagnostics(request = {}, normalized = {}) {
 }
 
 function missingDeclaredArtifacts(request = {}, artifacts = []) {
-	return declaredArtifactRequirements(request).filter((declaration) => !findArtifact(artifacts, declaration));
+	return uniqueDeclaredArtifactRequirements(request).filter((declaration) => !findArtifact(artifacts, declaration));
 }
 
 function declaredArtifactRequirements(request = {}) {
@@ -302,8 +302,7 @@ function opencodeFailureOutcome(context) {
 
 function collectOpenCodeArtifacts(context = {}) {
 	const request = context.request || {};
-	const config = context.config || {};
-	const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
+	const artifactDir = resolveArtifactDir(context);
 	if (!artifactDir) {
 		return {};
 	}
@@ -367,9 +366,7 @@ function collectOpenCodeArtifacts(context = {}) {
 }
 
 function collectOpenCodeRuntimeLogs(context = {}) {
-	const request = context.request || {};
-	const config = context.config || {};
-	const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
+	const artifactDir = resolveArtifactDir(context);
 	if (!artifactDir) {
 		return {};
 	}
@@ -563,7 +560,7 @@ function validateOpenCodeRequest(request) {
 }
 
 function openCodeRuntimeLogPaths(request = {}, config = {}) {
-	const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
+	const artifactDir = resolveArtifactDir({ request, config });
 	if (!artifactDir) {
 		return {};
 	}
@@ -571,6 +568,17 @@ function openCodeRuntimeLogPaths(request = {}, config = {}) {
 		stdout: path.join(artifactDir, `${safeFileSegment(request.task_id)}-opencode-runtime-stdout.log`),
 		stderr: path.join(artifactDir, `${safeFileSegment(request.task_id)}-opencode-runtime-stderr.log`),
 	};
+}
+
+function resolveArtifactDir(context = {}) {
+	const request = context.request || {};
+	const config = context.config || {};
+	const configured = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
+	if (configured) {
+		return configured;
+	}
+	const workspacePath = request.workspace_path || request.workspace?.path || '';
+	return workspacePath ? path.join(workspacePath, '.homeboy', 'opencode') : '';
 }
 
 function spawnOpenCodeStreaming(command, args, options = {}) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -250,6 +250,27 @@ process.exit(0);
 	assert.equal(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'transcript').path, 'utf8'), '');
 	const quietAgentResult = JSON.parse(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
 	assert.deepEqual(quietAgentResult.artifacts, { patch: false, transcript: false });
+
+	const implicitArtifactResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-implicit-artifact-dir',
+		workspace_path: quietWorkspace,
+		expected_artifacts: ['patch', 'transcript', 'agent_result'],
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				command_args: [quietCliPath],
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(implicitArtifactResult.status, 'succeeded');
+	assert.deepEqual(implicitArtifactResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'patch', 'transcript']);
+	assert.equal(implicitArtifactResult.metadata.missing_declared_artifacts, undefined);
+	assert.equal(
+		implicitArtifactResult.artifacts.every((artifact) => artifact.path.startsWith(path.join(quietWorkspace, '.homeboy', 'opencode'))),
+		true
+	);
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- default OpenCode artifact output to the request workspace when no artifact dir is provided
- reuse the same default for runtime logs and declared artifact collection
- dedupe missing declared artifact diagnostics before failing a successful run

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/2035

## Tests
- `npm --prefix agent-runtimes/opencode run test:opencode-agent-task-executor-boundary`
- `node tests/agent-task-provider-contract-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the OpenCode artifact contract failure, drafting the code change, and adding regression coverage.