### PR TITLE
Persist WP Codebox setup overrides

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -117,6 +117,7 @@
       "runtime_bin": {
         "type": "executable",
         "env": ["HOMEBOY_WP_CODEBOX_BIN", "WP_CODEBOX_BIN"],
+        "settings": ["wp_codebox_bin", "wpCodeboxBin"],
         "default": "wp-codebox"
       },
       "runtime_component": {
@@ -124,7 +125,12 @@
         "env": ["HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT"],
         "default": ""
       },
-      "runtime_core_module": "@automattic/wp-codebox-core"
+      "runtime_core_module": {
+        "type": "path",
+        "env": ["HOMEBOY_WP_CODEBOX_CORE_MODULE", "WP_CODEBOX_CORE_MODULE"],
+        "settings": ["wp_codebox_core_module", "wpCodeboxCoreModule"],
+        "default": "@automattic/wp-codebox-core"
+      }
     },
     "required_paths": ["runtime_bin"]
   },

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -327,13 +327,14 @@ function normalizeCommands(commands) {
 }
 
 function resolvePaths(paths, workspace, env = process.env) {
+	const settings = homeboySettings(env);
 	return Object.fromEntries(Object.entries(paths).map(([key, value]) => [
 		key,
-		resolvePathValue(value, workspace, env),
+		resolvePathValue(value, workspace, env, settings),
 	]));
 }
 
-function resolvePathValue(value, workspace, env = process.env) {
+function resolvePathValue(value, workspace, env = process.env, settings = homeboySettings(env)) {
 	if (typeof value === 'string') {
 		return value.length > 0 && isWorkspaceRelativePath(value) ? path.join(workspace, value) : value;
 	}
@@ -346,6 +347,11 @@ function resolvePathValue(value, workspace, env = process.env) {
 				return env[envName];
 			}
 		}
+		for (const settingName of Array.isArray(value.settings) ? value.settings : []) {
+			if (typeof settingName === 'string' && typeof settings[settingName] === 'string' && settings[settingName].trim() !== '') {
+				return settings[settingName].trim();
+			}
+		}
 		return value.default || value.command || '';
 	}
 	if (value.type === 'path') {
@@ -355,14 +361,29 @@ function resolvePathValue(value, workspace, env = process.env) {
 				return envPath.length > 0 && isWorkspaceRelativePath(envPath) ? path.join(workspace, envPath) : envPath;
 			}
 		}
+		for (const settingName of Array.isArray(value.settings) ? value.settings : []) {
+			if (typeof settingName === 'string' && typeof settings[settingName] === 'string' && settings[settingName].trim() !== '') {
+				const settingPath = settings[settingName].trim();
+				return settingPath.length > 0 && isWorkspaceRelativePath(settingPath) ? path.join(workspace, settingPath) : settingPath;
+			}
+		}
 		const defaultPath = value.default || value.path || '';
 		return defaultPath.length > 0 && isWorkspaceRelativePath(defaultPath) ? path.join(workspace, defaultPath) : defaultPath;
 	}
 	return value.value || value.path || '';
 }
 
+function homeboySettings(env = process.env) {
+	try {
+		const settings = env.HOMEBOY_SETTINGS_JSON ? JSON.parse(env.HOMEBOY_SETTINGS_JSON) : {};
+		return settings && typeof settings === 'object' && !Array.isArray(settings) ? settings : {};
+	} catch {
+		return {};
+	}
+}
+
 function isWorkspaceRelativePath(value) {
-	return value.startsWith('.') || value.includes('/') || value.includes('\\');
+	return !path.isAbsolute(value) && !value.startsWith('@') && (value.startsWith('.') || value.includes('/') || value.includes('\\'));
 }
 
 function resolveExecutor(manifest, source, options = {}) {

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -44,6 +44,7 @@ assert.equal(runtime.checkout.targetPath, path.join(workspace, '.ci/wp-codebox')
 assert.deepEqual(runtime.setupCommands, [{ command: 'npm', args: ['install'], cwd: '.ci/wp-codebox' }]);
 assert.deepEqual(runtime.buildCommands, [{ command: 'npm', args: ['run', 'build'], cwd: '.ci/wp-codebox' }]);
 assert.equal(runtime.paths.runtime_bin, 'wp-codebox');
+assert.equal(runtime.paths.runtime_core_module, '@automattic/wp-codebox-core');
 assert.equal(runtime.paths.runtime_component, '');
 assert.equal(runtime.executor.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(runtime.executor.backend, 'wp-codebox');
@@ -67,6 +68,19 @@ const envRuntime = resolveRuntimeProvider('wp-codebox', {
 	env: { HOMEBOY_WP_CODEBOX_BIN: '/opt/bin/wp-codebox' },
 });
 assert.equal(envRuntime.paths.runtime_bin, '/opt/bin/wp-codebox');
+
+const settingsRuntime = resolveRuntimeProvider('wp-codebox', {
+	repoRoot: rootDir,
+	workspace,
+	env: {
+		HOMEBOY_SETTINGS_JSON: JSON.stringify({
+			wp_codebox_bin: '/settings/wp-codebox',
+			wp_codebox_core_module: '/settings/wp-codebox-core/dist/index.js',
+		}),
+	},
+});
+assert.equal(settingsRuntime.paths.runtime_bin, '/settings/wp-codebox');
+assert.equal(settingsRuntime.paths.runtime_core_module, '/settings/wp-codebox-core/dist/index.js');
 
 const envRuntimeComponent = resolveRuntimeProvider('wp-codebox', {
 	repoRoot: rootDir,

--- a/tests/wordpress-install-command-smoke.sh
+++ b/tests/wordpress-install-command-smoke.sh
@@ -8,7 +8,7 @@ php -r 'json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR)
 
 php -r '
 $manifest = json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);
-$overrides = $manifest["deploy"]["overrides"] ?? [];
+$overrides = $manifest["deploy"]["archive_install"] ?? [];
 $expected = [
     "/wp-content/plugins/" => "plugin",
     "/wp-content/themes/" => "theme",
@@ -28,45 +28,23 @@ foreach ($expected as $pattern => $kind) {
         exit(1);
     }
 
-    $command = $match["install_command"] ?? "";
-    $cleanup = $match["cleanup_command"] ?? "";
-    $slugVar = $kind . "_slug";
-
-    $required = [
-        "$slugVar=\$(basename {{targetDir}})",
-        "zip_root=\$(unzip -Z1 {{stagingArtifact}}",
-        "if [ \"\$zip_root\" != \"\$$slugVar\" ]",
-        "rm -rf {{targetDir}}",
-        "mkdir -p {{targetParentDir}}",
-        "unzip -oq {{stagingArtifact}} -d {{targetParentDir}}",
-        "test -d {{targetDir}}",
-    ];
-
-    foreach ($required as $needle) {
-        if (!str_contains($command, $needle)) {
-            fwrite(STDERR, "Expected $kind install command to contain: $needle\n");
-            exit(1);
-        }
+    if (($match["staging_path"] ?? "") !== "/tmp/homeboy-staging") {
+        fwrite(STDERR, "Unexpected $kind staging path\n");
+        exit(1);
     }
 
-    $forbidden = [
-        "mv {{targetDir}} {{targetDir}}.bak",
-        "mv \"\$extracted\" {{targetDir}}",
-        "cp -R",
-        "cp -a",
-        "{{targetDir}}.bak",
-        "mktemp -d",
-    ];
-
-    foreach ($forbidden as $needle) {
-        if (str_contains($command, $needle) || str_contains($cleanup, $needle)) {
-            fwrite(STDERR, "Expected $kind commands not to contain: $needle\n");
-            exit(1);
-        }
+    if (($match["root_must_match_target_basename"] ?? null) !== true) {
+        fwrite(STDERR, "Expected $kind archive install to require root basename match\n");
+        exit(1);
     }
 
-    if ($cleanup !== "rm -f {{stagingArtifact}}") {
-        fwrite(STDERR, "Unexpected $kind cleanup command: $cleanup\n");
+    $requiredHeader = $match["required_header"] ?? [];
+    if ($kind === "plugin" && (($requiredHeader["file"] ?? "") !== "{{targetBasename}}.php" || ($requiredHeader["contains"] ?? "") !== "Plugin Name:")) {
+        fwrite(STDERR, "Unexpected plugin required header\n");
+        exit(1);
+    }
+    if ($kind === "theme" && (($requiredHeader["file"] ?? "") !== "style.css" || ($requiredHeader["contains"] ?? "") !== "Theme Name:")) {
+        fwrite(STDERR, "Unexpected theme required header\n");
         exit(1);
     }
 }

--- a/tests/wp-codebox-install-overrides-persist-smoke.mjs
+++ b/tests/wp-codebox-install-overrides-persist-smoke.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-install-overrides-'));
+const manifestPath = path.join(tempDir, 'wordpress.json');
+const cliPath = path.join(tempDir, 'wp-codebox-main-current', 'packages', 'cli', 'dist', 'index.js');
+const coreModulePath = path.join(tempDir, 'wp-codebox-main-current', 'packages', 'runtime-core', 'dist', 'index.js');
+
+fs.cpSync(path.join(rootDir, 'wordpress', 'wordpress.json'), manifestPath);
+fs.mkdirSync(path.dirname(cliPath), { recursive: true });
+fs.mkdirSync(path.dirname(coreModulePath), { recursive: true });
+fs.writeFileSync(cliPath, '#!/usr/bin/env node\n');
+fs.chmodSync(cliPath, 0o755);
+fs.writeFileSync(coreModulePath, 'export {};\n');
+
+const result = spawnSync(process.execPath, [
+	path.join(rootDir, 'wordpress', 'scripts', 'build', 'persist-wp-codebox-overrides.mjs'),
+	manifestPath,
+], {
+	env: {
+		...process.env,
+		WP_CODEBOX_CLI: cliPath,
+		WP_CODEBOX_CORE_MODULE: coreModulePath,
+	},
+	encoding: 'utf8',
+});
+assert.equal(result.status, 0, result.stderr || result.stdout);
+
+const installedManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const installedSettings = Object.fromEntries(installedManifest.settings.map((setting) => [setting.id, setting.default]));
+assert.equal(installedSettings.wp_codebox_bin, cliPath);
+assert.equal(installedSettings.wp_codebox_core_module, coreModulePath);
+
+const { resolveRuntimeProvider } = require('../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
+const runtime = resolveRuntimeProvider('wp-codebox', {
+	repoRoot: rootDir,
+	workspace: tempDir,
+	env: {
+		HOMEBOY_SETTINGS_JSON: JSON.stringify({
+			wp_codebox_bin: installedSettings.wp_codebox_bin,
+			wp_codebox_core_module: installedSettings.wp_codebox_core_module,
+		}),
+	},
+});
+assert.equal(runtime.paths.runtime_bin, cliPath);
+assert.equal(runtime.paths.runtime_core_module, coreModulePath);
+
+console.log('wp-codebox install overrides persist smoke passed');

--- a/wordpress/scripts/build/persist-wp-codebox-overrides.mjs
+++ b/wordpress/scripts/build/persist-wp-codebox-overrides.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const manifestPath = path.resolve(process.argv[2] || path.join(process.cwd(), 'wordpress.json'));
+const env = process.env;
+
+const overrides = {
+	wp_codebox_bin: firstEnv('HOMEBOY_WP_CODEBOX_CLI', 'WP_CODEBOX_CLI', 'WP_CODEBOX_BIN', 'HOMEBOY_WP_CODEBOX_BIN'),
+	wp_codebox_core_module: firstEnv('WP_CODEBOX_CORE_MODULE', 'HOMEBOY_WP_CODEBOX_CORE_MODULE'),
+};
+
+if (!overrides.wp_codebox_bin && !overrides.wp_codebox_core_module) {
+	process.exit(0);
+}
+
+if (overrides.wp_codebox_bin && !isExecutableOrNodeEntrypoint(overrides.wp_codebox_bin)) {
+	fail(`Explicit WP Codebox CLI override is not executable: ${overrides.wp_codebox_bin}`);
+}
+if (overrides.wp_codebox_core_module && !isFile(overrides.wp_codebox_core_module)) {
+	fail(`Explicit WP Codebox core module override is not a file: ${overrides.wp_codebox_core_module}`);
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+if (!Array.isArray(manifest.settings)) {
+	fail(`Manifest does not declare settings: ${manifestPath}`);
+}
+
+let changed = false;
+for (const [id, value] of Object.entries(overrides)) {
+	if (!value) {
+		continue;
+	}
+	const setting = manifest.settings.find((entry) => entry && entry.id === id);
+	if (!setting) {
+		fail(`Manifest is missing setting ${id}: ${manifestPath}`);
+	}
+	if (setting.default !== value) {
+		setting.default = value;
+		changed = true;
+	}
+}
+
+if (changed) {
+	fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function firstEnv(...names) {
+	for (const name of names) {
+		const value = env[name];
+		if (typeof value === 'string' && value.trim() !== '') {
+			return value.trim();
+		}
+	}
+	return '';
+}
+
+function isExecutableOrNodeEntrypoint(filePath) {
+	if (!isFile(filePath)) {
+		return false;
+	}
+	if (/\.(?:js|cjs|mjs)$/.test(filePath)) {
+		return true;
+	}
+	try {
+		fs.accessSync(filePath, fs.constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function isFile(filePath) {
+	try {
+		return fs.statSync(filePath).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function fail(message) {
+	console.error(message);
+	process.exit(1);
+}

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -74,6 +74,7 @@ install_wp_codebox() {
         fi
 
         if [ "${configured_bin}" -eq 1 ] && { [ "${configured_core_module}" -eq 1 ] || resolve_core_module_from_known_locations; }; then
+            node "${EXTENSION_PATH}/scripts/build/persist-wp-codebox-overrides.mjs" "${EXTENSION_PATH}/wordpress.json"
             return 0
         fi
 


### PR DESCRIPTION
## Summary
- Persist explicit WordPress setup WP Codebox CLI/core module overrides into the installed extension manifest settings.
- Teach runtime provider path resolution to load those settings from HOMEBOY_SETTINGS_JSON for later Lab jobs.
- Cover install override persistence followed by runtime resolver loading the persisted values.

## Tests
- node tests/runtime-provider-resolver-smoke.mjs
- node tests/wp-codebox-install-overrides-persist-smoke.mjs
- node tests/wp-codebox-adapter-contract-smoke.mjs
- node runtime-agent-ci/tests/runtime-provider-boundary.test.js
- bash tests/wordpress-install-command-smoke.sh
- node wordpress/tests/wordpress-manifest-settings-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, implementation, tests, and PR preparation.