### PR TITLE
fix: stage WP Codebox workload PHP files

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -306,11 +306,12 @@ function loadWpCodeboxRuntimeContractSourceDirect(options = {}) {
 	}
 	try {
 		const core = require(isPathSpecifier(specifier) ? path.resolve(specifier) : specifier);
-		const manifest = typeof core?.runtimeContractManifest === 'function'
-			? core.runtimeContractManifest()
-			: typeof core?.default?.runtimeContractManifest === 'function'
-				? core.default.runtimeContractManifest()
-				: null;
+		let manifest = null;
+		if (typeof core?.runtimeContractManifest === 'function') {
+			manifest = core.runtimeContractManifest();
+		} else if (typeof core?.default?.runtimeContractManifest === 'function') {
+			manifest = core.default.runtimeContractManifest();
+		}
 		return objectOrUndefined(manifest) ? {
 			source: specifier,
 			manifest,
@@ -542,7 +543,7 @@ function normalizeWpCodeboxFuzzSuiteCases(source = {}, context = {}) {
 
 function homeboyFuzzWorkloadDefaultCase(manifest = {}) {
 	const workload = objectOrUndefined(manifest.workload) || {};
-	const workloadPath = workload.path || manifest.workload_path || manifest.workloadPath || manifest.metadata?.workload_path || manifest.metadata?.workloadPath;
+	const workloadPath = homeboyFuzzManifestWorkloadPath(manifest);
 	const workloadDefinition = objectOrUndefined(workload.definition || manifest.workload_definition || manifest.workloadDefinition || manifest.metadata?.workload_definition || manifest.metadata?.workloadDefinition);
 	const genericCommand = homeboyFuzzWorkloadGenericPrimitiveCommand(manifest);
 	if (!genericCommand && !workloadDefinition && (typeof workloadPath !== 'string' || workloadPath.trim() === '')) {
@@ -568,6 +569,11 @@ function homeboyFuzzWorkloadDefaultCase(manifest = {}) {
 			collect: normalizeArray(manifest.artifacts?.expected).map((artifact) => ({ artifact: artifact.name })).filter((item) => item.artifact),
 		}),
 	};
+}
+
+function homeboyFuzzManifestWorkloadPath(manifest = {}) {
+	const workload = objectOrUndefined(manifest.workload) || {};
+	return workload.path || manifest.workload_path || manifest.workloadPath || manifest.metadata?.workload_path || manifest.metadata?.workloadPath;
 }
 
 function typeFromWorkloadPath(value) {
@@ -818,7 +824,7 @@ function homeboyFuzzWorkloadRuntimeCommandInput(entry = {}, manifest = {}, execu
 	if (workloadDefinition) {
 		return homeboyFuzzWorkloadRunInputFromDefinition(workloadDefinition, { entry: execute.entry || manifest.workload?.entry });
 	}
-	const workloadPath = resolveWorkloadPath(execute.path || manifest.workload?.path, context);
+	const workloadPath = resolveWorkloadPath(execute.path || homeboyFuzzManifestWorkloadPath(manifest), context);
 	if (typeof workloadPath === 'string' && workloadPath.trim() !== '') {
 		const workloadType = String(execute.type || manifest.workload?.type || typeFromWorkloadPath(workloadPath) || '').toLowerCase();
 		if (workloadType === 'php') {
@@ -925,7 +931,7 @@ function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, a
 	}
 	const execute = objectOrUndefined(intent.execute) || {};
 	const activation = intent.plugin?.activation;
-	const workloadPath = resolveWorkloadPath(execute.path || manifest.workload?.path, context);
+	const workloadPath = resolveWorkloadPath(execute.path || homeboyFuzzManifestWorkloadPath(manifest), context);
 	const workloadDefinition = objectOrUndefined(execute.definition) || objectOrUndefined(manifest.workload?.definition);
 	const genericCommand = homeboyFuzzWorkloadGenericPrimitiveCommand(manifest);
 	const setup = typeof activation === 'string' && activation.trim() !== ''
@@ -1096,7 +1102,8 @@ function wpCodeboxFuzzExecutionRequest(options = {}) {
 }
 
 function wpCodeboxWordPressWorkloadRunInput(options = {}) {
-	return stripUndefined({
+	const metadata = objectOrUndefined(options.metadata);
+	return stageWordPressRunWorkloadPhpFiles(stripUndefined({
 		schema: wpCodeboxWordPressWorkloadRunSchema(options),
 		id: options.id || options.runId || options.run_id,
 		wordpress_version: options.wordpressVersion || options.wordpress_version,
@@ -1111,8 +1118,54 @@ function wpCodeboxWordPressWorkloadRunInput(options = {}) {
 		before: normalizeArray(options.before),
 		steps: normalizeWordPressWorkloadSteps(options.steps, options),
 		after: normalizeArray(options.after),
-		metadata: objectOrUndefined(options.metadata),
-	});
+		metadata,
+	}), { packageRoot: options.packageRoot || options.package_root, sourcePath: metadata?.source_path || metadata?.sourcePath });
+}
+
+function stageWordPressRunWorkloadPhpFiles(workload = {}, options = {}) {
+	const originalStagedFileCount = normalizeArray(workload.staged_files || workload.stagedFiles).length;
+	const stagedFiles = [...normalizeArray(workload.staged_files || workload.stagedFiles)];
+	const packageRoot = options.packageRoot || (typeof options.sourcePath === 'string' ? packageRootFromWorkloadPath(options.sourcePath) : undefined);
+	let changed = false;
+	const phases = Object.fromEntries(['before', 'steps', 'after'].map((phase) => [phase, normalizeArray(workload[phase]).map((step) => {
+		const stagedStep = stageWordPressRunWorkloadPhpStep(step, { stagedFiles, packageRoot });
+		if (stagedStep !== step) {
+			changed = true;
+		}
+		return stagedStep;
+	})]));
+	return changed || stagedFiles.length !== originalStagedFileCount ? { ...workload, ...phases, staged_files: stagedFiles, stagedFiles: undefined } : workload;
+}
+
+function stageWordPressRunWorkloadPhpStep(step = {}, { stagedFiles = [], packageRoot } = {}) {
+	if (step?.command !== 'wordpress.run-workload' || !Array.isArray(step.args)) {
+		return step;
+	}
+	const pathArg = step.args.find((arg) => typeof arg === 'string' && arg.startsWith('path='));
+	if (!pathArg) {
+		return step;
+	}
+	const source = pathArg.slice('path='.length);
+	const type = step.args.find((arg) => typeof arg === 'string' && arg.startsWith('type='))?.slice('type='.length).toLowerCase();
+	if (!isLocalAbsolutePath(source) || !fs.existsSync(source) || (type && type !== 'php') || (!type && !source.toLowerCase().endsWith('.php'))) {
+		return step;
+	}
+	const target = wpCodeboxStagedWorkloadFileTarget(source, packageRoot);
+	if (!stagedFiles.some((entry) => objectOrUndefined(entry)?.source === source && objectOrUndefined(entry)?.target === target)) {
+		stagedFiles.push({ source, target });
+	}
+	return { ...step, args: step.args.map((arg) => arg === pathArg ? `path=${target}` : arg) };
+}
+
+function wpCodeboxStagedWorkloadFileTarget(source, packageRoot) {
+	let relative = path.basename(source);
+	if (typeof packageRoot === 'string' && packageRoot.trim() && path.isAbsolute(packageRoot)) {
+		const candidate = path.relative(packageRoot, source).replaceAll(path.sep, '/');
+		if (candidate && !candidate.startsWith('..') && !path.isAbsolute(candidate)) {
+			relative = candidate;
+		}
+	}
+	return `/tmp/homeboy-wp-codebox-workloads/${relative}`;
 }
 
 function normalizeWordPressWorkloadSteps(steps, options = {}) {

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -178,6 +178,7 @@
     "test:wordpress-runtime-task-planner": "node tests/wordpress-runtime-task-planner-smoke.js",
     "test:wordpress-hook-surface-discovery": "node tests/wordpress-hook-surface-discovery-smoke.js",
     "test:wp-codebox-fuzz-suite": "node tests/wp-codebox-fuzz-run-smoke.js",
+    "test:wp-codebox-fuzz-workload-staging": "node tests/wp-codebox-fuzz-workload-staging-smoke.js",
     "test:wordpress-fuzz-destructive-codebox-readiness-gate": "node tests/wordpress-fuzz-destructive-codebox-readiness-gate.test.js",
     "test:wordpress-fuzz-runner": "node tests/wordpress-fuzz-runner-smoke.js",
     "test:wordpress-fuzz-runtime-task": "node tests/wordpress-fuzz-runtime-task.test.js",

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -561,10 +561,16 @@ fs.rmSync(mismatchRoot, { recursive: true, force: true });
 const tempPackageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-run-smoke-'));
 const tempWorkloadDir = path.join(tempPackageRoot, 'bench');
 fs.mkdirSync(tempWorkloadDir, { recursive: true });
+const nestedPhpWorkloadPath = path.join(tempWorkloadDir, 'rest-product-batch-import.php');
+const nestedPhpWorkloadSandboxPath = '/tmp/homeboy-wp-codebox-workloads/bench/rest-product-batch-import.php';
+fs.writeFileSync(nestedPhpWorkloadPath, '<?php return function (): array { return array("status" => "passed"); };\n', 'utf8');
 const jsonWorkloadPath = path.join(tempWorkloadDir, 'json-workload-smoke.workload.json');
 fs.writeFileSync(jsonWorkloadPath, `${JSON.stringify({
 	id: 'json-workload-smoke',
-	run: [{ command: 'wp-codebox/run-fuzz-suite', args: ['suite=${package.root}/manifests/codebox-fuzz-suite-smoke.json'] }],
+	run: [
+		{ command: 'wordpress.run-workload', args: [`path=${nestedPhpWorkloadPath}`, 'type=php'] },
+		{ command: 'wp-codebox/run-fuzz-suite', args: ['suite=${package.root}/manifests/codebox-fuzz-suite-smoke.json'] },
+	],
 	metadata: { fixture: 'json-workload-smoke', package_root: '${package.root}' },
 })}\n`, 'utf8');
 
@@ -606,16 +612,19 @@ assert.deepEqual(jsonWorkloadInput.cases[0].input, {
 	runtime_stack_mounts: [],
 	runtime_overlays: [],
 	secret_env: [],
-	staged_files: [],
+	staged_files: [{ source: nestedPhpWorkloadPath, target: nestedPhpWorkloadSandboxPath }],
 	before: [],
-	steps: [{ command: 'wp-codebox/run-fuzz-suite', args: [`suite=${tempPackageRoot}/manifests/codebox-fuzz-suite-smoke.json`] }],
+	steps: [
+		{ command: 'wordpress.run-workload', args: [`path=${nestedPhpWorkloadSandboxPath}`, 'type=php'] },
+		{ command: 'wp-codebox/run-fuzz-suite', args: [`suite=${tempPackageRoot}/manifests/codebox-fuzz-suite-smoke.json`] },
+	],
 	after: [],
 	metadata: { fixture: 'json-workload-smoke', package_root: tempPackageRoot, source_path: jsonWorkloadPath, source_entry: 'wp-codebox/run-fuzz-suite' },
 });
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.plugin-state', args: ['action=activate', 'plugin=sample-plugin/sample-plugin.php'] }]);
 assert.equal(JSON.stringify(jsonWorkloadInput).includes('wordpress.ensure-plugin-active'), false);
 assert.equal(jsonWorkloadInput.cases[0].phases.action[0].command, 'wordpress.run-workload');
-assert.deepEqual(JSON.parse(jsonWorkloadInput.cases[0].phases.action[0].args[0].replace(/^workload-json=/, '')).steps, [{ command: 'wp-codebox/run-fuzz-suite', args: [`suite=${tempPackageRoot}/manifests/codebox-fuzz-suite-smoke.json`] }]);
+assert.deepEqual(JSON.parse(jsonWorkloadInput.cases[0].phases.action[0].args[0].replace(/^workload-json=/, '')).steps, jsonWorkloadInput.cases[0].input.steps);
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].required, true);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].metadata.semantic_key, 'fuzz.suite_result');
@@ -634,8 +643,11 @@ const phpWorkloadInput = wpCodeboxFuzzSuiteInput({
 	},
 });
 assert.equal(phpWorkloadInput.cases[0].input.schema, DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA);
+assert.deepEqual(phpWorkloadInput.cases[0].input.staged_files, [
+	{ source: phpWorkloadPath, target: '/tmp/homeboy-wp-codebox-workloads/bench/rest-product-batch-import.php' },
+]);
 assert.deepEqual(phpWorkloadInput.cases[0].input.steps, [
-	{ command: 'wordpress.run-workload', args: [`path=${phpWorkloadPath}`, 'type=php'] },
+	{ command: 'wordpress.run-workload', args: ['path=/tmp/homeboy-wp-codebox-workloads/bench/rest-product-batch-import.php', 'type=php'] },
 ]);
 
 const wooDbApiWorkloadPath = path.join(tempWorkloadDir, 'rest-db-query-profile.workload.json');

--- a/wordpress/tests/wp-codebox-fuzz-workload-staging-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-workload-staging-smoke.js
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { wpCodeboxFuzzSuiteInput } = require('../lib/wp-codebox-fuzz-run');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-workload-staging-'));
+const bench = path.join(root, 'bench');
+fs.mkdirSync(bench, { recursive: true });
+
+const phpWorkloadPath = path.join(bench, 'rest-product-batch-import.php');
+const jsonWorkloadPath = path.join(bench, 'rest-product-batch-import.workload.json');
+const sandboxPhpWorkloadPath = '/tmp/homeboy-wp-codebox-workloads/bench/rest-product-batch-import.php';
+
+fs.writeFileSync(phpWorkloadPath, '<?php return function (): array { return array("status" => "passed"); };\n', 'utf8');
+fs.writeFileSync(jsonWorkloadPath, `${JSON.stringify({
+	schema: 'wp-codebox/wordpress-workload-run/v1',
+	run: [{ command: 'wordpress.run-workload', args: [`path=${phpWorkloadPath}`, 'type=php'] }],
+})}\n`, 'utf8');
+
+for (const pathRef of ['metadata.workload_path', 'workload.path', 'intent.execute.path']) {
+	const manifest = {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: `rest-product-batch-import-${pathRef}`,
+		workload: {},
+		metadata: {},
+		cases: [{ id: 'default', intent: { execute: { type: 'json' } } }],
+	};
+
+	if (pathRef === 'metadata.workload_path') {
+		manifest.metadata.workload_path = jsonWorkloadPath;
+	}
+	if (pathRef === 'workload.path') {
+		manifest.workload.path = jsonWorkloadPath;
+	}
+	if (pathRef === 'intent.execute.path') {
+		manifest.cases[0].intent.execute.path = jsonWorkloadPath;
+	}
+
+	const input = wpCodeboxFuzzSuiteInput({ id: `run-${pathRef}`, homeboyFuzzWorkload: manifest });
+	assert.deepEqual(input.cases[0].input.staged_files, [{ source: phpWorkloadPath, target: sandboxPhpWorkloadPath }]);
+	assert.deepEqual(input.cases[0].input.steps, [{ command: 'wordpress.run-workload', args: [`path=${sandboxPhpWorkloadPath}`, 'type=php'] }]);
+}
+
+fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- stage PHP file references in nested WP Codebox workload definitions before execution
- resolve workload paths consistently from workload, metadata, and intent shapes
- add focused smoke coverage for workload staging

Fixes #2088.

## Testing
- `npm run test:wp-codebox-fuzz-workload-staging`
- `npx eslint lib/wp-codebox-fuzz-run.js`
- `git diff --check`

## Notes
- `npm run test:wp-codebox-fuzz-suite` currently fails on an existing contract-source assertion before the new regression path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the staging gap, implementing the fix, and adding regression coverage.