### PR TITLE
Align runtime status vocabulary

### DIFF
--- a/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
+++ b/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
@@ -1,7 +1,15 @@
 'use strict';
 
 const { AGENT_TASK_OUTCOME_SCHEMA } = require('../../agent-task-contracts/agent-task-provider-contract');
-const { normalizeAgentTaskOutcomeStatus } = require('./runtime-status.cjs');
+const {
+  RUN_LIFECYCLE_STATUS_SCHEMA,
+  RUN_LIFECYCLE_STATUSES,
+  normalizeAgentTaskOutcomeStatus,
+  normalizeRunLifecycleStatus,
+  runLifecycleStatusIsRetryable,
+  runLifecycleStatusIsSuccess,
+  runLifecycleStatusIsTerminal,
+} = require('./runtime-status.cjs');
 
 const TERMINAL_FAILURE_STATUSES = ['failed', 'provider_error', 'timeout', 'unable_to_remediate'];
 const SUCCESS_STATUSES = ['succeeded', 'no_op', 'follow_up_issue'];
@@ -63,7 +71,12 @@ function normalizeAgentTaskStatus(result = {}, options = {}) {
   if (TERMINAL_FAILURE_STATUSES.includes(explicitStatus)) {
     return explicitStatus;
   }
-  return normalizeAgentTaskOutcomeStatus({ ...result, status: explicitStatus || resultStatus }, { exitStatus });
+  if (TERMINAL_FAILURE_STATUSES.includes(resultStatus)) {
+    return resultStatus;
+  }
+  const status = explicitStatus || resultStatus;
+  const statusResult = status === undefined ? result : { ...result, status };
+  return normalizeAgentTaskOutcomeStatus(statusResult, { exitStatus });
 }
 
 function normalizeProviderStatus(result = {}, exitStatus = 0) {
@@ -227,11 +240,17 @@ function plainObject(value) {
 }
 
 module.exports = {
+  RUN_LIFECYCLE_STATUS_SCHEMA,
+  RUN_LIFECYCLE_STATUSES,
   agentTaskFailureCategory,
   agentTaskFailureRetryable,
   normalizeAgentTaskOutcome,
   normalizeAgentTaskStatus,
   normalizeProviderTaskOutcome,
   normalizeProviderStatus,
+  normalizeRunLifecycleStatus,
   providerFailureClassification,
+  runLifecycleStatusIsRetryable,
+  runLifecycleStatusIsSuccess,
+  runLifecycleStatusIsTerminal,
 };

--- a/runtime-agent-ci/lib/runtime-status.cjs
+++ b/runtime-agent-ci/lib/runtime-status.cjs
@@ -1,5 +1,11 @@
 'use strict';
 
+const RUN_LIFECYCLE_STATUS_SCHEMA = 'homeboy/run-lifecycle-status/v1';
+// Mirrors Homeboy core RunLifecycleStatus until a JS package export is available.
+const RUN_LIFECYCLE_STATUSES = Object.freeze(['unknown', 'queued', 'running', 'succeeded', 'partial_failure', 'failed', 'cancelled', 'timed_out', 'stale']);
+const RUN_LIFECYCLE_TERMINAL_STATUSES = Object.freeze(['succeeded', 'partial_failure', 'failed', 'cancelled', 'timed_out', 'stale']);
+const RUN_LIFECYCLE_SUCCESS_STATUSES = Object.freeze(['succeeded']);
+const RUN_LIFECYCLE_RETRYABLE_STATUSES = Object.freeze(['failed', 'timed_out', 'stale']);
 const HOST_RECORD_SUCCESS_STATUSES = Object.freeze(['completed']);
 const HOST_RECORD_FAILURE_STATUSES = Object.freeze(['failed', 'missing_record']);
 const HOST_RUN_SUCCESS_STATUSES = Object.freeze(['completed']);
@@ -65,6 +71,51 @@ function normalizeAgentTaskOutcomeStatus(result = {}, options = {}) {
   return Object.keys(result || {}).length > 0 ? 'provider_error' : 'failed';
 }
 
+function normalizeRunLifecycleStatus(value = {}, options = {}) {
+  const source = plainObject(value) ? value : { status: value };
+  const status = text(options.status || source.status || source.state || source.outcome_status || source.provider_status);
+  if (RUN_LIFECYCLE_STATUSES.includes(status)) {
+    return status;
+  }
+  if (['pending', 'queued', 'waiting'].includes(status)) {
+    return 'queued';
+  }
+  if (['incomplete', 'running', 'started', 'in_progress'].includes(status) || source.incomplete === true || options.incomplete === true) {
+    return 'running';
+  }
+  if (['completed', 'accepted', 'passed', 'success', 'no_op', 'follow_up_issue'].includes(status) || source.success === true || source.accepted === true) {
+    return 'succeeded';
+  }
+  if (['partial', 'partial_failure', 'partial_failures'].includes(status)) {
+    return 'partial_failure';
+  }
+  if (['timeout', 'timed_out'].includes(status) || source.timeout === true) {
+    return 'timed_out';
+  }
+  if (['cancelled', 'canceled'].includes(status) || source.cancelled === true || source.canceled === true) {
+    return 'cancelled';
+  }
+  if (['missing_record', 'stale'].includes(status) || source.stale === true) {
+    return 'stale';
+  }
+  if (['provider_error', 'unable_to_remediate', 'failed', 'error'].includes(status) || source.success === false || source.provider_error || source.unable_to_remediate) {
+    return 'failed';
+  }
+  return 'unknown';
+}
+
+function runLifecycleStatusIsTerminal(status) {
+  return RUN_LIFECYCLE_TERMINAL_STATUSES.includes(text(status));
+}
+
+function runLifecycleStatusIsSuccess(status) {
+  return RUN_LIFECYCLE_SUCCESS_STATUSES.includes(text(status));
+}
+
+function runLifecycleStatusIsRetryable(status) {
+  return RUN_LIFECYCLE_RETRYABLE_STATUSES.includes(text(status));
+}
+
 function providerStatusSucceeded(status) {
   return PROVIDER_SUCCESS_STATUSES.includes(text(status));
 }
@@ -89,9 +140,18 @@ module.exports = {
   HOST_RUN_SUCCESS_STATUSES,
   PROVIDER_FAILURE_STATUSES,
   PROVIDER_SUCCESS_STATUSES,
+  RUN_LIFECYCLE_RETRYABLE_STATUSES,
+  RUN_LIFECYCLE_STATUS_SCHEMA,
+  RUN_LIFECYCLE_STATUSES,
+  RUN_LIFECYCLE_SUCCESS_STATUSES,
+  RUN_LIFECYCLE_TERMINAL_STATUSES,
   normalizeAgentTaskOutcomeStatus,
   normalizeHostRecordStatus,
   normalizeHostRunStatus,
+  normalizeRunLifecycleStatus,
   providerStatusFailed,
   providerStatusSucceeded,
+  runLifecycleStatusIsRetryable,
+  runLifecycleStatusIsSuccess,
+  runLifecycleStatusIsTerminal,
 };

--- a/runtime-agent-ci/tests/agent-task-outcome-normalizer.test.js
+++ b/runtime-agent-ci/tests/agent-task-outcome-normalizer.test.js
@@ -3,13 +3,19 @@
 const assert = require('node:assert/strict');
 
 const {
+  RUN_LIFECYCLE_STATUS_SCHEMA,
+  RUN_LIFECYCLE_STATUSES,
   agentTaskFailureCategory,
   agentTaskFailureRetryable,
   normalizeAgentTaskOutcome,
   normalizeAgentTaskStatus,
   normalizeProviderTaskOutcome,
   normalizeProviderStatus,
+  normalizeRunLifecycleStatus,
   providerFailureClassification,
+  runLifecycleStatusIsRetryable,
+  runLifecycleStatusIsSuccess,
+  runLifecycleStatusIsTerminal,
 } = require('../lib/agent-task-outcome-normalizer');
 
 const request = { task_id: 'provider-task-123' };
@@ -148,6 +154,17 @@ assert.equal(providerFailureClassification('max_turns', 'timeout'), 'timeout');
 assert.equal(providerFailureClassification('custom-runtime-detail', 'failed'), 'unknown');
 assert.equal(agentTaskFailureCategory({ provider_error: true }, [{ class: 'provider.rate_limit', message: 'rate limit' }], 'provider', 'provider_error'), 'provider.rate_limit');
 assert.equal(agentTaskFailureRetryable('provider.rate_limit', 'provider', 'provider_error'), true);
+assert.equal(RUN_LIFECYCLE_STATUS_SCHEMA, 'homeboy/run-lifecycle-status/v1');
+assert.deepEqual(RUN_LIFECYCLE_STATUSES, ['unknown', 'queued', 'running', 'succeeded', 'partial_failure', 'failed', 'cancelled', 'timed_out', 'stale']);
+assert.equal(normalizeRunLifecycleStatus({ status: 'completed' }), 'succeeded');
+assert.equal(normalizeRunLifecycleStatus({ status: 'incomplete' }), 'running');
+assert.equal(normalizeRunLifecycleStatus({ status: 'timeout' }), 'timed_out');
+assert.equal(normalizeRunLifecycleStatus({ status: 'missing_record' }), 'stale');
+assert.equal(normalizeRunLifecycleStatus({ status: 'provider_error' }), 'failed');
+assert.equal(normalizeRunLifecycleStatus({ arbitrary: 'payload' }), 'unknown');
+assert.equal(runLifecycleStatusIsTerminal('partial_failure'), true);
+assert.equal(runLifecycleStatusIsSuccess('succeeded'), true);
+assert.equal(runLifecycleStatusIsRetryable('timed_out'), true);
 assert.throws(() => normalizeProviderTaskOutcome({}, {}), /request.task_id/);
 
 console.log('✓ agent task outcome normalizer boundary test PASSED');

--- a/wordpress/tests/provider-outcome-normalizer.test.js
+++ b/wordpress/tests/provider-outcome-normalizer.test.js
@@ -3,11 +3,17 @@
 const assert = require('node:assert/strict');
 
 const {
+  RUN_LIFECYCLE_STATUS_SCHEMA,
+  RUN_LIFECYCLE_STATUSES,
   normalizeAgentTaskOutcome,
   normalizeAgentTaskStatus,
   normalizeProviderTaskOutcome,
   normalizeProviderStatus,
+  normalizeRunLifecycleStatus,
   providerFailureClassification,
+  runLifecycleStatusIsRetryable,
+  runLifecycleStatusIsSuccess,
+  runLifecycleStatusIsTerminal,
 } = require('../../agent-runtimes/wp-codebox/lib/provider-outcome-normalizer');
 
 const request = { task_id: 'provider-task-123' };
@@ -110,6 +116,14 @@ assert.equal(providerFailureClassification('task', 'failed'), 'execution_failed'
 assert.equal(providerFailureClassification('incomplete', 'failed'), 'execution_failed');
 assert.equal(providerFailureClassification('max_turns', 'timeout'), 'timeout');
 assert.equal(providerFailureClassification('custom-runtime-detail', 'failed'), 'unknown');
+assert.equal(RUN_LIFECYCLE_STATUS_SCHEMA, 'homeboy/run-lifecycle-status/v1');
+assert.deepEqual(RUN_LIFECYCLE_STATUSES, ['unknown', 'queued', 'running', 'succeeded', 'partial_failure', 'failed', 'cancelled', 'timed_out', 'stale']);
+assert.equal(normalizeRunLifecycleStatus({ status: 'completed' }), 'succeeded');
+assert.equal(normalizeRunLifecycleStatus({ status: 'incomplete' }), 'running');
+assert.equal(normalizeRunLifecycleStatus({ status: 'timeout' }), 'timed_out');
+assert.equal(runLifecycleStatusIsTerminal('stale'), true);
+assert.equal(runLifecycleStatusIsSuccess('succeeded'), true);
+assert.equal(runLifecycleStatusIsRetryable('failed'), true);
 assert.throws(() => normalizeProviderTaskOutcome({}, {}), /request.task_id/);
 
 console.log('✓ provider outcome normalizer boundary test PASSED');


### PR DESCRIPTION
## Summary
- Add a shared JS mirror of Homeboy core's RunLifecycleStatus vocabulary and schema in runtime-agent-ci status normalization.
- Expose lifecycle status normalization through the agent task/provider outcome normalizer boundary.
- Cover legacy/provider status mappings in runtime-agent-ci and WP Codebox provider normalizer tests.

## Testing
- npm run test:agent-task-outcome-normalizer
- npm run test:provider-outcome-normalizer (wordpress)
- npm test (runtime-agent-ci)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected normalization surfaces, implemented the status vocabulary alignment and boundary tests, ran targeted verification, and drafted this PR description.