### PR TITLE
Fail configured PHPUnit runs with no tests directory

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -56,6 +56,12 @@ fi
 settings_json="${HOMEBOY_SETTINGS_JSON:-}"
 [ -n "$settings_json" ] || settings_json="{}"
 
+PHPUNIT_NO_TESTS="skipped"
+if [ "$settings_json" != "{}" ]; then
+    extracted=$(printf '%s' "$settings_json" | jq -r '.phpunit_no_tests // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PHPUNIT_NO_TESTS="$extracted"
+fi
+
 WP_CODEBOX_SOURCE_ROOT=""
 WP_CODEBOX_SOURCE_SUBPATH=""
 WP_CODEBOX_PLUGIN_SOURCE_PATH="$PLUGIN_PATH"
@@ -360,6 +366,17 @@ if [ ! -d "$TEST_DIR" ]; then
     if component_npm_test_script; then
         run_npm_test_script
         exit $?
+    fi
+
+    if [ "$PHPUNIT_NO_TESTS" = "failed" ] || [ "$PHPUNIT_NO_TESTS" = "fail" ]; then
+        echo ""
+        echo "NO PHPUNIT TEST DIRECTORY DISCOVERED"
+        echo "  Expected: ${TEST_DIR}"
+        echo "  PHPUnit no-test discovery is configured as failure, and no PHPUnit test directory exists."
+        echo ""
+        FAILED_STEP="PHPUnit tests (configured suite has no test directory, wp-codebox)"
+        write_phpunit_discovery_result failed "no-phpunit-test-directory-configured" "No PHPUnit test directory exists at the WordPress runner discovery path; no PHPUnit assertions ran."
+        exit 1
     fi
 
     echo ""
@@ -722,7 +739,6 @@ WP_CONFIG_DEFINES_JSON="{}"
 PHPUNIT_ENV_JSON="{}"
 WP_CODEBOX_FILE_MOUNTS_JSON="[]"
 WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON="null"
-PHPUNIT_NO_TESTS="skipped"
 WP_CODEBOX_WORDPRESS_VERSION=""
 WP_CODEBOX_MULTISITE=""
 if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then

--- a/wordpress/scripts/test/wp-codebox-missing-tests-fail-policy-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-missing-tests-fail-policy-smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/test-runner-wp-codebox.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PLUGIN_DIR="${TMPDIR}/sample-plugin"
+FAKE_BIN="${TMPDIR}/wp-codebox"
+RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
+OUTPUT="${TMPDIR}/output.txt"
+
+mkdir -p "$PLUGIN_DIR"
+cat > "${PLUGIN_DIR}/sample-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Sample Plugin
+ */
+PHP
+
+cat > "$FAKE_BIN" <<'SH'
+#!/usr/bin/env bash
+echo "fake wp-codebox should not run when the test directory is missing" >&2
+exit 99
+SH
+chmod +x "$FAKE_BIN"
+
+cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
+#!/usr/bin/env bash
+homeboy_resolve_context() {
+    PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+    COMPONENT_ID="$HOMEBOY_COMPONENT_ID"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+SH
+chmod +x "$RESOLVE_CONTEXT_HELPER"
+
+set +e
+HOMEBOY_COMPONENT_ID="sample-plugin" \
+HOMEBOY_COMPONENT_PATH="$PLUGIN_DIR" \
+HOMEBOY_PROJECT_PATH="$PLUGIN_DIR" \
+HOMEBOY_EXTENSION_PATH="${SCRIPT_DIR}/.." \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
+HOMEBOY_SETTINGS_JSON='{"phpunit_no_tests":"fail"}' \
+bash "$RUNNER" >"$OUTPUT" 2>&1
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    echo "Expected missing tests directory to fail when phpunit_no_tests=fail" >&2
+    cat "$OUTPUT" >&2
+    exit 1
+fi
+
+if ! grep -q "NO PHPUNIT TEST DIRECTORY DISCOVERED" "$OUTPUT"; then
+    echo "Expected structured missing test directory failure output" >&2
+    cat "$OUTPUT" >&2
+    exit 1
+fi
+
+echo "WP Codebox missing tests fail policy smoke passed"


### PR DESCRIPTION
## Summary
- parse `phpunit_no_tests` before the missing test-directory branch
- make `phpunit_no_tests=fail` fail when the default WordPress PHPUnit test directory is absent
- add a smoke test covering the missing-directory false-green regression

## Testing
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh`
- `bash wordpress/scripts/test/wp-codebox-missing-tests-fail-policy-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Drafting and applying the implementation, focused verification, and PR preparation.