### PR TITLE
Fix WP Codebox cache runner exec invocation

### DIFF
--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -92,7 +92,23 @@ case "$OUTPUT" in
         ;;
 esac
 
-DRY_RUN_OUTPUT="$("$SCRIPT" --runner example-runner --source "$REMOTE_REPO" --ref fixture-ref --dry-run)"
+cat > "${FAKE_BIN}/homeboy" <<'HOMEBOY'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*"
+cat
+HOMEBOY
+chmod +x "${FAKE_BIN}/homeboy"
+
+DRY_RUN_OUTPUT="$(PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --runner example-runner --source "$REMOTE_REPO" --ref fixture-ref --dry-run)"
+case "$DRY_RUN_OUTPUT" in
+    "runner exec --script-file - --raw --env SOURCE="*) ;;
+    *)
+        echo "Dry-run did not pass runner exec options before runner id" >&2
+        echo "$DRY_RUN_OUTPUT" >&2
+        exit 1
+        ;;
+esac
 case "$DRY_RUN_OUTPUT" in
     *"Fetching WP Codebox ref"*) ;;
     *)

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -84,7 +84,7 @@ if [ -z "$NPM_BIN" ]; then
 fi
 
 RUNNER_ID="${TARGET:-local}"
-RUNNER_ARGS=(runner exec "$RUNNER_ID" --script-file - --raw --env "SOURCE=$SOURCE" --env "REQUESTED_REF=$REF" --env "CACHE_DIR=$CACHE_DIR" --env "NPM_BIN=$NPM_BIN")
+RUNNER_ARGS=(runner exec --script-file - --raw --env "SOURCE=$SOURCE" --env "REQUESTED_REF=$REF" --env "CACHE_DIR=$CACHE_DIR" --env "NPM_BIN=$NPM_BIN")
 
 if [ -n "$TARGET" ]; then
     RUNNER_ARGS+=(--ssh)
@@ -93,6 +93,8 @@ fi
 if [ "$DRY_RUN" -eq 1 ]; then
     RUNNER_ARGS+=(--dry-run)
 fi
+
+RUNNER_ARGS+=("$RUNNER_ID")
 
 homeboy "${RUNNER_ARGS[@]}" <<'REMOTE_SCRIPT'
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Pass homeboy runner exec options before the runner ID in the WP Codebox cache updater.
- Add dry-run smoke coverage that validates the generated runner exec argument order without needing a configured runner.

## Tests
- bash wordpress/scripts/build/update-wp-codebox-cache-smoke.sh

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the failed Lab cache refresh path, fixing the runner exec invocation, and updating smoke coverage.