### PR TITLE
Emit OpenCode evidence ref URIs

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -330,7 +330,7 @@ function collectOpenCodeArtifacts(context = {}) {
 			bytes: Buffer.byteLength(artifactContent),
 		};
 		artifacts.push(artifact);
-		evidence_refs.push({ kind: artifact.kind, label: requirement.name, path: filePath });
+		evidence_refs.push({ kind: artifact.kind, label: requirement.name, uri: fileUri(filePath) });
 	};
 
 	const spawnResult = context.spawnResult || {};
@@ -391,9 +391,13 @@ function collectOpenCodeRuntimeLogs(context = {}) {
 			bytes,
 		};
 		artifacts.push(artifact);
-		evidence_refs.push({ kind: artifact.kind, label: `OpenCode ${stream}`, path: filePath });
+		evidence_refs.push({ kind: artifact.kind, label: `OpenCode ${stream}`, uri: fileUri(filePath) });
 	}
 	return { artifacts, evidence_refs };
+}
+
+function fileUri(filePath) {
+	return `file://${filePath}`;
 }
 
 function mergeEvidence(primary = {}, secondary = {}) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -198,6 +198,8 @@ process.exit(0);
 	assert.equal(transcript.includes('refresh-token-must-not-leak'), false);
 	assert.match(transcript, /\[redacted\]/);
 	assert.equal(artifactResult.artifacts.some((artifact) => artifact.name === 'opencode-runtime-stdout'), true);
+	assert.equal(artifactResult.evidence_refs.every((ref) => ref.uri.startsWith('file://')), true);
+	assert.equal(artifactResult.evidence_refs.some((ref) => Object.hasOwn(ref, 'path')), false);
 	const runtimeStdout = fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'opencode-runtime-stdout').path, 'utf8');
 	assert.match(runtimeStdout, /transcript output/);
 	assert.equal(runtimeStdout.includes('refresh-token-must-not-leak'), false);


### PR DESCRIPTION
## Summary
- emit `uri` on OpenCode evidence refs instead of non-contract `path`
- keep artifact records unchanged with filesystem `path`
- add regression coverage for evidence refs parsing as Homeboy `AgentTaskEvidenceRef`

Refs https://github.com/Extra-Chill/homeboy-extensions/issues/2035

## Evidence
- After artifacts were produced, Homeboy rejected the provider output as malformed JSON: `missing field uri`.
- Failed rerun child: `cook-issue-2035`
- Runner job: `homeboy runner job logs homeboy-lab f7de079a-26dc-42d6-8f69-68a2fff12831`

## Tests
- `npm --prefix agent-runtimes/opencode run test:opencode-agent-task-executor-boundary`
- `node tests/agent-task-provider-contract-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the provider evidence-ref contract failure, drafting the URI fix, and adding regression coverage.