### PR TITLE
Resolve OpenCode artifacts from workspace root

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -577,7 +577,7 @@ function resolveArtifactDir(context = {}) {
 	if (configured) {
 		return configured;
 	}
-	const workspacePath = request.workspace_path || request.workspace?.path || '';
+	const workspacePath = config.workspace_root || config.workspaceRoot || request.workspace_path || request.workspace?.path || request.workspace?.root || '';
 	return workspacePath ? path.join(workspacePath, '.homeboy', 'opencode') : '';
 }
 

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -271,6 +271,31 @@ process.exit(0);
 		implicitArtifactResult.artifacts.every((artifact) => artifact.path.startsWith(path.join(quietWorkspace, '.homeboy', 'opencode'))),
 		true
 	);
+
+	const workspaceRootResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-workspace-root-artifact-dir',
+		workspace: {
+			mode: 'existing',
+			root: quietWorkspace,
+		},
+		expected_artifacts: ['patch', 'transcript', 'agent_result'],
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				command_args: [quietCliPath],
+				workspace_root: quietWorkspace,
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(workspaceRootResult.status, 'succeeded');
+	assert.deepEqual(workspaceRootResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'patch', 'transcript']);
+	assert.equal(workspaceRootResult.metadata.missing_declared_artifacts, undefined);
+	assert.equal(
+		workspaceRootResult.artifacts.every((artifact) => artifact.path.startsWith(path.join(quietWorkspace, '.homeboy', 'opencode'))),
+		true
+	);
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- resolve OpenCode artifact output from `executor.config.workspace_root` / `workspace.root`
- keep explicit artifact path and legacy workspace path precedence
- add regression coverage for Homeboy-provisioned workspace requests

Refs https://github.com/Extra-Chill/homeboy-extensions/issues/2035

## Evidence
- After Extra-Chill/homeboy#7071, the Lab request includes `executor.config.workspace_root` and `workspace.root`, but OpenCode still reported missing artifacts because the runtime fallback only checked `workspace_path` / `workspace.path`.
- Failed rerun child: `cook-issue-2035`
- Runner job: `homeboy runner job logs homeboy-lab 082553a1-2bd8-4d88-b7a3-0c54a98e6df8`

## Tests
- `npm --prefix agent-runtimes/opencode run test:opencode-agent-task-executor-boundary`
- `node tests/agent-task-provider-contract-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the remaining OpenCode artifact path gap, drafting the runtime fallback fix, and adding regression coverage.