### PR TITLE
Add dependency adapter manifest examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ exported from `homeboy-runtime-agent-ci/generic-orchestration`; provider and
 workflow adapters are exported from `homeboy-runtime-agent-ci/provider-adapters`.
 The legacy `homeboy-runtime-agent-ci` root export is a deprecated compatibility
 barrel and should not be used by new callers. Module internals live in
+
+Declarative dependency adapter manifests live in
+[`dependency-adapters/`](dependency-adapters/). They describe extension-owned
+Node.js, Composer, and WordPress dependency materialization surfaces without
+teaching Homeboy core ecosystem-specific package-manager behavior.
+
 `runtime-agent-ci/lib/` and are documented in
 [`docs/generic-fanout-reconcile-workflow.md`](docs/generic-fanout-reconcile-workflow.md).
 Use `.github/workflows/runtime-agent-full-run.yml` for the standard single-task

--- a/dependency-adapters/README.md
+++ b/dependency-adapters/README.md
@@ -1,0 +1,39 @@
+# Dependency Adapter Manifests
+
+Homeboy Extensions owns concrete dependency materialization knowledge for
+ecosystems. Homeboy core can discover and dispatch adapter manifests without
+knowing how Node.js, Composer, or WordPress projects install dependencies.
+
+The manifest contract is declarative. It describes adapter capabilities,
+project signals, lockfile priority, dependency outputs, and helper surfaces. It
+does not execute installs, choose product-specific packages, or embed caller
+policy.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `schema.json` | Stable manifest shape for extension-owned dependency adapters. |
+| `examples/nodejs.json` | Node.js package manager selection and dependency outputs. |
+| `examples/composer.json` | Composer dependency materialization for PHP projects. |
+| `examples/wordpress.json` | WordPress helper composition over Composer, Node.js, and WP-CLI surfaces. |
+
+## Boundary
+
+Adapters may describe:
+
+| Field | Meaning |
+| --- | --- |
+| `ecosystem` | Generic ecosystem identity, such as `nodejs`, `php`, or `wordpress`. |
+| `project_signals` | Files that identify a project root or optional capability. |
+| `package_managers` | Selection signals, install intent, script runner commands, and dependency outputs. |
+| `helpers` | Extension-owned helper capabilities that prepare dependencies without requiring core to know their implementation. |
+
+Adapters should not describe:
+
+| Excluded Concern | Owner |
+| --- | --- |
+| Product-specific package/plugin choices | Caller or product extension. |
+| Credential mapping | Caller workflow or runtime profile. |
+| Remote execution substrate details | Runner/runtime provider. |
+| Core dispatch behavior | Homeboy core.

--- a/dependency-adapters/examples/composer.json
+++ b/dependency-adapters/examples/composer.json
@@ -1,0 +1,43 @@
+{
+  "schema": "homeboy-extension/dependency-adapter-manifest/v1",
+  "id": "composer-package-manager",
+  "version": 1,
+  "ecosystem": "php",
+  "description": "Declarative Composer dependency materialization outputs for PHP projects.",
+  "project_signals": {
+    "root_files": ["composer.json"],
+    "optional_files": ["composer.lock"]
+  },
+  "capabilities": {
+    "discover_project_root": true,
+    "select_package_manager": false,
+    "install_dependencies": true,
+    "run_named_scripts": true,
+    "execute_bins": true,
+    "prepare_runtime_helpers": false
+  },
+  "package_managers": [
+    {
+      "id": "composer",
+      "selection": {
+        "priority": 1,
+        "default": true,
+        "files": ["composer.json", "composer.lock"]
+      },
+      "install": {
+        "intent": "locked-or-refresh",
+        "command": "composer install",
+        "fallback_command": "composer update"
+      },
+      "scripts": {
+        "manifest": "composer.json",
+        "run_command": "composer run-script",
+        "exec_command": "composer exec"
+      },
+      "outputs": [
+        { "kind": "directory", "path": "vendor", "required": true },
+        { "kind": "file", "path": "vendor/autoload.php", "required": true }
+      ]
+    }
+  ]
+}

--- a/dependency-adapters/examples/nodejs.json
+++ b/dependency-adapters/examples/nodejs.json
@@ -1,0 +1,74 @@
+{
+  "schema": "homeboy-extension/dependency-adapter-manifest/v1",
+  "id": "nodejs-package-managers",
+  "version": 1,
+  "ecosystem": "nodejs",
+  "description": "Declarative Node.js package manager selection and dependency materialization outputs.",
+  "project_signals": {
+    "root_files": ["package.json"],
+    "optional_files": ["pnpm-workspace.yaml", "pnpm-lock.yaml", "yarn.lock", "package-lock.json"]
+  },
+  "capabilities": {
+    "discover_project_root": true,
+    "select_package_manager": true,
+    "install_dependencies": true,
+    "run_named_scripts": true,
+    "execute_bins": true,
+    "prepare_runtime_helpers": false
+  },
+  "package_managers": [
+    {
+      "id": "pnpm",
+      "selection": {
+        "priority": 1,
+        "files": ["pnpm-workspace.yaml", "pnpm-lock.yaml"]
+      },
+      "install": {
+        "intent": "frozen-lockfile",
+        "command": "pnpm install --frozen-lockfile"
+      },
+      "scripts": {
+        "manifest": "package.json",
+        "run_command": "pnpm run",
+        "exec_command": "pnpm exec"
+      },
+      "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
+    },
+    {
+      "id": "yarn",
+      "selection": {
+        "priority": 2,
+        "files": ["yarn.lock"]
+      },
+      "install": {
+        "intent": "frozen-lockfile",
+        "command": "yarn install --frozen-lockfile"
+      },
+      "scripts": {
+        "manifest": "package.json",
+        "run_command": "yarn",
+        "exec_command": "yarn"
+      },
+      "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
+    },
+    {
+      "id": "npm",
+      "selection": {
+        "priority": 3,
+        "default": true,
+        "files": ["package-lock.json"]
+      },
+      "install": {
+        "intent": "locked-or-refresh",
+        "command": "npm ci",
+        "fallback_command": "npm install"
+      },
+      "scripts": {
+        "manifest": "package.json",
+        "run_command": "npm run",
+        "exec_command": "npx"
+      },
+      "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
+    }
+  ]
+}

--- a/dependency-adapters/examples/wordpress.json
+++ b/dependency-adapters/examples/wordpress.json
@@ -1,0 +1,42 @@
+{
+  "schema": "homeboy-extension/dependency-adapter-manifest/v1",
+  "id": "wordpress-dependency-helpers",
+  "version": 1,
+  "ecosystem": "wordpress",
+  "description": "WordPress extension helper surface for composing PHP, JavaScript, and WP-CLI dependency preparation.",
+  "project_signals": {
+    "root_files": ["wp-content", "wp-includes"],
+    "optional_files": ["composer.json", "package.json", "wp-cli.yml"]
+  },
+  "capabilities": {
+    "discover_project_root": true,
+    "select_package_manager": true,
+    "install_dependencies": true,
+    "run_named_scripts": true,
+    "execute_bins": true,
+    "prepare_runtime_helpers": true
+  },
+  "helpers": [
+    {
+      "id": "wordpress-php-dependencies",
+      "description": "Prepare PHP dependencies when a WordPress project or extension declares Composer metadata.",
+      "requires": ["composer-package-manager"],
+      "outputs": [
+        { "kind": "directory", "path": "vendor", "required": false },
+        { "kind": "file", "path": "vendor/autoload.php", "required": false }
+      ]
+    },
+    {
+      "id": "wordpress-js-dependencies",
+      "description": "Prepare JavaScript dependencies and scripts when a WordPress project or extension declares package metadata.",
+      "requires": ["nodejs-package-managers"],
+      "outputs": [{ "kind": "directory", "path": "node_modules", "required": false }]
+    },
+    {
+      "id": "wordpress-cli-helper",
+      "description": "Expose WP-CLI as a runtime helper after the caller supplies a WordPress runtime.",
+      "requires": ["wordpress-runtime"],
+      "outputs": [{ "kind": "runtime-capability", "path": "wp-cli", "required": false }]
+    }
+  ]
+}

--- a/dependency-adapters/schema.json
+++ b/dependency-adapters/schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Extra-Chill/homeboy-extensions/dependency-adapters/schema.json",
+  "title": "Homeboy Extensions Dependency Adapter Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "id", "version", "ecosystem", "project_signals", "capabilities"],
+  "properties": {
+    "schema": {
+      "const": "homeboy-extension/dependency-adapter-manifest/v1"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "ecosystem": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "description": {
+      "type": "string"
+    },
+    "project_signals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["root_files"],
+      "properties": {
+        "root_files": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "optional_files": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "discover_project_root": { "type": "boolean" },
+        "select_package_manager": { "type": "boolean" },
+        "install_dependencies": { "type": "boolean" },
+        "run_named_scripts": { "type": "boolean" },
+        "execute_bins": { "type": "boolean" },
+        "prepare_runtime_helpers": { "type": "boolean" }
+      }
+    },
+    "package_managers": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/package_manager" }
+    },
+    "helpers": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/helper" }
+    }
+  },
+  "$defs": {
+    "package_manager": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "selection", "install", "outputs"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*$"
+        },
+        "selection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["priority"],
+          "properties": {
+            "priority": { "type": "integer", "minimum": 1 },
+            "files": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "default": { "type": "boolean" }
+          }
+        },
+        "install": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["intent"],
+          "properties": {
+            "intent": {
+              "type": "string",
+              "enum": ["frozen-lockfile", "locked-or-refresh", "install"]
+            },
+            "command": { "type": "string" },
+            "fallback_command": { "type": "string" }
+          }
+        },
+        "scripts": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "manifest": { "type": "string" },
+            "run_command": { "type": "string" },
+            "exec_command": { "type": "string" }
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/output" }
+        }
+      }
+    },
+    "helper": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description", "requires", "outputs"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*$"
+        },
+        "description": { "type": "string" },
+        "requires": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "outputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/output" }
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "path"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["file", "directory", "glob", "runtime-capability"]
+        },
+        "path": { "type": "string" },
+        "required": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/docs/project-script-runtime.md
+++ b/docs/project-script-runtime.md
@@ -51,6 +51,13 @@ Lockfiles are authoritative even when the corresponding executable is missing on
 the current host. That keeps discovery deterministic; execution then fails with a
 normal missing-tool error instead of silently running the wrong package manager.
 
+The declarative version of this package-manager knowledge lives in
+[`../dependency-adapters/examples/nodejs.json`](../dependency-adapters/examples/nodejs.json).
+Composer and WordPress helper examples live beside it. These manifests are the
+extension-owned seam for dependency materialization adapters; they document
+capabilities and outputs without adding package-manager knowledge to Homeboy
+core.
+
 ## Homeboy Core Seam
 
 This helper is the extension-owned implementation seam for a future Homeboy core

--- a/tests/dependency-adapter-manifests-smoke.mjs
+++ b/tests/dependency-adapter-manifests-smoke.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const manifestRoot = path.join(repoRoot, 'dependency-adapters');
+const schema = JSON.parse(fs.readFileSync(path.join(manifestRoot, 'schema.json'), 'utf8'));
+const exampleDir = path.join(manifestRoot, 'examples');
+const exampleFiles = fs.readdirSync(exampleDir).filter((file) => file.endsWith('.json')).sort();
+
+assert.equal(schema.properties.schema.const, 'homeboy-extension/dependency-adapter-manifest/v1');
+assert.ok(schema.required.includes('ecosystem'));
+assert.ok(schema.required.includes('project_signals'));
+assert.ok(schema.required.includes('capabilities'));
+assert.deepEqual(exampleFiles, ['composer.json', 'nodejs.json', 'wordpress.json']);
+
+const ids = new Set();
+const productSpecificTerms = ['woocommerce', 'jetpack', 'studio-native'];
+
+for (const file of exampleFiles) {
+	const manifest = JSON.parse(fs.readFileSync(path.join(exampleDir, file), 'utf8'));
+	const serialized = JSON.stringify(manifest).toLowerCase();
+
+	assert.equal(manifest.schema, schema.properties.schema.const, `${file} uses the adapter schema`);
+	assert.equal(typeof manifest.id, 'string', `${file} has an id`);
+	assert.equal(typeof manifest.version, 'number', `${file} has a version`);
+	assert.equal(typeof manifest.ecosystem, 'string', `${file} has an ecosystem`);
+	assert.ok(Array.isArray(manifest.project_signals.root_files), `${file} declares root files`);
+	assert.ok(manifest.project_signals.root_files.length > 0, `${file} declares at least one root signal`);
+	assert.equal(typeof manifest.capabilities, 'object', `${file} declares capabilities`);
+	assert.ok(!ids.has(manifest.id), `${manifest.id} is unique`);
+	ids.add(manifest.id);
+
+	for (const term of productSpecificTerms) {
+		assert.equal(serialized.includes(term), false, `${file} stays product-neutral: ${term}`);
+	}
+
+	for (const manager of manifest.package_managers || []) {
+		assert.equal(typeof manager.id, 'string', `${file} package manager has id`);
+		assert.equal(typeof manager.selection.priority, 'number', `${manager.id} has priority`);
+		assert.equal(typeof manager.install.intent, 'string', `${manager.id} has install intent`);
+		assert.ok(Array.isArray(manager.outputs), `${manager.id} declares outputs`);
+		assert.ok(manager.outputs.length > 0, `${manager.id} has at least one output`);
+	}
+
+	for (const helper of manifest.helpers || []) {
+		assert.equal(typeof helper.id, 'string', `${file} helper has id`);
+		assert.ok(Array.isArray(helper.requires), `${helper.id} declares requirements`);
+		assert.ok(Array.isArray(helper.outputs), `${helper.id} declares outputs`);
+	}
+}
+
+const nodeManifest = JSON.parse(fs.readFileSync(path.join(exampleDir, 'nodejs.json'), 'utf8'));
+assert.deepEqual(
+	nodeManifest.package_managers.map((manager) => manager.id),
+	['pnpm', 'yarn', 'npm'],
+	'Node.js adapter documents the current deterministic package-manager priority'
+);
+
+console.log('dependency adapter manifest smoke passed');


### PR DESCRIPTION
## Summary
- Add a declarative dependency adapter manifest schema owned by Homeboy Extensions.
- Add Node.js, Composer, and WordPress helper examples for dependency materialization surfaces.
- Document the extension/core boundary and add a smoke test for manifest shape, uniqueness, package-manager priority, and product-neutral examples.

## Testing
- node --check tests/dependency-adapter-manifests-smoke.mjs
- node tests/dependency-adapter-manifests-smoke.mjs
- git diff --cached --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted the dependency adapter manifests, documentation, smoke test, and verification workflow.