### PR TITLE
Validate secret env plans with Homeboy contract

### DIFF
--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -14,6 +15,23 @@ const {
 const { normalizeProviderPlugin } = require('../lib/full-run-inputs.cjs');
 
 assert.equal(typeof buildConfig, 'function');
+
+function validateSecretEnvPlan(plan) {
+  const fixturePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-secret-env-plan-')), 'plan.json');
+  fs.writeFileSync(fixturePath, `${JSON.stringify(plan, null, 2)}\n`);
+  const result = spawnSync(process.env.HOMEBOY_COMMAND || 'homeboy', [
+    'contract',
+    'validate',
+    SECRET_ENV_PLAN_SCHEMA,
+    '--file',
+    fixturePath,
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.success, true);
+  assert.equal(output.data.valid, true);
+  return output;
+}
 
 assert.deepEqual(loopPolicyFromEnv({}), {});
 assert.deepEqual(loopPolicyFromEnv({
@@ -54,38 +72,26 @@ try {
 
   assert.equal(config.execution_kind, 'runtime_execution');
   assert.deepEqual(config.secret_env.slice(0, 2), ['GITHUB_TOKEN', 'HOMEBOY_GITHUB_APP_TOKEN']);
-  assert.equal(config.secret_env_plan.schema, SECRET_ENV_PLAN_SCHEMA);
-  assert.deepEqual(config.secret_env_plan.inheritance, {
-    require_declaration: true,
-    allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
-  });
+  validateSecretEnvPlan(config.secret_env_plan);
   assert.deepEqual(config.secret_env_plan.secret_env_names, config.secret_env);
 } finally {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 }
 
-assert.deepEqual(
-  buildSecretEnvPlan({
-    secretEnv: ['PRIVATE_TOKEN'],
-    runtimeEnv: { PUBLIC_MODE: 'test', PRIVATE_MODE: false },
-    providerSecretEnvMapping: { token: 'PROVIDER_SECRET_1' },
-    secretEnvFallbacks: { PRIVATE_TOKEN: ['PROVIDER_SECRET_1'] },
-  }),
-  {
-    schema: SECRET_ENV_PLAN_SCHEMA,
-    public_env: { PUBLIC_MODE: 'test' },
-    secret_env_names: ['PRIVATE_TOKEN'],
-    requirements: [{ name: 'PRIVATE_TOKEN', required: true }],
-    env_name_mapping: {
-      provider_secret_env: ['PROVIDER_SECRET_1'],
-      secret_env_fallbacks: ['PROVIDER_SECRET_1'],
-    },
-    inheritance: {
-      require_declaration: true,
-      allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
-    },
-  }
-);
+const mappedSecretEnvPlan = buildSecretEnvPlan({
+  secretEnv: ['PRIVATE_TOKEN'],
+  runtimeEnv: { PUBLIC_MODE: 'test', PRIVATE_MODE: false },
+  providerSecretEnvMapping: { token: 'PROVIDER_SECRET_1' },
+  secretEnvFallbacks: { PRIVATE_TOKEN: ['PROVIDER_SECRET_1'] },
+});
+validateSecretEnvPlan(mappedSecretEnvPlan);
+assert.deepEqual(mappedSecretEnvPlan.public_env, { PUBLIC_MODE: 'test' });
+assert.deepEqual(mappedSecretEnvPlan.secret_env_names, ['PRIVATE_TOKEN']);
+assert.deepEqual(mappedSecretEnvPlan.requirements, [{ name: 'PRIVATE_TOKEN', required: true }]);
+assert.deepEqual(mappedSecretEnvPlan.env_name_mapping, {
+  provider_secret_env: ['PROVIDER_SECRET_1'],
+  secret_env_fallbacks: ['PROVIDER_SECRET_1'],
+});
 
 assert.deepEqual(
   normalizeProviderPlugin('{"providerSecretEnv":{"token":"PROVIDER_TOKEN"}}', 'fixture', true).provider_secret_env,

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -46,6 +47,22 @@ function restoreEnv(name, value) {
     return;
   }
   process.env[name] = value;
+}
+
+function validateSecretEnvPlan(plan) {
+  const fixturePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-secret-env-plan-')), 'plan.json');
+  fs.writeFileSync(fixturePath, `${JSON.stringify(plan, null, 2)}\n`);
+  const result = spawnSync(process.env.HOMEBOY_COMMAND || 'homeboy', [
+    'contract',
+    'validate',
+    runtimeAgentCi.SECRET_ENV_PLAN_SCHEMA,
+    '--file',
+    fixturePath,
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.success, true);
+  assert.equal(output.data.valid, true);
 }
 
 function secretEnvRequirementForProvider(contract, provider) {
@@ -1437,14 +1454,16 @@ assert.deepEqual(codexTaskInput.provider_plugin_paths, ['/missing/stale-openai-p
 assert.deepEqual(codexTaskInput.secret_env, provider.provider_defaults.codex.secret_env);
 
 const previousSecretEnvPlan = process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON;
-process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = JSON.stringify({
+const plannedSecretEnvPlan = {
   schema: 'homeboy/secret-env-plan/v1',
   secret_env_names: ['HOMEBOY_PLANNED_CODEBOX_SECRET'],
   env_name_mapping: {
     'wordpress.codebox-agent-task-executor': ['HOMEBOY_PLANNED_CODEBOX_SECRET'],
   },
   status: [{ name: 'HOMEBOY_PLANNED_CODEBOX_SECRET', configured: true, source: 'env' }],
-});
+};
+validateSecretEnvPlan(plannedSecretEnvPlan);
+process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = JSON.stringify(plannedSecretEnvPlan);
 let plannedSecretEnvTaskInput;
 try {
   plannedSecretEnvTaskInput = codeboxTaskRequestFromAgentTaskRequest({
@@ -1474,7 +1493,7 @@ assert.deepEqual(plannedSecretEnvTaskInput.secret_env, [
 // provider-credential names and requirement-derived names were previously
 // dropped, so those declared secrets silently never reached the sandbox.
 const previousFullPlan = process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON;
-process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = JSON.stringify({
+const fullSecretEnvPlan = {
   schema: 'homeboy/secret-env-plan/v1',
   secret_env_names: ['HOMEBOY_PLANNED_CODEBOX_SECRET'],
   requirements: [
@@ -1490,7 +1509,9 @@ process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = JSON.stringify({
     'wordpress.codebox-agent-task-executor': ['HOMEBOY_MAPPED_CODEBOX_SECRET'],
   },
   status: [{ name: 'HOMEBOY_PLANNED_CODEBOX_SECRET', configured: true, source: 'env' }],
-});
+};
+validateSecretEnvPlan(fullSecretEnvPlan);
+process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = JSON.stringify(fullSecretEnvPlan);
 let fullPlanSecretEnvTaskInput;
 try {
   fullPlanSecretEnvTaskInput = codeboxTaskRequestFromAgentTaskRequest({


### PR DESCRIPTION
## Summary
- Validate generated runtime-agent-ci SecretEnvPlan JSON through released `homeboy contract validate homeboy/secret-env-plan/v1`.
- Keep behavior-specific assertions for public env filtering, source/env-name mapping, and WP Codebox secret forwarding.
- Replace redundant local shape assertions where Homeboy now owns the contract validation.

## Tests
- `homeboy contract validate homeboy/secret-env-plan/v1 --file /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/secret-env-plan-fixture.json`
- `npm test` in `runtime-agent-ci`
- `node tests/codebox-agent-task-executor-boundary.test.js` in `wordpress`
- `npm run test:codebox-agent-task-executor-boundary` in `wordpress`

## Notes
- Upgraded local Homeboy from `0.274.0` to released `0.275.0` because `contract validate` was not available in `0.274.0`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing test updates, running validation/tests, and drafting this PR description.