### PR TITLE
Honor explicit WP Codebox setup overrides

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -47,6 +47,14 @@ WP Codebox contract discovery uses public modules such as
 provided by the runner. Homeboy does not scan WP Codebox source/cache package
 layouts to discover private core files.
 
+WordPress extension setup accepts explicit WP Codebox runtime overrides through
+`WP_CODEBOX_CLI` or `HOMEBOY_WP_CODEBOX_CLI` for the built CLI entrypoint and
+`WP_CODEBOX_CORE_MODULE` or `HOMEBOY_WP_CODEBOX_CORE_MODULE` for the built
+runtime-core module. Explicit overrides replace previously persisted
+`HOMEBOY_WP_CODEBOX_BIN` and `HOMEBOY_WP_CODEBOX_CORE_MODULE` values during
+reinstall; persisted values are reused only when no explicit override is
+provided.
+
 ## WP Codebox Artifact Lookup
 
 WordPress helpers that consume WP Codebox browser or recipe artifacts should use

--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -12,6 +12,7 @@ EXTENSION_DIR="${TMPDIR}/extension"
 GITHUB_ENV_FILE="${TMPDIR}/github-env"
 SOURCE_GITHUB_ENV_FILE="${TMPDIR}/source-github-env"
 MISSING_RELEASE_GITHUB_ENV_FILE="${TMPDIR}/missing-release-github-env"
+OVERRIDE_GITHUB_ENV_FILE="${TMPDIR}/override-github-env"
 ARTIFACT_ROOT="${TMPDIR}/artifact-root"
 ARTIFACT_PATH="${TMPDIR}/wp-codebox-cli-linux-x64.tar.gz"
 
@@ -227,6 +228,61 @@ fi
 if grep -qi 'Installing WP Codebox CLI' "${TMPDIR}/cold-setup.out"; then
     echo "Cold-cache path must not reinstall the CLI when a cached bin and module exist" >&2
     cat "${TMPDIR}/cold-setup.out" >&2
+    exit 1
+fi
+
+STALE_ROOT="${TMPDIR}/stale-wp-codebox"
+CURRENT_ROOT="${TMPDIR}/wp-codebox-main-current"
+mkdir -p \
+    "${STALE_ROOT}/packages/cli/dist" \
+    "${STALE_ROOT}/packages/runtime-core/dist" \
+    "${CURRENT_ROOT}/packages/cli/dist" \
+    "${CURRENT_ROOT}/packages/runtime-core/dist"
+
+cat > "${STALE_ROOT}/packages/cli/dist/index.js" <<'NODE'
+#!/usr/bin/env node
+console.log('stale wp-codebox');
+NODE
+chmod +x "${STALE_ROOT}/packages/cli/dist/index.js"
+printf '%s\n' 'export const fixture = "stale";' > "${STALE_ROOT}/packages/runtime-core/dist/index.js"
+
+cat > "${CURRENT_ROOT}/packages/cli/dist/index.js" <<'NODE'
+#!/usr/bin/env node
+console.log('current wp-codebox');
+NODE
+chmod +x "${CURRENT_ROOT}/packages/cli/dist/index.js"
+printf '%s\n' 'export const fixture = "current";' > "${CURRENT_ROOT}/packages/runtime-core/dist/index.js"
+
+(
+    cd "${EXTENSION_DIR}"
+    HOME="${HOME_DIR}" \
+    PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GITHUB_ENV="${OVERRIDE_GITHUB_ENV_FILE}" \
+    HOMEBOY_WP_CODEBOX_BIN="${STALE_ROOT}/packages/cli/dist/index.js" \
+    HOMEBOY_WP_CODEBOX_CORE_MODULE="${STALE_ROOT}/packages/runtime-core/dist/index.js" \
+    WP_CODEBOX_CLI="${CURRENT_ROOT}/packages/cli/dist/index.js" \
+    WP_CODEBOX_CORE_MODULE="${CURRENT_ROOT}/packages/runtime-core/dist/index.js" \
+    bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/override-setup.out"
+)
+
+override_wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${OVERRIDE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
+override_wp_codebox_core_module="$(grep '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${OVERRIDE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
+
+if [ "${override_wp_codebox_bin}" != "${CURRENT_ROOT}/packages/cli/dist/index.js" ]; then
+    echo "Expected explicit WP_CODEBOX_CLI to replace stale configured CLI, got: ${override_wp_codebox_bin}" >&2
+    cat "${TMPDIR}/override-setup.out" >&2
+    exit 1
+fi
+
+if [ "${override_wp_codebox_core_module}" != "${CURRENT_ROOT}/packages/runtime-core/dist/index.js" ]; then
+    echo "Expected explicit WP_CODEBOX_CORE_MODULE to replace stale configured core module, got: ${override_wp_codebox_core_module}" >&2
+    cat "${TMPDIR}/override-setup.out" >&2
+    exit 1
+fi
+
+if grep -q "${STALE_ROOT}" "${OVERRIDE_GITHUB_ENV_FILE}"; then
+    echo "Explicit override reinstall must not export stale WP Codebox paths" >&2
+    cat "${OVERRIDE_GITHUB_ENV_FILE}" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -35,6 +35,51 @@ install_wp_codebox() {
         return 0
     }
 
+    first_non_empty_env() {
+        local name
+        for name in "$@"; do
+            if [ -n "${!name:-}" ]; then
+                printf '%s' "${!name}"
+                return 0
+            fi
+        done
+        return 1
+    }
+
+    configure_explicit_overrides() {
+        local explicit_bin=""
+        local explicit_core_module=""
+        local configured_bin=0
+        local configured_core_module=0
+
+        explicit_bin="$(first_non_empty_env HOMEBOY_WP_CODEBOX_CLI WP_CODEBOX_CLI WP_CODEBOX_BIN || true)"
+        if [ -n "${explicit_bin}" ]; then
+            if [ ! -x "${explicit_bin}" ]; then
+                echo "Explicit WP Codebox CLI override is not executable: ${explicit_bin}" >&2
+                exit 1
+            fi
+            export HOMEBOY_WP_CODEBOX_BIN="${explicit_bin}"
+            write_github_env "HOMEBOY_WP_CODEBOX_BIN" "${explicit_bin}"
+            echo "WP Codebox CLI override configured: ${explicit_bin}"
+            configured_bin=1
+        fi
+
+        explicit_core_module="$(first_non_empty_env WP_CODEBOX_CORE_MODULE HOMEBOY_WP_CODEBOX_CORE_MODULE || true)"
+        if [ -n "${explicit_core_module}" ]; then
+            configure_core_module "${explicit_core_module}" || {
+                echo "Explicit WP Codebox core module override is not a file: ${explicit_core_module}" >&2
+                exit 1
+            }
+            configured_core_module=1
+        fi
+
+        if [ "${configured_bin}" -eq 1 ] && { [ "${configured_core_module}" -eq 1 ] || resolve_core_module_from_known_locations; }; then
+            return 0
+        fi
+
+        return 1
+    }
+
     # Re-derive the core runtime module from the deterministic install
     # locations on disk. The CLI binary is persisted across GitHub Actions
     # steps via GITHUB_ENV, but HOMEBOY_WP_CODEBOX_CORE_MODULE does not always
@@ -46,6 +91,7 @@ install_wp_codebox() {
         local probe_root="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
         local candidate
         for candidate in \
+            "${WP_CODEBOX_CORE_MODULE:-}" \
             "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" \
             "${probe_root}/source/node_modules/@automattic/wp-codebox-core/dist/index.js" \
             "${probe_root}/release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"; do
@@ -55,6 +101,10 @@ install_wp_codebox() {
         done
         return 1
     }
+
+    if configure_explicit_overrides; then
+        return 0
+    fi
 
     if [ -n "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && [ -x "${HOMEBOY_WP_CODEBOX_BIN}" ]; then
         echo "WP Codebox already configured: ${HOMEBOY_WP_CODEBOX_BIN}"


### PR DESCRIPTION
## Summary
- Normalize explicit WP Codebox CLI/core override env vars before accepting cached setup config.
- Let explicit WP_CODEBOX_CLI and WP_CODEBOX_CORE_MODULE replace stale persisted HOMEBOY_WP_CODEBOX_* paths during reinstall.
- Add setup smoke coverage for reinstalling with stale config plus explicit current paths.
- Document accepted override env vars.

## Tests
- bash -n wordpress/scripts/build/setup.sh
- bash -n wordpress/scripts/build/setup-wp-codebox-smoke.sh
- bash wordpress/scripts/build/setup-wp-codebox-smoke.sh

## Notes
- npm run lint:js currently fails on unrelated pre-existing lint errors in untouched WordPress JS files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, code changes, regression test, documentation, and PR drafting.
