### PR TITLE
Validate artifact postprocess contract export when available

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -69,6 +69,7 @@ const DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY = 'wp-codebox/run-wordpress-workloa
 const DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA = 'wp-codebox/wordpress-workload-run/v1';
 const WP_CODEBOX_PUBLIC_CLI_COMMANDS = WP_CODEBOX_FUZZ_PUBLIC_COMMANDS;
 const ARTIFACT_POSTPROCESS_COMMAND = 'homeboy.artifact-postprocess';
+const ARTIFACT_POSTPROCESS_CONTRACT = 'homeboy/artifact-postprocess/v1';
 const ARTIFACT_POSTPROCESS_COMMAND_ALIASES = new Set([ARTIFACT_POSTPROCESS_COMMAND, 'artifact-postprocess', 'homeboy.artifact_postprocess']);
 const DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS = [
 	'wp-codebox-fuzz-suite-result',
@@ -1152,7 +1153,7 @@ function normalizeWordPressWorkloadStep(step, options = {}) {
 		metadata: stripUndefined({
 			...(objectOrUndefined(step.metadata) || {}),
 			adapter: 'homeboy-extensions',
-			contract: 'homeboy/artifact-postprocess/v1',
+			contract: ARTIFACT_POSTPROCESS_CONTRACT,
 		}),
 	});
 }
@@ -3193,6 +3194,7 @@ module.exports = {
 	DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
 	DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
 	ARTIFACT_POSTPROCESS_COMMAND,
+	ARTIFACT_POSTPROCESS_CONTRACT,
 	FUZZ_ARTIFACT_SEMANTIC_KEYS,
 	WORDPRESS_FUZZ_POSTPROCESS_BINDING_SCHEMA,
 	WORDPRESS_FUZZ_POSTPROCESS_OUTPUTS,

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -12,6 +13,7 @@ const {
 	DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY,
 	DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA,
 	ARTIFACT_POSTPROCESS_COMMAND,
+	ARTIFACT_POSTPROCESS_CONTRACT,
 	WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA,
 	WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA,
 	WORDPRESS_FUZZ_OBSERVATION_SCHEMA,
@@ -41,6 +43,24 @@ const {
 	wpCodeboxRuntimeContractManifest,
 } = require('../lib/wp-codebox-fuzz-run');
 const { buildWordPressFuzzRunnerResult } = require('../lib/wordpress-fuzz-runner');
+
+function exportedHomeboyContract(contractId) {
+	const exportRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-contract-export-'));
+	try {
+		const result = spawnSync('homeboy', ['contract', 'export', '--dir', exportRoot], { encoding: 'utf8' });
+		if (result.status !== 0) {
+			return undefined;
+		}
+		const catalogPath = path.join(exportRoot, 'schema-catalog.json');
+		if (!fs.existsSync(catalogPath)) {
+			return undefined;
+		}
+		const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+		return (Array.isArray(catalog.contracts) ? catalog.contracts : []).find((contract) => contract.id === contractId);
+	} finally {
+		fs.rmSync(exportRoot, { recursive: true, force: true });
+	}
+}
 
 const input = wpCodeboxFuzzSuiteInput({
 	id: 'fuzz-smoke',
@@ -225,7 +245,12 @@ assert.equal(artifactPostprocessWorkloadInput.steps[0].artifactName, 'coverage_g
 assert.equal(artifactPostprocessWorkloadInput.steps[0].artifactKind, 'json');
 assert.equal(artifactPostprocessWorkloadInput.steps[0].semantic, 'fuzz.coverage.gap_report');
 assert.deepEqual(artifactPostprocessWorkloadInput.steps[0].args, ['coverage-gap-report', '${inputArtifactRoot}', '${outputArtifactPath}', JSON.stringify({ max_bytes: 1024 })]);
-assert.equal(artifactPostprocessWorkloadInput.steps[0].metadata.contract, 'homeboy/artifact-postprocess/v1');
+assert.equal(artifactPostprocessWorkloadInput.steps[0].metadata.contract, ARTIFACT_POSTPROCESS_CONTRACT);
+const artifactPostprocessHomeboyContract = exportedHomeboyContract(ARTIFACT_POSTPROCESS_CONTRACT);
+if (artifactPostprocessHomeboyContract) {
+	assert.equal(artifactPostprocessHomeboyContract.id, artifactPostprocessWorkloadInput.steps[0].metadata.contract);
+	assert.equal(artifactPostprocessHomeboyContract.version, 1);
+}
 const artifactPostprocessWorkloadInputAgain = wpCodeboxWordPressWorkloadRunInput(artifactPostprocessWorkloadInput);
 assert.equal(artifactPostprocessWorkloadInputAgain.steps[0].helperPath, '${package.root}/tools/artifact-helper.mjs');
 assert.equal(artifactPostprocessWorkloadInputAgain.steps[0].inputArtifactRoot, '${artifacts.root}');


### PR DESCRIPTION
## Summary
- Hoist the canonical artifact-postprocess contract id into the WP Codebox fuzz adapter export.
- Update the focused fuzz smoke test to consume Homeboy contract export and assert alignment when Homeboy exports homeboy/artifact-postprocess/v1.
- Preserve existing alias/local shape checks because Homeboy does not yet register the artifact-postprocess contract id.

## Tests
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-campaign
- npm run test:wordpress-fuzz-runner

## Homeboy contract blocker
- Active Homeboy after command-surface refresh: 0.275.0 from /Users/chubes/.cargo/bin/homeboy.
- homeboy contract list/show/validate are available.
- homeboy contract list does not include homeboy/artifact-postprocess/v1 or any artifact-postprocess entry.
- homeboy contract show homeboy/artifact-postprocess/v1 and homeboy contract validate --file /dev/null homeboy/artifact-postprocess/v1 both fail with unknown contract schema/id.
- homeboy contract export works, but schema-catalog.json does not include homeboy/artifact-postprocess/v1, artifact-postprocess, or postprocess entries, so this PR cannot safely delete alias translation or local schema checks yet.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, focused test updates, local validation, and PR drafting.