### PR TITLE
Centralize runtime contract adapter helpers

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -6,6 +6,7 @@ const path = require('node:path');
 const {
   buildConfig,
   buildSecretEnvFallbacks,
+  buildSecretEnvPlan,
   loopPolicyFromEnv,
   projectRuntimeConfig,
   providerBenchEnvFromManifest,
@@ -30,4 +31,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired };

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -27,6 +27,9 @@ const {
   providerFailureClassification,
 } = require('../../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
 const {
+  SECRET_ENV_PLAN_SCHEMA,
+} = require('../../../runtime-agent-ci/lib/runtime-contracts.cjs');
+const {
   artifactResultEnvelopeFromCodeboxResult,
   artifactNameFromDeclaration,
   normalizeCodeboxArtifactDeclaration,
@@ -1777,7 +1780,7 @@ function homeboyAgentTaskSecretEnvPlan() {
 }
 
 function secretEnvNamesFromPlan(plan) {
-  if (!plan || plan.schema !== 'homeboy/secret-env-plan/v1') {
+  if (!plan || plan.schema !== SECRET_ENV_PLAN_SCHEMA) {
     return [];
   }
   // Mirror core's authoritative SecretEnvPlan::secret_env_names() aggregation

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -17,4 +17,5 @@ Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));
 Object.assign(module.exports, require('./lib/gate-plan-evaluator'));
 Object.assign(module.exports, require('./lib/loop-lifecycle.cjs'));
 Object.assign(module.exports, require('./lib/runtime-status.cjs'));
+Object.assign(module.exports, require('./lib/runtime-contracts.cjs'));
 Object.assign(module.exports, require('./lib/full-run-config.cjs'));

--- a/runtime-agent-ci/lib/artifact-paths.cjs
+++ b/runtime-agent-ci/lib/artifact-paths.cjs
@@ -1,20 +1,13 @@
 'use strict';
 
 const path = require('node:path');
-
-const ARTIFACT_PATHS_SCHEMA = 'homeboy/runtime-agent-artifact-paths/v1';
-const ARTIFACT_MANIFEST_SCHEMA = 'homeboy/artifact-manifest/v1';
-const ARTIFACT_MANIFEST_FILE = 'homeboy-artifact-manifest.json';
-const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = 'homeboy/runner-artifact-manifest-ref/v1';
-const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
-  events: 'events.json',
-  status: 'status.json',
-  results: 'results.json',
-  outcome: 'outcome.json',
-  fanout_run: 'fanout-run.json',
-  loop_result: 'loop-result.json',
-  loop_policy: 'loop-policy.json',
-});
+const {
+  ARTIFACT_MANIFEST_FILE,
+  ARTIFACT_MANIFEST_SCHEMA,
+  ARTIFACT_PATHS_SCHEMA,
+  CANONICAL_RUN_ARTIFACT_FILES,
+  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+} = require('./runtime-contracts.cjs');
 
 function runtimeAgentArtifactPaths(options = {}) {
   const provided = options.artifact_paths && typeof options.artifact_paths === 'object' && !Array.isArray(options.artifact_paths) ? options.artifact_paths : {};

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -20,6 +20,10 @@ const {
 const {
   renderRuntimeWorkflowInputs,
 } = require('./runtime-workflow-inputs.cjs');
+const {
+  buildSecretEnvFallbacks,
+  buildSecretEnvPlan,
+} = require('./runtime-contracts.cjs');
 
 function main() {
   const config = buildConfig(process.env);
@@ -302,54 +306,6 @@ function uniqueStrings(values) {
   return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
 }
 
-// Build the declarative secret-env fallback map consumed by the run step. Each
-// entry maps a target secret env name to an ordered list of source env names;
-// the run step sets target = first non-empty source when target is unset. This
-// keeps the translation generic (driven by the runtime manifest + caller
-// credential mapping) with no per-consumer or per-provider hardcoding.
-function buildSecretEnvFallbacks({
-  githubTokenEnv,
-  githubRepositoryTokenEnv,
-  providerCanonicalSecretEnvNames = [],
-  providerCredentialSourceEnvNames = [],
-} = {}) {
-  const fallbacks = {};
-  // The Homeboy app token falls back to the repository GITHUB_TOKEN for
-  // consumers that run with require_homeboy_app_token=false and no app creds.
-  if (githubTokenEnv && githubRepositoryTokenEnv && githubTokenEnv !== githubRepositoryTokenEnv) {
-    fallbacks[githubTokenEnv] = [githubRepositoryTokenEnv];
-  }
-  // When the caller maps provider credentials to generic secret env names, the
-  // provider plugin still reads the runtime's canonical name (e.g.
-  // OPENAI_API_KEY), so source the canonical name from the mapped secret.
-  if (providerCredentialSourceEnvNames.length > 0) {
-    for (const canonical of providerCanonicalSecretEnvNames) {
-      const sources = providerCredentialSourceEnvNames.filter((name) => name !== canonical);
-      if (sources.length > 0) {
-        fallbacks[canonical] = uniqueStrings([...(fallbacks[canonical] || []), ...sources]);
-      }
-    }
-  }
-  return fallbacks;
-}
-
-function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvFallbacks = {} } = {}) {
-  return {
-    schema: 'homeboy/secret-env-plan/v1',
-    public_env: Object.fromEntries(Object.entries(runtimeEnv).filter(([, value]) => typeof value === 'string')),
-    secret_env_names: uniqueStrings(secretEnv),
-    requirements: uniqueStrings(secretEnv).map((name) => ({ name, required: true })),
-    env_name_mapping: Object.fromEntries(Object.entries({
-      provider_secret_env: Object.values(providerSecretEnvMapping).filter((value) => typeof value === 'string' && value.length > 0),
-      secret_env_fallbacks: Object.values(secretEnvFallbacks).flat().filter((value) => typeof value === 'string' && value.length > 0),
-    }).filter(([, names]) => names.length > 0)),
-    inheritance: {
-      require_declaration: true,
-      allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
-    },
-  };
-}
-
 function runtimeWorkloadFromEnv(env, fallbackId) {
   const workload = parseJsonInput('workload', env.WORKLOAD || '{}', 'object', {});
   return Object.keys(workload).length > 0 ? workload : { id: fallbackId };
@@ -529,4 +485,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys };

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -1,0 +1,74 @@
+'use strict';
+
+const SECRET_ENV_PLAN_SCHEMA = 'homeboy/secret-env-plan/v1';
+const ARTIFACT_PATHS_SCHEMA = 'homeboy/runtime-agent-artifact-paths/v1';
+const ARTIFACT_MANIFEST_SCHEMA = 'homeboy/artifact-manifest/v1';
+const ARTIFACT_MANIFEST_FILE = 'homeboy-artifact-manifest.json';
+const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = 'homeboy/runner-artifact-manifest-ref/v1';
+const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
+  events: 'events.json',
+  status: 'status.json',
+  results: 'results.json',
+  outcome: 'outcome.json',
+  fanout_run: 'fanout-run.json',
+  loop_result: 'loop-result.json',
+  loop_policy: 'loop-policy.json',
+});
+
+// Local adapter seam for the secret materialization contract. Keep the emitted
+// shape stable until Homeboy core owns this schema and assembly.
+function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvFallbacks = {} } = {}) {
+  return {
+    schema: SECRET_ENV_PLAN_SCHEMA,
+    public_env: Object.fromEntries(Object.entries(runtimeEnv).filter(([, value]) => typeof value === 'string')),
+    secret_env_names: uniqueStrings(secretEnv),
+    requirements: uniqueStrings(secretEnv).map((name) => ({ name, required: true })),
+    env_name_mapping: Object.fromEntries(Object.entries({
+      provider_secret_env: Object.values(providerSecretEnvMapping).filter((value) => typeof value === 'string' && value.length > 0),
+      secret_env_fallbacks: Object.values(secretEnvFallbacks).flat().filter((value) => typeof value === 'string' && value.length > 0),
+    }).filter(([, names]) => names.length > 0)),
+    inheritance: {
+      require_declaration: true,
+      allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
+    },
+  };
+}
+
+// Build the declarative secret-env fallback map consumed by the run step. Each
+// entry maps a target secret env name to an ordered list of source env names;
+// the run step sets target = first non-empty source when target is unset.
+function buildSecretEnvFallbacks({
+  githubTokenEnv,
+  githubRepositoryTokenEnv,
+  providerCanonicalSecretEnvNames = [],
+  providerCredentialSourceEnvNames = [],
+} = {}) {
+  const fallbacks = {};
+  if (githubTokenEnv && githubRepositoryTokenEnv && githubTokenEnv !== githubRepositoryTokenEnv) {
+    fallbacks[githubTokenEnv] = [githubRepositoryTokenEnv];
+  }
+  if (providerCredentialSourceEnvNames.length > 0) {
+    for (const canonical of providerCanonicalSecretEnvNames) {
+      const sources = providerCredentialSourceEnvNames.filter((name) => name !== canonical);
+      if (sources.length > 0) {
+        fallbacks[canonical] = uniqueStrings([...(fallbacks[canonical] || []), ...sources]);
+      }
+    }
+  }
+  return fallbacks;
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
+}
+
+module.exports = {
+  ARTIFACT_MANIFEST_FILE,
+  ARTIFACT_MANIFEST_SCHEMA,
+  ARTIFACT_PATHS_SCHEMA,
+  CANONICAL_RUN_ARTIFACT_FILES,
+  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+  SECRET_ENV_PLAN_SCHEMA,
+  buildSecretEnvFallbacks,
+  buildSecretEnvPlan,
+};

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -21,6 +21,7 @@
     "./full-run-inputs": "./lib/full-run-inputs.cjs",
     "./runtime-status": "./lib/runtime-status.cjs",
     "./artifact-paths": "./lib/artifact-paths.cjs",
+    "./runtime-contracts": "./lib/runtime-contracts.cjs",
     "./loop-lifecycle": "./lib/loop-lifecycle.cjs",
     "./workspace-publication-lifecycle": "./lib/workspace-publication-lifecycle.cjs"
   },

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -7,7 +7,9 @@ const path = require('node:path');
 
 const {
   buildConfig,
+  buildSecretEnvPlan,
   loopPolicyFromEnv,
+  SECRET_ENV_PLAN_SCHEMA,
 } = require('..');
 const { normalizeProviderPlugin } = require('../lib/full-run-inputs.cjs');
 
@@ -52,7 +54,7 @@ try {
 
   assert.equal(config.execution_kind, 'runtime_execution');
   assert.deepEqual(config.secret_env.slice(0, 2), ['GITHUB_TOKEN', 'HOMEBOY_GITHUB_APP_TOKEN']);
-  assert.equal(config.secret_env_plan.schema, 'homeboy/secret-env-plan/v1');
+  assert.equal(config.secret_env_plan.schema, SECRET_ENV_PLAN_SCHEMA);
   assert.deepEqual(config.secret_env_plan.inheritance, {
     require_declaration: true,
     allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
@@ -61,6 +63,29 @@ try {
 } finally {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 }
+
+assert.deepEqual(
+  buildSecretEnvPlan({
+    secretEnv: ['PRIVATE_TOKEN'],
+    runtimeEnv: { PUBLIC_MODE: 'test', PRIVATE_MODE: false },
+    providerSecretEnvMapping: { token: 'PROVIDER_SECRET_1' },
+    secretEnvFallbacks: { PRIVATE_TOKEN: ['PROVIDER_SECRET_1'] },
+  }),
+  {
+    schema: SECRET_ENV_PLAN_SCHEMA,
+    public_env: { PUBLIC_MODE: 'test' },
+    secret_env_names: ['PRIVATE_TOKEN'],
+    requirements: [{ name: 'PRIVATE_TOKEN', required: true }],
+    env_name_mapping: {
+      provider_secret_env: ['PROVIDER_SECRET_1'],
+      secret_env_fallbacks: ['PROVIDER_SECRET_1'],
+    },
+    inheritance: {
+      require_declaration: true,
+      allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
+    },
+  }
+);
 
 assert.deepEqual(
   normalizeProviderPlugin('{"providerSecretEnv":{"token":"PROVIDER_TOKEN"}}', 'fixture', true).provider_secret_env,


### PR DESCRIPTION
## Summary
- Add a local runtime contract adapter seam for shared runtime-agent schema constants and secret-env plan construction.
- Reuse the seam from runtime-agent config, artifact path handling, and WP Codebox validation.
- Export the helper module for downstream runtime-agent consumers.

## Testing
- npm test
- npm run test:codebox-agent-task-executor-boundary
- node tests/runtime-agent-full-run-provider-neutral-smoke.mjs

## Notes
- Existing smoke mismatch remains in runtime-agent-ci-contract-smoke: test passes runtimeProfile while the code expects runtime_profile.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, focused test selection, and PR preparation.