### PR TITLE
Add optional Homeboy contract surface probe

### DIFF
--- a/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
+++ b/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
@@ -1,0 +1,169 @@
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+
+const {
+  ARTIFACT_MANIFEST_FILE,
+  ARTIFACT_MANIFEST_SCHEMA,
+  ARTIFACT_PATHS_SCHEMA,
+  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+} = require('./runtime-contracts.cjs');
+
+const CONTRACT_COMMANDS = Object.freeze([
+  ['contract', 'constants', '--format=json'],
+  ['contract', 'show', '--format=json'],
+  ['contract', 'export', '--format=json'],
+]);
+
+const MIRRORED_ARTIFACT_MANIFEST_CONSTANTS = Object.freeze({
+  ARTIFACT_MANIFEST_FILE,
+  ARTIFACT_MANIFEST_SCHEMA,
+  ARTIFACT_PATHS_SCHEMA,
+  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+});
+
+function probeHomeboyContractSurface(options = {}) {
+  const command = options.homeboyCommand || process.env.HOMEBOY_COMMAND || 'homeboy';
+  const spawn = options.spawnSync || spawnSync;
+  const env = { ...process.env, ...(options.env || {}) };
+  const attempts = [];
+
+  for (const argv of CONTRACT_COMMANDS) {
+    const result = spawn(command, argv, { encoding: 'utf8', env });
+    const stdout = typeof result.stdout === 'string' ? result.stdout.trim() : '';
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+    attempts.push({ argv, status: result.status, stdout, stderr, error: result.error ? result.error.message : '' });
+
+    if (result.error && result.error.code === 'ENOENT') {
+      return skip(`homeboy contract surface probe skipped: ${command} was not found`, attempts);
+    }
+
+    if (result.status !== 0 || !stdout) {
+      continue;
+    }
+
+    let contract;
+    try {
+      contract = JSON.parse(stdout);
+    } catch (error) {
+      return fail(`homeboy contract surface probe failed: ${argv.join(' ')} did not emit JSON (${error.message})`, attempts);
+    }
+
+    return validateArtifactManifestConstants({ contract, command, argv, attempts });
+  }
+
+  return skip('homeboy contract surface probe skipped: no supported Homeboy contract command is available yet', attempts);
+}
+
+function validateArtifactManifestConstants({ contract, command, argv, attempts }) {
+  const errors = [];
+
+  for (const [name, expected] of Object.entries(MIRRORED_ARTIFACT_MANIFEST_CONSTANTS)) {
+    const actual = contractValue(contract, name);
+    if (typeof actual !== 'string' || actual.length === 0) {
+      errors.push(`${name} is missing from Homeboy contract output`);
+    } else if (actual !== expected) {
+      errors.push(`${name} expected ${expected}, got ${actual}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    return fail(`homeboy contract surface probe failed: ${errors.join('; ')}`, attempts, { command, argv });
+  }
+
+  return {
+    status: 'passed',
+    message: `homeboy contract surface probe passed via ${command} ${argv.join(' ')}`,
+    command,
+    argv,
+    constants: MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
+    attempts,
+  };
+}
+
+function contractValue(contract, name) {
+  const candidates = valueCandidates(name);
+  for (const path of candidates) {
+    const value = readPath(contract, path);
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return '';
+}
+
+function valueCandidates(name) {
+  const camel = name.toLowerCase().replace(/_([a-z])/g, (_match, letter) => letter.toUpperCase());
+  const lower = name.toLowerCase();
+
+  const candidates = [
+    ['constants', name],
+    ['constants', lower],
+    ['constants', camel],
+    [name],
+    [lower],
+    [camel],
+  ];
+
+  if (name === 'ARTIFACT_MANIFEST_SCHEMA') {
+    candidates.push(
+      ['artifact_manifest', 'schema'],
+      ['artifactManifest', 'schema'],
+      ['schemas', 'artifact_manifest'],
+      ['schemas', 'artifactManifest'],
+      ['schemas', 'artifact', 'manifest'],
+      ['contracts', 'artifact_manifest', 'schema']
+    );
+  } else if (name === 'ARTIFACT_MANIFEST_FILE') {
+    candidates.push(
+      ['artifact_manifest', 'file'],
+      ['artifactManifest', 'file'],
+      ['files', 'artifact_manifest'],
+      ['files', 'artifactManifest'],
+      ['contracts', 'artifact_manifest', 'file']
+    );
+  } else if (name === 'ARTIFACT_PATHS_SCHEMA') {
+    candidates.push(
+      ['artifact_paths', 'schema'],
+      ['artifactPaths', 'schema'],
+      ['schemas', 'artifact_paths'],
+      ['schemas', 'artifactPaths'],
+      ['contracts', 'artifact_paths', 'schema']
+    );
+  } else if (name === 'RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA') {
+    candidates.push(
+      ['runner_artifact_manifest_ref', 'schema'],
+      ['runnerArtifactManifestRef', 'schema'],
+      ['schemas', 'runner_artifact_manifest_ref'],
+      ['schemas', 'runnerArtifactManifestRef'],
+      ['contracts', 'runner_artifact_manifest_ref', 'schema']
+    );
+  }
+
+  return candidates;
+}
+
+function readPath(value, path) {
+  let current = value;
+  for (const segment of path) {
+    if (!current || typeof current !== 'object' || Array.isArray(current) || !Object.hasOwn(current, segment)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+function skip(message, attempts) {
+  return { status: 'skipped', message, attempts };
+}
+
+function fail(message, attempts, extra = {}) {
+  return { status: 'failed', message, attempts, ...extra };
+}
+
+module.exports = {
+  CONTRACT_COMMANDS,
+  MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
+  probeHomeboyContractSurface,
+};

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "test": "set -e; for test in tests/*.test.js; do node \"$test\"; done",
+    "probe:homeboy-contract": "node scripts/probe-homeboy-contract-surface.cjs",
     "test:controller-loop-proof-validator": "node ../tests/controller-loop-proof-validator.test.mjs",
     "test:generic-fanout-reconcile-boundary": "node ../tests/generic-fanout-reconcile-boundary.test.mjs",
     "test:workspace-publication-lifecycle": "node tests/workspace-publication-lifecycle.test.js",

--- a/runtime-agent-ci/scripts/probe-homeboy-contract-surface.cjs
+++ b/runtime-agent-ci/scripts/probe-homeboy-contract-surface.cjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+'use strict';
+
+const { probeHomeboyContractSurface } = require('../lib/homeboy-contract-surface-probe.cjs');
+
+const result = probeHomeboyContractSurface();
+process.stdout.write(`${result.message}\n`);
+
+if (result.status === 'failed') {
+  process.exitCode = 1;
+}

--- a/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
+++ b/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
+  probeHomeboyContractSurface,
+} = require('../lib/homeboy-contract-surface-probe.cjs');
+
+const missing = probeHomeboyContractSurface({
+  homeboyCommand: 'homeboy',
+  spawnSync: () => ({ status: 2, stdout: '', stderr: "error: unrecognized subcommand 'contract'" }),
+});
+
+assert.equal(missing.status, 'skipped');
+assert.match(missing.message, /skipped/);
+
+const failedFirstCommand = probeHomeboyContractSurface({
+  homeboyCommand: 'homeboy',
+  spawnSync: (_command, argv) => {
+    if (argv[1] === 'constants') {
+      return { status: 2, stdout: '', stderr: "error: unrecognized subcommand 'constants'" };
+    }
+    return {
+      status: 0,
+      stdout: JSON.stringify({ constants: MIRRORED_ARTIFACT_MANIFEST_CONSTANTS }),
+      stderr: '',
+    };
+  },
+});
+
+assert.equal(failedFirstCommand.status, 'passed');
+assert.deepEqual(failedFirstCommand.argv, ['contract', 'show', '--format=json']);
+
+const nestedContractShape = probeHomeboyContractSurface({
+  homeboyCommand: 'homeboy',
+  spawnSync: () => ({
+    status: 0,
+    stdout: JSON.stringify({
+      artifact_manifest: {
+        schema: 'homeboy/artifact-manifest/v1',
+        file: 'homeboy-artifact-manifest.json',
+      },
+      artifact_paths: {
+        schema: 'homeboy/runtime-agent-artifact-paths/v1',
+      },
+      runner_artifact_manifest_ref: {
+        schema: 'homeboy/runner-artifact-manifest-ref/v1',
+      },
+    }),
+    stderr: '',
+  }),
+});
+
+assert.equal(nestedContractShape.status, 'passed');
+
+const drift = probeHomeboyContractSurface({
+  homeboyCommand: 'homeboy',
+  spawnSync: () => ({
+    status: 0,
+    stdout: JSON.stringify({
+      constants: {
+        ...MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
+        ARTIFACT_MANIFEST_SCHEMA: 'homeboy/artifact-manifest/v2',
+      },
+    }),
+    stderr: '',
+  }),
+});
+
+assert.equal(drift.status, 'failed');
+assert.match(drift.message, /ARTIFACT_MANIFEST_SCHEMA expected homeboy\/artifact-manifest\/v1/);
+
+const live = probeHomeboyContractSurface();
+if (live.status === 'skipped') {
+  process.stdout.write(`${live.message}\n`);
+} else {
+  assert.equal(live.status, 'passed', live.message);
+  process.stdout.write(`${live.message}\n`);
+}
+
+process.stdout.write('Homeboy contract surface probe check passed\n');


### PR DESCRIPTION
## Summary
- Add an optional runtime-agent-ci probe for the new Homeboy contract command surface.
- Validate the mirrored artifact manifest constant group against `homeboy contract constants/show/export --format=json` when available.
- Self-skip with a clear message when the installed Homeboy does not expose the unreleased contract subcommand yet, so CI does not require upstream Homeboy.

## Tests
- `npm test` from `runtime-agent-ci`
- `npm run probe:homeboy-contract` from `runtime-agent-ci` (self-skips on current local Homeboy: no `contract` subcommand)

## Upstream dependency
- Live validation depends on the upstream Homeboy contract surface being merged/released with `homeboy contract constants` or `homeboy contract show/export --format=json`.
- Until then, this stays an optional adoption hook and does not fail CI.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the optional contract probe, tests, verification, and PR preparation.