### PR TITLE
Resolve monorepo WordPress plugin file paths

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -352,6 +352,7 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 	const wordpressExtension = objectOrUndefined(component?.extensions?.wordpress);
 	const sourceSubpath = nonEmptyString(wordpressExtension?.wp_codebox_source_subpath || wordpressExtension?.wpCodeboxSourceSubpath);
 	const sourceLayout = wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot });
+	const pluginFile = wpCodeboxPluginFile({ activation, sourceLayout, wordpressExtension });
 	return {
 		extraPlugin: stripUndefined({
 			slug,
@@ -359,7 +360,7 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 			sourceRoot: sourceLayout.sourceRoot,
 			sourceSubpath: sourceLayout.sourceSubpath,
 			path: source,
-			pluginFile: activation,
+			pluginFile,
 			loadAs: 'plugin',
 			metadata: stripUndefined({
 				component: componentId,
@@ -372,10 +373,42 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 			path: source,
 			sourceRoot: sourceLayout.sourceRoot,
 			sourceSubpath: sourceLayout.sourceSubpath,
-			pluginFile: activation,
+			pluginFile,
 			loadAs: 'plugin',
 		}),
 	};
+}
+
+function wpCodeboxPluginFile({ activation, sourceLayout = {}, wordpressExtension = {} } = {}) {
+	const configured = nonEmptyString(wordpressExtension?.wp_codebox_plugin_file || wordpressExtension?.wpCodeboxPluginFile);
+	if (configured) {
+		if (sourceLayout.sourceIsPluginRoot && sourceLayout.sourceSubpath && configured.startsWith(`${sourceLayout.sourceSubpath}/`)) {
+			return joinRelativePath(path.basename(sourceLayout.sourceSubpath), configured.slice(sourceLayout.sourceSubpath.length + 1));
+		}
+		return configured.includes('/') || configured.includes('\\') || !sourceLayout.sourceSubpath
+			? normalizePathSeparators(configured)
+			: joinRelativePath(sourceLayout.sourceSubpath, configured);
+	}
+
+	const normalizedActivation = nonEmptyString(activation);
+	if (!normalizedActivation) {
+		return undefined;
+	}
+	if (sourceLayout.sourceIsPluginRoot || !sourceLayout.sourceSubpath || normalizedActivation.startsWith(`${sourceLayout.sourceSubpath}/`)) {
+		return normalizePathSeparators(normalizedActivation);
+	}
+	return joinRelativePath(sourceLayout.sourceSubpath, path.basename(normalizedActivation));
+}
+
+function joinRelativePath(...parts) {
+	return parts
+		.map((part) => normalizePathSeparators(part).replace(/^\/+|\/+$/g, ''))
+		.filter(Boolean)
+		.join('/');
+}
+
+function normalizePathSeparators(value) {
+	return String(value || '').replace(/\\+/g, '/');
 }
 
 function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot } = {}) {
@@ -384,6 +417,7 @@ function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, chec
 		return {
 			sourceRoot: source.slice(0, -normalizedSubpath.length - 1),
 			sourceSubpath: normalizedSubpath,
+			sourceIsPluginRoot: true,
 		};
 	}
 	const normalizedCheckoutRoot = nonEmptyString(checkoutRoot);
@@ -391,6 +425,7 @@ function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, chec
 		return {
 			sourceRoot: normalizedCheckoutRoot,
 			sourceSubpath: source.slice(normalizedCheckoutRoot.length + 1),
+			sourceIsPluginRoot: true,
 		};
 	}
 

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -40,6 +40,7 @@ const {
 	wpCodeboxFuzzSuiteTaskRequest,
 	wpCodeboxRuntimeContractManifest,
 } = require('../lib/wp-codebox-fuzz-run');
+const { buildWordPressFuzzRunnerResult } = require('../lib/wordpress-fuzz-runner');
 
 const input = wpCodeboxFuzzSuiteInput({
 	id: 'fuzz-smoke',
@@ -316,6 +317,42 @@ const publicCliInput = wpCodeboxPublicCliInput(runtimeRequirementRequest);
 assert.equal(publicCliInput.metadata.runtime_requirements.extra_plugins[0].sourceRoot, runtimePluginRoot);
 assert.equal(publicCliInput.metadata.runtime_requirements.component_contracts[0].sourceSubpath, 'plugins/sample-plugin');
 assert.deepEqual(publicCliInput.metadata.runtime_requirements.runtime_mounts, [{ source: runtimeWorkloadRoot, target: runtimeWorkloadRoot, mode: 'readonly' }]);
+
+const monorepoPluginRuntimeRequirementRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-monorepo-plugin-'));
+const monorepoPluginCheckoutRoot = path.join(monorepoPluginRuntimeRequirementRoot, 'checkout');
+const monorepoPluginSource = path.join(monorepoPluginCheckoutRoot, 'plugins', 'woocommerce');
+fs.mkdirSync(monorepoPluginSource, { recursive: true });
+fs.writeFileSync(path.join(monorepoPluginSource, 'woocommerce.php'), '<?php\n/**\n * Plugin Name: WooCommerce\n */\n');
+const monorepoPluginResult = buildWordPressFuzzRunnerResult({
+	workload: {
+		id: 'monorepo-plugin-file-path',
+		target: { component: 'woocommerce', slug: 'woocommerce' },
+		metadata: {
+			homeboy_runtime_context: {
+				schema: 'homeboy/rig-runtime-context/v1',
+				rig_id: 'woocommerce-performance',
+				components: {
+					woocommerce: {
+						path: monorepoPluginCheckoutRoot,
+						extensions: {
+							wordpress: {
+								wp_codebox_source_subpath: 'plugins/woocommerce',
+								wp_codebox_plugin_file: 'plugins/woocommerce/woocommerce.php',
+							},
+						},
+					},
+				},
+			},
+		},
+		cases: [{ id: 'activate-woocommerce', intent: { plugin: { activation: 'woocommerce/woocommerce.php' } } }],
+	},
+	env: {
+		workloadPath: path.join(monorepoPluginRuntimeRequirementRoot, 'workload.json'),
+		runId: 'monorepo-plugin-file-path',
+	},
+});
+assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].pluginFile, 'plugins/woocommerce/woocommerce.php');
+assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.component_contracts[0].pluginFile, 'plugins/woocommerce/woocommerce.php');
 assert.throws(
 	() => validateWpCodeboxRuntimeRequirementMounts({ runtime_mounts: [{ source: path.join(runtimeRequirementRoot, 'missing-workloads'), target: '/tmp/missing-workloads' }] }),
 	/WP Codebox runtime requirement runtime_mounts\[0\] source does not exist/


### PR DESCRIPTION
## Summary
- honor generic WordPress component plugin file metadata when building WP Codebox runtime requirements
- derive checkout-relative pluginFile values from source subpaths for monorepo plugin checkouts
- cover Woo-style monorepo plugin metadata in the WP Codebox fuzz smoke test

## Tests
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner
- npx eslint lib/wordpress-fuzz-runner.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the generic plugin file path resolution fix and focused tests.