### PR TITLE
Deprecate WordPress fanout compatibility wrappers

### DIFF
--- a/docs/generic-fanout-reconcile-workflow.md
+++ b/docs/generic-fanout-reconcile-workflow.md
@@ -62,7 +62,7 @@ For Homeboy agent-task fanout, keep record status host-owned: map provider outco
 
 ## Finding Packets
 
-`runtime-agent-ci` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` export helpers for diagnostic/finding packet inputs. `wordpress/lib/generic-fanout-reconcile-workflow.js` re-exports the same helpers for existing entrypoints.
+`runtime-agent-ci` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` export helpers for diagnostic/finding packet inputs. Existing WordPress callers may still resolve the deprecated compatibility re-export at `wordpress/lib/generic-fanout-reconcile-workflow.js`, but new callers should import the `runtime-agent-ci` module directly so the WordPress wrapper can be removed in a later cleanup.
 
 - `normalizeFindingPacketItems(packets, policy)` flattens packet-level `findings` or `diagnostics` arrays into generic items with stable packet/finding IDs.
 - `materializeFindingPacketFanoutConfig({ packets, policy, ...config })` applies policy-driven grouping and returns the generic config/groups/items needed by the planner.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -665,10 +665,11 @@ homeboy refactor <component> \
 
 Audit fanout has two boundaries. Generic extraction and reconcile mechanics live
 in `../runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` and
-`../runtime-agent-ci/lib/fanout-reconcile-runner.js`; WordPress keeps thin
-`lib/` re-export wrappers and the `scripts/agent/homeboy-generic-fanout-reconcile.cjs`
-JSON CLI for existing entrypoints. The generic
-runtime provider interface lives in `lib/audit-fanout-runtime-provider.js` and is
+`../runtime-agent-ci/lib/fanout-reconcile-runner.js`. WordPress still keeps thin
+deprecated `lib/` re-export wrappers and the `scripts/agent/homeboy-generic-fanout-reconcile.cjs`
+JSON CLI for existing entrypoints. New callers should import the `runtime-agent-ci`
+modules directly so the WordPress compatibility wrappers can be removed in a
+later cleanup. The generic runtime provider interface lives in `lib/audit-fanout-runtime-provider.js` and is
 exported from the WordPress package. Runtime providers own execution: they map
 generic grouped work into their provider task contract, run the task, and
 normalize records back for reconcile.


### PR DESCRIPTION
## Summary
- Document `wordpress/lib/generic-fanout-reconcile-workflow.js` and `wordpress/lib/fanout-reconcile-runner.js` as deprecated compatibility wrappers.
- Point new callers at the canonical `runtime-agent-ci` fanout/reconcile modules so the wrappers can be removed later.
- Did not delete a wrapper because repo-wide reference checks found the listed candidates are still referenced by docs/package exports/tests/tooling.

## Verification
- Searched for `generic-fanout-reconcile-workflow`, `fanout-reconcile-runner`, `audit-wp-codebox-fanout`, and `homeboy-audit-wp-codebox-fanout` before changing files.
- `npm run test:generic-fanout-reconcile-workflow`
- `npm run test:fanout-reconcile-runner`
- `npm run test:generic-fanout-reconcile-boundary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Repository search, documentation edit, focused test execution, commit, and PR creation.