### PR TITLE
Split runtime agent CI module boundaries

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -13,7 +13,7 @@ const {
   runtimePathRequired,
   withoutInternalKeys,
   workflowInputCompatibility,
-} = require('../../../runtime-agent-ci');
+} = require('../../../runtime-agent-ci/provider-adapters');
 const { writeGithubOutput } = require('../../../runtime-agent-ci/lib/full-run-inputs.cjs');
 
 function main() {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ documented in [`docs/project-script-runtime.md`](docs/project-script-runtime.md)
 They are extension-owned until Homeboy core grows an ecosystem-neutral runtime
 helper contract.
 
-Generic runtime fanout/reconcile planning and runner primitives live in
+Generic runtime loop, fanout/reconcile, proof, and lifecycle primitives are
+exported from `homeboy-runtime-agent-ci/generic-orchestration`; provider and
+workflow adapters are exported from `homeboy-runtime-agent-ci/provider-adapters`.
+The legacy `homeboy-runtime-agent-ci` root export is a deprecated compatibility
+barrel and should not be used by new callers. Module internals live in
 `runtime-agent-ci/lib/` and are documented in
 [`docs/generic-fanout-reconcile-workflow.md`](docs/generic-fanout-reconcile-workflow.md).
 Use `.github/workflows/runtime-agent-full-run.yml` for the standard single-task
@@ -179,6 +183,8 @@ The public `runtime-agent-ci` binaries are the package `bin` entries. Legacy
 agent-loop, artifact-fanout, agent-task-to-review, and WordPress compatibility
 wrapper commands were removed after active callsites migrated to the canonical
 loop, fanout, and review publication primitives. Use
+`homeboy-runtime-agent-ci/generic-orchestration`,
+`homeboy-runtime-agent-ci/provider-adapters`,
 `homeboy-runtime-agent-ci/generic-fanout-reconcile-workflow`,
 `homeboy-runtime-agent-ci/fanout-reconcile-runner`,
 `runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs`, and the

--- a/runtime-agent-ci/generic-orchestration.js
+++ b/runtime-agent-ci/generic-orchestration.js
@@ -1,0 +1,18 @@
+'use strict';
+
+// Incubating Homeboy-core candidates: executor-neutral loop, fanout,
+// proof, gate, and lifecycle helpers. Runtime provider selection and
+// GitHub/full-run adapter wiring live in ./provider-adapters.
+Object.assign(module.exports, require('./lib/generic-agent-loop-runner'));
+Object.assign(module.exports, require('./lib/deterministic-loop-runner'));
+Object.assign(module.exports, require('./lib/loop-policy'));
+Object.assign(module.exports, require('./lib/fanout-reconcile-runner'));
+Object.assign(module.exports, require('./lib/generic-fanout-reconcile-workflow'));
+Object.assign(module.exports, require('./lib/headless-deterministic-loop-runner'));
+Object.assign(module.exports, require('./lib/headless-production-loop-spec'));
+Object.assign(module.exports, require('./lib/controller-loop-proof-validator'));
+Object.assign(module.exports, require('./lib/bounded-production-loop-runner'));
+Object.assign(module.exports, require('./lib/workspace-publication-lifecycle.cjs'));
+Object.assign(module.exports, require('./lib/gate-plan-evaluator'));
+Object.assign(module.exports, require('./lib/loop-lifecycle.cjs'));
+Object.assign(module.exports, require('./lib/runtime-status.cjs'));

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -1,21 +1,6 @@
 'use strict';
 
-module.exports = require('./lib/runtime-agent-ci-plan');
-Object.assign(module.exports, require('./lib/generic-agent-loop-runner'));
-Object.assign(module.exports, require('./lib/deterministic-loop-runner'));
-Object.assign(module.exports, require('./lib/loop-policy'));
-Object.assign(module.exports, require('./lib/fanout-reconcile-runner'));
-Object.assign(module.exports, require('./lib/generic-fanout-reconcile-workflow'));
-Object.assign(module.exports, require('./lib/runtime-workflow-inputs.cjs'));
-Object.assign(module.exports, require('./lib/headless-deterministic-loop-runner'));
-Object.assign(module.exports, require('./lib/headless-production-loop-spec'));
-Object.assign(module.exports, require('./lib/preview-materialization'));
-Object.assign(module.exports, require('./lib/controller-loop-proof-validator'));
-Object.assign(module.exports, require('./lib/bounded-production-loop-runner'));
-Object.assign(module.exports, require('./lib/workspace-publication-lifecycle.cjs'));
-Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));
-Object.assign(module.exports, require('./lib/gate-plan-evaluator'));
-Object.assign(module.exports, require('./lib/loop-lifecycle.cjs'));
-Object.assign(module.exports, require('./lib/runtime-status.cjs'));
-Object.assign(module.exports, require('./lib/runtime-contracts.cjs'));
-Object.assign(module.exports, require('./lib/full-run-config.cjs'));
+// Deprecated compatibility barrel. New imports should use the narrower
+// ./generic-orchestration or ./provider-adapters package boundaries.
+Object.assign(module.exports, require('./generic-orchestration'));
+Object.assign(module.exports, require('./provider-adapters'));

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -1029,7 +1029,7 @@ function runtimeTaskOptions(plan) {
   }
   return {
     ability: runtimeTask.ability,
-    abilityInput: optionalObject(runtimeTask.input),
+    ability_input: optionalObject(runtimeTask.input),
   };
 }
 

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
+    "./generic-orchestration": "./generic-orchestration.js",
+    "./provider-adapters": "./provider-adapters.js",
     "./controller-loop-proof-validator": "./lib/controller-loop-proof-validator.js",
     "./agent-task-outcome-normalizer": "./lib/agent-task-outcome-normalizer.js",
     "./bounded-production-loop-runner": "./lib/bounded-production-loop-runner.js",
@@ -20,6 +22,7 @@
     "./full-run-config": "./lib/full-run-config.cjs",
     "./full-run-inputs": "./lib/full-run-inputs.cjs",
     "./runtime-status": "./lib/runtime-status.cjs",
+    "./runtime-provider-resolver": "./lib/runtime-provider-resolver.cjs",
     "./artifact-paths": "./lib/artifact-paths.cjs",
     "./runtime-contracts": "./lib/runtime-contracts.cjs",
     "./loop-lifecycle": "./lib/loop-lifecycle.cjs",

--- a/runtime-agent-ci/provider-adapters.js
+++ b/runtime-agent-ci/provider-adapters.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Runtime-provider and workflow-adapter boundary. Keep executor-neutral loop,
+// fanout, proof, and lifecycle imports on ./generic-orchestration.
+Object.assign(module.exports, require('./lib/runtime-agent-ci-plan'));
+Object.assign(module.exports, require('./lib/runtime-provider-resolver.cjs'));
+Object.assign(module.exports, require('./lib/runtime-workflow-inputs.cjs'));
+Object.assign(module.exports, require('./lib/preview-materialization'));
+Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));
+Object.assign(module.exports, require('./lib/runtime-contracts.cjs'));
+Object.assign(module.exports, require('./lib/full-run-config.cjs'));

--- a/tests/generic-agent-loop-runner-smoke.mjs
+++ b/tests/generic-agent-loop-runner-smoke.mjs
@@ -11,7 +11,7 @@ const {
   runDeterministicLoop,
   runGenericAgentLoop,
   validateGenericAgentLoopOutcomeContract,
-} = require(path.join(repoRoot, 'runtime-agent-ci'));
+} = require(path.join(repoRoot, 'runtime-agent-ci/generic-orchestration'));
 
 const runtimeProfile = {
   schema: 'homeboy/runtime-profile/v1',

--- a/tests/generic-fanout-reconcile-boundary.test.mjs
+++ b/tests/generic-fanout-reconcile-boundary.test.mjs
@@ -9,7 +9,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const require = createRequire(import.meta.url);
 const before = new Set(Object.keys(require.cache));
 
-const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci'));
+const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci/generic-orchestration'));
 const genericWorkflow = require(path.join(repoRoot, 'runtime-agent-ci/lib/generic-fanout-reconcile-workflow'));
 const runner = require(path.join(repoRoot, 'runtime-agent-ci/lib/fanout-reconcile-runner'));
 
@@ -37,6 +37,8 @@ assert.deepEqual(
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'runtime-agent-ci/package.json'), 'utf8'));
 assert.equal(packageJson.main, 'index.js');
+assert.equal(packageJson.exports['./generic-orchestration'], './generic-orchestration.js');
+assert.equal(packageJson.exports['./provider-adapters'], './provider-adapters.js');
 assert.equal(packageJson.exports['./controller-loop-proof-validator'], './lib/controller-loop-proof-validator.js');
 assert.equal(packageJson.exports['./fanout-reconcile-runner'], './lib/fanout-reconcile-runner.js');
 assert.equal(packageJson.exports['./generic-fanout-reconcile-workflow'], './lib/generic-fanout-reconcile-workflow.js');
@@ -45,6 +47,8 @@ assert.equal(packageJson.bin['homeboy-generic-fanout-reconcile'], './scripts/hom
 
 const runtimeSources = [
   'runtime-agent-ci/index.js',
+  'runtime-agent-ci/generic-orchestration.js',
+  'runtime-agent-ci/provider-adapters.js',
   'runtime-agent-ci/lib/controller-loop-proof-validator.js',
   'runtime-agent-ci/lib/fanout-reconcile-runner.js',
   'runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js',


### PR DESCRIPTION
## Summary
- Add explicit runtime-agent-ci package boundaries for generic orchestration and provider adapters.
- Keep the root export as a deprecated compatibility barrel while documenting the narrower imports.
- Move the GitHub full-run config builder and a generic smoke test to the thinner boundaries.
- Preserve runtime task input propagation when building generic loop requests.

## Tests
- `npm test` in `runtime-agent-ci`
- `node tests/generic-agent-loop-runner-smoke.mjs`
- `node tests/generic-fanout-reconcile-boundary.test.mjs`
- `node --check runtime-agent-ci/index.js && node --check runtime-agent-ci/generic-orchestration.js && node --check runtime-agent-ci/provider-adapters.js && node --check runtime-agent-ci/lib/generic-agent-loop-runner.js && node --check .github/scripts/runtime-agent-full-run/build-runner-config.cjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated runtime-agent-ci module ownership, implemented the boundary split, migrated one caller/import, ran safe JS verification, and drafted this PR.