### PR TITLE
Fix Codebox fuzz nested plugin metadata

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -330,7 +330,7 @@ function buildWpCodeboxFuzzRuntimeRequirements({ workload = {}, env = {} } = {})
 		|| component?.checkoutRoot
 		|| component?.extensions?.wordpress?.checkout_root
 		|| component?.extensions?.wordpress?.checkoutRoot;
-	const pluginRequirement = buildWpCodeboxFuzzPluginRequirement({ workload, componentId, source, activation, context, checkoutRoot });
+	const pluginRequirement = buildWpCodeboxFuzzPluginRequirement({ workload, componentId, source, activation, context, checkoutRoot, env });
 	return {
 		extra_plugins: pluginRequirement ? [pluginRequirement.extraPlugin] : undefined,
 		component_contracts: pluginRequirement ? [pluginRequirement.componentContract] : undefined,
@@ -343,7 +343,7 @@ function buildWpCodeboxFuzzRuntimeRequirements({ workload = {}, env = {} } = {})
 	};
 }
 
-function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, source, activation, context = {}, checkoutRoot } = {}) {
+function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, source, activation, context = {}, checkoutRoot, env = {} } = {}) {
 	if (!componentId || typeof source !== 'string' || source.trim() === '') {
 		return undefined;
 	}
@@ -356,7 +356,7 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 		|| wordpressExtension?.wp_codebox_source_subpath
 		|| wordpressExtension?.wpCodeboxSourceSubpath
 	);
-	const sourceLayout = wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot });
+	const sourceLayout = wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot, env });
 	const mountSlug = nonEmptyString(wordpressExtension?.wp_codebox_mount_slug || wordpressExtension?.wpCodeboxMountSlug) || slug;
 	const pluginFile = wpCodeboxPluginFile({ activation, sourceLayout, wordpressExtension, mountSlug });
 	return {
@@ -426,9 +426,9 @@ function normalizePathSeparators(value) {
 	return String(value || '').replace(/\\+/g, '/');
 }
 
-function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot } = {}) {
+function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, checkoutRoot, env = {} } = {}) {
 	const normalizedSubpath = nonEmptyString(sourceSubpath);
-	const configuredSourcePath = nonEmptyString(wordpressExtension?.wp_codebox_source_path || wordpressExtension?.wpCodeboxSourcePath);
+	const configuredSourcePath = resolvedMetadataString(wordpressExtension?.wp_codebox_source_path || wordpressExtension?.wpCodeboxSourcePath, env);
 	if (configuredSourcePath && !configuredSourcePath.startsWith('~/')) {
 		return {
 			sourcePath: configuredSourcePath,
@@ -455,7 +455,7 @@ function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, chec
 		};
 	}
 
-	const configured = nonEmptyString(wordpressExtension?.wp_codebox_source_root || wordpressExtension?.wpCodeboxSourceRoot);
+	const configured = resolvedMetadataString(wordpressExtension?.wp_codebox_source_root || wordpressExtension?.wpCodeboxSourceRoot, env);
 	if (configured && configured.startsWith('~/')) {
 		return {};
 	}
@@ -468,7 +468,28 @@ function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension, chec
 		};
 	}
 
+	if (normalizedSubpath) {
+		return {
+			sourcePath: source,
+			sourceRoot: source,
+			sourceSubpath: normalizedSubpath,
+			sourceIsPluginRoot: false,
+		};
+	}
+
 	return {};
+}
+
+function resolvedMetadataString(value, env = {}) {
+	const normalized = nonEmptyString(value);
+	if (!normalized) {
+		return undefined;
+	}
+	const resolved = normalized.replace(/\$\{env\.([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, name) => {
+		const replacement = nonEmptyString(env[name]);
+		return replacement || match;
+	});
+	return resolved.includes('${env.') ? undefined : resolved;
 }
 
 function componentPathOverridesFromEnv(env = {}, prefix = '') {

--- a/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
+++ b/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
@@ -22,6 +22,8 @@ const workloadPath = path.join(tempDir, 'workload.json');
 const resultsPath = path.join(tempDir, 'campaign.json');
 const observedRequestPath = path.join(tempDir, 'observed-fuzz-suite-request.json');
 const emptyCodeboxInstallRoot = path.join(tempDir, 'empty-wp-codebox-install');
+const checkoutRoot = path.join(tempDir, 'checkout');
+const pluginRoot = path.join(checkoutRoot, 'plugins', 'woocommerce');
 const fakeCodeboxCoreModule = path.join(tempDir, 'wp-codebox-core-contracts.cjs');
 const fakeCodeboxBin = path.join(tempDir, 'wp-codebox');
 const runnerPath = path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs');
@@ -46,11 +48,36 @@ const workload = {
 			},
 		],
 	},
-	metadata: { canary: 'wp-codebox-fuzz-suite-contract' },
+	target: { type: 'wordpress-plugin', slug: 'woocommerce', component: 'woocommerce' },
+	cases: [{ id: 'contract-workload:default', intent: { plugin: { activation: 'woocommerce/woocommerce.php' } } }],
+	metadata: {
+		canary: 'wp-codebox-fuzz-suite-contract',
+		fixture: { component: 'woocommerce', activation: 'woocommerce/woocommerce.php' },
+		homeboy_runtime_context: {
+			schema: 'homeboy/fuzz-workload-runtime-context/v1',
+			rig_id: 'woocommerce-performance',
+			components: {
+				woocommerce: {
+					path: checkoutRoot,
+					extensions: {
+						wordpress: {
+							wp_codebox_source_path: '${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}',
+							wp_codebox_source_root: '${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}',
+							wp_codebox_source_subdir: 'plugins/woocommerce',
+							wp_codebox_mount_slug: 'woocommerce',
+							wp_codebox_plugin_file: 'woocommerce/woocommerce.php',
+						},
+					},
+				},
+			},
+		},
+	},
 };
 
 fs.writeFileSync(workloadPath, `${JSON.stringify(workload, null, 2)}\n`);
 fs.mkdirSync(emptyCodeboxInstallRoot, { recursive: true });
+fs.mkdirSync(pluginRoot, { recursive: true });
+fs.writeFileSync(path.join(pluginRoot, 'woocommerce.php'), '<?php\n/**\n * Plugin Name: WooCommerce\n */\n');
 fs.writeFileSync(fakeCodeboxCoreModule, `module.exports.runtimeContractManifest = () => ({
   schema: 'wp-codebox/runtime-contract-manifest/v1',
   version: 1,
@@ -141,6 +168,7 @@ const cli = spawnSync(runnerPath, [], {
 		HOMEBOY_FUZZ_SEED: 'seed-contract',
 		HOMEBOY_FUZZ_MAX_DURATION: '5',
 		HOMEBOY_FUZZ_RESULTS_FILE: resultsPath,
+		HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE: checkoutRoot,
 	},
 });
 
@@ -176,6 +204,12 @@ assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.expected
 assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.expected_artifacts.includes('replay-data'), true);
 assert.equal(observedRequest.metadata.homeboy_wp_codebox_fuzz_execution.expected_artifacts.includes('coverage-summary'), true);
 assert.equal(observedRequest.metadata.homeboy_agent_task_request, undefined);
+const observedPlugin = observedRequest.metadata.runtime_requirements.extra_plugins[0];
+assert.equal(observedPlugin.sourcePath, checkoutRoot);
+assert.equal(observedPlugin.sourceSubdir, 'plugins/woocommerce');
+assert.equal(observedPlugin.mountSlug, 'woocommerce');
+assert.equal(observedPlugin.pluginFile, 'woocommerce/woocommerce.php');
+assert.notEqual(observedPlugin.pluginFile, 'woocommerce.php');
 
 const campaign = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
 assert.equal(campaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -447,6 +447,55 @@ assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.
 assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].mountSlug, 'woocommerce');
 assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourceRoot, rigQualifiedPluginRoot);
 assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].sourceSubpath, 'plugins/woocommerce');
+assert.equal(rigQualifiedEnvMountedPluginResult.wp_codebox_runtime_requirements.extra_plugins[0].pluginFile, 'woocommerce/woocommerce.php');
+
+const nestedMetadataCheckoutRoot = path.join(os.tmpdir(), 'homeboy-wordpress-placeholder-checkout');
+const nestedMetadataResult = buildWordPressFuzzRunnerResult({
+	env: readWordPressFuzzRunnerEnv({
+		HOMEBOY_FUZZ_WORKLOAD_PATH: '/unused/in-unit-test.json',
+		HOMEBOY_FUZZ_WORKLOAD_ID: 'nested-metadata-plugin',
+		HOMEBOY_FUZZ_RUN_ID: 'nested-metadata-plugin-run',
+		HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE: nestedMetadataCheckoutRoot,
+	}),
+	workload: {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: 'nested-metadata-plugin',
+		target: { type: 'wordpress-plugin', slug: 'woocommerce', component: 'woocommerce' },
+		metadata: {
+			fixture: { component: 'woocommerce', activation: 'woocommerce/woocommerce.php' },
+			homeboy_runtime_context: {
+				schema: 'homeboy/fuzz-workload-runtime-context/v1',
+				rig_id: 'woocommerce-performance',
+				components: {
+					woocommerce: {
+						path: nestedMetadataCheckoutRoot,
+						extensions: {
+							wordpress: {
+								wp_codebox_source_path: '${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}',
+								wp_codebox_source_root: '${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}',
+								wp_codebox_source_subdir: 'plugins/woocommerce',
+								wp_codebox_mount_slug: 'woocommerce',
+								wp_codebox_plugin_file: 'woocommerce/woocommerce.php',
+							},
+						},
+					},
+				},
+			},
+		},
+		cases: [{ id: 'nested-metadata-plugin:default', intent: { plugin: { activation: 'woocommerce/woocommerce.php' } } }],
+	},
+});
+const nestedExtraPlugin = nestedMetadataResult.wp_codebox_runtime_requirements.extra_plugins[0];
+assert.equal(nestedExtraPlugin.sourcePath, nestedMetadataCheckoutRoot);
+assert.equal(nestedExtraPlugin.sourceSubdir, 'plugins/woocommerce');
+assert.equal(nestedExtraPlugin.mountSlug, 'woocommerce');
+assert.equal(nestedExtraPlugin.pluginFile, 'woocommerce/woocommerce.php');
+assert.notEqual(nestedExtraPlugin.pluginFile, 'woocommerce.php');
+const nestedRuntimeTaskPlugin = nestedMetadataResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0];
+assert.equal(nestedRuntimeTaskPlugin.sourcePath, nestedMetadataCheckoutRoot);
+assert.equal(nestedRuntimeTaskPlugin.sourceSubdir, 'plugins/woocommerce');
+assert.equal(nestedRuntimeTaskPlugin.mountSlug, 'woocommerce');
+assert.equal(nestedRuntimeTaskPlugin.pluginFile, 'woocommerce/woocommerce.php');
 
 const genericPrimitiveResult = buildWordPressFuzzRunnerResult({
 	env: {


### PR DESCRIPTION
## Summary
- Resolve env-placeholder Codebox source metadata when building WordPress fuzz runtime requirements.
- Preserve nested plugin sourcePath/sourceSubdir/mountSlug/pluginFile fields for Codebox public fuzz-suite inputs.
- Add regression coverage for the rerun5 nested plugin shape and public CLI request payload.

## Tests
- npm run lint:js -- lib/wordpress-fuzz-runner.js
- npm run test:wordpress-fuzz-runner
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner-codebox-contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Root-cause analysis, code changes, regression tests, and PR drafting.