### PR TITLE
Prefer materialized WP Codebox runtime paths

### DIFF
--- a/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
+++ b/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
@@ -49,11 +49,13 @@ function exportRuntimeBin(workspace, env = process.env) {
 }
 
 function exportRuntimePath(workspace, env, existingEnvNames, relativePath, exportName) {
-  // Already provided by the caller/env — don't override an explicit value.
-  if (existingEnvNames.some((name) => env[name])) {
+  const resolvedPath = path.join(workspace, relativePath);
+  // A checked-out runtime build is the deterministic contract for this job. Keep
+  // an explicit value only when it already points inside the materialized
+  // workspace; stale runner-global env must not outrank the fresh checkout.
+  if (existingEnvNames.some((name) => envPathIsInsideWorkspace(env[name], workspace))) {
     return;
   }
-  const resolvedPath = path.join(workspace, relativePath);
   if (!fs.existsSync(resolvedPath)) {
     // Build did not produce the artifact; let the downstream check surface a
     // clear, accurate error rather than a wrong path.
@@ -63,6 +65,15 @@ function exportRuntimePath(workspace, env, existingEnvNames, relativePath, expor
   if (githubEnv) {
     fs.appendFileSync(githubEnv, `${exportName}=${resolvedPath}\n`);
   }
+}
+
+function envPathIsInsideWorkspace(value, workspace) {
+  if (!value) {
+    return false;
+  }
+  const resolvedValue = path.resolve(String(value));
+  const resolvedWorkspace = path.resolve(workspace);
+  return resolvedValue === resolvedWorkspace || resolvedValue.startsWith(`${resolvedWorkspace}${path.sep}`);
 }
 
 function requiresWordPressDependencies(env = process.env) {
@@ -84,6 +95,7 @@ function requiresWordPressDependencies(env = process.env) {
 }
 
 module.exports = {
+  envPathIsInsideWorkspace,
   requiresWordPressDependencies,
   setupRuntime,
 };

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider, runtimeIdFromOptions } = require('../lib/runtime-provider-resolver.cjs');
 const { runtimeAgentCiRunnerSpec } = require('..');
 const { runRuntimeSetup, runtimeSetupAdapter } = require('../../.github/scripts/runtime-agent-full-run/setup-runtime.cjs');
-const { requiresWordPressDependencies, setupRuntime } = require('../../agent-runtimes/wp-codebox/lib/runtime-setup.cjs');
+const { envPathIsInsideWorkspace, requiresWordPressDependencies, setupRuntime } = require('../../agent-runtimes/wp-codebox/lib/runtime-setup.cjs');
 
 assert.equal(DEFAULT_RUNTIME_ID, 'local-shell');
 
@@ -104,5 +107,50 @@ setupRuntime({
   },
 });
 assert.equal(installedCheckedOutDependencies, true);
+
+const runtimeWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-runtime-'));
+const githubEnvPath = path.join(runtimeWorkspace, 'github-env');
+const builtCliPath = path.join(runtimeWorkspace, '.ci/wp-codebox/packages/cli/dist/index.js');
+const builtContractsPath = path.join(runtimeWorkspace, '.ci/wp-codebox/packages/runtime-core/dist/contracts.js');
+fs.mkdirSync(path.dirname(builtCliPath), { recursive: true });
+fs.mkdirSync(path.dirname(builtContractsPath), { recursive: true });
+fs.writeFileSync(builtCliPath, '#!/usr/bin/env node\n');
+fs.writeFileSync(builtContractsPath, 'export {};\n');
+
+assert.equal(envPathIsInsideWorkspace(path.join(runtimeWorkspace, '.ci/wp-codebox/packages/cli/dist/index.js'), runtimeWorkspace), true);
+assert.equal(envPathIsInsideWorkspace('/home/chubes/Developer/wp-codebox@main-fuzz-proof-20260625/packages/cli/dist/index.js', runtimeWorkspace), false);
+
+setupRuntime({
+  phase: 'after_commands',
+  workspace: runtimeWorkspace,
+  env: {
+    GITHUB_ENV: githubEnvPath,
+    HOMEBOY_WP_CODEBOX_BIN: '/home/chubes/Developer/wp-codebox@main-fuzz-proof-20260625/packages/cli/dist/index.js',
+    HOMEBOY_WP_CODEBOX_CORE_MODULE: '/home/chubes/Developer/wp-codebox@main-fuzz-proof-20260625/packages/runtime-core/dist/index.js',
+  },
+  run: () => {},
+  installCheckedOutPhpDependencies: () => {},
+});
+const githubEnv = fs.readFileSync(githubEnvPath, 'utf8');
+assert.match(githubEnv, new RegExp(`HOMEBOY_WP_CODEBOX_BIN=${escapeRegExp(builtCliPath)}`));
+assert.match(githubEnv, new RegExp(`HOMEBOY_WP_CODEBOX_CORE_MODULE=${escapeRegExp(builtContractsPath)}`));
+
+fs.writeFileSync(githubEnvPath, '');
+setupRuntime({
+  phase: 'after_commands',
+  workspace: runtimeWorkspace,
+  env: {
+    GITHUB_ENV: githubEnvPath,
+    HOMEBOY_WP_CODEBOX_BIN: builtCliPath,
+    HOMEBOY_WP_CODEBOX_CORE_MODULE: builtContractsPath,
+  },
+  run: () => {},
+  installCheckedOutPhpDependencies: () => {},
+});
+assert.equal(fs.readFileSync(githubEnvPath, 'utf8'), '');
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 process.stdout.write('Runtime provider boundary passed\n');


### PR DESCRIPTION
## Summary
- Make WP Codebox runtime setup prefer the job-materialized checkout when runner-global WP Codebox env points outside the workspace.
- Keep explicit values only when they already point inside the current materialized workspace.
- Add coverage for stale runner-global HOMEBOY_WP_CODEBOX_BIN and HOMEBOY_WP_CODEBOX_CORE_MODULE being replaced through GITHUB_ENV.

## Tests
- node runtime-agent-ci/tests/runtime-provider-boundary.test.js
- node tests/wp-codebox-runtime-contract-source-smoke.mjs
- HOMEBOY_WP_CODEBOX_CORE_MODULE=/Users/chubes/Developer/wp-codebox@fix-lab-runtime-contract-blocker-20260630/packages/runtime-core/dist/contracts.js node tests/wp-codebox-runtime-contract-built-module-canary.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing stale Lab runtime env precedence, implementing the setup fix, and running targeted verification.