### PR TITLE
Clarify generic runtime workflow compatibility

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -12,6 +12,7 @@ const {
   providerBenchEnvFromManifest,
   runtimePathRequired,
   withoutInternalKeys,
+  workflowInputCompatibility,
 } = require('../../../runtime-agent-ci');
 const { writeGithubOutput } = require('../../../runtime-agent-ci/lib/full-run-inputs.cjs');
 
@@ -31,4 +32,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, workflowInputCompatibility };

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,16 +57,17 @@ JSON results/events outside GitHub Actions.
 
 The generic workflow requires callers to provide their domain runtime profile,
 runtime component dependencies, required abilities, and runtime task/execution
-descriptor. Homeboy Extensions assumes the runtime provider contract only;
-WordPress/WP Codebox behavior is selected by passing `runtime: wp-codebox`.
-Domain ability names and component stacks are caller inputs.
+descriptor. Homeboy Extensions assumes the runtime provider contract only.
+Domain ability names and component stacks are caller inputs. WordPress/WP Codebox
+callers should keep compatibility translation in a caller wrapper; see
+[`docs/wp-codebox-runtime-workflow.md`](../../docs/wp-codebox-runtime-workflow.md).
 
 ```yaml
 jobs:
   run-agent:
     uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
     with:
-      runtime: wp-codebox
+      runtime: local-shell
       runtime_ref: main
       profile: example-agent
       runtime_profiles: |
@@ -142,12 +143,13 @@ The workflow keeps two GitHub authentication modes:
 The run summary includes the selected auth mode, target repository, token scope,
 and whether the caller required a Homeboy App token. Tokens are never printed.
 
-## Runtime Bundle Example
+## WP Codebox Runtime Bundle Examples
 
-Workflows that need a WP Codebox-backed bundle can pass the runtime profile,
-dependencies, WordPress sandbox configuration, pre-run bootstrap work, and extra
-ability assertions through the generic full-run inputs by selecting
-`runtime: wp-codebox`.
+WP Codebox-backed bundles are documented in
+[`docs/wp-codebox-runtime-workflow.md`](../../docs/wp-codebox-runtime-workflow.md). Keep WordPress sandbox configuration,
+pre-run bootstrap work, and WP Codebox-specific artifact schemas in a caller
+wrapper or caller workflow, then invoke this generic workflow with canonical
+runtime inputs.
 
 ```yaml
 jobs:
@@ -193,7 +195,7 @@ jobs:
 
 ## Inputs worth calling out
 
-- Agent CI runs through the selected `runtime`. Empty runtime input selects `local-shell`. Deprecated compatibility aliases remain available only for existing callers: `runtime_provider` maps to `runtime`, and the legacy `codebox` runtime id maps to canonical `wp-codebox`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
+- Agent CI runs through the selected `runtime`. Empty runtime input selects `local-shell`. Deprecated compatibility aliases remain available only for existing callers: `runtime_provider` and `backend` map to `runtime`. The legacy `codebox` value is not a generic runtime id; use `wp-codebox`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
 - `profile` is the runtime profile selector. Deprecated compatibility alias: `runtime_profile`.
 - `runtime_ref` controls the selected runtime ref.
 - `runtime_execution` declares bundle, workflow, or ability execution. When `runtime_task` or `ability_request` is supplied, the workflow builds a direct runtime task instead.
@@ -204,7 +206,7 @@ jobs:
 - `component_contracts` forwards explicit runtime component/plugin contracts to the selected runtime adapter. WP Codebox maps them through its `wp-codebox/runtime-profile/v1` payload.
 - WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, tool profiles, and declarative runtime requirements through the generic runtime workflow input renderer. Domain policy belongs in caller inputs and runtime profiles, not in the generic WP Codebox provider manifest.
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to the selected runtime adapter.
-- `tool_profile` is the runtime-neutral tool policy input. The selected runtime adapter maps it into runtime-owned workflow fields; for WP Codebox that becomes the sandbox tool policy. Deprecated compatibility alias: `tool_policy`.
+- `tool_profile` is the runtime-neutral tool policy input. The selected runtime adapter maps it into runtime-owned workflow fields. Deprecated compatibility alias: `tool_policy`.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. The generic workflow does not choose a provider plugin or secret for callers; provider dependencies and credential mappings are explicit caller inputs, and runtime manifests advertise provider-specific defaults/capabilities. Deprecated compatibility alias: `credentials`; generated config uses `provider_secret_env_mapping`.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - Bundle sources in `runtime_execution` are resolved relative to the consumer checkout unless the caller materializes external bundle sources through dependencies or validation checkouts.
@@ -221,11 +223,11 @@ jobs:
 - `proof_profile` controls controller-loop proof evidence. `artifact_only` is the generic default and does not require preview or PR/publication evidence, `cook_to_pr` requires durable preview plus pull-request evidence, and `none` declares no extra proof requirements. Explicit `controller_loop_proof` / `controller_loop_proof_policy` config still overrides profile fields.
 - `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
-- `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. Deprecated compatibility alias: `tool_recorders`, only for existing callers that also need forced parameters.
+- `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. Deprecated compatibility alias: `tool_recorders`, only for existing WP Codebox callers that still need forced-parameter behavior.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
-- `runner_workspace` provisions a selected-runtime runner workspace before the agent runs. WP Codebox uses its runner workspace API for this path. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the selected runtime after completion.
+- `runner_workspace` provisions a selected-runtime runner workspace before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the selected runtime after completion.
 - `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.
-- `verification_commands` and `drift_checks` run through the WP Codebox runner workspace command API, so remote runner workspaces do not require Homeboy to know backend-local paths.
+- `verification_commands` and `drift_checks` run through the selected runtime runner workspace command API when the runtime provides one, so remote runner workspaces do not require Homeboy to know backend-local paths.
 - If runner-owned workspace publication is unavailable or fails, the run fails as `write_without_pr`; Homeboy does not compose alternate PR fallback calls.
 
 ## External Bundle And Tool Recording

--- a/README.md
+++ b/README.md
@@ -141,15 +141,18 @@ New callers should select runtimes with `runtime` and `profile`. Omitting
 `runtime` selects the neutral `local-shell` runtime for generic contract smokes;
 WordPress callers must pass `runtime: wp-codebox` explicitly. Deprecated
 compatibility aliases remain available only for existing callers:
-`runtime_provider` maps to `runtime`, `runtime_profile` maps to `profile`, and
-the legacy `codebox` runtime value maps to `wp-codebox`. Do not add new callers
-or examples that depend on those aliases.
+`runtime_provider` and `backend` map to `runtime`, `runtime_profile` maps to
+`profile`, and `tool_policy` maps to `tool_profile`. The legacy `codebox`
+runtime value is not accepted by the generic runtime registry; use `wp-codebox`.
+Do not add new callers or examples that depend on those aliases.
 
 Call `.github/workflows/runtime-agent-full-run.yml` directly for runtime-backed
 agent runs. Former domain-specific reusable workflow wrappers have been removed
 after active default-branch consumers migrated to the generic workflow.
 See [`.github/workflows/README.md`](.github/workflows/README.md) for workflow
-inputs and integration examples.
+inputs and integration examples, and
+[`docs/wp-codebox-runtime-workflow.md`](docs/wp-codebox-runtime-workflow.md) for
+WP Codebox wrapper migration guidance.
 
 Use `component_contracts` only when the ability provider plugin or runtime
 component must be mounted explicitly. Keep ability names, schemas, and artifact

--- a/docs/wp-codebox-runtime-workflow.md
+++ b/docs/wp-codebox-runtime-workflow.md
@@ -1,0 +1,54 @@
+# WP Codebox runtime workflow migration
+
+`runtime-agent-full-run.yml` is the runtime-neutral GitHub Actions shell. New
+WordPress/WP Codebox callers should keep WP-specific setup in their caller
+workflow or a local wrapper job, then invoke the generic shell with
+`runtime: wp-codebox` and canonical input names.
+
+## Canonical call shape
+
+```yaml
+jobs:
+  run-wp-codebox-agent:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
+    with:
+      runtime: wp-codebox
+      runtime_ref: main
+      profile: example-agent-ci
+      runtime_profiles: >-
+        {"example-agent-ci":{"id":"example-agent-ci","runtime_task_ability":"example/run-task","runtime_bundle_ability":"example/run-agent-bundle","capabilities":["ability_execution","agent_bundle_execution"],"runtime_execution_contracts":{"bundle":{"ability_field":"runtime_bundle_ability","required_capabilities":["agent_bundle_execution"]}},"ability_requirements":["example/run-agent-bundle"]}}
+      runtime_dependencies: '["Example/runtime-plugin@main"]'
+      workload_id: example-agent-flow
+      target_repo: Example/project
+      runtime_execution: '{"kind":"bundle","source":"bundles/example-agent"}'
+      runtime_wordpress_version: beta
+      extra_wp_config_defines: '{"EXAMPLE_RUNTIME_MODE":"primary"}'
+      runtime_mounts: '["${{ github.workspace }}/.ci/example-runtime-plugin:/wordpress/wp-content/plugins/example-runtime-plugin:readonly"]'
+      required_abilities: '["example/run-agent-bundle"]'
+      runtime_output_projections: '{"example_pr_url":"metadata.engine_data.example.pr_url"}'
+      transcript_artifact_name: example-agent-transcript-${{ github.run_id }}
+    secrets: inherit
+```
+
+## Deprecated aliases
+
+These aliases are compatibility-only for existing callers. New wrappers should
+emit the canonical names.
+
+| Deprecated alias | Canonical input |
+| --- | --- |
+| `runtime_provider` | `runtime` |
+| `backend` | `runtime` |
+| `runtime_profile` | `profile` |
+| `tool_policy` | `tool_profile` |
+| `tool_recorders` | `evidence_projections` for generic projections; keep `tool_recorders` only when a WP Codebox runner still requires its legacy forced-parameter behavior. |
+
+The old `codebox` runtime id is not a generic runtime id. Use `wp-codebox`.
+
+## Wrapper guidance
+
+A product-owned wrapper should translate product vocabulary to the canonical
+inputs above before calling `runtime-agent-full-run.yml`. Keep ability names,
+WordPress bootstrap hooks, plugin mounts, and WP Codebox artifact declaration
+schemas in that wrapper or caller repository. The generic workflow should only
+see selected runtime inputs, generic execution descriptors, and projection maps.

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -39,8 +39,9 @@ function buildConfig(env) {
   const targetRepo = required(env.TARGET_REPO, 'TARGET_REPO');
   const componentId = env.COMPONENT_ID || path.basename(workspace);
   const componentPath = env.COMPONENT_PATH || workspace;
-  const runtimeId = runtimeIdFromOptions({}, env);
-  const runtimeProfile = required(env.PROFILE || env.RUNTIME_PROFILE, 'PROFILE or RUNTIME_PROFILE');
+  const compatibility = workflowInputCompatibility(env);
+  const runtimeId = compatibility.runtimeId;
+  const runtimeProfile = required(compatibility.profile, 'PROFILE or RUNTIME_PROFILE');
   const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
   const runtime = resolveRuntimeProvider(runtimeId, { workspace, env });
   const runtimeBin = runtime.paths.runtime_bin;
@@ -79,7 +80,7 @@ function buildConfig(env) {
   const runtimeTask = runtimeTaskFromEnv(env);
   const runtimeExecution = parseJsonInput('runtime_execution', env.RUNTIME_EXECUTION || '{}', 'object', {});
   const workload = runtimeWorkloadFromEnv(env, workloadId);
-  const toolProfile = parseJsonInput('tool_profile', env.TOOL_PROFILE || env.TOOL_POLICY || '{}', 'object', {});
+  const toolProfile = parseJsonInput('tool_profile', compatibility.toolProfile, 'object', {});
   const runtimeOutputProjections = parseJsonInput('runtime_output_projections', env.RUNTIME_OUTPUT_PROJECTIONS || '{}', 'object', {});
   const evidenceProjections = parseJsonInput('evidence_projections', env.EVIDENCE_PROJECTIONS || '[]', 'array', []);
   const runtimeComponents = parseJsonInput('runtime_components', env.RUNTIME_COMPONENTS || '{}', 'object', {});
@@ -242,7 +243,47 @@ function buildConfig(env) {
       GITHUB_RUN_ID: env.GITHUB_RUN_ID_VALUE || '',
       GITHUB_RUN_ATTEMPT: env.GITHUB_RUN_ATTEMPT_VALUE || '',
     },
+    _workflowInputCompatibility: compatibility,
   };
+}
+
+function workflowInputCompatibility(env) {
+  const aliases = [];
+  const runtime = aliasValue(env, aliases, 'runtime', [
+    ['RUNTIME', 'runtime'],
+    ['RUNTIME_PROVIDER', 'runtime_provider'],
+    ['BACKEND', 'backend'],
+  ], '');
+  const profile = aliasValue(env, aliases, 'profile', [
+    ['PROFILE', 'profile'],
+    ['RUNTIME_PROFILE', 'runtime_profile'],
+  ], '');
+  const toolProfile = aliasValue(env, aliases, 'tool_profile', [
+    ['TOOL_PROFILE', 'tool_profile'],
+    ['TOOL_POLICY', 'tool_policy'],
+  ], '{}');
+
+  return {
+    runtimeId: runtimeIdFromOptions({ runtime }, env),
+    runtime,
+    profile,
+    toolProfile,
+    deprecated_aliases: aliases,
+  };
+}
+
+function aliasValue(env, aliases, canonicalName, candidates, fallback) {
+  for (let index = 0; index < candidates.length; index += 1) {
+    const [envName, inputName] = candidates[index];
+    if (env[envName] === undefined || env[envName] === '') {
+      continue;
+    }
+    if (index > 0) {
+      aliases.push({ input: inputName, canonical_input: canonicalName });
+    }
+    return env[envName];
+  }
+  return fallback;
 }
 
 function loopPolicyFromEnv(env) {
@@ -485,4 +526,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys, workflowInputCompatibility };

--- a/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
+++ b/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
@@ -13,7 +13,7 @@ const RUNTIME_WORKFLOW_INPUTS_SCHEMA = 'homeboy/runtime-workflow-inputs/v1';
 function renderRuntimeWorkflowInputs(options = {}) {
 	const runtimeInput = options.runtime_id || options.runtime?.id || options.runtime;
 	const runtimeId = normalizeRuntimeId(runtimeInput);
-	const runtime = options.runtime || resolveRuntimeProvider(runtimeId, options);
+	const runtime = runtimeFromOptions(runtimeId, options);
 	const workloadProfile = namedProfile(options.workloadProfile || options.workload_profile, workloadProfiles(runtime));
 	const profileSelection = normalizeRuntimeProfileSelection(options.runtime_profile || workloadProfile.runtime_profile);
 	const runtimeProfiles = plainObject(options.runtime_profiles);
@@ -43,6 +43,19 @@ function renderRuntimeWorkflowInputs(options = {}) {
 		workload_profile: workloadProfile.id,
 		workflow_inputs: stripUndefined(rendered.workflow_inputs || {}),
 	});
+}
+
+function runtimeFromOptions(runtimeId, options = {}) {
+	if (isPlainObject(options.runtime)) {
+		return options.runtime;
+	}
+	if (isPlainObject(options.runtimeProviderConfig)) {
+		return options.runtimeProviderConfig;
+	}
+	if (isPlainObject(options.runtime_provider_config)) {
+		return options.runtime_provider_config;
+	}
+	return resolveRuntimeProvider(runtimeId, options);
 }
 
 function runtimeWorkflowInputAdapter(runtime, options = {}) {

--- a/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
+++ b/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const { dependencyEntries, resolvePlan } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs'));
-const { buildConfig, buildSecretEnvFallbacks, providerBenchEnvFromManifest } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
+const { buildConfig, buildSecretEnvFallbacks, providerBenchEnvFromManifest, workflowInputCompatibility } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
 const { normalizeProviderPlugin } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/lib/common.cjs'));
 const { resolveRuntimeProvider } = require(path.join(repoRoot, 'runtime-agent-ci/lib/runtime-provider-resolver.cjs'));
 
@@ -24,6 +24,17 @@ const baseEnv = {
 assert.deepEqual(dependencyEntries(baseEnv), []);
 assert.deepEqual(resolvePlan(dependencyEntries(baseEnv), true), []);
 assert.deepEqual(normalizeProviderPlugin('{}', 'openai', true).provider_secret_env, {});
+assert.deepEqual(workflowInputCompatibility({ RUNTIME_PROVIDER: 'wp-codebox', RUNTIME_PROFILE: 'legacy-profile', TOOL_POLICY: '{"tools":{}}' }), {
+  runtimeId: 'wp-codebox',
+  runtime: 'wp-codebox',
+  profile: 'legacy-profile',
+  toolProfile: '{"tools":{}}',
+  deprecated_aliases: [
+    { input: 'runtime_provider', canonical_input: 'runtime' },
+    { input: 'runtime_profile', canonical_input: 'profile' },
+    { input: 'tool_policy', canonical_input: 'tool_profile' },
+  ],
+});
 
 const explicitProviderPlugin = {
   repo: 'WordPress/ai-provider-for-openai',


### PR DESCRIPTION
## Summary
- Add an explicit compatibility boundary for deprecated runtime workflow aliases in full-run config construction.
- Fix runtime workflow input rendering so string runtime ids still resolve the runtime adapter, while explicit runtime provider configs remain supported.
- Move WP Codebox-specific workflow migration guidance into docs/wp-codebox-runtime-workflow.md and update generic docs to prefer canonical runtime inputs.

## Tests
- node tests/runtime-agent-full-run-provider-neutral-smoke.mjs
- node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs
- node tests/runtime-provider-resolver-smoke.mjs
- node tests/runtime-workflow-input-renderer-smoke.mjs
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runtime-agent-full-run.yml"); puts "runtime-agent-full-run yaml ok"'
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the runtime workflow/docs/scripts, implemented the compatibility split and docs updates, ran targeted validation, and prepared this PR.