### PR TITLE
Conform runtime status normalization with Homeboy

### DIFF
--- a/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
+++ b/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
@@ -63,7 +63,11 @@ function normalizeAgentTaskStatus(result = {}, options = {}) {
   if (TERMINAL_FAILURE_STATUSES.includes(explicitStatus)) {
     return explicitStatus;
   }
-  return normalizeAgentTaskOutcomeStatus({ ...result, status: explicitStatus || resultStatus }, { exitStatus });
+  if (TERMINAL_FAILURE_STATUSES.includes(resultStatus)) {
+    return resultStatus;
+  }
+  const status = explicitStatus || resultStatus;
+  return normalizeAgentTaskOutcomeStatus(status === undefined ? result : { ...result, status }, { exitStatus });
 }
 
 function normalizeProviderStatus(result = {}, exitStatus = 0) {

--- a/runtime-agent-ci/lib/runtime-status.cjs
+++ b/runtime-agent-ci/lib/runtime-status.cjs
@@ -7,6 +7,11 @@ const HOST_RUN_FAILURE_STATUSES = Object.freeze(['failed']);
 const HOST_RUN_PENDING_STATUSES = Object.freeze(['incomplete']);
 const PROVIDER_SUCCESS_STATUSES = Object.freeze(['accepted', 'completed', 'passed', 'success', 'succeeded', 'no_op']);
 const PROVIDER_FAILURE_STATUSES = Object.freeze(['cancelled', 'failed', 'provider_error', 'timeout', 'unable_to_remediate']);
+const RUN_LIFECYCLE_STATUSES = Object.freeze(['unknown', 'queued', 'running', 'succeeded', 'partial_failure', 'failed', 'cancelled', 'timed_out', 'stale']);
+const RUN_LIFECYCLE_PENDING_STATUSES = Object.freeze(['unknown', 'queued', 'running']);
+const RUN_LIFECYCLE_SUCCESS_STATUSES = Object.freeze(['succeeded']);
+const RUN_LIFECYCLE_FAILURE_STATUSES = Object.freeze(['partial_failure', 'failed', 'cancelled', 'timed_out', 'stale']);
+const RUN_LIFECYCLE_RETRYABLE_STATUSES = Object.freeze(['failed', 'timed_out', 'stale']);
 
 function normalizeHostRecordStatus(value = {}, options = {}) {
   const record = plainObject(value) ? value : { status: value };
@@ -65,6 +70,24 @@ function normalizeAgentTaskOutcomeStatus(result = {}, options = {}) {
   return Object.keys(result || {}).length > 0 ? 'provider_error' : 'failed';
 }
 
+function normalizeRunLifecycleStatus(value = {}) {
+  const run = plainObject(value) ? value : { status: value };
+  const status = text(run.status || run.state);
+  return RUN_LIFECYCLE_STATUSES.includes(status) ? status : 'unknown';
+}
+
+function classifyRunLifecycleStatus(value = {}) {
+  const status = normalizeRunLifecycleStatus(value);
+  return {
+    is_retryable: RUN_LIFECYCLE_RETRYABLE_STATUSES.includes(status),
+    is_success: RUN_LIFECYCLE_SUCCESS_STATUSES.includes(status),
+    is_terminal: RUN_LIFECYCLE_SUCCESS_STATUSES.includes(status) || RUN_LIFECYCLE_FAILURE_STATUSES.includes(status),
+    kind: 'run_lifecycle_status',
+    schema: 'homeboy/run-lifecycle-status/v1',
+    status,
+  };
+}
+
 function providerStatusSucceeded(status) {
   return PROVIDER_SUCCESS_STATUSES.includes(text(status));
 }
@@ -89,9 +112,16 @@ module.exports = {
   HOST_RUN_SUCCESS_STATUSES,
   PROVIDER_FAILURE_STATUSES,
   PROVIDER_SUCCESS_STATUSES,
+  RUN_LIFECYCLE_FAILURE_STATUSES,
+  RUN_LIFECYCLE_PENDING_STATUSES,
+  RUN_LIFECYCLE_RETRYABLE_STATUSES,
+  RUN_LIFECYCLE_STATUSES,
+  RUN_LIFECYCLE_SUCCESS_STATUSES,
+  classifyRunLifecycleStatus,
   normalizeAgentTaskOutcomeStatus,
   normalizeHostRecordStatus,
   normalizeHostRunStatus,
+  normalizeRunLifecycleStatus,
   providerStatusFailed,
   providerStatusSucceeded,
 };

--- a/runtime-agent-ci/tests/agent-task-outcome-normalizer.test.js
+++ b/runtime-agent-ci/tests/agent-task-outcome-normalizer.test.js
@@ -132,6 +132,17 @@ assert.equal(noOpOutcome.failure_classification, undefined);
 assert.equal(noOpOutcome.failure_category, undefined);
 assert.equal(noOpOutcome.retryable, undefined);
 
+const failedStatusWithoutSuccess = normalizeAgentTaskOutcome(request, {
+  status: 'failed',
+  summary: 'Provider reported a terminal failure without success false.',
+}, { status: 'succeeded' });
+assert.equal(failedStatusWithoutSuccess.status, 'failed');
+assert.equal(failedStatusWithoutSuccess.failure_classification, 'execution_failed');
+
+const emptyJsonOutcome = normalizeAgentTaskOutcome(request, {});
+assert.equal(emptyJsonOutcome.status, 'failed');
+assert.equal(emptyJsonOutcome.failure_classification, 'execution_failed');
+
 assert.equal(normalizeAgentTaskStatus({ status: 'completed' }), 'succeeded');
 assert.equal(normalizeAgentTaskStatus({ success: false }), 'failed');
 assert.equal(normalizeProviderStatus({ success: true, status: 'completed' }, 1), 'failed');

--- a/runtime-agent-ci/tests/run-lifecycle-status-conformance.test.js
+++ b/runtime-agent-ci/tests/run-lifecycle-status-conformance.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+
+const {
+  RUN_LIFECYCLE_FAILURE_STATUSES,
+  RUN_LIFECYCLE_PENDING_STATUSES,
+  RUN_LIFECYCLE_RETRYABLE_STATUSES,
+  RUN_LIFECYCLE_STATUSES,
+  RUN_LIFECYCLE_SUCCESS_STATUSES,
+  classifyRunLifecycleStatus,
+  normalizeRunLifecycleStatus,
+} = require('../lib/runtime-status.cjs');
+
+function homeboyNormalizeRunLifecycleStatus(status) {
+  const command = process.env.HOMEBOY_COMMAND || 'homeboy';
+  const result = spawnSync(command, ['contract', 'normalize', 'run-lifecycle-status', '--input', JSON.stringify(status)], {
+    encoding: 'utf8',
+  });
+
+  if (result.error && result.error.code === 'ENOENT') {
+    return { skipped: true, message: `${command} was not found` };
+  }
+
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+    if (/unrecognized subcommand/.test(stderr)) {
+      return { skipped: true, message: `homeboy run-lifecycle-status normalizer is unavailable: ${stderr}` };
+    }
+    assert.fail(`homeboy contract normalize run-lifecycle-status failed for ${status}: ${stderr}`);
+  }
+
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.success, true, `homeboy normalized ${status}`);
+  return payload.data;
+}
+
+const allKnownStatuses = [
+  ...RUN_LIFECYCLE_PENDING_STATUSES,
+  ...RUN_LIFECYCLE_SUCCESS_STATUSES,
+  ...RUN_LIFECYCLE_FAILURE_STATUSES,
+];
+
+assert.deepEqual(allKnownStatuses, RUN_LIFECYCLE_STATUSES);
+assert.deepEqual(RUN_LIFECYCLE_RETRYABLE_STATUSES.filter((status) => !RUN_LIFECYCLE_FAILURE_STATUSES.includes(status)), []);
+
+for (const status of RUN_LIFECYCLE_STATUSES) {
+  const expected = homeboyNormalizeRunLifecycleStatus(status);
+  if (expected.skipped) {
+    process.stdout.write(`run lifecycle status conformance skipped: ${expected.message}\n`);
+    process.exit(0);
+  }
+
+  assert.equal(normalizeRunLifecycleStatus(status), status);
+  assert.deepEqual(classifyRunLifecycleStatus(status), expected, `${status} classification matches Homeboy contract`);
+}
+
+assert.equal(normalizeRunLifecycleStatus('not-a-status'), 'unknown');
+
+process.stdout.write('Run lifecycle status conformance check passed\n');


### PR DESCRIPTION
## Summary
- Add pure-JS run-lifecycle status normalization/classification in runtime-agent-ci using the released Homeboy canonical vocabulary.
- Add a test-only conformance check against `homeboy contract normalize run-lifecycle-status`.
- Tighten agent task outcome status precedence so provider terminal failures and empty provider results normalize consistently through the shared provider normalizer.

## Tests
- `npm test` from `runtime-agent-ci`
- `npm run test:provider-outcome-normalizer` from `wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the runtime normalizer conformance test, shared JS status helpers, provider normalizer edge-case fixes, and running verification.