### PR TITLE
Adopt runtime artifact manifest constants in tests

### DIFF
--- a/runtime-agent-ci/lib/artifact-paths.cjs
+++ b/runtime-agent-ci/lib/artifact-paths.cjs
@@ -100,11 +100,15 @@ function relativeArtifactPath(root, filePath) {
 }
 
 function safeRelativePath(value) {
-  const normalized = String(value || '').replaceAll(path.sep, '/');
-  if (!normalized || normalized.startsWith('../') || normalized === '..' || normalized.startsWith('/') || normalized.includes('/../') || normalized === '.') {
+  const normalized = String(value || '').replace(/\\/g, '/');
+  if (!normalized || normalized.startsWith('/') || /^[A-Za-z]:\//.test(normalized)) {
     return '';
   }
-  return normalized;
+  const parts = normalized.split('/');
+  if (parts.some((part) => part === '..')) {
+    return '';
+  }
+  return parts.filter((part) => part && part !== '.').join('/');
 }
 
 function runArtifactPath(runDir, key) {

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -2,6 +2,9 @@
 
 const SECRET_ENV_PLAN_SCHEMA = 'homeboy/secret-env-plan/v1';
 const ARTIFACT_PATHS_SCHEMA = 'homeboy/runtime-agent-artifact-paths/v1';
+// Blocked from importing Homeboy core directly: artifact manifest constants are
+// currently exposed through Rust (`homeboy::core::artifacts`), not a Node or CLI
+// contract consumable by this package.
 const ARTIFACT_MANIFEST_SCHEMA = 'homeboy/artifact-manifest/v1';
 const ARTIFACT_MANIFEST_FILE = 'homeboy-artifact-manifest.json';
 const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = 'homeboy/runner-artifact-manifest-ref/v1';

--- a/runtime-agent-ci/tests/artifact-paths.test.js
+++ b/runtime-agent-ci/tests/artifact-paths.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { artifactManifestForFiles } = require('../lib/artifact-paths.cjs');
+
+const root = path.join(process.cwd(), 'artifacts');
+const manifest = artifactManifestForFiles({ run_dir: root }, [
+  path.join(root, 'nested', '.', 'result.json'),
+  path.join(root, 'nested', '..'),
+  path.join(root, '..', 'outside.json'),
+  { path: path.join(root, 'events.json'), role: 'events' },
+]);
+
+assert.deepEqual(manifest.artifacts.map((artifact) => artifact.path).sort(), [
+  'events.json',
+  'nested/result.json',
+]);
+assert.equal(manifest.artifacts.every((artifact) => !path.isAbsolute(artifact.path)), true);

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const genericLoopRunner = require('../lib/generic-agent-loop-runner');
+const { ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA } = require('../lib/artifact-paths.cjs');
 
 assert.equal(
   Object.prototype.hasOwnProperty.call(genericLoopRunner, 'runDeterministicLoop'),
@@ -358,8 +359,8 @@ process.stdout.write(JSON.stringify({
     results: sharedArtifactsRun.results,
     artifact_paths: { run_dir: sharedArtifactDir },
   });
-  const sharedManifest = JSON.parse(fs.readFileSync(path.join(sharedArtifactDir, 'homeboy-artifact-manifest.json'), 'utf8'));
-  assert.equal(sharedManifest.schema, 'homeboy/artifact-manifest/v1');
+  const sharedManifest = JSON.parse(fs.readFileSync(path.join(sharedArtifactDir, ARTIFACT_MANIFEST_FILE), 'utf8'));
+  assert.equal(sharedManifest.schema, ARTIFACT_MANIFEST_SCHEMA);
   assert.deepEqual(sharedManifest.artifacts.map((artifact) => artifact.path).sort(), [
     'outcome.json',
     'results.json',

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -9,6 +9,7 @@ const {
   runHeadlessDeterministicLoop,
   writeHeadlessDeterministicLoopArtifacts,
 } = require('../lib/headless-deterministic-loop-runner');
+const { ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA } = require('../lib/artifact-paths.cjs');
 
 const runtime = { id: 'fixture-runtime', executor: { backend: 'fixture', path: '/unused' } };
 const baseSpec = {
@@ -200,8 +201,8 @@ assert.equal(expiredDeadline.tasks[0].loop_policy.iteration_count, 0);
 const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headless-loop-artifact-manifest-'));
 try {
   writeHeadlessDeterministicLoopArtifacts({ result: twoRevolution, artifact_paths: { run_dir: artifactDir } });
-  const manifest = JSON.parse(fs.readFileSync(path.join(artifactDir, 'homeboy-artifact-manifest.json'), 'utf8'));
-  assert.equal(manifest.schema, 'homeboy/artifact-manifest/v1');
+  const manifest = JSON.parse(fs.readFileSync(path.join(artifactDir, ARTIFACT_MANIFEST_FILE), 'utf8'));
+  assert.equal(manifest.schema, ARTIFACT_MANIFEST_SCHEMA);
   assert.equal(manifest.artifacts.some((artifact) => artifact.path === 'loop-result.json'), true);
   assert.equal(manifest.artifacts.some((artifact) => artifact.path === 'events.json'), true);
   assert.equal(manifest.artifacts.every((artifact) => !path.isAbsolute(artifact.path)), true);


### PR DESCRIPTION
## Summary
- Replaces duplicate artifact manifest schema/filename literals in runtime-agent-ci tests with the package contract constants.
- Tightens artifact manifest relative path normalization to reject parent traversal segments and normalize dot/empty segments.
- Leaves the Homeboy core adoption blocker inline: core currently exposes artifact manifest constants through the Rust facade, not a Node package or CLI/helper contract consumable by this package.

## Tests
- npm test in runtime-agent-ci

## Residual risk / blocker
- Homeboy core has homeboy::core::artifacts::{ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA}, but homeboy runtime helper only exposes helper paths. A future upstream Node/JSON/CLI contract is needed before runtime-agent-ci can import core artifact manifest constants directly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting contract surfaces, making the focused cleanup, adding test coverage, and drafting this PR.