### PR TITLE
Pass Codebox nested plugin source fields

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -350,12 +350,21 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 	const slug = workload.target?.slug || componentId;
 	const component = componentFromContext(context.components, componentId);
 	const wordpressExtension = objectOrUndefined(component?.extensions?.wordpress);
-	const sourceSubpath = nonEmptyString(wordpressExtension?.wp_codebox_source_subpath || wordpressExtension?.wpCodeboxSourceSubpath);
+	const sourceSubpath = nonEmptyString(
+		wordpressExtension?.wp_codebox_source_subdir
+		|| wordpressExtension?.wpCodeboxSourceSubdir
+		|| wordpressExtension?.wp_codebox_source_subpath
+		|| wordpressExtension?.wpCodeboxSourceSubpath
+	);
 	const sourceLayout = wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot });
-	const pluginFile = wpCodeboxPluginFile({ activation, sourceLayout, wordpressExtension });
+	const mountSlug = nonEmptyString(wordpressExtension?.wp_codebox_mount_slug || wordpressExtension?.wpCodeboxMountSlug) || slug;
+	const pluginFile = wpCodeboxPluginFile({ activation, sourceLayout, wordpressExtension, mountSlug });
 	return {
 		extraPlugin: stripUndefined({
 			slug,
+			sourcePath: sourceLayout.sourcePath,
+			sourceSubdir: sourceLayout.sourceSubpath,
+			mountSlug,
 			source,
 			sourceRoot: sourceLayout.sourceRoot,
 			sourceSubpath: sourceLayout.sourceSubpath,
@@ -370,6 +379,9 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 		}),
 		componentContract: stripUndefined({
 			slug,
+			sourcePath: sourceLayout.sourcePath,
+			sourceSubdir: sourceLayout.sourceSubpath,
+			mountSlug,
 			path: source,
 			sourceRoot: sourceLayout.sourceRoot,
 			sourceSubpath: sourceLayout.sourceSubpath,
@@ -379,11 +391,11 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 	};
 }
 
-function wpCodeboxPluginFile({ activation, sourceLayout = {}, wordpressExtension = {} } = {}) {
+function wpCodeboxPluginFile({ activation, sourceLayout = {}, wordpressExtension = {}, mountSlug } = {}) {
 	const configured = nonEmptyString(wordpressExtension?.wp_codebox_plugin_file || wordpressExtension?.wpCodeboxPluginFile);
 	if (configured) {
 		if (sourceLayout.sourceIsPluginRoot && sourceLayout.sourceSubpath && configured.startsWith(`${sourceLayout.sourceSubpath}/`)) {
-			return joinRelativePath(path.basename(sourceLayout.sourceSubpath), configured.slice(sourceLayout.sourceSubpath.length + 1));
+			return joinRelativePath(mountSlug || path.basename(sourceLayout.sourceSubpath), configured.slice(sourceLayout.sourceSubpath.length + 1));
 		}
 		return configured.includes('/') || configured.includes('\\') || !sourceLayout.sourceSubpath
 			? normalizePathSeparators(configured)
@@ -413,8 +425,18 @@ function normalizePathSeparators(value) {
 
 function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot } = {}) {
 	const normalizedSubpath = nonEmptyString(sourceSubpath);
+	const configuredSourcePath = nonEmptyString(wordpressExtension?.wp_codebox_source_path || wordpressExtension?.wpCodeboxSourcePath);
+	if (configuredSourcePath && !configuredSourcePath.startsWith('~/')) {
+		return {
+			sourcePath: configuredSourcePath,
+			sourceRoot: configuredSourcePath,
+			sourceSubpath: normalizedSubpath,
+			sourceIsPluginRoot: normalizedSubpath ? source.endsWith(`/${normalizedSubpath}`) : false,
+		};
+	}
 	if (normalizedSubpath && source.endsWith(`/${normalizedSubpath}`)) {
 		return {
+			sourcePath: source.slice(0, -normalizedSubpath.length - 1),
 			sourceRoot: source.slice(0, -normalizedSubpath.length - 1),
 			sourceSubpath: normalizedSubpath,
 			sourceIsPluginRoot: true,
@@ -423,6 +445,7 @@ function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, chec
 	const normalizedCheckoutRoot = nonEmptyString(checkoutRoot);
 	if (normalizedCheckoutRoot && source.startsWith(`${normalizedCheckoutRoot}/`)) {
 		return {
+			sourcePath: normalizedCheckoutRoot,
 			sourceRoot: normalizedCheckoutRoot,
 			sourceSubpath: source.slice(normalizedCheckoutRoot.length + 1),
 			sourceIsPluginRoot: true,
@@ -436,6 +459,7 @@ function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, chec
 
 	if (configured && !configured.startsWith('~/')) {
 		return {
+			sourcePath: configured,
 			sourceRoot: configured,
 			sourceSubpath: normalizedSubpath,
 		};

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -1298,7 +1298,7 @@ function validateWpCodeboxRuntimeRequirementMounts(runtimeRequirements = {}, opt
 			if (!requirement) {
 				continue;
 			}
-			const source = requirement.sourceRoot || requirement.source || requirement.path;
+			const source = requirement.sourcePath || requirement.sourceRoot || requirement.source || requirement.path;
 			if (!isLocalAbsolutePath(source) || fs.existsSync(source)) {
 				continue;
 			}

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -303,6 +303,9 @@ assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].artifacts[0].required,
 assert.equal(jsonWorkloadResult.wp_codebox_input.metadata.artifacts.expected[0].semantic_key, 'fuzz.suite_result');
 assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.extra_plugins, [{
 	slug: 'sample-plugin',
+	sourcePath: '/runner/components/sample-plugin',
+	sourceSubdir: 'plugins/sample-plugin',
+	mountSlug: 'sample-plugin',
 	source: '/runner/components/sample-plugin/plugins/sample-plugin',
 	sourceRoot: '/runner/components/sample-plugin',
 	sourceSubpath: 'plugins/sample-plugin',
@@ -316,7 +319,9 @@ assert.equal(
 	jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0].source,
 	'/runner/components/sample-plugin/plugins/sample-plugin'
 );
+assert.equal(jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0].sourcePath, '/runner/components/sample-plugin');
 assert.equal(jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0].sourceRoot, '/runner/components/sample-plugin');
+assert.equal(jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceSubdir, 'plugins/sample-plugin');
 assert.equal(jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceSubpath, 'plugins/sample-plugin');
 assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.runtime_mounts, [{ source: '/runner/workloads', target: '/runner/workloads', mode: 'readonly' }]);
 assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.runtime_env, { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: '/runner/workloads' });
@@ -363,9 +368,14 @@ const remappedPluginRootResult = buildWordPressFuzzRunnerResult({
 });
 const remappedPlugin = remappedPluginRootResult.wp_codebox_runtime_requirements.extra_plugins[0];
 assert.equal(remappedPlugin.source, '/home/chubes/Developer/_lab_workspaces/jetpack-1234');
+assert.equal(remappedPlugin.sourcePath, undefined);
+assert.equal(remappedPlugin.sourceSubdir, undefined);
 assert.equal(remappedPlugin.sourceRoot, undefined);
 assert.equal(remappedPlugin.sourceSubpath, undefined);
+assert.equal(remappedPlugin.mountSlug, 'jetpack');
 assert.equal(remappedPlugin.pluginFile, 'jetpack/jetpack.php');
+assert.equal(remappedPluginRootResult.wp_codebox_runtime_requirements.component_contracts[0].sourcePath, undefined);
+assert.equal(remappedPluginRootResult.wp_codebox_runtime_requirements.component_contracts[0].sourceSubdir, undefined);
 assert.equal(remappedPluginRootResult.wp_codebox_runtime_requirements.component_contracts[0].sourceRoot, undefined);
 assert.equal(remappedPluginRootResult.wp_codebox_runtime_requirements.component_contracts[0].sourceSubpath, undefined);
 
@@ -389,6 +399,9 @@ const envMountedPluginResult = buildWordPressFuzzRunnerResult({
 });
 assert.deepEqual(envMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0], {
 	slug: 'sample-plugin',
+	sourcePath: envMountedPluginRoot,
+	sourceSubdir: 'plugins/sample-plugin',
+	mountSlug: 'sample-plugin',
 	source: envMountedPluginPath,
 	sourceRoot: envMountedPluginRoot,
 	sourceSubpath: 'plugins/sample-plugin',
@@ -397,6 +410,8 @@ assert.deepEqual(envMountedPluginResult.wp_codebox_runtime_requirements.extra_pl
 	loadAs: 'plugin',
 	metadata: { component: 'sample-plugin', activation: 'fuzz-suite-setup-step' },
 });
+assert.equal(envMountedPluginResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourcePath, envMountedPluginRoot);
+assert.equal(envMountedPluginResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceSubdir, 'plugins/sample-plugin');
 assert.equal(envMountedPluginResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceRoot, envMountedPluginRoot);
 assert.equal(envMountedPluginResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceSubpath, 'plugins/sample-plugin');
 
@@ -427,6 +442,9 @@ const rigQualifiedEnvMountedPluginResult = buildWordPressFuzzRunnerResult({
 	},
 });
 assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].source, rigQualifiedPluginPath);
+assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourcePath, rigQualifiedPluginRoot);
+assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourceSubdir, 'plugins/woocommerce');
+assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].mountSlug, 'woocommerce');
 assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourceRoot, rigQualifiedPluginRoot);
 assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourceSubpath, 'plugins/woocommerce');
 


### PR DESCRIPTION
## Summary
- Add WP Codebox #1667 nested plugin fields to fuzz runtime requirements: sourcePath, sourceSubdir, mountSlug, and pluginFile.
- Preserve legacy sourceRoot/sourceSubpath fields for existing Homeboy consumers.
- Validate sourcePath when checking runtime requirement mounts.

## Tests
- node tests/wordpress-fuzz-runner-smoke.js
- node tests/wp-codebox-fuzz-run-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the HBEX Codebox runtime requirement mapping, updating implementation/tests, and running focused verification.