### PR TITLE
Declare extension contract producers

### DIFF
--- a/agent-runtimes/claude-code/claude-code.json
+++ b/agent-runtimes/claude-code/claude-code.json
@@ -2,8 +2,26 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "claude-code",
   "name": "Claude Code",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Claude Code agent runtime contract for OAuth-backed provider execution.",
+  "contract_producers": [
+    {
+      "id": "claude-code.agent-task-result",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/agent/homeboy-claude-code-agent-task-executor.cjs",
+        "input_schema": "homeboy/agent-task-request/v1",
+        "output_schema": "homeboy/agent-task-outcome/v1"
+      },
+      "produces": [
+        {
+          "kind": "status",
+          "name": "agent-task-outcome",
+          "schema": "homeboy/agent-task-outcome/v1"
+        }
+      ]
+    }
+  ],
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",

--- a/agent-runtimes/codex/codex.json
+++ b/agent-runtimes/codex/codex.json
@@ -2,8 +2,26 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "codex",
   "name": "Codex",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Standalone Codex agent runtime for repository-scoped agent tasks.",
+  "contract_producers": [
+    {
+      "id": "codex.agent-task-result",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/agent/homeboy-codex-agent-task-executor.cjs",
+        "input_schema": "homeboy/agent-task-request/v1",
+        "output_schema": "homeboy/agent-task-outcome/v1"
+      },
+      "produces": [
+        {
+          "kind": "status",
+          "name": "agent-task-outcome",
+          "schema": "homeboy/agent-task-outcome/v1"
+        }
+      ]
+    }
+  ],
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",

--- a/agent-runtimes/local-shell/local-shell.json
+++ b/agent-runtimes/local-shell/local-shell.json
@@ -2,8 +2,26 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "local-shell",
   "name": "Local Shell",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Minimal host-shell runtime adapter for generic agent-task contract smokes.",
+  "contract_producers": [
+    {
+      "id": "local-shell.agent-task-result",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/agent/homeboy-local-shell-agent-task-executor.cjs",
+        "input_schema": "homeboy/agent-task-request/v1",
+        "output_schema": "homeboy/agent-task-outcome/v1"
+      },
+      "produces": [
+        {
+          "kind": "status",
+          "name": "agent-task-outcome",
+          "schema": "homeboy/agent-task-outcome/v1"
+        }
+      ]
+    }
+  ],
   "ci_materialization": {
     "paths": {}
   },

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,8 +2,26 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
+  "contract_producers": [
+    {
+      "id": "opencode.agent-task-result",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/agent/homeboy-opencode-agent-task-executor.cjs",
+        "input_schema": "homeboy/agent-task-request/v1",
+        "output_schema": "homeboy/agent-task-outcome/v1"
+      },
+      "produces": [
+        {
+          "kind": "status",
+          "name": "agent-task-outcome",
+          "schema": "homeboy/agent-task-outcome/v1"
+        }
+      ]
+    }
+  ],
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",

--- a/agent-runtimes/pi/pi.json
+++ b/agent-runtimes/pi/pi.json
@@ -2,8 +2,26 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "pi",
   "name": "Pi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Conservative Pi agent runtime integration for generic Homeboy agent task requests.",
+  "contract_producers": [
+    {
+      "id": "pi.agent-task-result",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/agent/homeboy-pi-agent-task-executor.cjs",
+        "input_schema": "homeboy/agent-task-request/v1",
+        "output_schema": "homeboy/agent-task-outcome/v1"
+      },
+      "produces": [
+        {
+          "kind": "status",
+          "name": "agent-task-outcome",
+          "schema": "homeboy/agent-task-outcome/v1"
+        }
+      ]
+    }
+  ],
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -2,8 +2,26 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "wp-codebox",
   "name": "WP Codebox",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
+  "contract_producers": [
+    {
+      "id": "wp-codebox.agent-task-result",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/agent/homeboy-codebox-agent-task-executor.cjs",
+        "input_schema": "homeboy/agent-task-request/v1",
+        "output_schema": "homeboy/agent-task-outcome/v1"
+      },
+      "produces": [
+        {
+          "kind": "status",
+          "name": "agent-task-outcome",
+          "schema": "homeboy/agent-task-outcome/v1"
+        }
+      ]
+    }
+  ],
   "tool_profiles": {
     "workspace_iteration": {
       "id": "workspace_iteration",

--- a/go/go.json
+++ b/go/go.json
@@ -1,7 +1,7 @@
 {
   "name": "Go",
   "id": "go",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "icon": "g.circle.fill",
   "description": "Go CLI integration for services, bridges, and binaries",
   "author": "Extra Chill",
@@ -16,6 +16,24 @@
     "test.coverage": false,
     "annotations": false
   },
+  "contract_producers": [
+    {
+      "id": "go.lint-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/lint-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "lint.findings" }
+      ]
+    },
+    {
+      "id": "go.test-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/test-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "test.failures" }
+      ]
+    }
+  ],
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "validate": "scripts/validate.sh",

--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -1,6 +1,6 @@
 {
   "name": "Node.js",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "icon": "server.rack",
   "description": "Node.js project type — discovery, audit grammar, and npm release lifecycle",
   "author": "Extra Chill",
@@ -18,6 +18,49 @@
     "trace.artifacts": true,
     "annotations": false
   },
+  "contract_producers": [
+    {
+      "id": "nodejs.lint-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/lint/lint-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "lint.findings" }
+      ]
+    },
+    {
+      "id": "nodejs.test-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/test/test-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "test.results" },
+        { "kind": "artifact", "name": "test.failures" }
+      ]
+    },
+    {
+      "id": "nodejs.bench-results",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/bench/bench-runner.sh",
+        "output_schema": "homeboy/bench-results/v1"
+      },
+      "produces": [
+        {
+          "kind": "artifact",
+          "name": "bench.results",
+          "schema": "homeboy/bench-results/v1"
+        }
+      ]
+    },
+    {
+      "id": "nodejs.trace-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/trace/trace-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "trace.results" },
+        { "kind": "artifact", "name": "trace.artifacts" }
+      ]
+    }
+  ],
   "scripts": {
     "validate": "scripts/validate.sh",
     "format": "scripts/format.sh"

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
@@ -16,6 +16,40 @@
     "bench.results": true,
     "annotations": true
   },
+  "contract_producers": [
+    {
+      "id": "rust.lint-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/lint-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "lint.findings" }
+      ]
+    },
+    {
+      "id": "rust.test-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/test-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "test.results" },
+        { "kind": "artifact", "name": "test.failures" }
+      ]
+    },
+    {
+      "id": "rust.bench-results",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/bench/bench-runner.sh",
+        "output_schema": "homeboy/bench-results/v1"
+      },
+      "produces": [
+        {
+          "kind": "artifact",
+          "name": "bench.results",
+          "schema": "homeboy/bench-results/v1"
+        }
+      ]
+    }
+  ],
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.sh",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.22.19",
+  "version": "3.23.0",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
@@ -21,6 +21,109 @@
     "trace.results": true,
     "annotations": false
   },
+  "contract_producers": [
+    {
+      "id": "wordpress.live-surface-discovery",
+      "phase": "discovery",
+      "invocation": {
+        "script": "scripts/runtime/wordpress-live-surface-discovery.php",
+        "output_schema": "homeboy/wordpress-live-surface-discovery-raw/v1"
+      },
+      "produces": [
+        {
+          "kind": "capability",
+          "name": "wordpress-live-surface-discovery",
+          "schema": "homeboy/wordpress-live-surface-discovery-raw/v1"
+        }
+      ]
+    },
+    {
+      "id": "wordpress.runtime-task-plan",
+      "phase": "planning",
+      "invocation": {
+        "script": "scripts/agent/homeboy-wordpress-runtime-task-plan.cjs",
+        "output_schema": "homeboy/agent-task-plan/v1"
+      },
+      "produces": [
+        {
+          "kind": "execution_plan",
+          "name": "agent-task-plan",
+          "schema": "homeboy/agent-task-plan/v1"
+        }
+      ]
+    },
+    {
+      "id": "wordpress.generic-fanout-reconcile-plan",
+      "phase": "planning",
+      "invocation": {
+        "script": "scripts/agent/homeboy-generic-fanout-reconcile.cjs",
+        "output_schema": "homeboy/fanout-reconcile-plan/v1"
+      },
+      "produces": [
+        {
+          "kind": "execution_plan",
+          "name": "fanout-reconcile-plan",
+          "schema": "homeboy/fanout-reconcile-plan/v1"
+        }
+      ]
+    },
+    {
+      "id": "wordpress.generic-fanout-reconcile-result",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/agent/homeboy-generic-fanout-reconcile.cjs",
+        "output_schema": "homeboy/generic-fanout-reconcile-result/v1"
+      },
+      "produces": [
+        {
+          "kind": "status",
+          "name": "generic-fanout-reconcile-result",
+          "schema": "homeboy/generic-fanout-reconcile-result/v1"
+        }
+      ]
+    },
+    {
+      "id": "wordpress.lint-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/lint/lint-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "lint.findings" },
+        { "kind": "artifact", "name": "lint.producers" }
+      ]
+    },
+    {
+      "id": "wordpress.test-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/test/test-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "test.results" },
+        { "kind": "artifact", "name": "test.failures" }
+      ]
+    },
+    {
+      "id": "wordpress.bench-results",
+      "phase": "result",
+      "invocation": {
+        "script": "scripts/bench/bench-runner.sh",
+        "output_schema": "homeboy/bench-results/v1"
+      },
+      "produces": [
+        {
+          "kind": "artifact",
+          "name": "bench.results",
+          "schema": "homeboy/bench-results/v1"
+        }
+      ]
+    },
+    {
+      "id": "wordpress.trace-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/trace/trace-runner.sh" },
+      "produces": [
+        { "kind": "artifact", "name": "trace.results" }
+      ]
+    }
+  ],
   "agent_task": {
     "runtime_requirements": {
       "required_capabilities": [

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -56,7 +56,7 @@
       "id": "wordpress.generic-fanout-reconcile-plan",
       "phase": "planning",
       "invocation": {
-        "script": "scripts/agent/homeboy-generic-fanout-reconcile.cjs",
+        "script": "../runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs",
         "output_schema": "homeboy/fanout-reconcile-plan/v1"
       },
       "produces": [
@@ -71,7 +71,7 @@
       "id": "wordpress.generic-fanout-reconcile-result",
       "phase": "result",
       "invocation": {
-        "script": "scripts/agent/homeboy-generic-fanout-reconcile.cjs",
+        "script": "../runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs",
         "output_schema": "homeboy/generic-fanout-reconcile-result/v1"
       },
       "produces": [


### PR DESCRIPTION
## Summary
- Declare `contract_producers` in agent runtime manifests for existing agent-task executor result contracts.
- Declare `contract_producers` in WordPress, Node.js, Rust, and Go extension manifests for existing discovery/planning/result scripts and structured sidecar outputs.
- Bump affected manifest versions per repo guidance.

## Tests
- `jq empty agent-runtimes/opencode/opencode.json agent-runtimes/claude-code/claude-code.json agent-runtimes/codex/codex.json agent-runtimes/pi/pi.json agent-runtimes/local-shell/local-shell.json agent-runtimes/wp-codebox/wp-codebox.json wordpress/wordpress.json nodejs/nodejs.json rust/rust.json go/go.json`
- `homeboy extension list` and `homeboy extension show wordpress`, `homeboy extension show nodejs`, `homeboy extension show rust`, `homeboy extension show go` against a temporary Homeboy registry linked to this branch
- `homeboy agent-task --force-hot providers` against a temporary runtime registry linked to this branch
- Direct Node manifest check that every declared producer has a valid phase, existing invocation script, and produced outputs
- `node wordpress/tests/wordpress-manifest-settings-smoke.js`
- `node wordpress/tests/wordpress-fuzz-manifest-smoke.js`
- `node wordpress/tests/helper-manifest-smoke.js`

## Blockers / notes
- WordPress extension readiness reported blocked in the temporary registry because WP Codebox core recipe-builder modules were not installed there; manifest parsing and `contract_producers` emission still succeeded.
- No handoff producer was declared for WordPress/agent runtimes because the existing handoff surface is runtime ability metadata, not a manifest-callable script.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting existing manifests/scripts, editing manifest declarations, running validation, and drafting this PR description.
