### PR TITLE
Use Homeboy artifact manifest contract constants

### DIFF
--- a/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
+++ b/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
@@ -3,23 +3,15 @@
 const { spawnSync } = require('node:child_process');
 
 const {
-  ARTIFACT_MANIFEST_FILE,
-  ARTIFACT_MANIFEST_SCHEMA,
-  ARTIFACT_PATHS_SCHEMA,
-  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+  ARTIFACT_MANIFEST_CONTRACT_CONSTANTS,
 } = require('./runtime-contracts.cjs');
 
 const CONTRACT_COMMANDS = Object.freeze([
-  ['contract', 'constants', '--format=json'],
-  ['contract', 'show', '--format=json'],
-  ['contract', 'export', '--format=json'],
+  ['contract', 'constants', 'artifact-manifest'],
 ]);
 
-const MIRRORED_ARTIFACT_MANIFEST_CONSTANTS = Object.freeze({
-  ARTIFACT_MANIFEST_FILE,
-  ARTIFACT_MANIFEST_SCHEMA,
-  ARTIFACT_PATHS_SCHEMA,
-  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+const LOCAL_ARTIFACT_MANIFEST_CONSTANTS = Object.freeze({
+  ...ARTIFACT_MANIFEST_CONTRACT_CONSTANTS,
 });
 
 function probeHomeboyContractSurface(options = {}) {
@@ -58,7 +50,7 @@ function probeHomeboyContractSurface(options = {}) {
 function validateArtifactManifestConstants({ contract, command, argv, attempts }) {
   const errors = [];
 
-  for (const [name, expected] of Object.entries(MIRRORED_ARTIFACT_MANIFEST_CONSTANTS)) {
+  for (const [name, expected] of Object.entries(LOCAL_ARTIFACT_MANIFEST_CONSTANTS)) {
     const actual = contractValue(contract, name);
     if (typeof actual !== 'string' || actual.length === 0) {
       errors.push(`${name} is missing from Homeboy contract output`);
@@ -76,7 +68,7 @@ function validateArtifactManifestConstants({ contract, command, argv, attempts }
     message: `homeboy contract surface probe passed via ${command} ${argv.join(' ')}`,
     command,
     argv,
-    constants: MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
+    constants: LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
     attempts,
   };
 }
@@ -97,6 +89,9 @@ function valueCandidates(name) {
   const lower = name.toLowerCase();
 
   const candidates = [
+    ['data', 'constants', name],
+    ['data', 'constants', lower],
+    ['data', 'constants', camel],
     ['constants', name],
     ['constants', lower],
     ['constants', camel],
@@ -105,38 +100,23 @@ function valueCandidates(name) {
     [camel],
   ];
 
-  if (name === 'ARTIFACT_MANIFEST_SCHEMA') {
+  if (name === 'schema_id') {
     candidates.push(
+      ['data', 'constants', 'schema'],
+      ['data', 'constants', 'schemaId'],
+      ['constants', 'schema'],
+      ['constants', 'schemaId'],
       ['artifact_manifest', 'schema'],
-      ['artifactManifest', 'schema'],
-      ['schemas', 'artifact_manifest'],
-      ['schemas', 'artifactManifest'],
-      ['schemas', 'artifact', 'manifest'],
-      ['contracts', 'artifact_manifest', 'schema']
+      ['artifactManifest', 'schema']
     );
-  } else if (name === 'ARTIFACT_MANIFEST_FILE') {
+  } else if (name === 'file_name') {
     candidates.push(
+      ['data', 'constants', 'file'],
+      ['data', 'constants', 'fileName'],
+      ['constants', 'file'],
+      ['constants', 'fileName'],
       ['artifact_manifest', 'file'],
-      ['artifactManifest', 'file'],
-      ['files', 'artifact_manifest'],
-      ['files', 'artifactManifest'],
-      ['contracts', 'artifact_manifest', 'file']
-    );
-  } else if (name === 'ARTIFACT_PATHS_SCHEMA') {
-    candidates.push(
-      ['artifact_paths', 'schema'],
-      ['artifactPaths', 'schema'],
-      ['schemas', 'artifact_paths'],
-      ['schemas', 'artifactPaths'],
-      ['contracts', 'artifact_paths', 'schema']
-    );
-  } else if (name === 'RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA') {
-    candidates.push(
-      ['runner_artifact_manifest_ref', 'schema'],
-      ['runnerArtifactManifestRef', 'schema'],
-      ['schemas', 'runner_artifact_manifest_ref'],
-      ['schemas', 'runnerArtifactManifestRef'],
-      ['contracts', 'runner_artifact_manifest_ref', 'schema']
+      ['artifactManifest', 'file']
     );
   }
 
@@ -164,6 +144,6 @@ function fail(message, attempts, extra = {}) {
 
 module.exports = {
   CONTRACT_COMMANDS,
-  MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
+  LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
   probeHomeboyContractSurface,
 };

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -2,8 +2,12 @@
 
 const SECRET_ENV_PLAN_SCHEMA = 'homeboy/secret-env-plan/v1';
 const ARTIFACT_PATHS_SCHEMA = 'homeboy/runtime-agent-artifact-paths/v1';
-const ARTIFACT_MANIFEST_SCHEMA = 'homeboy/artifact-manifest/v1';
-const ARTIFACT_MANIFEST_FILE = 'homeboy-artifact-manifest.json';
+const ARTIFACT_MANIFEST_CONTRACT_CONSTANTS = Object.freeze({
+  file_name: 'homeboy-artifact-manifest.json',
+  schema_id: 'homeboy/artifact-manifest/v1',
+});
+const ARTIFACT_MANIFEST_SCHEMA = ARTIFACT_MANIFEST_CONTRACT_CONSTANTS.schema_id;
+const ARTIFACT_MANIFEST_FILE = ARTIFACT_MANIFEST_CONTRACT_CONSTANTS.file_name;
 const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = 'homeboy/runner-artifact-manifest-ref/v1';
 const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
   events: 'events.json',
@@ -63,6 +67,7 @@ function uniqueStrings(values) {
 }
 
 module.exports = {
+  ARTIFACT_MANIFEST_CONTRACT_CONSTANTS,
   ARTIFACT_MANIFEST_FILE,
   ARTIFACT_MANIFEST_SCHEMA,
   ARTIFACT_PATHS_SCHEMA,

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -6,6 +6,10 @@ const os = require('node:os');
 const path = require('node:path');
 
 const genericLoopRunner = require('../lib/generic-agent-loop-runner');
+const {
+  ARTIFACT_MANIFEST_FILE,
+  ARTIFACT_MANIFEST_SCHEMA,
+} = require('../lib/runtime-contracts.cjs');
 
 assert.equal(
   Object.prototype.hasOwnProperty.call(genericLoopRunner, 'runDeterministicLoop'),
@@ -358,8 +362,8 @@ process.stdout.write(JSON.stringify({
     results: sharedArtifactsRun.results,
     artifact_paths: { run_dir: sharedArtifactDir },
   });
-  const sharedManifest = JSON.parse(fs.readFileSync(path.join(sharedArtifactDir, 'homeboy-artifact-manifest.json'), 'utf8'));
-  assert.equal(sharedManifest.schema, 'homeboy/artifact-manifest/v1');
+  const sharedManifest = JSON.parse(fs.readFileSync(path.join(sharedArtifactDir, ARTIFACT_MANIFEST_FILE), 'utf8'));
+  assert.equal(sharedManifest.schema, ARTIFACT_MANIFEST_SCHEMA);
   assert.deepEqual(sharedManifest.artifacts.map((artifact) => artifact.path).sort(), [
     'outcome.json',
     'results.json',

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -9,6 +9,11 @@ const {
   runHeadlessDeterministicLoop,
   writeHeadlessDeterministicLoopArtifacts,
 } = require('../lib/headless-deterministic-loop-runner');
+const {
+  ARTIFACT_MANIFEST_FILE,
+  ARTIFACT_MANIFEST_SCHEMA,
+  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+} = require('../lib/runtime-contracts.cjs');
 
 const runtime = { id: 'fixture-runtime', executor: { backend: 'fixture', path: '/unused' } };
 const baseSpec = {
@@ -77,11 +82,11 @@ assert.equal(twoRevolution.tasks[0].loop_policy.iterations[1].accepted, true);
 assert.equal(twoRevolution.tasks[0].loop_result.schema, 'homeboy/headless-loop-result-envelope/v1');
 assert.equal(twoRevolution.tasks[0].loop_result.mode, 'count');
 assert.equal(twoRevolution.tasks[0].loop_result.revolutions, 2);
-assert.equal(twoRevolution.tasks[0].loop_result.artifact_manifest.schema, 'homeboy/runner-artifact-manifest-ref/v1');
-assert.equal(twoRevolution.tasks[0].loop_result.artifact_manifest.manifest_schema, 'homeboy/artifact-manifest/v1');
+assert.equal(twoRevolution.tasks[0].loop_result.artifact_manifest.schema, RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA);
+assert.equal(twoRevolution.tasks[0].loop_result.artifact_manifest.manifest_schema, ARTIFACT_MANIFEST_SCHEMA);
 assert.equal(twoRevolution.loop_result.schema, 'homeboy/headless-loop-result-envelope/v1');
 assert.equal(twoRevolution.loop_result.revolutions, 2);
-assert.equal(twoRevolution.loop_result.artifact_manifest.schema, 'homeboy/runner-artifact-manifest-ref/v1');
+assert.equal(twoRevolution.loop_result.artifact_manifest.schema, RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA);
 assert.equal(twoRevolution.tasks[0].outcome.metadata.headless_loop_policy_status.iteration_count, 2);
 assert.equal(twoRevolution.tasks[0].results.scenarios[0].metadata.completion_outcome_satisfied, true);
 assert.equal(twoRevolution.fanout.records[0].status, 'completed');
@@ -200,8 +205,8 @@ assert.equal(expiredDeadline.tasks[0].loop_policy.iteration_count, 0);
 const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headless-loop-artifact-manifest-'));
 try {
   writeHeadlessDeterministicLoopArtifacts({ result: twoRevolution, artifact_paths: { run_dir: artifactDir } });
-  const manifest = JSON.parse(fs.readFileSync(path.join(artifactDir, 'homeboy-artifact-manifest.json'), 'utf8'));
-  assert.equal(manifest.schema, 'homeboy/artifact-manifest/v1');
+  const manifest = JSON.parse(fs.readFileSync(path.join(artifactDir, ARTIFACT_MANIFEST_FILE), 'utf8'));
+  assert.equal(manifest.schema, ARTIFACT_MANIFEST_SCHEMA);
   assert.equal(manifest.artifacts.some((artifact) => artifact.path === 'loop-result.json'), true);
   assert.equal(manifest.artifacts.some((artifact) => artifact.path === 'events.json'), true);
   assert.equal(manifest.artifacts.every((artifact) => !path.isAbsolute(artifact.path)), true);

--- a/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
+++ b/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
@@ -3,38 +3,45 @@
 const assert = require('node:assert/strict');
 
 const {
-  MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
+  LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
   probeHomeboyContractSurface,
 } = require('../lib/homeboy-contract-surface-probe.cjs');
 const {
   checkHomeboyContractExportFixtures,
   compareSchemaCatalogFixture,
 } = require('../scripts/check-homeboy-contract-export-fixtures.cjs');
+const {
+  ARTIFACT_MANIFEST_FILE,
+  ARTIFACT_MANIFEST_SCHEMA,
+  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+} = require('../lib/runtime-contracts.cjs');
 
 const missing = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',
-  spawnSync: () => ({ status: 2, stdout: '', stderr: "error: unrecognized subcommand 'contract'" }),
+  spawnSync: () => ({ status: 2, stdout: '', stderr: "error: unrecognized subcommand 'constants'" }),
 });
 
 assert.equal(missing.status, 'skipped');
 assert.match(missing.message, /skipped/);
 
-const failedFirstCommand = probeHomeboyContractSurface({
+const releasedContractShape = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',
-  spawnSync: (_command, argv) => {
-    if (argv[1] === 'constants') {
-      return { status: 2, stdout: '', stderr: "error: unrecognized subcommand 'constants'" };
-    }
-    return {
-      status: 0,
-      stdout: JSON.stringify({ constants: MIRRORED_ARTIFACT_MANIFEST_CONSTANTS }),
-      stderr: '',
-    };
-  },
+  spawnSync: () => ({
+    status: 0,
+    stdout: JSON.stringify({
+      success: true,
+      data: {
+        constants: LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
+        contract_id: 'artifact-manifest',
+        schema: 'homeboy/contract-constants/v1',
+      },
+    }),
+    stderr: '',
+  }),
 });
 
-assert.equal(failedFirstCommand.status, 'passed');
-assert.deepEqual(failedFirstCommand.argv, ['contract', 'show', '--format=json']);
+assert.equal(releasedContractShape.status, 'passed');
+assert.deepEqual(releasedContractShape.argv, ['contract', 'constants', 'artifact-manifest']);
 
 const nestedContractShape = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',
@@ -42,14 +49,14 @@ const nestedContractShape = probeHomeboyContractSurface({
     status: 0,
     stdout: JSON.stringify({
       artifact_manifest: {
-        schema: 'homeboy/artifact-manifest/v1',
-        file: 'homeboy-artifact-manifest.json',
+        schema: ARTIFACT_MANIFEST_SCHEMA,
+        file: ARTIFACT_MANIFEST_FILE,
       },
       artifact_paths: {
         schema: 'homeboy/runtime-agent-artifact-paths/v1',
       },
       runner_artifact_manifest_ref: {
-        schema: 'homeboy/runner-artifact-manifest-ref/v1',
+        schema: RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
       },
     }),
     stderr: '',
@@ -64,8 +71,8 @@ const drift = probeHomeboyContractSurface({
     status: 0,
     stdout: JSON.stringify({
       constants: {
-        ...MIRRORED_ARTIFACT_MANIFEST_CONSTANTS,
-        ARTIFACT_MANIFEST_SCHEMA: 'homeboy/artifact-manifest/v2',
+        ...LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
+        schema_id: 'homeboy/artifact-manifest/v2',
       },
     }),
     stderr: '',
@@ -73,7 +80,7 @@ const drift = probeHomeboyContractSurface({
 });
 
 assert.equal(drift.status, 'failed');
-assert.match(drift.message, /ARTIFACT_MANIFEST_SCHEMA expected homeboy\/artifact-manifest\/v1/);
+assert.match(drift.message, /schema_id expected homeboy\/artifact-manifest\/v1/);
 
 const fixtureDrift = compareSchemaCatalogFixture({
   schema: 'homeboy/contract-schema-catalog/v1',


### PR DESCRIPTION
## Summary
- centralize local artifact manifest constants into one runtime contract object matching the released Homeboy contract surface
- update the Homeboy contract probe to validate against `homeboy contract constants artifact-manifest`
- remove safe duplicate artifact manifest string literals from runtime-agent-ci tests

## Tests
- `homeboy --version` -> `homeboy 0.275.0`
- `homeboy contract constants artifact-manifest`
- `npm run probe:homeboy-contract`
- `npm test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the runtime-agent-ci contract constants/probe implementation, making the code/test updates, running validation, and drafting this PR.