### PR TITLE
Document extension runtime materialization contract adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Generic runtime package requirements are documented in
 Use `tests/fixtures/agent-runtime-manifest.json` for static contract assertions;
 `agent-runtimes/` contains only shipped runtime packages.
 
+Runtime materialization source declarations belong in the manifest root
+`materialization` field, which Homeboy core converts into
+`homeboy/agent-runtime-materialization-plan/v1`. Extension-local workflow setup
+fields such as `ci_materialization` are transitional compatibility surfaces for
+existing GitHub Actions adapters, not the canonical runtime setup contract.
+
 Generic project-root, package-manager, and named-script execution helpers live in
 [`scripts/lib/project-scripts.sh`](scripts/lib/project-scripts.sh) and are
 documented in [`docs/project-script-runtime.md`](docs/project-script-runtime.md).
@@ -191,9 +197,11 @@ other substrate details remain WP Codebox-owned; Homeboy task schemas and
 caller-owned artifact declarations are prepared by Homeboy Extensions before WP
 Codebox runs the task.
 
-Codebox contract discovery is limited to public package exports or an explicit
-`HOMEBOY_WP_CODEBOX_CORE_MODULE` supplied by the runner. Homeboy Extensions does
-not probe WP Codebox cache/source package layouts for private files.
+Codebox contract discovery is limited to public package exports. The explicit
+`HOMEBOY_WP_CODEBOX_CORE_MODULE` loader path remains as a transitional runner
+compatibility escape hatch for environments that have not exposed the public
+package module on Node's resolution path. Homeboy Extensions does not probe WP
+Codebox cache/source package layouts for private files.
 
 Homeboy Extensions consumes a Codebox-owned `wp-codebox/parent-tool-bridge/v1`
 when the runtime profile exposes one. When it is missing, the adapter declares

--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -55,6 +55,12 @@ and invokes the stable `run-agent-task` CLI.
 
 Runtime-package callers should invoke `wp-codebox/run-runtime-package`.
 
+Runtime source, executable, readiness, and diagnostic declarations live in the
+manifest root `materialization` field. Homeboy core owns that source contract and
+projects it into `homeboy/agent-runtime-materialization-plan/v1`; the older
+`ci_materialization` block is retained only for the reusable GitHub Actions
+adapter until those callsites move to the core materialization plan.
+
 Provider credentials stay outside adapter payloads. The adapter forwards
 `secret_env` names and a `provider_credential_boundary` descriptor, and rejects
 raw credential fields such as `secret_env_values` or `credentials` before a task

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -31,6 +31,8 @@ The manifest root must declare:
 - `version`: runtime package contract version.
 - `description`: one-sentence runtime summary.
 - `agent_task_executors`: non-empty list of provider declarations.
+- `materialization`: optional runtime materialization source contract consumed by
+  Homeboy core.
 
 Each `agent_task_executors[]` entry must declare:
 
@@ -57,6 +59,68 @@ Each `agent_task_executors[]` entry must declare:
 
 Runtime-specific fields are allowed when they are additive. The public manifest
 fields give Homeboy core the information it needs to invoke the provider.
+
+## Runtime Materialization Source Contract
+
+Homeboy core owns the runtime materialization source contract. Runtime manifests
+declare materialization inputs under the root `materialization` field; core reads
+that field and emits `homeboy/agent-runtime-materialization-plan/v1` for runner
+setup and diagnostics. Extension packages should point at the core contract
+instead of copying provider-specific setup rules into workflow glue.
+
+The core-owned materialization fields are:
+
+- `source_roots`: named source checkouts or caches needed by the runtime.
+- `dependencies`: additional runtime dependency requirements tied to a source
+  root, environment variable, or operator action.
+- `executable_requirements`: binaries Homeboy can check before dispatch.
+- `readiness_checks`: runner-readable setup checks.
+- `env_passthrough`: environment names the materialization plan may pass through.
+- `workspace`: generic workspace shape for the runtime package.
+- `diagnostics`: tool/runtime diagnostic declarations consumed by
+  `homeboy extension show`.
+
+Example:
+
+```json
+{
+  "schema": "homeboy/agent-runtime-manifest/v1",
+  "id": "example-runtime",
+  "materialization": {
+    "source_roots": [
+      {
+        "id": "example-runtime",
+        "label": "Example runtime source",
+        "path": "~/.cache/homeboy/example-runtime/source",
+        "remote_url": "https://github.com/example/runtime.git",
+        "git_ref": "main"
+      }
+    ],
+    "executable_requirements": [
+      {
+        "id": "example-runtime.cli",
+        "label": "Example runtime CLI",
+        "env": ["EXAMPLE_RUNTIME_BIN"],
+        "candidates": ["example-runtime"],
+        "version_command": ["--version"]
+      }
+    ],
+    "env_passthrough": ["EXAMPLE_RUNTIME_BIN"],
+    "workspace": {
+      "cwd": "git_checkout",
+      "requires_git": true,
+      "write_scope": "artifacts",
+      "artifact_paths": [".homeboy/example-runtime"]
+    }
+  }
+}
+```
+
+`ci_materialization` remains a Homeboy Extensions workflow compatibility surface
+for the reusable GitHub Actions adapter. New runtime materialization docs and
+manifest examples should prefer the core `materialization` contract above. Keep
+`ci_materialization` only while callsites still depend on the local workflow
+loader.
 
 Generic runner specs must declare `executor.backend` explicitly. Runtime-specific
 planners may provide their own defaults, but the shared contract does not assume
@@ -284,6 +348,12 @@ Common fields:
 
 The provider must not infer workspace shape from any current runtime unless that
 shape is declared here.
+
+Runtime-level workspace requirements that apply before provider selection should
+also be declared in `materialization.workspace` so Homeboy core can include them
+in the materialization plan. Provider-level `workspace_materialization` remains
+the executor promise; root `materialization.workspace` is the core source for
+runtime setup and diagnostics.
 
 Caller-owned wrappers should pass domain-specific runtime requirements explicitly.
 For example, a caller can supply its ability provider, runtime components,

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -43,9 +43,10 @@ preflight fails with guidance instead of calling provider internals.
 
 WP Codebox contract discovery uses public modules such as
 `@automattic/wp-codebox-core`, `@automattic/wp-codebox-core/contracts`, and
-`wp-codebox-workspace/*`, or an explicit `HOMEBOY_WP_CODEBOX_CORE_MODULE` path
-provided by the runner. Homeboy does not scan WP Codebox source/cache package
-layouts to discover private core files.
+`wp-codebox-workspace/*`. The explicit `HOMEBOY_WP_CODEBOX_CORE_MODULE` path is a
+transitional runner compatibility loader for environments that have not exposed a
+public package module on Node's resolution path. Homeboy does not scan WP Codebox
+source/cache package layouts to discover private core files.
 
 ## WP Codebox Artifact Lookup
 

--- a/docs/remote-runner-bootstrap.md
+++ b/docs/remote-runner-bootstrap.md
@@ -166,9 +166,10 @@ missing that extension.
 WordPress test and bench workloads use the runner-side WP Codebox cache at
 `~/.cache/homeboy/wp-codebox/source` when WP Codebox is installed from source.
 Homeboy extension adapters do not inspect that cache to discover private Codebox
-package files; runners should expose public Codebox package exports or set
-`HOMEBOY_WP_CODEBOX_CORE_MODULE` explicitly when a public module is not on
-Node's resolution path.
+package files; runners should expose public Codebox package exports. Setting
+`HOMEBOY_WP_CODEBOX_CORE_MODULE` explicitly remains a transitional compatibility
+loader for runner images that have not exposed a public module on Node's
+resolution path.
 Refresh that cache before collecting lab evidence that must point at a known WP
 Codebox revision:
 

--- a/tests/fixtures/agent-runtime-manifest.json
+++ b/tests/fixtures/agent-runtime-manifest.json
@@ -4,6 +4,55 @@
   "name": "Fixture Agent Runtime",
   "version": "1.0.0",
   "description": "Static manifest fixture for Homeboy contract tests.",
+  "materialization": {
+    "source_roots": [
+      {
+        "id": "fixture-runtime",
+        "label": "Fixture runtime source",
+        "path": "~/.cache/homeboy/fixture-runtime/source",
+        "remote_url": "https://github.com/example/fixture-runtime.git",
+        "git_ref": "main",
+        "remediation": "Refresh the fixture runtime source before dispatching fixture-backed runner workloads."
+      }
+    ],
+    "dependencies": [
+      {
+        "id": "fixture-runtime.contracts",
+        "label": "Fixture runtime contracts",
+        "source_root": "fixture-runtime",
+        "requirement": "Runtime package contract files are present in the materialized source root."
+      }
+    ],
+    "executable_requirements": [
+      {
+        "id": "fixture-runtime.executable",
+        "label": "Fixture runtime executable",
+        "env": ["FIXTURE_RUNTIME_BIN"],
+        "candidates": ["fixture-runtime"],
+        "version_command": ["--version"],
+        "install_hint": "Install the fixture runtime CLI or set FIXTURE_RUNTIME_BIN."
+      }
+    ],
+    "readiness_checks": [
+      {
+        "id": "fixture-runtime.ready",
+        "label": "Fixture runtime readiness",
+        "executable": {
+          "env": ["FIXTURE_RUNTIME_BIN"],
+          "candidates": ["fixture-runtime"],
+          "version_command": ["--version"],
+          "install_hint": "Install the fixture runtime CLI or set FIXTURE_RUNTIME_BIN."
+        }
+      }
+    ],
+    "env_passthrough": ["FIXTURE_RUNTIME_BIN"],
+    "workspace": {
+      "cwd": "git_checkout",
+      "requires_git": true,
+      "write_scope": "artifacts",
+      "artifact_paths": [".homeboy/fixture-runtime"]
+    }
+  },
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",


### PR DESCRIPTION
## Summary
- Document Homeboy core's root manifest `materialization` contract and `homeboy/agent-runtime-materialization-plan/v1` projection in the runtime package contract.
- Extend the static runtime manifest fixture with materialization source, dependency, executable, readiness, env passthrough, and workspace examples.
- Mark `ci_materialization` and `HOMEBOY_WP_CODEBOX_CORE_MODULE` loader paths as transitional compatibility surfaces where they remain in use.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('tests/fixtures/agent-runtime-manifest.json','utf8')); console.log('fixture json ok')"`
- `node tests/runtime-provider-resolver-smoke.mjs`
- `npm run test:wp-codebox-runtime-contract-source` from `agent-runtimes/wp-codebox`
- `npm run test:wp-codebox-adapter-contract` from `agent-runtimes/wp-codebox`
- `npm run fixture:agent-task-core-contract:check` from `wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the documentation/fixture updates, running validation, and preparing this PR.