### PR TITLE
Remove artifact postprocess command aliases

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -69,7 +69,6 @@ const DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY = 'wp-codebox/run-wordpress-workloa
 const DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA = 'wp-codebox/wordpress-workload-run/v1';
 const WP_CODEBOX_PUBLIC_CLI_COMMANDS = WP_CODEBOX_FUZZ_PUBLIC_COMMANDS;
 const ARTIFACT_POSTPROCESS_COMMAND = 'homeboy.artifact-postprocess';
-const ARTIFACT_POSTPROCESS_COMMAND_ALIASES = new Set([ARTIFACT_POSTPROCESS_COMMAND, 'artifact-postprocess', 'homeboy.artifact_postprocess']);
 const DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS = [
 	'wp-codebox-fuzz-suite-result',
 	'wordpress-fuzz-coverage',
@@ -1193,7 +1192,7 @@ function phpCallableSourceWrapper(source) {
 }
 
 function isArtifactPostprocessCommand(value) {
-	return ARTIFACT_POSTPROCESS_COMMAND_ALIASES.has(String(value || '').trim());
+	return String(value || '').trim() === ARTIFACT_POSTPROCESS_COMMAND;
 }
 
 async function runWpCodeboxFuzzSuite(options = {}) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -192,7 +192,7 @@ assert.deepEqual(wpCodeboxWordPressWorkloadRunInput({
 const artifactPostprocessWorkloadInput = wpCodeboxWordPressWorkloadRunInput({
 	id: 'artifact-postprocess-workload-run',
 	steps: [{
-		command: 'artifact-postprocess',
+		command: ARTIFACT_POSTPROCESS_COMMAND,
 		args: {
 			helper: '${package.root}/tools/artifact-helper.mjs',
 			action: 'coverage-gap-report',
@@ -218,9 +218,13 @@ const artifactPostprocessWorkloadInputAgain = wpCodeboxWordPressWorkloadRunInput
 assert.equal(artifactPostprocessWorkloadInputAgain.steps[0].helperPath, '${package.root}/tools/artifact-helper.mjs');
 assert.equal(artifactPostprocessWorkloadInputAgain.steps[0].inputArtifactRoot, '${artifacts.root}');
 assert.equal(artifactPostprocessWorkloadInputAgain.steps[0].outputArtifactPath, 'coverage/gaps.json');
+const legacyArtifactPostprocessAliasInput = wpCodeboxWordPressWorkloadRunInput({
+	steps: [{ command: 'artifact-postprocess', args: { action: 'coverage-gap-report' } }],
+});
+assert.deepEqual(legacyArtifactPostprocessAliasInput.steps[0], { command: 'artifact-postprocess', args: { action: 'coverage-gap-report' } });
 const artifactPostprocessAbsoluteHelper = wpCodeboxWordPressWorkloadRunInput({
 	packageRoot: '/runner/package',
-	steps: [{ command: 'artifact-postprocess', args: { helper: '/runner/package/tools/artifact-helper.mjs', action: 'coverage-gap-report', input: { path: '${artifacts.root}' }, output: { path: 'coverage/gaps.json' } } }],
+	steps: [{ command: ARTIFACT_POSTPROCESS_COMMAND, args: { helper: '/runner/package/tools/artifact-helper.mjs', action: 'coverage-gap-report', input: { path: '${artifacts.root}' }, output: { path: 'coverage/gaps.json' } } }],
 });
 assert.equal(artifactPostprocessAbsoluteHelper.steps[0].helperPath, 'tools/artifact-helper.mjs');
 
@@ -1319,7 +1323,7 @@ runWpCodeboxFuzzSuite({
 			input: wpCodeboxWordPressWorkloadRunInput({
 				id: 'staged-helper-workload',
 				packageRoot: stagedHelperDir,
-				steps: [{ command: 'artifact-postprocess', args: { helper: stagedHelperPath, action: 'coverage-gap-report', input: { path: '${artifacts.root}' }, output: { path: 'coverage/gaps.json' } } }],
+				steps: [{ command: ARTIFACT_POSTPROCESS_COMMAND, args: { helper: stagedHelperPath, action: 'coverage-gap-report', input: { path: '${artifacts.root}' }, output: { path: 'coverage/gaps.json' } } }],
 				metadata: { source_path: stagedWorkloadPath },
 			}),
 		}],


### PR DESCRIPTION
## Summary
- Remove legacy `artifact-postprocess` / `homeboy.artifact_postprocess` command alias handling from the WordPress WP Codebox fuzz workload normalizer.
- Keep the canonical `homeboy.artifact-postprocess` path and update focused tests to use it.
- Add regression coverage that the removed short alias is no longer translated.

## Tests
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-campaign`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, minimal cleanup implementation, focused test execution, commit/PR preparation.
