### PR TITLE
Resolve WP Codebox core from selected cache

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -279,20 +279,29 @@ function wpCodeboxWordPressRuntimeContracts(options = {}) {
 }
 
 function wpCodeboxCanonicalRuntimeContractSource(options = {}) {
+	const resolvedOptions = wpCodeboxRuntimeContractSourceOptions(options);
 	if (typeof options.loadRuntimeContractSource === 'function') {
-		return options.loadRuntimeContractSource(options);
+		return options.loadRuntimeContractSource(resolvedOptions);
 	}
 	if (typeof options.loadCanonicalRuntimeContractSourceSync === 'function') {
-		return options.loadCanonicalRuntimeContractSourceSync({ ...options, required: false });
+		return options.loadCanonicalRuntimeContractSourceSync({ ...resolvedOptions, required: false });
 	}
 	if (!loadCanonicalRuntimeContractSourceSync) {
 		return null;
 	}
 	try {
-		return loadCanonicalRuntimeContractSourceSync({ ...options, required: false });
+		return loadCanonicalRuntimeContractSourceSync({ ...resolvedOptions, required: false });
 	} catch {
 		return null;
 	}
+}
+
+function wpCodeboxRuntimeContractSourceOptions(options = {}) {
+	if (options.wpCodeboxCoreModule || options.coreModule) {
+		return options;
+	}
+	const identity = createCodeboxClient(options).identity();
+	return { ...options, wpCodeboxCoreModule: identity.coreModulePath };
 }
 
 function missingWpCodeboxFuzzRuntimeContractPaths(manifest) {

--- a/wordpress/lib/wp-codebox-resolver.js
+++ b/wordpress/lib/wp-codebox-resolver.js
@@ -174,17 +174,26 @@ function resolveInstallRoot(selection, sourceRoot, options, env, settings) {
 }
 
 function resolveCoreModulePath(sourceRoot, installRoot, options, env) {
-	const explicit = firstString(options.wpCodeboxCoreModule, options.coreModule, env.HOMEBOY_WP_CODEBOX_CORE_MODULE, env.WP_CODEBOX_CORE_MODULE);
+	const explicit = firstString(options.wpCodeboxCoreModule, options.coreModule);
 	if (explicit) {
 		return isPathSpecifier(explicit) ? path.resolve(expandHome(explicit)) : explicit;
 	}
-	return firstExistingFile([
+	const discovered = firstExistingFile([
 		sourceRoot && path.resolve(sourceRoot, options.runtimeCoreEntry || DEFAULT_RUNTIME_CORE_ENTRY),
 		installRoot && path.resolve(installRoot, 'source', options.runtimeCoreEntry || DEFAULT_RUNTIME_CORE_ENTRY),
 		installRoot && path.resolve(installRoot, 'release', 'wp-codebox-cli', options.runtimeCoreEntry || DEFAULT_RUNTIME_CORE_ENTRY),
 		installRoot && path.resolve(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
 		installRoot && path.resolve(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
-	]) || DEFAULT_CORE_MODULE;
+	]);
+	const envExplicit = firstString(env.HOMEBOY_WP_CODEBOX_CORE_MODULE, env.WP_CODEBOX_CORE_MODULE);
+	if (envExplicit) {
+		const resolvedEnvExplicit = isPathSpecifier(envExplicit) ? path.resolve(expandHome(envExplicit)) : envExplicit;
+		if (!discovered || !isPathSpecifier(resolvedEnvExplicit) || pathIsInside(resolvedEnvExplicit, sourceRoot) || pathIsInside(resolvedEnvExplicit, installRoot)) {
+			return resolvedEnvExplicit;
+		}
+		return discovered;
+	}
+	return discovered || DEFAULT_CORE_MODULE;
 }
 
 function resolveRuntimePackagePath(sourceRoot, installRoot, options, env) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -142,6 +142,35 @@ assert.deepEqual(REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS, [
 	'schemas.wordpressRuntime.workloadRun',
 ]);
 assert.equal(wpCodeboxRuntimeContractManifest({ loadRuntimeContractSource: () => ({ manifest }) }), manifest);
+const contractSourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-contract-source-'));
+try {
+	const cacheRoot = path.join(contractSourceRoot, 'cache', 'wp-codebox');
+	const cacheSourceRoot = path.join(cacheRoot, 'source');
+	const staleSourceRoot = path.join(contractSourceRoot, 'wp-codebox@stale');
+	const cacheCoreModule = path.join(cacheSourceRoot, 'packages', 'runtime-core', 'dist', 'index.js');
+	fs.mkdirSync(path.join(cacheSourceRoot, 'packages', 'cli', 'dist'), { recursive: true });
+	fs.mkdirSync(path.dirname(cacheCoreModule), { recursive: true });
+	fs.mkdirSync(path.join(cacheSourceRoot, 'packages', 'runtime-playground', 'dist'), { recursive: true });
+	fs.mkdirSync(path.join(staleSourceRoot, 'packages', 'runtime-core', 'dist'), { recursive: true });
+	fs.writeFileSync(path.join(cacheSourceRoot, 'packages', 'cli', 'dist', 'index.js'), '#!/usr/bin/env node\n');
+	fs.writeFileSync(cacheCoreModule, 'module.exports = {};\n');
+	fs.writeFileSync(path.join(cacheSourceRoot, 'packages', 'runtime-playground', 'dist', 'index.js'), 'module.exports = {};\n');
+	const staleCoreModule = path.join(staleSourceRoot, 'packages', 'runtime-core', 'dist', 'index.js');
+	fs.writeFileSync(staleCoreModule, 'module.exports = {};\n');
+	assert.equal(wpCodeboxRuntimeContractManifest({
+		env: {
+			HOMEBOY_WP_CODEBOX_BIN: path.join(staleSourceRoot, 'packages', 'cli', 'dist', 'index.js'),
+			HOMEBOY_WP_CODEBOX_CORE_MODULE: staleCoreModule,
+			HOMEBOY_WP_CODEBOX_INSTALL_DIR: cacheRoot,
+		},
+		loadRuntimeContractSource: (options) => {
+			assert.equal(options.wpCodeboxCoreModule, cacheCoreModule);
+			return { manifest };
+		},
+	}), manifest);
+} finally {
+	fs.rmSync(contractSourceRoot, { recursive: true, force: true });
+}
 assert.deepEqual(wpCodeboxWordPressWorkloadRunInput({
 	id: 'workload-run',
 	steps: [{ command: 'wordpress.run-declarative-fuzz' }],

--- a/wordpress/tests/wp-codebox-resolver-smoke.js
+++ b/wordpress/tests/wp-codebox-resolver-smoke.js
@@ -72,10 +72,14 @@ try {
 
 	const staleEnvWithCacheIdentity = resolveWpCodeboxIdentity({
 		wpCodeboxInstallDir: cacheRoot,
-		env: { HOMEBOY_WP_CODEBOX_BIN: envBin },
+		env: {
+			HOMEBOY_WP_CODEBOX_BIN: envBin,
+			HOMEBOY_WP_CODEBOX_CORE_MODULE: path.join(envRoot, 'packages', 'runtime-core', 'dist', 'index.js'),
+		},
 	});
 	assert.equal(staleEnvWithCacheIdentity.selectionSource, 'cache');
 	assert.equal(staleEnvWithCacheIdentity.bin, path.join(cacheSourceRoot, 'packages', 'cli', 'dist', 'index.js'));
+	assert.equal(staleEnvWithCacheIdentity.coreModulePath, path.join(cacheSourceRoot, 'packages', 'runtime-core', 'dist', 'index.js'));
 
 	const explicitBinWithCacheIdentity = resolveWpCodeboxIdentity({
 		wpCodeboxBin: envBin,


### PR DESCRIPTION
## Summary
- Resolve WP Codebox core modules from the selected cache/source root before stale ambient core env.
- Load runtime contract manifests from the same resolved WP Codebox identity used for CLI/runtime dispatch.
- Add smoke coverage for stale bin/core env with a configured cache.

## Tests
- node wordpress/tests/wp-codebox-resolver-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node tests/wp-codebox-runtime-contract-source-smoke.mjs
- HOMEBOY_WP_CODEBOX_CORE_MODULE="/Users/chubes/Developer/wp-codebox@fix-lab-runtime-contract-blocker-20260630/packages/runtime-core/dist/contracts.js" node tests/wp-codebox-runtime-contract-built-module-canary.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab WP Codebox core/cache identity mismatch, implementing the core-module resolver fix, and adding focused tests.