### PR TITLE
Fix OpenCode executor hang on inherited pipes

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -592,6 +592,7 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 		let settled = false;
 		let timedOut = false;
 		let child;
+		let exitFallbackTimer = null;
 
 		for (const filePath of Object.values(options.runtimeLogPaths || {})) {
 			fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -616,6 +617,9 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 				return;
 			}
 			settled = true;
+			if (exitFallbackTimer) {
+				clearTimeout(exitFallbackTimer);
+			}
 			resolve({
 				stdout: stdoutChunks.join(''),
 				stderr: stderrChunks.join(''),
@@ -638,6 +642,20 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 		child.stdout.on('data', (chunk) => append('stdout', chunk));
 		child.stderr.on('data', (chunk) => append('stderr', chunk));
 		child.on('error', (error) => finish({ error }));
+		child.on('exit', (status, signal) => {
+			// Some runtimes leave descendants holding inherited stdio open after the
+			// command exits. Fall back to process exit so Homeboy does not wait forever
+			// for a `close` event that cannot arrive until those descendants die.
+			exitFallbackTimer = setTimeout(() => {
+				child.stdout.destroy();
+				child.stderr.destroy();
+				finish({
+					status,
+					signal,
+					...(timedOut ? { error: Object.assign(new Error('OpenCode execution timed out.'), { code: 'ETIMEDOUT' }) } : {}),
+				});
+			}, 250);
+		});
 		child.on('close', (status, signal) => {
 			if (timer) {
 				clearTimeout(timer);

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -253,6 +253,30 @@ process.exit(0);
 	const quietAgentResult = JSON.parse(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
 	assert.deepEqual(quietAgentResult.artifacts, { patch: false, transcript: false });
 
+	const inheritedPipeCliPath = path.join(root, 'mock-opencode-inherited-pipe.cjs');
+	fs.writeFileSync(inheritedPipeCliPath, `#!/usr/bin/env node
+const { spawn } = require('node:child_process');
+spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10000)'], { detached: true, stdio: ['ignore', 'inherit', 'inherit'] }).unref();
+process.stdout.write('parent finished');
+process.exit(0);
+`);
+	const inheritedPipeResult = await Promise.race([
+		executeOpenCodeAgentTask({
+			...request,
+			task_id: 'opencode-inherited-pipe-exit',
+			executor: {
+				...request.executor,
+				config: {
+					...request.executor.config,
+					command_args: [inheritedPipeCliPath],
+				},
+			},
+		}, { env: fixtureEnv }),
+		new Promise((_, reject) => setTimeout(() => reject(new Error('OpenCode executor hung on inherited stdio pipes')), 2000)),
+	]);
+	assert.equal(inheritedPipeResult.status, 'succeeded');
+	assert.match(inheritedPipeResult.diagnostics[0].message, /status 0/);
+
 	const implicitArtifactResult = await executeOpenCodeAgentTask({
 		...request,
 		task_id: 'opencode-implicit-artifact-dir',


### PR DESCRIPTION
## Summary
- Resolve OpenCode runtime execution from process `exit` when descendant processes keep inherited stdout/stderr pipes open.
- Preserve normal `close` handling for complete stream capture and use the exit fallback only when close cannot arrive.
- Add a boundary regression where a mock OpenCode command leaves a detached child holding inherited stdio.

## Verification
- `npm --prefix agent-runtimes/opencode run test:opencode-agent-task-executor-boundary`
- `node tests/agent-task-provider-contract-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the OpenCode executor hang from runner process evidence, implementing the inherited-pipe exit fallback, and adding regression coverage.
