### PR TITLE
Prefer WP Codebox contracts module for runtime manifest

### DIFF
--- a/wordpress/lib/wp-codebox-resolver.js
+++ b/wordpress/lib/wp-codebox-resolver.js
@@ -11,7 +11,8 @@ const path = require('node:path');
 const DEFAULT_WP_CODEBOX_BIN = 'wp-codebox';
 const DEFAULT_WP_CLI_BIN = 'wp';
 const DEFAULT_CORE_MODULE = '@automattic/wp-codebox-core';
-const DEFAULT_RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
+const DEFAULT_RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/contracts.js';
+const DEFAULT_RUNTIME_CORE_FALLBACK_ENTRY = 'packages/runtime-core/dist/index.js';
 const DEFAULT_RUNTIME_PLAYGROUND_ENTRY = 'packages/runtime-playground/dist/index.js';
 const DEFAULT_CLI_ENTRY = 'packages/cli/dist/index.js';
 
@@ -180,9 +181,14 @@ function resolveCoreModulePath(sourceRoot, installRoot, options, env) {
 	}
 	const discovered = firstExistingFile([
 		sourceRoot && path.resolve(sourceRoot, options.runtimeCoreEntry || DEFAULT_RUNTIME_CORE_ENTRY),
+		sourceRoot && path.resolve(sourceRoot, DEFAULT_RUNTIME_CORE_FALLBACK_ENTRY),
 		installRoot && path.resolve(installRoot, 'source', options.runtimeCoreEntry || DEFAULT_RUNTIME_CORE_ENTRY),
+		installRoot && path.resolve(installRoot, 'source', DEFAULT_RUNTIME_CORE_FALLBACK_ENTRY),
 		installRoot && path.resolve(installRoot, 'release', 'wp-codebox-cli', options.runtimeCoreEntry || DEFAULT_RUNTIME_CORE_ENTRY),
+		installRoot && path.resolve(installRoot, 'release', 'wp-codebox-cli', DEFAULT_RUNTIME_CORE_FALLBACK_ENTRY),
+		installRoot && path.resolve(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js'),
 		installRoot && path.resolve(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
+		installRoot && path.resolve(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js'),
 		installRoot && path.resolve(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
 	]);
 	const envExplicit = firstString(env.HOMEBOY_WP_CODEBOX_CORE_MODULE, env.WP_CODEBOX_CORE_MODULE);

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -147,7 +147,7 @@ try {
 	const cacheRoot = path.join(contractSourceRoot, 'cache', 'wp-codebox');
 	const cacheSourceRoot = path.join(cacheRoot, 'source');
 	const staleSourceRoot = path.join(contractSourceRoot, 'wp-codebox@stale');
-	const cacheCoreModule = path.join(cacheSourceRoot, 'packages', 'runtime-core', 'dist', 'index.js');
+	const cacheCoreModule = path.join(cacheSourceRoot, 'packages', 'runtime-core', 'dist', 'contracts.js');
 	fs.mkdirSync(path.join(cacheSourceRoot, 'packages', 'cli', 'dist'), { recursive: true });
 	fs.mkdirSync(path.dirname(cacheCoreModule), { recursive: true });
 	fs.mkdirSync(path.join(cacheSourceRoot, 'packages', 'runtime-playground', 'dist'), { recursive: true });

--- a/wordpress/tests/wp-codebox-resolver-smoke.js
+++ b/wordpress/tests/wp-codebox-resolver-smoke.js
@@ -22,6 +22,7 @@ function makeCodeboxRoot(name, version = '1.2.3') {
 	fs.mkdirSync(runtimeDist, { recursive: true });
 	fs.writeFileSync(path.join(sourceRoot, 'package.json'), JSON.stringify({ version }));
 	fs.writeFileSync(path.join(cliDist, 'index.js'), '#!/usr/bin/env node\n');
+	fs.writeFileSync(path.join(coreDist, 'contracts.js'), 'export const contracts = true;\n');
 	fs.writeFileSync(path.join(coreDist, 'index.js'), 'export const ok = true;\n');
 	fs.writeFileSync(path.join(runtimeDist, 'index.js'), 'export const runtime = true;\n');
 	return sourceRoot;
@@ -49,7 +50,7 @@ try {
 	assert.equal(envIdentity.selectionSource, 'env');
 	assert.equal(envIdentity.bin, envBin);
 	assert.equal(envIdentity.sourceRoot, envRoot);
-	assert.equal(envIdentity.coreModulePath, path.join(envRoot, 'packages', 'runtime-core', 'dist', 'index.js'));
+	assert.equal(envIdentity.coreModulePath, path.join(envRoot, 'packages', 'runtime-core', 'dist', 'contracts.js'));
 	assert.equal(envIdentity.runtimePackagePath, path.join(envRoot, 'packages', 'runtime-playground', 'dist', 'index.js'));
 	assert.equal(envIdentity.fingerprint.version, '1.0.0');
 	assert.deepEqual(envIdentity.invocation, { command: process.execPath, args: [envBin] });
@@ -79,7 +80,7 @@ try {
 	});
 	assert.equal(staleEnvWithCacheIdentity.selectionSource, 'cache');
 	assert.equal(staleEnvWithCacheIdentity.bin, path.join(cacheSourceRoot, 'packages', 'cli', 'dist', 'index.js'));
-	assert.equal(staleEnvWithCacheIdentity.coreModulePath, path.join(cacheSourceRoot, 'packages', 'runtime-core', 'dist', 'index.js'));
+	assert.equal(staleEnvWithCacheIdentity.coreModulePath, path.join(cacheSourceRoot, 'packages', 'runtime-core', 'dist', 'contracts.js'));
 
 	const explicitBinWithCacheIdentity = resolveWpCodeboxIdentity({
 		wpCodeboxBin: envBin,


### PR DESCRIPTION
## Summary
- Prefer WP Codebox runtime-core `contracts.js` when resolving the core module for runtime contract manifests.
- Keep `index.js` as a fallback for older builds.
- Update resolver/fuzz smoke coverage to assert the canonical contracts module path.

## Tests
- node wordpress/tests/wp-codebox-resolver-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node wordpress/tests/wp-codebox-core-loader-smoke.js
- node tests/wp-codebox-runtime-contract-source-smoke.mjs
- HOMEBOY_WP_CODEBOX_CORE_MODULE="/Users/chubes/Developer/wp-codebox@fix-lab-runtime-contract-blocker-20260630/packages/runtime-core/dist/contracts.js" node tests/wp-codebox-runtime-contract-built-module-canary.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab runtime manifest loader path, implementing canonical contracts-module resolution, and adding focused smoke coverage.