### PR TITLE
Validate loop lifecycle payloads with Homeboy contracts

### DIFF
--- a/runtime-agent-ci/lib/loop-lifecycle.cjs
+++ b/runtime-agent-ci/lib/loop-lifecycle.cjs
@@ -7,12 +7,14 @@ const LOOP_ITERATION_SCHEMA = 'homeboy/loop-iteration/v1';
 const LOOP_EVIDENCE_SCHEMA = 'homeboy/loop-evidence/v1';
 
 function loopRun(input = {}) {
+  const loopId = input.loop_id || input.loopId || input.id || 'loop';
   const iterations = normalizeArray(input.iterations);
   const evidence = normalizeArray(input.evidence);
   return {
     schema: LOOP_RUN_SCHEMA,
-    loop_id: input.loop_id || input.loopId || input.id || 'loop',
-    status: input.status || 'completed',
+    id: loopId,
+    loop_id: loopId,
+    status: normalizeLoopStatus(input.status),
     stop_reason: input.stop_reason || input.stopReason || '',
     max_iterations: positiveInteger(input.max_iterations || input.maxIterations) || iterations.length,
     iteration_count: positiveInteger(input.iteration_count || input.iterationCount) || iterations.length,
@@ -24,10 +26,16 @@ function loopRun(input = {}) {
 }
 
 function loopIteration(input = {}) {
+  const loopId = input.loop_id || input.loopId || '';
+  const iteration = positiveInteger(input.iteration) || 1;
   return {
     schema: LOOP_ITERATION_SCHEMA,
-    loop_id: input.loop_id || input.loopId || '',
-    iteration: positiveInteger(input.iteration) || 1,
+    id: input.id || `${loopId}:${iteration}`,
+    run_id: input.run_id || input.runId || loopId,
+    index: positiveInteger(input.index) || iteration,
+    status: normalizeLoopStatus(input.status || input.result?.status || input.outcome?.status),
+    loop_id: loopId,
+    iteration,
     task: input.task || input.input || null,
     result: input.result || input.outcome || null,
     artifacts: normalizeArray(input.artifacts),
@@ -42,6 +50,9 @@ function loopEvidence(input = {}) {
   const uri = input.uri || input.url || input.href || input.path || input.ref || '';
   return {
     schema: LOOP_EVIDENCE_SCHEMA,
+    id: input.id || uri,
+    run_id: input.run_id || input.runId || input.loop_id || input.loopId || '',
+    status: input.status || 'captured',
     kind: input.kind || input.type || 'evidence',
     uri,
     ref: uri,
@@ -149,6 +160,13 @@ function plainObject(value) {
 function positiveInteger(value) {
   const parsed = Number.parseInt(value || '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function normalizeLoopStatus(status) {
+  if (status === 'completed') {
+    return 'succeeded';
+  }
+  return status || 'succeeded';
 }
 
 module.exports = {

--- a/runtime-agent-ci/tests/loop-lifecycle.test.js
+++ b/runtime-agent-ci/tests/loop-lifecycle.test.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   assertLoopSuccess,
@@ -50,14 +54,30 @@ const failedGate = withLoopGateResult('workspace_contract', { enabled: true, suc
 assert.equal(failedGate.gate_result.success, false);
 assert.equal(loopGateSummary([commandGate.gate_result, failedGate.gate_result]).success, false);
 
-const evidence = loopEvidence({ kind: 'preview', url: 'https://example.test/preview/1', iteration: 2 });
+const evidence = loopEvidence({ loop_id: 'fixture-loop', kind: 'preview', url: 'https://example.test/preview/1', iteration: 2 });
 const iteration = loopIteration({ loop_id: 'fixture-loop', iteration: 2, result: { status: 'succeeded' }, evidence_refs: [evidence], gate_result: commandGate.gate_result, accepted: true });
 const run = loopRun({ loop_id: 'fixture-loop', status: 'completed', max_iterations: 3, iterations: [iteration], evidence: [evidence], gate_summary: loopGateSummary([commandGate.gate_result]) });
 
-assert.equal(evidence.schema, 'homeboy/loop-evidence/v1');
-assert.equal(iteration.schema, 'homeboy/loop-iteration/v1');
-assert.equal(run.schema, 'homeboy/loop-run/v1');
+validateHomeboyContract('homeboy/loop-evidence/v1', evidence);
+validateHomeboyContract('homeboy/loop-iteration/v1', iteration);
+validateHomeboyContract('homeboy/loop-run/v1', run);
 assert.equal(run.iteration_count, 1);
 assert.equal(run.gate_summary.success, true);
 
 process.stdout.write('Loop lifecycle helpers behavior checks passed\n');
+
+function validateHomeboyContract(schemaId, payload) {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-loop-lifecycle-'));
+  const fixturePath = path.join(fixtureDir, `${schemaId.replaceAll('/', '-')}.json`);
+  fs.writeFileSync(fixturePath, `${JSON.stringify(payload, null, 2)}\n`);
+
+  try {
+    const result = spawnSync('homeboy', ['contract', 'validate', schemaId, '--file', fixturePath], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- Validate loop lifecycle helper payloads with released `homeboy contract validate` for `homeboy/loop-run/v1`, `homeboy/loop-iteration/v1`, and `homeboy/loop-evidence/v1`.
- Align emitted lifecycle payloads with the released contracts by adding required lifecycle identifiers/status fields while preserving existing fields.
- Normalize legacy `completed` lifecycle status to the contract `succeeded` status for run/iteration payloads.

## Tests
- `homeboy --version && homeboy contract validate --help` verified released Homeboy `0.275.0` exposes the validator.
- `npm run test:loop-lifecycle`
- `npm test` in `runtime-agent-ci`

## Notes
- `npm test` prints an existing WP Codebox sandbox boot diagnostic and the legacy Homeboy contract surface probe skip message, but the runtime-agent-ci test script exits successfully.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Worktree setup, code/test updates, validation, commit, and PR creation.