### PR TITLE
Derive OpenCode manifest from provider contract

### DIFF
--- a/agent-runtimes/opencode/index.js
+++ b/agent-runtimes/opencode/index.js
@@ -2,4 +2,5 @@
 
 module.exports = {
 	...require('./lib/opencode-agent-task-executor'),
+	...require('./lib/opencode-runtime-manifest'),
 };

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const {
+	providerContract,
+} = require('./opencode-agent-task-executor');
+
+function runtimeManifest() {
+	return {
+		schema: 'homeboy/agent-runtime-manifest/v1',
+		id: 'opencode',
+		name: 'OpenCode',
+		version: '1.1.0',
+		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
+		contract_producers: [
+			{
+				id: 'opencode.agent-task-result',
+				phase: 'result',
+				invocation: {
+					script: 'scripts/agent/homeboy-opencode-agent-task-executor.cjs',
+					input_schema: 'homeboy/agent-task-request/v1',
+					output_schema: 'homeboy/agent-task-outcome/v1',
+				},
+				produces: [
+					{
+						kind: 'status',
+						name: 'agent-task-outcome',
+						schema: 'homeboy/agent-task-outcome/v1',
+					},
+				],
+			},
+		],
+		agent_task_executors: [providerContract()],
+	};
+}
+
+module.exports = {
+	runtimeManifest,
+};

--- a/agent-runtimes/opencode/package.json
+++ b/agent-runtimes/opencode/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
-    "./opencode-agent-task-executor": "./lib/opencode-agent-task-executor.js"
+    "./opencode-agent-task-executor": "./lib/opencode-agent-task-executor.js",
+    "./opencode-runtime-manifest": "./lib/opencode-runtime-manifest.js"
   },
   "homeboy": {
     "agent_runtime_manifest": "opencode.json"
@@ -14,6 +15,8 @@
     "homeboy-opencode-agent-task-executor": "./scripts/agent/homeboy-opencode-agent-task-executor.cjs"
   },
   "scripts": {
+    "generate:runtime-manifest": "node scripts/agent/homeboy-opencode-runtime-manifest.cjs --write",
+    "check:runtime-manifest": "node scripts/agent/homeboy-opencode-runtime-manifest.cjs --check",
     "test:opencode-agent-task-executor": "node tests/opencode-agent-task-executor-boundary.test.js",
     "test:opencode-agent-task-executor-boundary": "node tests/opencode-agent-task-executor-boundary.test.js"
   },

--- a/agent-runtimes/opencode/scripts/agent/homeboy-opencode-runtime-manifest.cjs
+++ b/agent-runtimes/opencode/scripts/agent/homeboy-opencode-runtime-manifest.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+
+const {
+	runtimeManifest,
+} = require('../../lib/opencode-runtime-manifest');
+
+const manifestPath = path.join(__dirname, '..', '..', 'opencode.json');
+const manifestJson = `${JSON.stringify(runtimeManifest(), null, 2)}\n`;
+const command = process.argv[2] || '--print';
+
+if (command === '--write') {
+	fs.writeFileSync(manifestPath, manifestJson);
+} else if (command === '--check') {
+	try {
+		assert.deepEqual(JSON.parse(fs.readFileSync(manifestPath, 'utf8')), runtimeManifest());
+	} catch {
+		process.stderr.write('agent-runtimes/opencode/opencode.json is out of date. Run `node scripts/agent/homeboy-opencode-runtime-manifest.cjs --write`.\n');
+		process.exit(1);
+	}
+} else if (command === '--print') {
+	process.stdout.write(manifestJson);
+} else {
+	process.stderr.write(`Unknown command: ${command}\n`);
+	process.exit(1);
+}

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -23,6 +23,7 @@ const {
 	OPENCODE_WORKSPACE_TOOLS,
 	executeOpenCodeAgentTask,
 	providerContract,
+	runtimeManifest,
 } = require('..');
 
 const runtimeRoot = path.join(__dirname, '..');
@@ -58,6 +59,7 @@ assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'opencode.json'), 'utf8'));
+assert.deepEqual(manifest, runtimeManifest());
 assert.equal(manifest.id, 'opencode');
 assert.equal(manifest.name, 'OpenCode');
 assert.equal(manifest.agent_task_executors.length, 1);


### PR DESCRIPTION
## Summary
- Add an OpenCode runtime manifest builder that uses the executor provider contract as the single source for agent_task_executors.
- Add a small manifest CLI with print/write/check modes so checked-in opencode.json can be validated against that source.
- Wire the existing OpenCode boundary test to assert the checked-in manifest matches the generated manifest.

## Tests
- node scripts/agent/homeboy-opencode-runtime-manifest.cjs --check
- npm run test:opencode-agent-task-executor-boundary
- node wordpress/tests/generic-agent-runtime-contract.test.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the OpenCode runtime contract duplication, implemented the manifest source/validator path, ran targeted tests, and prepared this PR.