### PR TITLE
Fix WordPress runtime planner package boundary

### DIFF
--- a/wordpress/agent-task-contracts/agent-task-runner-contract.js
+++ b/wordpress/agent-task-contracts/agent-task-runner-contract.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const AGENT_TASK_RUNNER_SPEC_SCHEMA = 'homeboy/agent-task-runner-spec/v1';
+
+function agentTaskRunnerSpec(options = {}) {
+  const executorConfig = options.config || options.executor_config;
+  if (!executorConfig || typeof executorConfig !== 'object' || Array.isArray(executorConfig)) {
+    throw new Error('config is required.');
+  }
+
+  const backend = requiredString(options.backend, 'backend');
+  const runtime = options.runtime || options.runtime_id;
+  const taskTimeoutSeconds = options.task_timeout_seconds || options.taskTimeoutSeconds;
+  const timeoutMs = options.timeout_ms || secondsToMs(taskTimeoutSeconds);
+  const maxRuntimeMs = options.max_runtime_ms || options.maxRuntimeMs;
+  const limits = stripUndefined({
+    ...(options.limits || {}),
+    ...(timeoutMs ? { timeout_ms: timeoutMs } : {}),
+    ...(maxRuntimeMs ? { max_runtime_ms: maxRuntimeMs } : {}),
+    // Compatibility for existing runtime adapters that still read seconds.
+    ...(taskTimeoutSeconds ? { task_timeout_seconds: taskTimeoutSeconds } : {}),
+  });
+  const artifactDeclarations = normalizeArray(options.artifact_declarations || options.artifactDeclarations);
+  const expectedArtifacts = normalizeArray(options.expected_artifacts || options.expectedArtifacts);
+
+  const spec = stripUndefined({
+    schema: AGENT_TASK_RUNNER_SPEC_SCHEMA,
+    executor: stripUndefined({
+      backend,
+      ...(runtime ? { runtime } : {}),
+      ...(normalizeArray(options.secret_env || options.secretEnv).length > 0
+        ? { secret_env: normalizeArray(options.secret_env || options.secretEnv) }
+        : {}),
+      config: executorConfig,
+    }),
+    limits,
+    artifact_declarations: artifactDeclarations,
+    // Compatibility for active workflows that still submit artifact names only.
+    expected_artifacts: expectedArtifacts,
+  });
+
+  validateAgentTaskRunnerSpec(spec);
+  return spec;
+}
+
+function agentTaskRequestFromRunnerSpec(options = {}) {
+  const runnerSpec = validateAgentTaskRunnerSpec(options.runnerSpec || options.runner_spec);
+  return stripUndefined({
+    executor: runnerSpec.executor,
+    limits: runnerSpec.limits,
+    artifact_declarations: runnerSpec.artifact_declarations,
+    expected_artifacts: runnerSpec.expected_artifacts,
+  });
+}
+
+function validateAgentTaskRunnerSpec(spec) {
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error('runner spec must be an object.');
+  }
+  if (spec.schema !== AGENT_TASK_RUNNER_SPEC_SCHEMA) {
+    throw new Error(`runner spec schema must be ${AGENT_TASK_RUNNER_SPEC_SCHEMA}.`);
+  }
+  if (!spec.executor || typeof spec.executor !== 'object' || Array.isArray(spec.executor)) {
+    throw new Error('runner spec executor is required.');
+  }
+  requiredString(spec.executor.backend, 'runner spec executor.backend');
+  if (spec.executor.runtime !== undefined) {
+    requiredString(spec.executor.runtime, 'runner spec executor.runtime');
+  }
+  if (!spec.executor.config || typeof spec.executor.config !== 'object' || Array.isArray(spec.executor.config)) {
+    throw new Error('runner spec executor.config is required.');
+  }
+  if (spec.executor.secret_env !== undefined && !Array.isArray(spec.executor.secret_env)) {
+    throw new Error('runner spec executor.secret_env must be an array.');
+  }
+  if (spec.limits !== undefined && (typeof spec.limits !== 'object' || Array.isArray(spec.limits))) {
+    throw new Error('runner spec limits must be an object.');
+  }
+  if (spec.expected_artifacts !== undefined && !Array.isArray(spec.expected_artifacts)) {
+    throw new Error('runner spec expected_artifacts must be an array.');
+  }
+  if (spec.artifact_declarations !== undefined && !Array.isArray(spec.artifact_declarations)) {
+    throw new Error('runner spec artifact_declarations must be an array.');
+  }
+  return spec;
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function stripUndefined(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
+}
+
+function secondsToMs(value) {
+  const seconds = Number(value || 0);
+  return seconds > 0 ? seconds * 1000 : undefined;
+}
+
+module.exports = {
+  AGENT_TASK_RUNNER_SPEC_SCHEMA,
+  agentTaskRequestFromRunnerSpec,
+  agentTaskRunnerSpec,
+  validateAgentTaskRunnerSpec,
+};

--- a/wordpress/agent-task-contracts/generic-agent-task-plan.js
+++ b/wordpress/agent-task-contracts/generic-agent-task-plan.js
@@ -1,0 +1,218 @@
+'use strict';
+
+/**
+ * Internal dependencies
+ */
+const {
+  agentTaskRequestFromRunnerSpec,
+  agentTaskRunnerSpec,
+} = require('./agent-task-runner-contract');
+
+const GENERIC_AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
+const GENERIC_AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
+
+function genericAgentTaskRunnerSpec(options = {}) {
+  const config = options.config || options.executor_config;
+  return agentTaskRunnerSpec({
+    backend: options.backend,
+    runtime: options.runtime || options.runtime_id,
+    config,
+    secret_env: normalizeArray(options.secret_env),
+    task_timeout_seconds: options.task_timeout_seconds,
+    artifact_declarations: options.artifact_declarations,
+    limits: options.limits,
+    expected_artifacts: options.expected_artifacts,
+  });
+}
+
+function genericAgentTaskRequest(options = {}) {
+  const taskId = requiredString(options.task_id, 'task_id');
+  const runnerRequest = agentTaskRequestFromRunnerSpec({
+    runnerSpec: options.runnerSpec || options.runner_spec || genericAgentTaskRunnerSpec(options),
+  });
+
+  const sourceRefs = options.sourceRefs || options.source_refs;
+
+  return stripUndefined({
+    schema: options.schema || GENERIC_AGENT_TASK_REQUEST_SCHEMA,
+    task_id: taskId,
+    group_key: options.group_key,
+    parent_plan_id: options.parent_plan_id,
+    cwd: options.cwd,
+    repo: options.repo,
+    workspace: options.workspace,
+    executor: runnerRequest.executor,
+    goal: options.goal,
+    instructions: options.instructions,
+    inputs: options.inputs,
+    source_refs: sourceRefs === undefined ? undefined : normalizeArray(sourceRefs),
+    policy: options.policy,
+    limits: runnerRequest.limits,
+    artifact_declarations: runnerRequest.artifact_declarations,
+    expected_artifacts: runnerRequest.expected_artifacts,
+    metadata: options.metadata,
+  });
+}
+
+function genericAgentTaskPlan(options = {}) {
+  const planId = requiredString(options.plan_id, 'plan_id');
+  const tasks = normalizeArray(options.tasks);
+  if (tasks.length === 0) {
+    throw new Error('tasks must contain at least one task request.');
+  }
+  return stripUndefined({
+    schema: options.schema || GENERIC_AGENT_TASK_PLAN_SCHEMA,
+    plan_id: planId,
+    tasks,
+    options: options.options,
+    metadata: options.metadata,
+  });
+}
+
+function normalizeRuntimeExecutionDescriptor(descriptor, runtimeProfile = {}) {
+  if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
+    return null;
+  }
+  if (Object.keys(descriptor).length === 0) {
+    return null;
+  }
+  const kind = descriptor.kind || descriptor.type || runtimeExecutionKindForDescriptor(descriptor);
+  const ability = abilityForRuntimeExecutionKind(kind, runtimeProfile);
+  const input = runtimeExecutionInput(descriptor, kind);
+  return stripUndefined({
+    schema: descriptor.schema || GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
+    kind,
+    ability,
+    input,
+    outputs: descriptor.outputs,
+    metadata: descriptor.metadata,
+  });
+}
+
+function runtimeExecutionKindForDescriptor(descriptor) {
+  if (descriptor.workflow) {
+    return 'workflow';
+  }
+  if (descriptor.bundle || descriptor.source || descriptor.path) {
+    return 'bundle';
+  }
+  return 'ability';
+}
+
+function abilityForRuntimeExecutionKind(kind, runtimeProfile = {}) {
+  const contract = runtimeExecutionContract(kind, runtimeProfile);
+  const ability = contract?.ability || abilityFromRuntimeExecutionContract(contract, runtimeProfile);
+  if (ability) {
+    assertRuntimeExecutionContractCapabilities(kind, contract, runtimeProfile);
+    return ability;
+  }
+  if (kind === 'ability') {
+    return runtimeProfile.runtime_task_ability;
+  }
+  throw new Error(`runtime_execution kind ${kind} is not supported by runtime profile ${runtimeProfile.id || '(unknown)'}.`);
+}
+
+function abilityFromRuntimeExecutionContract(contract, runtimeProfile = {}) {
+  const field = contract?.ability_field;
+  if (typeof field !== 'string' || field.trim() === '') {
+    return '';
+  }
+  return runtimeProfile[field] || '';
+}
+
+function assertRuntimeExecutionContractCapabilities(kind, contract, runtimeProfile) {
+  const requiredCapabilities = normalizeArray(contract.required_capabilities || contract.capabilities);
+  if (requiredCapabilities.length === 0) {
+    return;
+  }
+  const capabilities = normalizeArray(runtimeProfile.capabilities || runtimeProfile.provider_capabilities);
+  const missing = requiredCapabilities.filter((capability) => !capabilities.includes(capability));
+  if (missing.length > 0) {
+    throw new Error(`runtime_execution kind ${kind} requires unsupported provider capabilities: ${missing.join(', ')}.`);
+  }
+}
+
+function runtimeExecutionContract(kind, runtimeProfile = {}) {
+  const normalizedKind = String(kind || '').trim();
+  if (!normalizedKind) {
+    return null;
+  }
+  const contracts = runtimeProfile.runtime_execution_contracts || {};
+  const contract = contracts[normalizedKind];
+  if (typeof contract === 'string') {
+    return { kind: normalizedKind, ability: contract };
+  }
+  if (contract && typeof contract === 'object' && !Array.isArray(contract)) {
+    return { kind: normalizedKind, ...contract };
+  }
+  if (normalizedKind === 'bundle' && runtimeProfile.runtime_bundle_ability) {
+    return { kind: normalizedKind, ability: runtimeProfile.runtime_bundle_ability };
+  }
+  if (normalizedKind === 'workflow' && runtimeProfile.runtime_workflow_ability) {
+    return { kind: normalizedKind, ability: runtimeProfile.runtime_workflow_ability };
+  }
+  if (normalizedKind === 'ability' && runtimeProfile.runtime_task_ability) {
+    return { kind: normalizedKind, ability: runtimeProfile.runtime_task_ability };
+  }
+  return null;
+}
+
+function runtimeExecutionInput(descriptor, kind) {
+  const explicitInput = descriptor.input && typeof descriptor.input === 'object' && !Array.isArray(descriptor.input)
+    ? descriptor.input
+    : {};
+  const bundle = descriptor.bundle && typeof descriptor.bundle === 'object' && !Array.isArray(descriptor.bundle)
+    ? descriptor.bundle
+    : {};
+  const workflow = descriptor.workflow && typeof descriptor.workflow === 'object' && !Array.isArray(descriptor.workflow)
+    ? descriptor.workflow
+    : descriptor.workflow;
+  const source = descriptor.source || descriptor.path || bundle.source || bundle.path || bundle.bundle_path;
+  const normalizedBundle = Object.keys(bundle).length > 0 ? bundle : undefined;
+  const normalizedWorkflow = workflow && (typeof workflow !== 'object' || Object.keys(workflow).length > 0) ? workflow : undefined;
+  return stripUndefined({
+    ...(kind === 'bundle' ? {
+      source,
+      bundle: normalizedBundle,
+      workflow: normalizedWorkflow,
+    } : {}),
+    ...(kind === 'workflow' ? {
+      source,
+      path: descriptor.path,
+      workflow: normalizedWorkflow,
+    } : {}),
+    ...explicitInput,
+  });
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function stripUndefined(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
+}
+
+module.exports = {
+  GENERIC_AGENT_TASK_PLAN_SCHEMA,
+  GENERIC_AGENT_TASK_REQUEST_SCHEMA,
+  GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
+  genericAgentTaskPlan,
+  genericAgentTaskRequest,
+  genericAgentTaskRunnerSpec,
+  normalizeRuntimeExecutionDescriptor,
+  runtimeExecutionContract,
+};

--- a/wordpress/agent-task-contracts/index.js
+++ b/wordpress/agent-task-contracts/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  ...require('./agent-task-runner-contract'),
+  ...require('./generic-agent-task-plan'),
+};

--- a/wordpress/lib/agent-task-runner-spec.js
+++ b/wordpress/lib/agent-task-runner-spec.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('../../agent-task-contracts/agent-task-runner-contract');
+module.exports = require('../agent-task-contracts/agent-task-runner-contract');

--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -14,7 +14,7 @@ const {
 	genericAgentTaskPlan,
 	genericAgentTaskRequest,
 	genericAgentTaskRunnerSpec,
-} = require('../../agent-task-contracts/generic-agent-task-plan');
+} = require('../agent-task-contracts/generic-agent-task-plan');
 const {
 	WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA,
 } = require('./wordpress-generic-fuzz-primitives');

--- a/wordpress/tests/wordpress-runtime-task-planner-smoke.js
+++ b/wordpress/tests/wordpress-runtime-task-planner-smoke.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
@@ -101,18 +102,17 @@ assert.deepEqual(
 	request,
 	genericAgentTaskRequest({
 		schema: contract.schemas.request,
-		taskId: 'single-runtime-task-smoke',
-		parentPlanId: undefined,
+		task_id: 'single-runtime-task-smoke',
+		parent_plan_id: undefined,
 		goal: 'Run WordPress runtime ability example/materialize-artifact and return the declared artifacts.',
 		instructions: 'Run WordPress runtime ability example/materialize-artifact and return the declared artifacts.',
 		inputs: {
 			ability: 'example/materialize-artifact',
 			ability_input: { slug: 'example' },
 		},
-		sourceRefs: [],
+		source_refs: [],
 		policy: { read: 'sandbox', write: 'sandbox', apply: 'review' },
 		metadata: {},
-		includeArtifactDeclarations: false,
 		runnerSpec: wordpressRuntimeTaskRunnerSpec({
 			taskId: 'single-runtime-task-smoke',
 			ability: 'example/materialize-artifact',
@@ -174,5 +174,22 @@ assert.equal(cliPlan.tasks[0].executor.config.runtime_id, 'wp-codebox');
 assert.equal(cliPlan.tasks[0].executor.config.runtime_task.input.dla_url, 'https://dla.example/export/123');
 assert.deepEqual(cliPlan.tasks[0].expected_artifacts, ['validation-report']);
 assert.equal(cliPlan.tasks[0].limits.task_timeout_seconds, 60);
+
+const installCopy = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'homeboy-wordpress-extension-install-'));
+try {
+	const installedExtension = path.join(installCopy, 'wordpress');
+	fs.cpSync(path.join(__dirname, '..'), installedExtension, {
+		recursive: true,
+		filter: (source) => !source.split(path.sep).includes('node_modules'),
+	});
+	const installedRequire = spawnSync(process.execPath, [
+		'-e',
+		"require(process.argv[1]); process.stdout.write('installed planner require passed\\n');",
+		path.join(installedExtension, 'lib', 'wordpress-runtime-task-planner.js'),
+	], { encoding: 'utf8' });
+	assert.equal(installedRequire.status, 0, installedRequire.stderr || installedRequire.stdout);
+} finally {
+	fs.rmSync(installCopy, { recursive: true, force: true });
+}
 
 process.stdout.write('WordPress runtime task planner smoke passed\n');


### PR DESCRIPTION
## Summary
- Package the generic agent task contract modules inside the WordPress extension install layout.
- Load WordPress runtime planner contracts from the install-local contract path instead of the monorepo root.
- Extend the planner smoke test to require the planner from a WordPress-only copied install layout.

## Tests
- npm run test:wordpress-runtime-task-planner
- npx eslint --no-warn-ignored lib/wordpress-runtime-task-planner.js lib/agent-task-runner-spec.js tests/wordpress-runtime-task-planner-smoke.js agent-task-contracts/generic-agent-task-plan.js agent-task-contracts/agent-task-runner-contract.js agent-task-contracts/index.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the installed extension module boundary, implementing the package/import fix, adding regression coverage, and running verification.