### PR TITLE
Resolve rig-qualified fuzz component paths

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -318,12 +318,18 @@ function buildWpCodeboxFuzzRuntimeRequirements({ workload = {}, env = {} } = {})
 		|| workload.metadata?.fixture?.plugin
 		|| workload.target?.slug;
 	const component = componentId && components ? componentFromContext(components, componentId) : undefined;
-	const source = component?.path || component?.source || componentPathOverride(env.componentPathOverrides, componentId);
+	const source = componentPathOverride(env.componentPathOverrides, componentId, context?.rig_id)
+		|| component?.path
+		|| component?.source;
 	if ((!componentId || typeof source !== 'string' || source.trim() === '') && !workloadRoot) {
 		return undefined;
 	}
 	const activation = workload.metadata?.fixture?.activation || firstCasePluginActivation(workload);
-	const checkoutRoot = component?.checkout_root || component?.checkoutRoot || component?.extensions?.wordpress?.checkout_root || component?.extensions?.wordpress?.checkoutRoot || componentPathOverride(env.componentCheckoutRootOverrides, componentId);
+	const checkoutRoot = componentPathOverride(env.componentCheckoutRootOverrides, componentId, context?.rig_id)
+		|| component?.checkout_root
+		|| component?.checkoutRoot
+		|| component?.extensions?.wordpress?.checkout_root
+		|| component?.extensions?.wordpress?.checkoutRoot;
 	const pluginRequirement = buildWpCodeboxFuzzPluginRequirement({ workload, componentId, source, activation, context, checkoutRoot });
 	return {
 		extra_plugins: pluginRequirement ? [pluginRequirement.extraPlugin] : undefined,
@@ -429,8 +435,12 @@ function componentFromContext(components = {}, componentId) {
 	return undefined;
 }
 
-function componentPathOverride(overrides = {}, componentId) {
-	return objectOrUndefined(overrides)?.[normalizedComponentId(componentId)];
+function componentPathOverride(overrides = {}, componentId, rigId) {
+	const normalizedOverrides = objectOrUndefined(overrides) || {};
+	const componentKey = normalizedComponentId(componentId);
+	const rigKey = normalizedComponentId(rigId);
+	return normalizedOverrides[componentKey]
+		|| (rigKey ? normalizedOverrides[`${rigKey}-${componentKey}`] : undefined);
 }
 
 function normalizedComponentId(value) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -400,6 +400,36 @@ assert.deepEqual(envMountedPluginResult.wp_codebox_runtime_requirements.extra_pl
 assert.equal(envMountedPluginResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceRoot, envMountedPluginRoot);
 assert.equal(envMountedPluginResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceSubpath, 'plugins/sample-plugin');
 
+const rigQualifiedPluginRoot = path.join(os.tmpdir(), 'homeboy-wordpress-rig-qualified-checkout');
+const rigQualifiedPluginPath = path.join(rigQualifiedPluginRoot, 'plugins', 'woocommerce');
+const generatedWorkloadPackageRoot = path.join(os.tmpdir(), 'homeboy-wordpress-generated-workload-package');
+const rigQualifiedEnvMountedPluginResult = buildWordPressFuzzRunnerResult({
+	env: readWordPressFuzzRunnerEnv({
+		HOMEBOY_FUZZ_WORKLOAD_PATH: '/unused/in-unit-test.json',
+		HOMEBOY_FUZZ_WORKLOAD_ID: 'rig-qualified-env-mounted-plugin',
+		HOMEBOY_FUZZ_RUN_ID: 'rig-qualified-env-mounted-plugin-run',
+		HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE: rigQualifiedPluginPath,
+		HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE: rigQualifiedPluginRoot,
+	}),
+	workload: {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: 'rig-qualified-env-mounted-plugin',
+		target: { type: 'wordpress-plugin', slug: 'woocommerce', component: 'woocommerce' },
+		metadata: {
+			fixture: { component: 'woocommerce', activation: 'woocommerce/woocommerce.php' },
+			homeboy_runtime_context: {
+				schema: 'homeboy/fuzz-workload-runtime-context/v1',
+				rig_id: 'woocommerce-performance',
+				components: { woocommerce: { path: generatedWorkloadPackageRoot } },
+			},
+		},
+		cases: [{ id: 'rig-qualified-env-mounted-plugin:default', intent: { plugin: { activation: 'woocommerce/woocommerce.php' } } }],
+	},
+});
+assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].source, rigQualifiedPluginPath);
+assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourceRoot, rigQualifiedPluginRoot);
+assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourceSubpath, 'plugins/woocommerce');
+
 const genericPrimitiveResult = buildWordPressFuzzRunnerResult({
 	env: {
 		workloadPath: '/unused/in-unit-test.json',


### PR DESCRIPTION
## Summary
- resolve rig-qualified HOMEBOY_RIG_COMPONENT_PATH overrides for WordPress fuzz runtime requirements
- let remapped Lab component paths win over generated workload package paths
- add regression coverage for Woo-style monorepo plugin source layout

## Testing
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- jq empty wordpress/homeboy.json

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnose the Lab plugin-source materialization failure, update HBEX path resolution, and run focused verification.
