### PR TITLE
Harden OpenCode agent-task executor

### DIFF
--- a/agent-runtimes/opencode/README.md
+++ b/agent-runtimes/opencode/README.md
@@ -35,16 +35,16 @@ configuration can still control built-in agents such as `build` and `title`.
 For deterministic run-scoped selection, the executor also injects
 `OPENCODE_CONFIG_CONTENT` with:
 
-- `model` and `agent(s).build.model` from `executor.config.model`,
+- `model` and `agent.build.model` from `executor.config.model`,
   `executor.model`, or top-level `model`.
-- `small_model` and `agent(s).title.model` from `executor.config.small_model`
+- `small_model` and `agent.title.model` from `executor.config.small_model`
   or `executor.config.smallModel` when provided.
 
 Direct runtime verification can be done with a temporary config overlay, without
 editing global OpenCode config:
 
 ```sh
-OPENCODE_CONFIG_CONTENT='{"model":"opencode-go/kimi-k2.7-code","agent":{"build":{"model":"opencode-go/kimi-k2.7-code"}},"agents":{"build":{"model":"opencode-go/kimi-k2.7-code"}}}' opencode run --model opencode-go/kimi-k2.7-code 'Report the active provider/model for the build agent.'
+OPENCODE_CONFIG_CONTENT='{"model":"opencode-go/kimi-k2.7-code","agent":{"build":{"model":"opencode-go/kimi-k2.7-code"}}}' opencode run --model opencode-go/kimi-k2.7-code 'Report the active provider/model for the build agent.'
 ```
 
 The OpenCode binary is resolved from `executor.config.runtime_bin`,

--- a/agent-runtimes/opencode/README.md
+++ b/agent-runtimes/opencode/README.md
@@ -30,6 +30,23 @@ The executor reads one AgentTaskRequest JSON object from stdin or
 opencode run [--model <model>] [--agent <agent>] [--variant <variant>] [--title <title>] <instructions>
 ```
 
+OpenCode's `--model` argument selects the run session model, but agent-local
+configuration can still control built-in agents such as `build` and `title`.
+For deterministic run-scoped selection, the executor also injects
+`OPENCODE_CONFIG_CONTENT` with:
+
+- `model` and `agent(s).build.model` from `executor.config.model`,
+  `executor.model`, or top-level `model`.
+- `small_model` and `agent(s).title.model` from `executor.config.small_model`
+  or `executor.config.smallModel` when provided.
+
+Direct runtime verification can be done with a temporary config overlay, without
+editing global OpenCode config:
+
+```sh
+OPENCODE_CONFIG_CONTENT='{"model":"opencode-go/kimi-k2.7-code","agent":{"build":{"model":"opencode-go/kimi-k2.7-code"}},"agents":{"build":{"model":"opencode-go/kimi-k2.7-code"}}}' opencode run --model opencode-go/kimi-k2.7-code 'Report the active provider/model for the build agent.'
+```
+
 The OpenCode binary is resolved from `executor.config.runtime_bin`,
 `executor.config.command`, `HOMEBOY_OPENCODE_COMMAND`, or `opencode` in that
 order. Additional leading command args may be supplied with

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -497,10 +497,11 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 	}
 
 	const cwd = config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
+	const model = config.model || request.executor.model || request.model;
 	const args = [
 		...commandSpec.args,
 		'run',
-		...(config.model ? ['--model', config.model] : []),
+		...(model ? ['--model', model] : []),
 		...(config.agent ? ['--agent', config.agent] : []),
 		...(config.variant ? ['--variant', config.variant] : []),
 		...(config.title ? ['--title', config.title] : []),

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -245,19 +245,17 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 	const content = parseOpenCodeConfigContent(existingContent);
 	content.$schema = content.$schema || 'https://opencode.ai/config.json';
 	content.agent = objectValue(content.agent);
-	content.agents = objectValue(content.agents);
+	delete content.agents;
 
 	if (model) {
 		content.model = model;
 		const primaryAgent = config.agent || 'build';
 		content.agent[primaryAgent] = { ...objectValue(content.agent[primaryAgent]), model };
-		content.agents[primaryAgent] = { ...objectValue(content.agents[primaryAgent]), model };
 	}
 
 	if (smallModel) {
 		content.small_model = smallModel;
 		content.agent.title = { ...objectValue(content.agent.title), model: smallModel };
-		content.agents.title = { ...objectValue(content.agents.title), model: smallModel };
 	}
 
 	return JSON.stringify(content);
@@ -539,7 +537,7 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 		});
 	}
 
-	const cwd = config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
+	const cwd = config.cwd || config.workspace_root || config.workspaceRoot || request.workspace_path || request.workspace?.path || request.workspace?.root || process.cwd();
 	const model = config.model || request.executor.model || request.model;
 	const args = [
 		...commandSpec.args,

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -226,10 +226,53 @@ function opencodeSpawnEnv(request = {}, options = {}) {
 	if (config.inherit_env === true || config.inheritEnv === true) {
 		throw new Error('OpenCode ambient env inheritance is not supported; declare env_allowlist, runtime_env, and secret_env explicitly.');
 	}
-	return cliAgentTaskSpawnEnv(request, options, {
+	const env = cliAgentTaskSpawnEnv(request, options, {
 		allowlist: OPENCODE_PROCESS_ENV_ALLOWLIST,
 		secretEnv: OPENCODE_SECRET_ENV,
 	});
+	const configContent = opencodeConfigContentForRequest(request, env.OPENCODE_CONFIG_CONTENT);
+	return configContent ? { ...env, OPENCODE_CONFIG_CONTENT: configContent } : env;
+}
+
+function opencodeConfigContentForRequest(request = {}, existingContent = '') {
+	const config = request.executor?.config || {};
+	const model = config.model || request.executor?.model || request.model;
+	const smallModel = config.small_model || config.smallModel;
+	if (!model && !smallModel) {
+		return '';
+	}
+
+	const content = parseOpenCodeConfigContent(existingContent);
+	content.$schema = content.$schema || 'https://opencode.ai/config.json';
+	content.agent = objectValue(content.agent);
+	content.agents = objectValue(content.agents);
+
+	if (model) {
+		content.model = model;
+		const primaryAgent = config.agent || 'build';
+		content.agent[primaryAgent] = { ...objectValue(content.agent[primaryAgent]), model };
+		content.agents[primaryAgent] = { ...objectValue(content.agents[primaryAgent]), model };
+	}
+
+	if (smallModel) {
+		content.small_model = smallModel;
+		content.agent.title = { ...objectValue(content.agent.title), model: smallModel };
+		content.agents.title = { ...objectValue(content.agents.title), model: smallModel };
+	}
+
+	return JSON.stringify(content);
+}
+
+function parseOpenCodeConfigContent(content) {
+	if (!content || typeof content !== 'string') {
+		return {};
+	}
+	try {
+		const parsed = JSON.parse(content);
+		return objectValue(parsed);
+	} catch {
+		return {};
+	}
 }
 
 function withDeclaredArtifactDiagnostics(request = {}, normalized = {}) {

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -28,6 +28,14 @@ const OPENCODE_SECRET_ENV = [
 	'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
 	'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ];
+const OPENCODE_FATAL_LOG_PATTERNS = [
+	{
+		pattern: /Usage limit reached/i,
+		code: 'agent_task.opencode_usage_limit',
+		summary: 'OpenCode provider usage limit was reached.',
+		classification: 'provider_quota',
+	},
+];
 
 const OPENCODE_CAPABILITIES = [
 	'cli_runtime',
@@ -506,6 +514,7 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 		env: spawnExtra.env,
 		timeoutMs: timeoutSeconds > 0 ? timeoutSeconds * 1000 : 0,
 		runtimeLogPaths,
+		diagnosticLogPath: openCodeDiagnosticLogPath(config, spawnExtra.env),
 	});
 	const context = { request, config, commandSpec, cwd, spawnResult, spawnExtra, runtimeLogPaths };
 	const runtimeLogs = collectOpenCodeRuntimeLogs(context);
@@ -523,12 +532,13 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 
 	if (spawnResult.error) {
 		const timedOut = spawnResult.error.code === 'ETIMEDOUT';
+		const fatalRuntimeError = spawnResult.fatalRuntimeError;
 		return outcome(request, {
 			status: timedOut ? 'timeout' : 'provider_error',
-			failure_classification: timedOut ? 'timeout' : 'provider',
-			failure_code: timedOut ? 'agent_task.opencode_timeout' : 'agent_task.opencode_spawn_failed',
-			summary: timedOut ? 'OpenCode execution timed out.' : 'OpenCode process failed to start or complete.',
-			diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: spawnResult.error.message }],
+			failure_classification: fatalRuntimeError?.classification || (timedOut ? 'timeout' : 'provider'),
+			failure_code: fatalRuntimeError?.code || (timedOut ? 'agent_task.opencode_timeout' : 'agent_task.opencode_spawn_failed'),
+			summary: fatalRuntimeError?.summary || (timedOut ? 'OpenCode execution timed out.' : 'OpenCode process failed to start or complete.'),
+			diagnostics: [{ classification: fatalRuntimeError?.classification || (timedOut ? 'timeout' : 'provider_setup'), message: spawnResult.error.message }],
 			metadata: { opencode_session: sessionMetadata(context) },
 			...runtimeLogs,
 		});
@@ -574,6 +584,15 @@ function openCodeRuntimeLogPaths(request = {}, config = {}) {
 	};
 }
 
+function openCodeDiagnosticLogPath(config = {}, env = process.env) {
+	const configured = config.diagnostic_log_path || config.diagnosticLogPath || env.HOMEBOY_OPENCODE_LOG_PATH || '';
+	if (configured) {
+		return configured;
+	}
+	const home = env.HOME || process.env.HOME || '';
+	return home ? path.join(home, '.local', 'share', 'opencode', 'log', 'opencode.log') : '';
+}
+
 function resolveArtifactDir(context = {}) {
 	const request = context.request || {};
 	const config = context.config || {};
@@ -591,8 +610,11 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 		const stderrChunks = [];
 		let settled = false;
 		let timedOut = false;
+		let fatalRuntimeError = null;
 		let child;
 		let exitFallbackTimer = null;
+		let diagnosticLogTimer = null;
+		let diagnosticLogOffset = diagnosticLogInitialOffset(options.diagnosticLogPath);
 
 		for (const filePath of Object.values(options.runtimeLogPaths || {})) {
 			fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -620,9 +642,13 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			if (exitFallbackTimer) {
 				clearTimeout(exitFallbackTimer);
 			}
+			if (diagnosticLogTimer) {
+				clearInterval(diagnosticLogTimer);
+			}
 			resolve({
 				stdout: stdoutChunks.join(''),
 				stderr: stderrChunks.join(''),
+				...(fatalRuntimeError ? { fatalRuntimeError } : {}),
 				...result,
 			});
 		};
@@ -638,6 +664,15 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			timedOut = true;
 			child.kill('SIGTERM');
 		}, options.timeoutMs) : null;
+		diagnosticLogTimer = startOpenCodeDiagnosticLogMonitor({
+			logPath: options.diagnosticLogPath,
+			initialOffset: diagnosticLogOffset,
+			env: options.env,
+			onFatal: (detected) => {
+				fatalRuntimeError = detected;
+				child.kill('SIGTERM');
+			},
+		});
 
 		child.stdout.on('data', (chunk) => append('stdout', chunk));
 		child.stderr.on('data', (chunk) => append('stderr', chunk));
@@ -652,6 +687,7 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 				finish({
 					status,
 					signal,
+					...(fatalRuntimeError ? { error: Object.assign(new Error(fatalRuntimeError.message), { code: 'EOPENCODEFATAL' }) } : {}),
 					...(timedOut ? { error: Object.assign(new Error('OpenCode execution timed out.'), { code: 'ETIMEDOUT' }) } : {}),
 				});
 			}, 250);
@@ -663,10 +699,71 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			finish({
 				status,
 				signal,
+				...(fatalRuntimeError ? { error: Object.assign(new Error(fatalRuntimeError.message), { code: 'EOPENCODEFATAL' }) } : {}),
 				...(timedOut ? { error: Object.assign(new Error('OpenCode execution timed out.'), { code: 'ETIMEDOUT' }) } : {}),
 			});
 		});
 	});
+}
+
+function diagnosticLogInitialOffset(logPath) {
+	try {
+		if (!logPath || !fs.existsSync(logPath)) {
+			return 0;
+		}
+		return fs.statSync(logPath).size;
+	} catch {
+		return 0;
+	}
+}
+
+function startOpenCodeDiagnosticLogMonitor({ logPath, initialOffset = 0, env = process.env, onFatal }) {
+	if (!logPath || typeof onFatal !== 'function') {
+		return null;
+	}
+	let offset = initialOffset;
+	let reported = false;
+	return setInterval(() => {
+		let stat;
+		try {
+			if (reported || !fs.existsSync(logPath)) {
+				return;
+			}
+			stat = fs.statSync(logPath);
+		} catch {
+			return;
+		}
+		if (stat.size < offset) {
+			offset = 0;
+		}
+		if (stat.size === offset) {
+			return;
+		}
+
+		let fd;
+		try {
+			fd = fs.openSync(logPath, 'r');
+			const length = stat.size - offset;
+			const buffer = Buffer.alloc(length);
+			fs.readSync(fd, buffer, 0, length, offset);
+			offset = stat.size;
+			const content = redactKnownSecrets(buffer.toString('utf8'), env);
+			const matched = OPENCODE_FATAL_LOG_PATTERNS.find(({ pattern }) => pattern.test(content));
+			if (matched) {
+				reported = true;
+				onFatal({
+					code: matched.code,
+					summary: matched.summary,
+					classification: matched.classification,
+					message: `${matched.summary} OpenCode diagnostic log reported: ${content.trim()}`,
+				});
+			}
+		} finally {
+			if (fd !== undefined) {
+				fs.closeSync(fd);
+			}
+		}
+	}, 1000);
 }
 
 function parseEnvCommandArgs() {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -141,6 +141,26 @@ process.exit(0);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('refresh-token-must-not-leak'), false);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('access-token-must-not-leak'), false);
 
+	const modelCliPath = path.join(root, 'mock-opencode-model.cjs');
+	fs.writeFileSync(modelCliPath, `#!/usr/bin/env node
+const assert = require('node:assert/strict');
+assert.deepEqual(process.argv.slice(2, 5), ['run', '--model', 'opencode-go/kimi-k2.7-code']);
+process.exit(0);
+`);
+	const modelResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-executor-model',
+		executor: {
+			...request.executor,
+			model: 'opencode-go/kimi-k2.7-code',
+			config: {
+				...request.executor.config,
+				command_args: [modelCliPath],
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(modelResult.status, 'succeeded');
+
 	const missingArtifactResult = await executeOpenCodeAgentTask({
 		...request,
 		task_id: 'opencode-missing-artifact',

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -145,6 +145,13 @@ process.exit(0);
 	fs.writeFileSync(modelCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
 assert.deepEqual(process.argv.slice(2, 5), ['run', '--model', 'opencode-go/kimi-k2.7-code']);
+const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
+assert.equal(config.model, 'opencode-go/kimi-k2.7-code');
+assert.equal(config.agent.build.model, 'opencode-go/kimi-k2.7-code');
+assert.equal(config.agents.build.model, 'opencode-go/kimi-k2.7-code');
+assert.equal(config.small_model, 'zai-coding-plan/glm-5.2');
+assert.equal(config.agent.title.model, 'zai-coding-plan/glm-5.2');
+assert.equal(config.agents.title.model, 'zai-coding-plan/glm-5.2');
 process.exit(0);
 `);
 	const modelResult = await executeOpenCodeAgentTask({
@@ -156,6 +163,7 @@ process.exit(0);
 			config: {
 				...request.executor.config,
 				command_args: [modelCliPath],
+				small_model: 'zai-coding-plan/glm-5.2',
 			},
 		},
 	}, { env: fixtureEnv });

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -141,17 +141,22 @@ process.exit(0);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('refresh-token-must-not-leak'), false);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('access-token-must-not-leak'), false);
 
+	const modelWorkspace = path.join(root, 'model-workspace');
+	fs.mkdirSync(modelWorkspace, { recursive: true });
+	const realModelWorkspace = fs.realpathSync(modelWorkspace);
 	const modelCliPath = path.join(root, 'mock-opencode-model.cjs');
 	fs.writeFileSync(modelCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
+assert.equal(process.cwd(), ${JSON.stringify(realModelWorkspace)});
 assert.deepEqual(process.argv.slice(2, 5), ['run', '--model', 'opencode-go/kimi-k2.7-code']);
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
+assert.equal(config.$schema, 'https://opencode.ai/config.json');
 assert.equal(config.model, 'opencode-go/kimi-k2.7-code');
 assert.equal(config.agent.build.model, 'opencode-go/kimi-k2.7-code');
-assert.equal(config.agents.build.model, 'opencode-go/kimi-k2.7-code');
 assert.equal(config.small_model, 'zai-coding-plan/glm-5.2');
 assert.equal(config.agent.title.model, 'zai-coding-plan/glm-5.2');
-assert.equal(config.agents.title.model, 'zai-coding-plan/glm-5.2');
+assert.deepEqual(config.mcp, { example: { type: 'local' } });
+assert.equal(Object.hasOwn(config, 'agents'), false);
 process.exit(0);
 `);
 	const modelResult = await executeOpenCodeAgentTask({
@@ -163,6 +168,13 @@ process.exit(0);
 			config: {
 				...request.executor.config,
 				command_args: [modelCliPath],
+				workspace_root: modelWorkspace,
+				runtime_env: {
+					OPENCODE_CONFIG_CONTENT: JSON.stringify({
+						mcp: { example: { type: 'local' } },
+						agents: { build: { model: 'invalid-plural-key/must-not-survive' } },
+					}),
+				},
 				small_model: 'zai-coding-plan/glm-5.2',
 			},
 		},

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -277,6 +277,33 @@ process.exit(0);
 	assert.equal(inheritedPipeResult.status, 'succeeded');
 	assert.match(inheritedPipeResult.diagnostics[0].message, /status 0/);
 
+	const quotaLogPath = path.join(root, 'opencode-quota.log');
+	const quotaCliPath = path.join(root, 'mock-opencode-quota.cjs');
+	fs.writeFileSync(quotaCliPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.appendFileSync(${JSON.stringify(quotaLogPath)}, 'timestamp=2026-06-30T17:03:48.665Z level=ERROR message="stream error" error.error="AI_APICallError: Usage limit reached for 5 hour. Your limit will reset later"\\n');
+setTimeout(() => {}, 10000);
+`);
+	const quotaResult = await Promise.race([
+		executeOpenCodeAgentTask({
+			...request,
+			task_id: 'opencode-quota-fail-fast',
+			executor: {
+				...request.executor,
+				config: {
+					...request.executor.config,
+					command_args: [quotaCliPath],
+					diagnostic_log_path: quotaLogPath,
+				},
+			},
+		}, { env: fixtureEnv }),
+		new Promise((_, reject) => setTimeout(() => reject(new Error('OpenCode executor did not fail fast on provider quota exhaustion')), 3000)),
+	]);
+	assert.equal(quotaResult.status, 'provider_error');
+	assert.equal(quotaResult.failure_code, 'agent_task.opencode_usage_limit');
+	assert.equal(quotaResult.failure_classification, 'provider_quota');
+	assert.match(quotaResult.diagnostics[0].message, /Usage limit reached/);
+
 	const implicitArtifactResult = await executeOpenCodeAgentTask({
 		...request,
 		task_id: 'opencode-implicit-artifact-dir',


### PR DESCRIPTION
## Summary
- fail fast when OpenCode diagnostic logs report provider quota exhaustion
- honor Homeboy executor model overrides through run-scoped OpenCode config
- inject valid singular `agent.*.model` config and remove invalid plural `agents` overlays
- run OpenCode in the resolved Homeboy workspace root instead of the outer Lab snapshot cwd

## Why
Dogfooding OpenCode-backed Homeboy fanout exposed three runtime issues: quota errors could retry silently, `--model` alone did not control the built-in `build` agent model, and the executor ignored `executor.config.workspace_root`, causing OpenCode to run outside the materialized git worktree. OpenCode 1.17.11 also rejects the plural `agents` config key, so the run-scoped config now emits only valid `agent` entries.

## Verification
- `npm --prefix agent-runtimes/opencode run test:opencode-agent-task-executor-boundary`
- `node tests/agent-task-provider-contract-smoke.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing OpenCode quota retry behavior, implementing executor fail-fast handling, adding run-scoped model/cwd handling, and adding regression coverage.