### PR TITLE
Test Homeboy contract export fixtures

### DIFF
--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "test": "set -e; for test in tests/*.test.js; do node \"$test\"; done",
     "probe:homeboy-contract": "node scripts/probe-homeboy-contract-surface.cjs",
+    "test:homeboy-contract-export": "node scripts/check-homeboy-contract-export-fixtures.cjs",
     "test:controller-loop-proof-validator": "node ../tests/controller-loop-proof-validator.test.mjs",
     "test:generic-fanout-reconcile-boundary": "node ../tests/generic-fanout-reconcile-boundary.test.mjs",
     "test:workspace-publication-lifecycle": "node tests/workspace-publication-lifecycle.test.js",

--- a/runtime-agent-ci/scripts/check-homeboy-contract-export-fixtures.cjs
+++ b/runtime-agent-ci/scripts/check-homeboy-contract-export-fixtures.cjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const DEFAULT_FIXTURE_PATH = path.join(
+  __dirname,
+  '..',
+  'tests',
+  'fixtures',
+  'homeboy-contract-export.generated.json'
+);
+
+function checkHomeboyContractExportFixtures(options = {}) {
+  const command = options.homeboyCommand || process.env.HOMEBOY_COMMAND || 'homeboy';
+  const spawn = options.spawnSync || spawnSync;
+  const fixturePath = options.fixturePath || DEFAULT_FIXTURE_PATH;
+  const tempRoot = options.tempRoot || fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-contract-export-'));
+  const env = { ...process.env, ...(options.env || {}) };
+  const result = spawn(command, ['contract', 'export', '--dir', tempRoot], { encoding: 'utf8', env });
+  const stdout = typeof result.stdout === 'string' ? result.stdout.trim() : '';
+  const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+
+  if (result.error && result.error.code === 'ENOENT') {
+    return skip(`homeboy contract export fixture check skipped: ${command} was not found`, result);
+  }
+
+  if (result.status !== 0) {
+    if (/unrecognized|unknown|invalid/i.test(stderr)) {
+      return skip('homeboy contract export fixture check skipped: contract export is unavailable', result);
+    }
+    return fail(`homeboy contract export --dir failed with status ${result.status}: ${stderr || stdout}`, result);
+  }
+
+  const fixture = readJson(fixturePath);
+  const schemaCatalog = readJson(path.join(tempRoot, 'schema-catalog.json'));
+  const errors = compareSchemaCatalogFixture(schemaCatalog, fixture.schema_catalog || {});
+
+  if (errors.length > 0) {
+    return fail(`homeboy contract export fixture check failed: ${errors.join('; ')}`, result);
+  }
+
+  return {
+    status: 'passed',
+    message: `homeboy contract export fixture check passed via ${command} contract export --dir`,
+    tempRoot,
+  };
+}
+
+function compareSchemaCatalogFixture(schemaCatalog, fixture) {
+  const errors = [];
+  if (schemaCatalog.schema !== fixture.schema) {
+    errors.push(`schema catalog expected ${fixture.schema}, got ${schemaCatalog.schema || '(missing)'}`);
+  }
+
+  const contractsById = new Map((schemaCatalog.contracts || []).map((contract) => [contract.id, contract]));
+
+  for (const expectedId of fixture.contract_ids || []) {
+    const contract = contractsById.get(expectedId);
+    if (!contract) {
+      errors.push(`missing contract id ${expectedId}`);
+      continue;
+    }
+    if (!contract.example || contract.example.schema !== expectedId) {
+      errors.push(`${expectedId} example.schema expected ${expectedId}, got ${contract.example?.schema || '(missing)'}`);
+    }
+  }
+
+  for (const [contractId, expectedExample] of Object.entries(fixture.examples || {})) {
+    const actualExample = contractsById.get(contractId)?.example;
+    if (!actualExample) {
+      errors.push(`${contractId} example is missing`);
+      continue;
+    }
+    compareSubset(actualExample, expectedExample, `examples.${contractId}`, errors);
+  }
+
+  return errors;
+}
+
+function compareSubset(actual, expected, label, errors) {
+  if (expected && typeof expected === 'object' && !Array.isArray(expected)) {
+    if (!actual || typeof actual !== 'object' || Array.isArray(actual)) {
+      errors.push(`${label} expected object, got ${actual === undefined ? '(missing)' : typeof actual}`);
+      return;
+    }
+    for (const [key, expectedValue] of Object.entries(expected)) {
+      compareSubset(actual[key], expectedValue, `${label}.${key}`, errors);
+    }
+    return;
+  }
+
+  if (actual !== expected) {
+    errors.push(`${label} expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function skip(message, result) {
+  return { status: 'skipped', message, result };
+}
+
+function fail(message, result) {
+  return { status: 'failed', message, result };
+}
+
+module.exports = {
+  DEFAULT_FIXTURE_PATH,
+  checkHomeboyContractExportFixtures,
+  compareSchemaCatalogFixture,
+};
+
+if (require.main === module) {
+  const result = checkHomeboyContractExportFixtures();
+  process.stdout.write(`${result.message}\n`);
+  if (result.status === 'failed') {
+    process.exitCode = 1;
+  }
+}

--- a/runtime-agent-ci/tests/fixtures/homeboy-contract-export.generated.json
+++ b/runtime-agent-ci/tests/fixtures/homeboy-contract-export.generated.json
@@ -1,0 +1,31 @@
+{
+  "_generated_by": "homeboy contract export --dir",
+  "schema": "homeboy/runtime-agent-ci-contract-export-fixture/v1",
+  "schema_catalog": {
+    "contract_ids": [
+      "homeboy/runner-workload/v1",
+      "homeboy/runner-exec-handoff/v1",
+      "homeboy/run-location-index/v1"
+    ],
+    "examples": {
+      "homeboy/run-location-index/v1": {
+        "artifact_manifest_ref": {
+          "manifest_schema": "homeboy/artifact-manifest/v1",
+          "schema": "homeboy/runner-artifact-manifest-ref/v1"
+        },
+        "schema": "homeboy/run-location-index/v1"
+      },
+      "homeboy/runner-exec-handoff/v1": {
+        "artifact_manifest": {
+          "manifest_schema": "homeboy/artifact-manifest/v1",
+          "schema": "homeboy/runner-artifact-manifest-ref/v1"
+        },
+        "schema": "homeboy/runner-exec-handoff/v1"
+      },
+      "homeboy/runner-workload/v1": {
+        "schema": "homeboy/runner-workload/v1"
+      }
+    },
+    "schema": "homeboy/contract-schema-catalog/v1"
+  }
+}

--- a/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
+++ b/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
@@ -6,6 +6,10 @@ const {
   MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
   probeHomeboyContractSurface,
 } = require('../lib/homeboy-contract-surface-probe.cjs');
+const {
+  checkHomeboyContractExportFixtures,
+  compareSchemaCatalogFixture,
+} = require('../scripts/check-homeboy-contract-export-fixtures.cjs');
 
 const missing = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',
@@ -71,12 +75,38 @@ const drift = probeHomeboyContractSurface({
 assert.equal(drift.status, 'failed');
 assert.match(drift.message, /ARTIFACT_MANIFEST_SCHEMA expected homeboy\/artifact-manifest\/v1/);
 
+const fixtureDrift = compareSchemaCatalogFixture({
+  schema: 'homeboy/contract-schema-catalog/v1',
+  contracts: [
+    {
+      id: 'homeboy/runner-workload/v1',
+      example: { schema: 'homeboy/runner-workload/v1' },
+    },
+  ],
+}, {
+  schema: 'homeboy/contract-schema-catalog/v1',
+  contract_ids: ['homeboy/runner-workload/v1'],
+  examples: {
+    'homeboy/runner-workload/v1': { schema: 'homeboy/runner-workload/v2' },
+  },
+});
+
+assert.match(fixtureDrift.join('; '), /homeboy\/runner-workload\/v2/);
+
 const live = probeHomeboyContractSurface();
 if (live.status === 'skipped') {
   process.stdout.write(`${live.message}\n`);
 } else {
   assert.equal(live.status, 'passed', live.message);
   process.stdout.write(`${live.message}\n`);
+}
+
+const exportFixtures = checkHomeboyContractExportFixtures();
+if (exportFixtures.status === 'skipped') {
+  process.stdout.write(`${exportFixtures.message}\n`);
+} else {
+  assert.equal(exportFixtures.status, 'passed', exportFixtures.message);
+  process.stdout.write(`${exportFixtures.message}\n`);
 }
 
 process.stdout.write('Homeboy contract surface probe check passed\n');


### PR DESCRIPTION
## Summary
- Add a runtime-agent-ci contract export fixture check that runs `homeboy contract export --dir` into a temp directory.
- Compare selected schema catalog IDs and canonical example anchors against a committed generated fixture.
- Wire the export check into the existing Homeboy contract surface npm test.

## Tests
- `npm test` in `runtime-agent-ci`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the test helper, generated fixture, test wiring, local verification, commit, push, and PR creation.