### PR TITLE
Prefer WP Codebox cache over stale fuzz env

### DIFF
--- a/tests/fixtures/wp-codebox-core-runtime-contract.cjs
+++ b/tests/fixtures/wp-codebox-core-runtime-contract.cjs
@@ -60,7 +60,10 @@ const manifest = {
   },
   capabilities: {
     wordpressRuntime: {
-      commands: ['run-fuzz-suite', 'run-wordpress-workload'],
+      commands: {
+        runFuzzSuite: 'run-fuzz-suite',
+        runWorkload: 'run-wordpress-workload',
+      },
       capabilities: ['rest', 'disposable-runtime', 'runtime-isolation', 'artifact-export'],
       runner_modes: { 'runtime-backed': true },
     },
@@ -69,6 +72,7 @@ const manifest = {
     wordpressRuntime: {
       schema: 'wp-codebox/fuzz-runner-readiness/v1',
       status: 'ready',
+      entrypoint: 'wp-codebox/run-fuzz-suite',
       mode: 'runtime-backed',
       command_available: true,
     },

--- a/wordpress/lib/wp-codebox-resolver.js
+++ b/wordpress/lib/wp-codebox-resolver.js
@@ -74,6 +74,10 @@ function selectWpCodeboxSource(options, env, settings) {
 
 	const envBin = firstString(env.HOMEBOY_WP_CODEBOX_BIN, env.WP_CODEBOX_BIN, env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN);
 	if (envBin) {
+		const configuredCacheRoot = firstExistingDirectory(configuredCacheRootCandidates(options, env, settings));
+		if (configuredCacheRoot && !pathIsInside(envBin, configuredCacheRoot)) {
+			return { source: 'cache', path: configuredCacheRoot };
+		}
 		return { source: 'env', bin: envBin, path: envBin };
 	}
 
@@ -108,6 +112,19 @@ function selectWpCodeboxSource(options, env, settings) {
 	}
 
 	return { source: 'default', bin: DEFAULT_WP_CODEBOX_BIN, path: DEFAULT_WP_CODEBOX_BIN };
+}
+
+function configuredCacheRootCandidates(options, env, settings) {
+	const explicit = firstString(
+		options.wpCodeboxInstallDir,
+		options.wpCodeboxInstallRoot,
+		options.installRoot,
+		env.HOMEBOY_WP_CODEBOX_INSTALL_DIR,
+		env.HOMEBOY_WP_CODEBOX_INSTALL_ROOT,
+		settings.wp_codebox_install_dir,
+		settings.wpCodeboxInstallDir
+	);
+	return explicit ? [explicit] : [];
 }
 
 function resolveSourceRoot(selection, options, env, settings) {
@@ -297,6 +314,15 @@ function sourceRootFromPath(value) {
 		return absolute;
 	}
 	return undefined;
+}
+
+function pathIsInside(value, root) {
+	if (typeof value !== 'string' || !value.trim() || typeof root !== 'string' || !root.trim()) {
+		return false;
+	}
+	const resolvedValue = path.resolve(expandHome(value));
+	const resolvedRoot = path.resolve(expandHome(root));
+	return resolvedValue === resolvedRoot || resolvedValue.startsWith(`${resolvedRoot}${path.sep}`);
 }
 
 function wpCodeboxFingerprint({ sourceRoot, installRoot, bin, coreModulePath, runtimePackagePath } = {}) {

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -312,11 +312,27 @@ function discoverWpCodeboxBin(env) {
 
 function wpCodeboxCommand(env) {
 	const settings = parseJsonObject(env.HOMEBOY_SETTINGS_JSON);
-	return env.HOMEBOY_WP_CODEBOX_BIN
-		|| env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
+	const discoveredBin = discoverWpCodeboxBin(env);
+	if (env.HOMEBOY_WP_CODEBOX_BIN) {
+		const configuredInstallRoot = env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || env.HOMEBOY_WP_CODEBOX_INSTALL_ROOT;
+		if (!configuredInstallRoot || pathIsInside(env.HOMEBOY_WP_CODEBOX_BIN, configuredInstallRoot)) {
+			return env.HOMEBOY_WP_CODEBOX_BIN;
+		}
+		return discoveredBin || env.HOMEBOY_WP_CODEBOX_BIN;
+	}
+	return env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
 		|| settings?.wp_codebox_bin
-		|| discoverWpCodeboxBin(env)
+		|| discoveredBin
 		|| 'wp-codebox';
+}
+
+function pathIsInside(value, root) {
+	if (!value || !root) {
+		return false;
+	}
+	const resolvedValue = path.resolve(String(value));
+	const resolvedRoot = path.resolve(String(root));
+	return resolvedValue === resolvedRoot || resolvedValue.startsWith(`${resolvedRoot}${path.sep}`);
 }
 
 function parseJsonObject(value) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -600,8 +600,8 @@ assert.equal(
 		HOMEBOY_WP_CODEBOX_BIN: '/explicit/wp-codebox',
 		HOMEBOY_WP_CODEBOX_INSTALL_DIR: codeboxInstallRoot,
 	}),
-	'/explicit/wp-codebox',
-	'Explicit WP Codebox env should override the Homeboy-managed cache'
+	cachedCodeboxBin,
+	'Stale WP Codebox env outside the configured install root should not override the Homeboy-managed cache'
 );
 assert.equal(
 	wpCodeboxCommand({

--- a/wordpress/tests/wp-codebox-resolver-smoke.js
+++ b/wordpress/tests/wp-codebox-resolver-smoke.js
@@ -70,6 +70,21 @@ try {
 	assert.equal(cacheIdentity.sourceRoot, cacheSourceRoot);
 	assert.equal(cacheIdentity.bin, path.join(cacheSourceRoot, 'packages', 'cli', 'dist', 'index.js'));
 
+	const staleEnvWithCacheIdentity = resolveWpCodeboxIdentity({
+		wpCodeboxInstallDir: cacheRoot,
+		env: { HOMEBOY_WP_CODEBOX_BIN: envBin },
+	});
+	assert.equal(staleEnvWithCacheIdentity.selectionSource, 'cache');
+	assert.equal(staleEnvWithCacheIdentity.bin, path.join(cacheSourceRoot, 'packages', 'cli', 'dist', 'index.js'));
+
+	const explicitBinWithCacheIdentity = resolveWpCodeboxIdentity({
+		wpCodeboxBin: envBin,
+		wpCodeboxInstallDir: cacheRoot,
+		env: {},
+	});
+	assert.equal(explicitBinWithCacheIdentity.selectionSource, 'explicit');
+	assert.equal(explicitBinWithCacheIdentity.bin, envBin);
+
 	const workspaceIdentity = resolveWpCodeboxIdentity({
 		workspaceRoot,
 		wpCodeboxInstallDir: path.join(root, 'missing-cache'),


### PR DESCRIPTION
## Summary
- Prefer an explicitly configured Homeboy WP Codebox install/cache over stale runner-global WP Codebox env paths in fuzz resolution.
- Apply the same cache precedence to the legacy fuzz runner command helper.
- Update the runtime-contract fixture to the canonical WordPress runtime command/readiness shape.

## Tests
- node wordpress/tests/wp-codebox-resolver-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node tests/wp-codebox-runtime-contract-source-smoke.mjs
- HOMEBOY_WP_CODEBOX_CORE_MODULE="/Users/chubes/Developer/wp-codebox@fix-lab-runtime-contract-blocker-20260630/packages/runtime-core/dist/contracts.js" node tests/wp-codebox-runtime-contract-built-module-canary.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the stale WP Codebox fuzz-runner resolution path, implementing the resolver/runner fix, and updating focused tests.