### PR TITLE
Honor installed WP Codebox defaults in fuzz runner

### DIFF
--- a/wordpress/lib/wp-codebox-resolver.js
+++ b/wordpress/lib/wp-codebox-resolver.js
@@ -44,10 +44,11 @@ function resolveWpCodeboxIdentity(options = {}) {
 
 	const env = { ...process.env, ...(options.env || {}) };
 	const settings = homeboySettings(env);
-	const selection = selectWpCodeboxSource(options, env, settings);
+	const manifestDefaults = installedExtensionSettingDefaults(options, env);
+	const selection = selectWpCodeboxSource(options, env, settings, manifestDefaults);
 	const sourceRoot = resolveSourceRoot(selection, options, env, settings);
 	const installRoot = resolveInstallRoot(selection, sourceRoot, options, env, settings);
-	const coreModulePath = resolveCoreModulePath(sourceRoot, installRoot, options, env);
+	const coreModulePath = resolveCoreModulePath(sourceRoot, installRoot, options, env, manifestDefaults);
 	const runtimePackagePath = resolveRuntimePackagePath(sourceRoot, installRoot, options, env);
 	const bin = selection.bin || resolveBinFromRoots(sourceRoot, installRoot) || DEFAULT_WP_CODEBOX_BIN;
 	const invocation = wpCodeboxInvocation(bin, options);
@@ -67,7 +68,7 @@ function resolveWpCodeboxIdentity(options = {}) {
 	return diagnostics.length > 0 ? { ...identity, diagnostics } : identity;
 }
 
-function selectWpCodeboxSource(options, env, settings) {
+function selectWpCodeboxSource(options, env, settings, manifestDefaults = {}) {
 	const explicitBin = firstString(options.wpCodeboxBin, options.wp_codebox_bin, options.publicCliBin, options.public_cli_bin, options.bin);
 	if (explicitBin) {
 		return { source: 'explicit', bin: explicitBin, path: explicitBin };
@@ -87,6 +88,11 @@ function selectWpCodeboxSource(options, env, settings) {
 		return { source: 'settings', bin: settingsBin, path: settingsBin };
 	}
 
+	const manifestDefaultBin = firstString(manifestDefaults.wp_codebox_bin, manifestDefaults.wpCodeboxBin);
+	if (manifestDefaultBin) {
+		return { source: 'manifest-default', bin: manifestDefaultBin, path: manifestDefaultBin };
+	}
+
 	const explicitSourceRoot = firstString(options.wpCodeboxSourceRoot, options.wp_codebox_source_root, options.sourceRoot, options.source_root);
 	if (explicitSourceRoot) {
 		return { source: 'explicit', path: explicitSourceRoot };
@@ -100,6 +106,11 @@ function selectWpCodeboxSource(options, env, settings) {
 	const settingsSourceRoot = firstString(settings.wp_codebox_source_root, settings.wpCodeboxSourceRoot);
 	if (settingsSourceRoot) {
 		return { source: 'settings', path: settingsSourceRoot };
+	}
+
+	const manifestDefaultSourceRoot = firstString(manifestDefaults.wp_codebox_source_root, manifestDefaults.wpCodeboxSourceRoot);
+	if (manifestDefaultSourceRoot) {
+		return { source: 'manifest-default', path: manifestDefaultSourceRoot };
 	}
 
 	const cacheRoot = firstExistingDirectory(cacheRootCandidates(options, env, settings));
@@ -174,7 +185,7 @@ function resolveInstallRoot(selection, sourceRoot, options, env, settings) {
 	return undefined;
 }
 
-function resolveCoreModulePath(sourceRoot, installRoot, options, env) {
+function resolveCoreModulePath(sourceRoot, installRoot, options, env, manifestDefaults = {}) {
 	const explicit = firstString(options.wpCodeboxCoreModule, options.coreModule);
 	if (explicit) {
 		return isPathSpecifier(explicit) ? path.resolve(expandHome(explicit)) : explicit;
@@ -199,7 +210,56 @@ function resolveCoreModulePath(sourceRoot, installRoot, options, env) {
 		}
 		return discovered;
 	}
+	const manifestDefault = firstString(manifestDefaults.wp_codebox_core_module, manifestDefaults.wpCodeboxCoreModule);
+	if (manifestDefault) {
+		return isPathSpecifier(manifestDefault) ? path.resolve(expandHome(manifestDefault)) : manifestDefault;
+	}
 	return discovered || DEFAULT_CORE_MODULE;
+}
+
+function installedExtensionSettingDefaults(options = {}, env = process.env) {
+	const manifest = readInstalledExtensionManifest(options, env);
+	const settings = manifest?.settings;
+	const defaults = {};
+	if (Array.isArray(settings)) {
+		for (const setting of settings) {
+			if (!setting || typeof setting !== 'object' || typeof setting.id !== 'string' || setting.default === undefined || setting.default === '') {
+				continue;
+			}
+			defaults[setting.id] = setting.default;
+		}
+		return defaults;
+	}
+	if (settings && typeof settings === 'object') {
+		for (const [id, setting] of Object.entries(settings)) {
+			const value = setting && typeof setting === 'object' && Object.hasOwn(setting, 'default') ? setting.default : undefined;
+			if (value !== undefined && value !== '') {
+				defaults[id] = value;
+			}
+		}
+	}
+	return defaults;
+}
+
+function readInstalledExtensionManifest(options = {}, env = process.env) {
+	const explicitPath = firstString(options.extensionManifestPath, options.wordpressManifestPath, env.HOMEBOY_EXTENSION_MANIFEST_PATH);
+	const extensionPath = firstString(options.extensionPath, env.HOMEBOY_EXTENSION_PATH);
+	const candidates = [
+		explicitPath,
+		extensionPath && path.resolve(expandHome(extensionPath), 'wordpress.json'),
+		path.resolve(__dirname, '..', 'wordpress.json'),
+	];
+	for (const candidate of candidates.filter(Boolean)) {
+		try {
+			const parsed = JSON.parse(fs.readFileSync(path.resolve(expandHome(candidate)), 'utf8'));
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				return parsed;
+			}
+		} catch {
+			// Missing or invalid manifests do not contribute defaults.
+		}
+	}
+	return {};
 }
 
 function resolveRuntimePackagePath(sourceRoot, installRoot, options, env) {
@@ -465,6 +525,7 @@ module.exports = {
 	DEFAULT_RUNTIME_PLAYGROUND_ENTRY,
 	assertWpCodeboxIdentityMatches,
 	homeboySettings,
+	installedExtensionSettingDefaults,
 	resolveWpCodeboxIdentity,
 	wpCodeboxCommand,
 	wpCodeboxIdentityMismatchDiagnostics,

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -262,6 +262,7 @@ function resolveWpCodeboxRuntimePath(options = {}) {
 
 function wpCodeboxRuntimeEnv(env) {
 	const nextEnv = { ...env };
+	const manifestDefaults = installedExtensionSettingDefaults(nextEnv);
 	if (!nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE) {
 		const settings = parseJsonObject(nextEnv.HOMEBOY_SETTINGS_JSON);
 		if (settings?.wp_codebox_core_module) {
@@ -270,6 +271,9 @@ function wpCodeboxRuntimeEnv(env) {
 	}
 	if (!nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE && nextEnv.HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE) {
 		nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE = String(nextEnv.HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE);
+	}
+	if (!nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE && manifestDefaults.wp_codebox_core_module) {
+		nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE = String(manifestDefaults.wp_codebox_core_module);
 	}
 	if (!nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE) {
 		const discoveredCoreModule = discoverWpCodeboxCoreModule(nextEnv);
@@ -311,19 +315,64 @@ function discoverWpCodeboxBin(env) {
 }
 
 function wpCodeboxCommand(env) {
-	const settings = parseJsonObject(env.HOMEBOY_SETTINGS_JSON);
-	const discoveredBin = discoverWpCodeboxBin(env);
 	if (env.HOMEBOY_WP_CODEBOX_BIN) {
 		const configuredInstallRoot = env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || env.HOMEBOY_WP_CODEBOX_INSTALL_ROOT;
 		if (!configuredInstallRoot || pathIsInside(env.HOMEBOY_WP_CODEBOX_BIN, configuredInstallRoot)) {
 			return env.HOMEBOY_WP_CODEBOX_BIN;
 		}
+		const discoveredBin = discoverWpCodeboxBin(env);
 		return discoveredBin || env.HOMEBOY_WP_CODEBOX_BIN;
 	}
+	const settings = parseJsonObject(env.HOMEBOY_SETTINGS_JSON);
+	const manifestDefaults = installedExtensionSettingDefaults(env);
 	return env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
 		|| settings?.wp_codebox_bin
-		|| discoveredBin
+		|| manifestDefaults.wp_codebox_bin
+		|| discoverWpCodeboxBin(env)
 		|| 'wp-codebox';
+}
+
+function installedExtensionSettingDefaults(env) {
+	const manifest = readInstalledExtensionManifest(env);
+	const settings = manifest?.settings;
+	const defaults = {};
+	if (Array.isArray(settings)) {
+		for (const setting of settings) {
+			if (!setting || typeof setting !== 'object' || typeof setting.id !== 'string' || setting.default === undefined || setting.default === '') {
+				continue;
+			}
+			defaults[setting.id] = setting.default;
+		}
+		return defaults;
+	}
+	if (settings && typeof settings === 'object') {
+		for (const [id, setting] of Object.entries(settings)) {
+			const value = setting && typeof setting === 'object' && Object.hasOwn(setting, 'default') ? setting.default : undefined;
+			if (value !== undefined && value !== '') {
+				defaults[id] = value;
+			}
+		}
+	}
+	return defaults;
+}
+
+function readInstalledExtensionManifest(env) {
+	const candidates = [
+		env.HOMEBOY_EXTENSION_MANIFEST_PATH,
+		env.HOMEBOY_EXTENSION_PATH && path.resolve(env.HOMEBOY_EXTENSION_PATH, 'wordpress.json'),
+		path.resolve(__dirname, '..', '..', 'wordpress.json'),
+	];
+	for (const candidate of candidates.filter(Boolean)) {
+		try {
+			const parsed = JSON.parse(fs.readFileSync(path.resolve(candidate), 'utf8'));
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				return parsed;
+			}
+		} catch {
+			// Missing or invalid manifests do not contribute defaults.
+		}
+	}
+	return {};
 }
 
 function pathIsInside(value, root) {
@@ -465,4 +514,5 @@ module.exports = {
 	wpCodeboxRuntimeEnv,
 	discoverWpCodeboxBin,
 	wpCodeboxCommand,
+	installedExtensionSettingDefaults,
 };

--- a/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
+++ b/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 
 const {
 	resolveWpCodeboxRuntimePath,
+	wpCodeboxCommand,
 	wpCodeboxRuntimeEnv,
 } = require('../scripts/fuzz/fuzz-runner.cjs');
 
@@ -17,12 +18,20 @@ const installedRuntimePath = path.join(homeboyRoot, 'agent-runtimes', 'wp-codebo
 const legacyRuntimePath = path.join(homeboyRoot, 'extensions', 'agent-runtimes', 'wp-codebox');
 const cachedCoreModule = path.join(root, 'wp-codebox-cache', 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js');
 const cachedCoreIndex = path.join(root, 'wp-codebox-cache', 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
+const manifestDefaultBin = path.join(root, 'wp-codebox-main-current', 'packages', 'cli', 'dist', 'index.js');
+const manifestDefaultCoreModule = path.join(root, 'wp-codebox-main-current', 'packages', 'runtime-core', 'dist', 'index.js');
 
 fs.mkdirSync(extensionPath, { recursive: true });
 fs.mkdirSync(installedRuntimePath, { recursive: true });
 fs.mkdirSync(legacyRuntimePath, { recursive: true });
 fs.writeFileSync(path.join(installedRuntimePath, 'index.js'), 'module.exports = {};\n');
 fs.writeFileSync(path.join(legacyRuntimePath, 'index.js'), 'module.exports = {};\n');
+fs.writeFileSync(path.join(extensionPath, 'wordpress.json'), JSON.stringify({
+	settings: {
+		wp_codebox_bin: { default: manifestDefaultBin },
+		wp_codebox_core_module: { default: manifestDefaultCoreModule },
+	},
+}));
 fs.mkdirSync(path.dirname(cachedCoreModule), { recursive: true });
 fs.writeFileSync(cachedCoreModule, 'export {};\n');
 fs.writeFileSync(cachedCoreIndex, 'export {};\n');
@@ -43,11 +52,27 @@ assert.equal(
 );
 assert.equal(
 	wpCodeboxRuntimeEnv({
+		HOMEBOY_EXTENSION_PATH: extensionPath,
+	}).HOMEBOY_WP_CODEBOX_CORE_MODULE,
+	manifestDefaultCoreModule
+);
+assert.equal(
+	wpCodeboxRuntimeEnv({
 		HOMEBOY_WP_CODEBOX_CORE_MODULE: '/existing/core.mjs',
+		HOMEBOY_EXTENSION_PATH: extensionPath,
 		HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_core_module: '/tmp/wp-codebox-core.mjs' }),
 	}).HOMEBOY_WP_CODEBOX_CORE_MODULE,
 	'/existing/core.mjs'
 );
+assert.equal(wpCodeboxCommand({ HOMEBOY_EXTENSION_PATH: extensionPath }), manifestDefaultBin);
+assert.equal(wpCodeboxCommand({
+	HOMEBOY_EXTENSION_PATH: extensionPath,
+	HOMEBOY_WP_CODEBOX_BIN: '/explicit/wp-codebox',
+}), '/explicit/wp-codebox');
+assert.equal(wpCodeboxCommand({
+	HOMEBOY_EXTENSION_PATH: extensionPath,
+	HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: '/settings-json/wp-codebox' }),
+}), '/settings-json/wp-codebox');
 assert.equal(
 	wpCodeboxRuntimeEnv({
 		HOMEBOY_WP_CODEBOX_INSTALL_DIR: path.join(root, 'wp-codebox-cache'),

--- a/wordpress/tests/wp-codebox-resolver-smoke.js
+++ b/wordpress/tests/wp-codebox-resolver-smoke.js
@@ -31,15 +31,26 @@ function makeCodeboxRoot(name, version = '1.2.3') {
 try {
 	const envRoot = makeCodeboxRoot('wp-codebox@env', '1.0.0');
 	const settingsRoot = makeCodeboxRoot('wp-codebox@settings', '2.0.0');
+	const manifestDefaultRoot = makeCodeboxRoot('wp-codebox@manifest-default', '2.5.0');
 	const cacheRoot = path.join(root, 'cache', 'wp-codebox');
 	const cacheSourceRoot = makeCodeboxRoot(path.join('cache', 'wp-codebox', 'source'), '3.0.0');
 	const workspaceRoot = path.join(root, 'workspace');
 	const workspaceSourceRoot = makeCodeboxRoot(path.join('workspace', 'wp-codebox@feature'), '4.0.0');
+	const extensionPath = path.join(root, 'extensions', 'wordpress');
 	fs.mkdirSync(cacheRoot, { recursive: true });
 	fs.mkdirSync(workspaceRoot, { recursive: true });
+	fs.mkdirSync(extensionPath, { recursive: true });
 
 	const envBin = path.join(envRoot, 'packages', 'cli', 'dist', 'index.js');
 	const settingsBin = path.join(settingsRoot, 'packages', 'cli', 'dist', 'index.js');
+	const manifestDefaultBin = path.join(manifestDefaultRoot, 'packages', 'cli', 'dist', 'index.js');
+	const manifestDefaultCoreModule = path.join(manifestDefaultRoot, 'packages', 'runtime-core', 'dist', 'index.js');
+	fs.writeFileSync(path.join(extensionPath, 'wordpress.json'), JSON.stringify({
+		settings: [
+			{ id: 'wp_codebox_bin', default: manifestDefaultBin },
+			{ id: 'wp_codebox_core_module', default: manifestDefaultCoreModule },
+		],
+	}));
 
 	const envIdentity = resolveWpCodeboxIdentity({
 		env: {
@@ -61,6 +72,23 @@ try {
 	assert.equal(settingsIdentity.selectionSource, 'settings');
 	assert.equal(settingsIdentity.bin, settingsBin);
 	assert.equal(settingsIdentity.sourceRoot, settingsRoot);
+
+	const manifestDefaultIdentity = resolveWpCodeboxIdentity({
+		env: { HOMEBOY_EXTENSION_PATH: extensionPath },
+	});
+	assert.equal(manifestDefaultIdentity.selectionSource, 'manifest-default');
+	assert.equal(manifestDefaultIdentity.bin, manifestDefaultBin);
+	assert.equal(manifestDefaultIdentity.sourceRoot, manifestDefaultRoot);
+	assert.equal(manifestDefaultIdentity.coreModulePath, manifestDefaultCoreModule);
+
+	const envOverManifestDefaultIdentity = resolveWpCodeboxIdentity({
+		env: {
+			HOMEBOY_EXTENSION_PATH: extensionPath,
+			HOMEBOY_WP_CODEBOX_BIN: envBin,
+		},
+	});
+	assert.equal(envOverManifestDefaultIdentity.selectionSource, 'env');
+	assert.equal(envOverManifestDefaultIdentity.bin, envBin);
 
 	const cacheIdentity = resolveWpCodeboxIdentity({
 		wpCodeboxInstallDir: cacheRoot,


### PR DESCRIPTION
## Summary
- Read installed WordPress extension setting defaults from wordpress.json when WP Codebox bin/core paths are not provided by explicit options, env, or HOMEBOY_SETTINGS_JSON.
- Apply the same fallback in the legacy fuzz dispatch script path.
- Cover manifest-default resolution and explicit env/settings precedence with focused smoke tests.

## Tests
- npm run test:wp-codebox-resolver
- node tests/fuzz-runner-installed-runtime-path-smoke.js
- npm run test:wordpress-fuzz-runner
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-manifest-settings
- npx eslint lib/wp-codebox-resolver.js scripts/fuzz/fuzz-runner.cjs tests/wp-codebox-resolver-smoke.js tests/fuzz-runner-installed-runtime-path-smoke.js

Note: npm run lint:js is still blocked by pre-existing unrelated lint errors outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Root-cause investigation, implementation, test updates, and verification.