### PR TITLE
Remove WordPress fanout reconcile script shim

### DIFF
--- a/docs/generic-fanout-reconcile-workflow.md
+++ b/docs/generic-fanout-reconcile-workflow.md
@@ -1,6 +1,6 @@
 # Generic Fanout/Reconcile Workflow
 
-`runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` and `runtime-agent-ci/lib/fanout-reconcile-runner.js` provide executor-neutral fanout/reconcile primitives. `runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs` exposes the shared planner/reconciler through JSON files, and `wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs` remains as a compatibility entrypoint for existing WordPress-lane callers.
+`runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` and `runtime-agent-ci/lib/fanout-reconcile-runner.js` provide executor-neutral fanout/reconcile primitives. `runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs` exposes the shared planner/reconciler through JSON files.
 
 This helper is the planner/reconciler side of the audit fanout boundary, not a runtime provider. Runtime packages, provider names, credentials, WordPress setup, sandbox recipes, and provider task schemas stay behind the `audit-fanout-runtime-provider` interface. The current audit fanout implementation is the quarantined WP Codebox lane, which maps grouped audit findings to `wp-codebox/task-input/v1` requests and executes them through Codebox-owned task runner contracts.
 
@@ -62,7 +62,7 @@ For Homeboy agent-task fanout, keep record status host-owned: map provider outco
 
 ## Finding Packets
 
-`runtime-agent-ci` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` export helpers for diagnostic/finding packet inputs. `wordpress/lib/generic-fanout-reconcile-workflow.js` re-exports the same helpers for existing entrypoints.
+`runtime-agent-ci` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` export helpers for diagnostic/finding packet inputs.
 
 - `normalizeFindingPacketItems(packets, policy)` flattens packet-level `findings` or `diagnostics` arrays into generic items with stable packet/finding IDs.
 - `materializeFindingPacketFanoutConfig({ packets, policy, ...config })` applies policy-driven grouping and returns the generic config/groups/items needed by the planner.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -665,9 +665,9 @@ homeboy refactor <component> \
 
 Audit fanout has two boundaries. Generic extraction and reconcile mechanics live
 in `../runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` and
-`../runtime-agent-ci/lib/fanout-reconcile-runner.js`; WordPress keeps thin
-`lib/` re-export wrappers and the `scripts/agent/homeboy-generic-fanout-reconcile.cjs`
-JSON CLI for existing entrypoints. The generic
+`../runtime-agent-ci/lib/fanout-reconcile-runner.js`; use
+`../runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs` for JSON-file
+planning/reconcile workflows. The generic
 runtime provider interface lives in `lib/audit-fanout-runtime-provider.js` and is
 exported from the WordPress package. Runtime providers own execution: they map
 generic grouped work into their provider task contract, run the task, and

--- a/wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs
+++ b/wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-require('../../../runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs');

--- a/wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
+++ b/wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
@@ -101,7 +101,7 @@ async function main() {
     writeJson(itemsPath, items);
     writeJson(recordsPath, result.records);
 
-    const cliPath = path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-generic-fanout-reconcile.cjs');
+    const cliPath = path.join(__dirname, '..', '..', 'runtime-agent-ci', 'scripts', 'homeboy-generic-fanout-reconcile.cjs');
     const planRun = spawnSync(process.execPath, [cliPath, '--config', configPath, '--items', itemsPath, '--output', planPath], { encoding: 'utf8' });
     assert.equal(planRun.status, 0, planRun.stderr);
     assert.deepEqual(readJson(planPath), plan);


### PR DESCRIPTION
## Summary
- Delete the WordPress-lane generic fanout/reconcile script shim after the runtime-agent-ci CLI became the canonical contract surface.
- Retarget the WordPress smoke test to the runtime-agent-ci CLI.
- Narrow docs to point callers at the runtime-agent-ci script and helpers.

## Verification
- npm run test:generic-fanout-reconcile-workflow
- npm run test:generic-fanout-reconcile-boundary
- node --check tests/generic-fanout-reconcile-workflow-smoke.js && node --check ../runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Reference search, code/doc/test updates, focused verification, commit/PR preparation.