### PR TITLE
Fix WP Codebox resolver default precedence

### DIFF
--- a/wordpress/lib/wp-codebox-resolver.js
+++ b/wordpress/lib/wp-codebox-resolver.js
@@ -48,7 +48,7 @@ function resolveWpCodeboxIdentity(options = {}) {
 	const selection = selectWpCodeboxSource(options, env, settings, manifestDefaults);
 	const sourceRoot = resolveSourceRoot(selection, options, env, settings);
 	const installRoot = resolveInstallRoot(selection, sourceRoot, options, env, settings);
-	const coreModulePath = resolveCoreModulePath(sourceRoot, installRoot, options, env, manifestDefaults);
+	const coreModulePath = resolveCoreModulePath(sourceRoot, installRoot, options, env, settings, manifestDefaults);
 	const runtimePackagePath = resolveRuntimePackagePath(sourceRoot, installRoot, options, env);
 	const bin = selection.bin || resolveBinFromRoots(sourceRoot, installRoot) || DEFAULT_WP_CODEBOX_BIN;
 	const invocation = wpCodeboxInvocation(bin, options);
@@ -76,10 +76,6 @@ function selectWpCodeboxSource(options, env, settings, manifestDefaults = {}) {
 
 	const envBin = firstString(env.HOMEBOY_WP_CODEBOX_BIN, env.WP_CODEBOX_BIN, env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN);
 	if (envBin) {
-		const configuredCacheRoot = firstExistingDirectory(configuredCacheRootCandidates(options, env, settings));
-		if (configuredCacheRoot && !pathIsInside(envBin, configuredCacheRoot)) {
-			return { source: 'cache', path: configuredCacheRoot };
-		}
 		return { source: 'env', bin: envBin, path: envBin };
 	}
 
@@ -124,19 +120,6 @@ function selectWpCodeboxSource(options, env, settings, manifestDefaults = {}) {
 	}
 
 	return { source: 'default', bin: DEFAULT_WP_CODEBOX_BIN, path: DEFAULT_WP_CODEBOX_BIN };
-}
-
-function configuredCacheRootCandidates(options, env, settings) {
-	const explicit = firstString(
-		options.wpCodeboxInstallDir,
-		options.wpCodeboxInstallRoot,
-		options.installRoot,
-		env.HOMEBOY_WP_CODEBOX_INSTALL_DIR,
-		env.HOMEBOY_WP_CODEBOX_INSTALL_ROOT,
-		settings.wp_codebox_install_dir,
-		settings.wpCodeboxInstallDir
-	);
-	return explicit ? [explicit] : [];
 }
 
 function resolveSourceRoot(selection, options, env, settings) {
@@ -185,10 +168,22 @@ function resolveInstallRoot(selection, sourceRoot, options, env, settings) {
 	return undefined;
 }
 
-function resolveCoreModulePath(sourceRoot, installRoot, options, env, manifestDefaults = {}) {
+function resolveCoreModulePath(sourceRoot, installRoot, options, env, settings = {}, manifestDefaults = {}) {
 	const explicit = firstString(options.wpCodeboxCoreModule, options.coreModule);
 	if (explicit) {
 		return isPathSpecifier(explicit) ? path.resolve(expandHome(explicit)) : explicit;
+	}
+	const envExplicit = firstString(env.HOMEBOY_WP_CODEBOX_CORE_MODULE, env.WP_CODEBOX_CORE_MODULE, env.HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE);
+	if (envExplicit) {
+		return isPathSpecifier(envExplicit) ? path.resolve(expandHome(envExplicit)) : envExplicit;
+	}
+	const settingsExplicit = firstString(settings.wp_codebox_core_module, settings.wpCodeboxCoreModule);
+	if (settingsExplicit) {
+		return isPathSpecifier(settingsExplicit) ? path.resolve(expandHome(settingsExplicit)) : settingsExplicit;
+	}
+	const manifestDefault = firstString(manifestDefaults.wp_codebox_core_module, manifestDefaults.wpCodeboxCoreModule);
+	if (manifestDefault) {
+		return isPathSpecifier(manifestDefault) ? path.resolve(expandHome(manifestDefault)) : manifestDefault;
 	}
 	const discovered = firstExistingFile([
 		sourceRoot && path.resolve(sourceRoot, options.runtimeCoreEntry || DEFAULT_RUNTIME_CORE_ENTRY),
@@ -202,18 +197,6 @@ function resolveCoreModulePath(sourceRoot, installRoot, options, env, manifestDe
 		installRoot && path.resolve(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js'),
 		installRoot && path.resolve(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
 	]);
-	const envExplicit = firstString(env.HOMEBOY_WP_CODEBOX_CORE_MODULE, env.WP_CODEBOX_CORE_MODULE);
-	if (envExplicit) {
-		const resolvedEnvExplicit = isPathSpecifier(envExplicit) ? path.resolve(expandHome(envExplicit)) : envExplicit;
-		if (!discovered || !isPathSpecifier(resolvedEnvExplicit) || pathIsInside(resolvedEnvExplicit, sourceRoot) || pathIsInside(resolvedEnvExplicit, installRoot)) {
-			return resolvedEnvExplicit;
-		}
-		return discovered;
-	}
-	const manifestDefault = firstString(manifestDefaults.wp_codebox_core_module, manifestDefaults.wpCodeboxCoreModule);
-	if (manifestDefault) {
-		return isPathSpecifier(manifestDefault) ? path.resolve(expandHome(manifestDefault)) : manifestDefault;
-	}
 	return discovered || DEFAULT_CORE_MODULE;
 }
 
@@ -389,15 +372,6 @@ function sourceRootFromPath(value) {
 		return absolute;
 	}
 	return undefined;
-}
-
-function pathIsInside(value, root) {
-	if (typeof value !== 'string' || !value.trim() || typeof root !== 'string' || !root.trim()) {
-		return false;
-	}
-	const resolvedValue = path.resolve(expandHome(value));
-	const resolvedRoot = path.resolve(expandHome(root));
-	return resolvedValue === resolvedRoot || resolvedValue.startsWith(`${resolvedRoot}${path.sep}`);
 }
 
 function wpCodeboxFingerprint({ sourceRoot, installRoot, bin, coreModulePath, runtimePackagePath } = {}) {

--- a/wordpress/tests/wp-codebox-resolver-smoke.js
+++ b/wordpress/tests/wp-codebox-resolver-smoke.js
@@ -67,11 +67,15 @@ try {
 	assert.deepEqual(envIdentity.invocation, { command: process.execPath, args: [envBin] });
 
 	const settingsIdentity = resolveWpCodeboxIdentity({
-		env: { HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: settingsBin }) },
+		env: { HOMEBOY_SETTINGS_JSON: JSON.stringify({
+			wp_codebox_bin: settingsBin,
+			wp_codebox_core_module: path.join(settingsRoot, 'packages', 'runtime-core', 'dist', 'index.js'),
+		}) },
 	});
 	assert.equal(settingsIdentity.selectionSource, 'settings');
 	assert.equal(settingsIdentity.bin, settingsBin);
 	assert.equal(settingsIdentity.sourceRoot, settingsRoot);
+	assert.equal(settingsIdentity.coreModulePath, path.join(settingsRoot, 'packages', 'runtime-core', 'dist', 'index.js'));
 
 	const manifestDefaultIdentity = resolveWpCodeboxIdentity({
 		env: { HOMEBOY_EXTENSION_PATH: extensionPath },
@@ -80,6 +84,15 @@ try {
 	assert.equal(manifestDefaultIdentity.bin, manifestDefaultBin);
 	assert.equal(manifestDefaultIdentity.sourceRoot, manifestDefaultRoot);
 	assert.equal(manifestDefaultIdentity.coreModulePath, manifestDefaultCoreModule);
+
+	const manifestDefaultWithCacheIdentity = resolveWpCodeboxIdentity({
+		wpCodeboxInstallDir: cacheRoot,
+		env: { HOMEBOY_EXTENSION_PATH: extensionPath },
+	});
+	assert.equal(manifestDefaultWithCacheIdentity.selectionSource, 'manifest-default');
+	assert.equal(manifestDefaultWithCacheIdentity.bin, manifestDefaultBin);
+	assert.equal(manifestDefaultWithCacheIdentity.sourceRoot, manifestDefaultRoot);
+	assert.equal(manifestDefaultWithCacheIdentity.coreModulePath, manifestDefaultCoreModule);
 
 	const envOverManifestDefaultIdentity = resolveWpCodeboxIdentity({
 		env: {
@@ -106,9 +119,9 @@ try {
 			HOMEBOY_WP_CODEBOX_CORE_MODULE: path.join(envRoot, 'packages', 'runtime-core', 'dist', 'index.js'),
 		},
 	});
-	assert.equal(staleEnvWithCacheIdentity.selectionSource, 'cache');
-	assert.equal(staleEnvWithCacheIdentity.bin, path.join(cacheSourceRoot, 'packages', 'cli', 'dist', 'index.js'));
-	assert.equal(staleEnvWithCacheIdentity.coreModulePath, path.join(cacheSourceRoot, 'packages', 'runtime-core', 'dist', 'contracts.js'));
+	assert.equal(staleEnvWithCacheIdentity.selectionSource, 'env');
+	assert.equal(staleEnvWithCacheIdentity.bin, envBin);
+	assert.equal(staleEnvWithCacheIdentity.coreModulePath, path.join(envRoot, 'packages', 'runtime-core', 'dist', 'index.js'));
 
 	const explicitBinWithCacheIdentity = resolveWpCodeboxIdentity({
 		wpCodeboxBin: envBin,


### PR DESCRIPTION
## Summary
- Keep explicit WP Codebox binary env/settings ahead of configured cache discovery.
- Resolve WP Codebox core module from explicit env/settings/installed manifest defaults before cache/root filesystem discovery.
- Add resolver smoke coverage for installed defaults with cache present and env overrides with cache present.

## Tests
- npm run test:wp-codebox-resolver
- npm run test:wp-codebox-core-loader
- npm run test:wp-codebox-recipe-helper
- npx eslint lib/wp-codebox-resolver.js

Full `npm run lint:js` was attempted after `npm ci`, but the repo currently has unrelated pre-existing lint errors outside the touched resolver/test files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the resolver-ordering fix and regression test.
