### PR TITLE
Fix Codebox nested plugin file mapping

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -394,7 +394,7 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 function wpCodeboxPluginFile({ activation, sourceLayout = {}, wordpressExtension = {}, mountSlug } = {}) {
 	const configured = nonEmptyString(wordpressExtension?.wp_codebox_plugin_file || wordpressExtension?.wpCodeboxPluginFile);
 	if (configured) {
-		if (sourceLayout.sourceIsPluginRoot && sourceLayout.sourceSubpath && configured.startsWith(`${sourceLayout.sourceSubpath}/`)) {
+		if (sourceLayout.sourceSubpath && configured.startsWith(`${sourceLayout.sourceSubpath}/`)) {
 			return joinRelativePath(mountSlug || path.basename(sourceLayout.sourceSubpath), configured.slice(sourceLayout.sourceSubpath.length + 1));
 		}
 		return configured.includes('/') || configured.includes('\\') || !sourceLayout.sourceSubpath
@@ -406,10 +406,13 @@ function wpCodeboxPluginFile({ activation, sourceLayout = {}, wordpressExtension
 	if (!normalizedActivation) {
 		return undefined;
 	}
-	if (sourceLayout.sourceIsPluginRoot || !sourceLayout.sourceSubpath || normalizedActivation.startsWith(`${sourceLayout.sourceSubpath}/`)) {
+	if (sourceLayout.sourceSubpath && normalizedActivation.startsWith(`${sourceLayout.sourceSubpath}/`)) {
+		return joinRelativePath(mountSlug || path.basename(sourceLayout.sourceSubpath), normalizedActivation.slice(sourceLayout.sourceSubpath.length + 1));
+	}
+	if (sourceLayout.sourceIsPluginRoot || !sourceLayout.sourceSubpath || normalizedActivation.startsWith(`${mountSlug}/`)) {
 		return normalizePathSeparators(normalizedActivation);
 	}
-	return joinRelativePath(sourceLayout.sourceSubpath, path.basename(normalizedActivation));
+	return joinRelativePath(mountSlug || path.basename(sourceLayout.sourceSubpath), path.basename(normalizedActivation));
 }
 
 function joinRelativePath(...parts) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -336,6 +336,7 @@ const monorepoPluginResult = buildWordPressFuzzRunnerResult({
 						path: monorepoPluginCheckoutRoot,
 						extensions: {
 							wordpress: {
+								wp_codebox_source_path: monorepoPluginCheckoutRoot,
 								wp_codebox_source_subpath: 'plugins/woocommerce',
 								wp_codebox_plugin_file: 'plugins/woocommerce/woocommerce.php',
 							},
@@ -351,8 +352,12 @@ const monorepoPluginResult = buildWordPressFuzzRunnerResult({
 		runId: 'monorepo-plugin-file-path',
 	},
 });
-assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].pluginFile, 'plugins/woocommerce/woocommerce.php');
-assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.component_contracts[0].pluginFile, 'plugins/woocommerce/woocommerce.php');
+assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourceSubdir, 'plugins/woocommerce');
+assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].mountSlug, 'woocommerce');
+assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].pluginFile, 'woocommerce/woocommerce.php');
+assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.component_contracts[0].sourceSubdir, 'plugins/woocommerce');
+assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.component_contracts[0].mountSlug, 'woocommerce');
+assert.equal(monorepoPluginResult.wp_codebox_runtime_requirements.component_contracts[0].pluginFile, 'woocommerce/woocommerce.php');
 assert.throws(
 	() => validateWpCodeboxRuntimeRequirementMounts({ runtime_mounts: [{ source: path.join(runtimeRequirementRoot, 'missing-workloads'), target: '/tmp/missing-workloads' }] }),
 	/WP Codebox runtime requirement runtime_mounts\[0\] source does not exist/


### PR DESCRIPTION
## Summary
- Normalize nested WP Codebox plugin files to the mounted plugin slug when runtime metadata includes a source subdirectory.
- Keep `sourceSubdir/sourceSubpath` responsible for the monorepo source location and emit `pluginFile` as `<mountSlug>/...`.
- Update the Woo-style nested plugin smoke coverage to assert `sourceSubdir`, `mountSlug`, and `pluginFile` together.

## Tests
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wp-codebox-fuzz-suite`
- `npm run lint:js -- lib/wordpress-fuzz-runner.js`
- WP Codebox validator cross-check: `npx tsx tests/recipe-extra-plugin-nested-source.test.ts` in `wp-codebox@nested-plugin-source-mount`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the failed Homeboy run artifacts, tracing ownership across HBEX/Rigs/WP Codebox, implementing the mapper fix, and running verification.
