### PR TITLE
Load WP Codebox runtime contract directly from core

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -284,16 +284,45 @@ function wpCodeboxCanonicalRuntimeContractSource(options = {}) {
 		return options.loadRuntimeContractSource(resolvedOptions);
 	}
 	if (typeof options.loadCanonicalRuntimeContractSourceSync === 'function') {
-		return options.loadCanonicalRuntimeContractSourceSync({ ...resolvedOptions, required: false });
+		return options.loadCanonicalRuntimeContractSourceSync({ ...resolvedOptions, required: false })
+			|| loadWpCodeboxRuntimeContractSourceDirect(resolvedOptions);
 	}
 	if (!loadCanonicalRuntimeContractSourceSync) {
+		return loadWpCodeboxRuntimeContractSourceDirect(resolvedOptions);
+	}
+	try {
+		return loadCanonicalRuntimeContractSourceSync({ ...resolvedOptions, required: false })
+			|| loadWpCodeboxRuntimeContractSourceDirect(resolvedOptions);
+	} catch {
+		return loadWpCodeboxRuntimeContractSourceDirect(resolvedOptions);
+	}
+}
+
+function loadWpCodeboxRuntimeContractSourceDirect(options = {}) {
+	const specifier = options.wpCodeboxCoreModule || options.coreModule;
+	if (!specifier) {
 		return null;
 	}
 	try {
-		return loadCanonicalRuntimeContractSourceSync({ ...resolvedOptions, required: false });
+		const core = require(isPathSpecifier(specifier) ? path.resolve(specifier) : specifier);
+		const manifest = typeof core?.runtimeContractManifest === 'function'
+			? core.runtimeContractManifest()
+			: typeof core?.default?.runtimeContractManifest === 'function'
+				? core.default.runtimeContractManifest()
+				: null;
+		return objectOrUndefined(manifest) ? {
+			source: specifier,
+			manifest,
+			normalizers: core.RUNTIME_CONTRACT_NORMALIZERS || core.default?.RUNTIME_CONTRACT_NORMALIZERS || {},
+			canonical: true,
+		} : null;
 	} catch {
 		return null;
 	}
+}
+
+function isPathSpecifier(value) {
+	return typeof value === 'string' && (value.startsWith('.') || path.isAbsolute(value) || value.startsWith('~') || value.includes('\\'));
 }
 
 function wpCodeboxRuntimeContractSourceOptions(options = {}) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -142,6 +142,17 @@ assert.deepEqual(REQUIRED_WP_CODEBOX_FUZZ_CONTRACT_PATHS, [
 	'schemas.wordpressRuntime.workloadRun',
 ]);
 assert.equal(wpCodeboxRuntimeContractManifest({ loadRuntimeContractSource: () => ({ manifest }) }), manifest);
+const directContractSourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-direct-contract-source-'));
+try {
+	const directCoreModule = path.join(directContractSourceRoot, 'contracts.cjs');
+	fs.writeFileSync(directCoreModule, `module.exports.runtimeContractManifest = () => (${JSON.stringify(manifest)});\n`);
+	assert.deepEqual(wpCodeboxRuntimeContractManifest({
+		wpCodeboxCoreModule: directCoreModule,
+		loadCanonicalRuntimeContractSourceSync: () => null,
+	}), manifest);
+} finally {
+	fs.rmSync(directContractSourceRoot, { recursive: true, force: true });
+}
 const contractSourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-contract-source-'));
 try {
 	const cacheRoot = path.join(contractSourceRoot, 'cache', 'wp-codebox');


### PR DESCRIPTION
## Summary
- Fall back to loading `runtimeContractManifest()` directly from the resolved WP Codebox core module when the packaged runtime-contract helper is unavailable or returns no source.
- Preserve the canonical helper path when present.
- Add smoke coverage for the direct core-module fallback.

## Tests
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node --check wordpress/lib/wp-codebox-fuzz-run.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the installed WordPress extension manifest-loader fallback and implementing direct runtime-contract loading from WP Codebox core.