### PR TITLE
Align secret env plan source mapping

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -5,8 +5,8 @@ const fs = require('node:fs');
 const path = require('node:path');
 const {
   buildConfig,
-  buildSecretEnvFallbacks,
   buildSecretEnvPlan,
+  buildSecretEnvSourceMapping,
   loopPolicyFromEnv,
   projectRuntimeConfig,
   providerBenchEnvFromManifest,
@@ -31,4 +31,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired };
+module.exports = { buildConfig, buildSecretEnvPlan, buildSecretEnvSourceMapping, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired };

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1785,12 +1785,14 @@ function secretEnvNamesFromPlan(plan) {
   }
   // Mirror core's authoritative SecretEnvPlan::secret_env_names() aggregation
   // (homeboy src/core/secret_env_plan.rs): fold direct names, requirement-derived
-  // names, provider-credential names, and mapped env names so every declared
-  // secret is forwarded into the sandbox. Re-deriving only secret_env_names +
-  // env_name_mapping silently dropped requirement and provider-credential names.
+  // target/source names, provider-credential names, and mapped env names so every
+  // declared secret is forwarded into the sandbox.
   return uniquePaths([
     ...normalizeArray(plan.secret_env_names),
-    ...normalizeArray(plan.requirements).map((requirement) => requirement && requirement.name),
+    ...normalizeArray(plan.requirements).flatMap((requirement) => [
+      requirement && requirement.name,
+      ...normalizeArray(requirement && requirement.source_env_names),
+    ]),
     ...Object.values(plan.provider_credentials || {}).flatMap((mapping) => normalizeArray(mapping && mapping.secret_env)),
     ...Object.values(plan.env_name_mapping || {}).flatMap(normalizeArray),
   ]);

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -21,8 +21,8 @@ const {
   renderRuntimeWorkflowInputs,
 } = require('./runtime-workflow-inputs.cjs');
 const {
-  buildSecretEnvFallbacks,
   buildSecretEnvPlan,
+  buildSecretEnvSourceMapping,
 } = require('./runtime-contracts.cjs');
 
 function main() {
@@ -69,7 +69,7 @@ function buildConfig(env) {
     providerBenchEnvNames.add(providerEnvName);
     providerCredentialSourceEnvNames.push(providerEnvName);
   }
-  const secretEnvFallbacks = buildSecretEnvFallbacks({
+  const secretEnvSourceMapping = buildSecretEnvSourceMapping({
     githubTokenEnv,
     githubRepositoryTokenEnv,
     providerCanonicalSecretEnvNames,
@@ -180,14 +180,8 @@ function buildConfig(env) {
       secretEnv,
       runtimeEnv,
       providerSecretEnvMapping,
-      secretEnvFallbacks,
+      secretEnvSourceMapping,
     }),
-    // Fill a target secret env from a fallback source before the sandbox
-    // preflight runs: the provider's canonical key (e.g. OPENAI_API_KEY) from
-    // the caller's generic credential secret (PROVIDER_SECRET_n), and the
-    // Homeboy app token from the repository GITHUB_TOKEN when no app token is
-    // available. The run step applies these against its own environment.
-    ...(Object.keys(secretEnvFallbacks).length > 0 ? { secret_env_fallbacks: secretEnvFallbacks } : {}),
     github_profile_id: env.GITHUB_PROFILE_ID || `${workloadId}-ci`,
     target_repo: targetRepo,
     context_repositories: normalizeContextRepositories(env.CONTEXT_REPOSITORIES || '[]'),
@@ -485,4 +479,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys };
+module.exports = { buildConfig, buildSecretEnvPlan, buildSecretEnvSourceMapping, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys };

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -15,17 +15,24 @@ const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
   loop_policy: 'loop-policy.json',
 });
 
-// Local adapter seam for the secret materialization contract. Keep the emitted
-// shape stable until Homeboy core owns this schema and assembly.
-function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvFallbacks = {} } = {}) {
+// Local adapter seam for Homeboy core's SecretEnvPlan shape. Homeboy does not
+// expose this as a JS library yet, so keep this mirror intentionally small.
+function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvSourceMapping = {} } = {}) {
+  const secretEnvNames = uniqueStrings(secretEnv);
   return {
     schema: SECRET_ENV_PLAN_SCHEMA,
     public_env: Object.fromEntries(Object.entries(runtimeEnv).filter(([, value]) => typeof value === 'string')),
-    secret_env_names: uniqueStrings(secretEnv),
-    requirements: uniqueStrings(secretEnv).map((name) => ({ name, required: true })),
+    secret_env_names: secretEnvNames,
+    requirements: secretEnvNames.map((name) => {
+      const sourceEnvNames = normalizeSourceEnvNames(secretEnvSourceMapping[name]);
+      return {
+        name,
+        required: true,
+        ...(sourceEnvNames.length > 0 ? { source_env_names: sourceEnvNames } : {}),
+      };
+    }),
     env_name_mapping: Object.fromEntries(Object.entries({
       provider_secret_env: Object.values(providerSecretEnvMapping).filter((value) => typeof value === 'string' && value.length > 0),
-      secret_env_fallbacks: Object.values(secretEnvFallbacks).flat().filter((value) => typeof value === 'string' && value.length > 0),
     }).filter(([, names]) => names.length > 0)),
     inheritance: {
       require_declaration: true,
@@ -34,32 +41,43 @@ function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnv
   };
 }
 
-// Build the declarative secret-env fallback map consumed by the run step. Each
-// entry maps a target secret env name to an ordered list of source env names;
-// the run step sets target = first non-empty source when target is unset.
-function buildSecretEnvFallbacks({
+// Build SecretEnvRequirement.source_env_names candidates. The target name stays
+// first so an explicitly provided canonical secret wins over mapped sources.
+function buildSecretEnvSourceMapping({
   githubTokenEnv,
   githubRepositoryTokenEnv,
   providerCanonicalSecretEnvNames = [],
   providerCredentialSourceEnvNames = [],
 } = {}) {
-  const fallbacks = {};
+  const sourceMapping = {};
   if (githubTokenEnv && githubRepositoryTokenEnv && githubTokenEnv !== githubRepositoryTokenEnv) {
-    fallbacks[githubTokenEnv] = [githubRepositoryTokenEnv];
+    sourceMapping[githubTokenEnv] = [githubTokenEnv, githubRepositoryTokenEnv];
   }
   if (providerCredentialSourceEnvNames.length > 0) {
     for (const canonical of providerCanonicalSecretEnvNames) {
       const sources = providerCredentialSourceEnvNames.filter((name) => name !== canonical);
       if (sources.length > 0) {
-        fallbacks[canonical] = uniqueStrings([...(fallbacks[canonical] || []), ...sources]);
+        sourceMapping[canonical] = normalizeSourceEnvNames([...(sourceMapping[canonical] || [canonical]), ...sources]);
       }
     }
   }
-  return fallbacks;
+  return sourceMapping;
 }
 
 function uniqueStrings(values) {
   return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
+}
+
+function normalizeSourceEnvNames(values) {
+  const seen = new Set();
+  const names = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    if (typeof value === 'string' && value.length > 0 && !seen.has(value)) {
+      seen.add(value);
+      names.push(value);
+    }
+  }
+  return names;
 }
 
 module.exports = {
@@ -69,6 +87,6 @@ module.exports = {
   CANONICAL_RUN_ARTIFACT_FILES,
   RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
   SECRET_ENV_PLAN_SCHEMA,
-  buildSecretEnvFallbacks,
   buildSecretEnvPlan,
+  buildSecretEnvSourceMapping,
 };

--- a/runtime-agent-ci/scripts/run-headless-loop.cjs
+++ b/runtime-agent-ci/scripts/run-headless-loop.cjs
@@ -22,13 +22,7 @@ try {
   }
   const repoRoot = path.resolve(__dirname, '..', '..');
   const rawSpec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
-  // Fill required secret env names from declared fallbacks before any preflight
-  // runs. The provider's canonical key (e.g. OPENAI_API_KEY) is sourced from the
-  // caller's generic credential secret, and the Homeboy app token falls back to
-  // the repository GITHUB_TOKEN when no app token is present. Forwarding still
-  // happens through the secret-env-names-only boundary; only this process's env
-  // is populated so the names resolve.
-  applySecretEnvFallbacks(rawSpec.secret_env_fallbacks);
+  applySecretEnvPlanSourceEnvNames(rawSpec.secret_env_plan);
   const spec = materializeHeadlessProductionLoopSpec(rawSpec, {
     revolutions: args.revolutions || args.max_revolutions || process.env.HOMEBOY_HEADLESS_LOOP_REVOLUTIONS,
     runtime_id: args.runtime_id || process.env.HOMEBOY_AGENT_RUNTIME,
@@ -93,18 +87,22 @@ function listArg(value) {
   return String(value || '').split(',').map((item) => item.trim()).filter(Boolean);
 }
 
-function applySecretEnvFallbacks(fallbacks) {
-  if (!fallbacks || typeof fallbacks !== 'object' || Array.isArray(fallbacks)) {
+function applySecretEnvPlanSourceEnvNames(plan) {
+  if (!plan || typeof plan !== 'object' || Array.isArray(plan)) {
     return;
   }
-  for (const [target, sources] of Object.entries(fallbacks)) {
+  for (const requirement of Array.isArray(plan.requirements) ? plan.requirements : []) {
+    if (!requirement || typeof requirement !== 'object' || Array.isArray(requirement)) {
+      continue;
+    }
+    const target = requirement.name;
     if (typeof target !== 'string' || target === '') {
       continue;
     }
     if (typeof process.env[target] === 'string' && process.env[target] !== '') {
       continue;
     }
-    const sourceList = Array.isArray(sources) ? sources : [sources];
+    const sourceList = Array.isArray(requirement.source_env_names) ? requirement.source_env_names : [];
     for (const source of sourceList) {
       const value = typeof source === 'string' ? process.env[source] : undefined;
       if (typeof value === 'string' && value !== '') {

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -60,6 +60,11 @@ try {
     allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
   });
   assert.deepEqual(config.secret_env_plan.secret_env_names, config.secret_env);
+  assert.deepEqual(config.secret_env_plan.requirements.find((requirement) => requirement.name === 'HOMEBOY_GITHUB_APP_TOKEN'), {
+    name: 'HOMEBOY_GITHUB_APP_TOKEN',
+    required: true,
+    source_env_names: ['HOMEBOY_GITHUB_APP_TOKEN', 'GITHUB_TOKEN'],
+  });
 } finally {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 }
@@ -69,16 +74,15 @@ assert.deepEqual(
     secretEnv: ['PRIVATE_TOKEN'],
     runtimeEnv: { PUBLIC_MODE: 'test', PRIVATE_MODE: false },
     providerSecretEnvMapping: { token: 'PROVIDER_SECRET_1' },
-    secretEnvFallbacks: { PRIVATE_TOKEN: ['PROVIDER_SECRET_1'] },
+    secretEnvSourceMapping: { PRIVATE_TOKEN: ['PRIVATE_TOKEN', 'PROVIDER_SECRET_1'] },
   }),
   {
     schema: SECRET_ENV_PLAN_SCHEMA,
     public_env: { PUBLIC_MODE: 'test' },
     secret_env_names: ['PRIVATE_TOKEN'],
-    requirements: [{ name: 'PRIVATE_TOKEN', required: true }],
+    requirements: [{ name: 'PRIVATE_TOKEN', required: true, source_env_names: ['PRIVATE_TOKEN', 'PROVIDER_SECRET_1'] }],
     env_name_mapping: {
       provider_secret_env: ['PROVIDER_SECRET_1'],
-      secret_env_fallbacks: ['PROVIDER_SECRET_1'],
     },
     inheritance: {
       require_declaration: true,

--- a/runtime-agent-ci/tests/secret-env-plan-source-mapping.test.js
+++ b/runtime-agent-ci/tests/secret-env-plan-source-mapping.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+  buildSecretEnvPlan,
+  buildSecretEnvSourceMapping,
+} = require('../lib/runtime-contracts.cjs');
+
+const sourceMapping = buildSecretEnvSourceMapping({
+  githubTokenEnv: 'HOMEBOY_GITHUB_APP_TOKEN',
+  githubRepositoryTokenEnv: 'GITHUB_TOKEN',
+  providerCanonicalSecretEnvNames: ['OPENAI_API_KEY'],
+  providerCredentialSourceEnvNames: ['PROVIDER_SECRET_0'],
+});
+
+assert.deepEqual(sourceMapping, {
+  HOMEBOY_GITHUB_APP_TOKEN: ['HOMEBOY_GITHUB_APP_TOKEN', 'GITHUB_TOKEN'],
+  OPENAI_API_KEY: ['OPENAI_API_KEY', 'PROVIDER_SECRET_0'],
+});
+
+const plan = buildSecretEnvPlan({
+  secretEnv: ['OPENAI_API_KEY', 'PROVIDER_SECRET_0', 'HOMEBOY_GITHUB_APP_TOKEN', 'GITHUB_TOKEN'],
+  runtimeEnv: { PUBLIC_FLAG: '1', IGNORED_NON_STRING: 2 },
+  providerSecretEnvMapping: { default: 'PROVIDER_SECRET_0' },
+  secretEnvSourceMapping: sourceMapping,
+});
+
+assert.equal(plan.schema, 'homeboy/secret-env-plan/v1');
+assert.deepEqual(plan.public_env, { PUBLIC_FLAG: '1' });
+assert.equal(Object.hasOwn(plan, 'secret_env_fallbacks'), false);
+assert.deepEqual(plan.requirements.find((requirement) => requirement.name === 'OPENAI_API_KEY'), {
+  name: 'OPENAI_API_KEY',
+  required: true,
+  source_env_names: ['OPENAI_API_KEY', 'PROVIDER_SECRET_0'],
+});
+assert.deepEqual(plan.requirements.find((requirement) => requirement.name === 'HOMEBOY_GITHUB_APP_TOKEN'), {
+  name: 'HOMEBOY_GITHUB_APP_TOKEN',
+  required: true,
+  source_env_names: ['HOMEBOY_GITHUB_APP_TOKEN', 'GITHUB_TOKEN'],
+});
+
+process.stdout.write('SecretEnvPlan source env mapping checks passed\n');

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -1470,15 +1470,18 @@ assert.deepEqual(plannedSecretEnvTaskInput.secret_env, [
 ]);
 
 // Regression: the consumer must honor the FULL authoritative aggregation that
-// core's SecretEnvPlan::secret_env_names() folds (secret_env_plan.rs:214-235) —
-// provider-credential names and requirement-derived names were previously
-// dropped, so those declared secrets silently never reached the sandbox.
+// core's SecretEnvPlan::secret_env_names() folds — provider-credential names and
+// requirement-derived target/source names must reach the sandbox.
 const previousFullPlan = process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON;
 process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = JSON.stringify({
   schema: 'homeboy/secret-env-plan/v1',
   secret_env_names: ['HOMEBOY_PLANNED_CODEBOX_SECRET'],
   requirements: [
-    { name: 'HOMEBOY_REQUIRED_CODEBOX_SECRET', required: true },
+    {
+      name: 'HOMEBOY_REQUIRED_CODEBOX_SECRET',
+      required: true,
+      source_env_names: ['HOMEBOY_REQUIRED_CODEBOX_SECRET', 'HOMEBOY_REQUIRED_CODEBOX_SECRET_SOURCE'],
+    },
     { name: 'HOMEBOY_OPTIONAL_CODEBOX_SECRET', required: false },
   ],
   provider_credentials: {
@@ -1513,6 +1516,7 @@ try {
 for (const declaredSecret of [
   'HOMEBOY_PLANNED_CODEBOX_SECRET',
   'HOMEBOY_REQUIRED_CODEBOX_SECRET',
+  'HOMEBOY_REQUIRED_CODEBOX_SECRET_SOURCE',
   'HOMEBOY_OPTIONAL_CODEBOX_SECRET',
   'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
   'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',


### PR DESCRIPTION
## Summary
- Align runtime-agent CI secret env plans with Homeboy core's landed `requirements[].source_env_names` mapping shape.
- Remove the duplicate `secret_env_fallbacks` config path and apply mapped sources from `secret_env_plan` in the headless runner.
- Forward requirement source env names through the WP Codebox secret-env names boundary.

## Homeboy core alignment
Homeboy core's primitive is present on `origin/main` in `src/core/secret_env_plan.rs` as `SecretEnvRequirement.source_env_names`. There is not yet a consumable JS package/library export for Homeboy Extensions, so this PR keeps the existing local JS mirror small and schema-compatible instead of pretending to import Homeboy core.

## Tests
- `npm test` in `runtime-agent-ci`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, focused tests, and PR drafting.