### PR TITLE
Support canonical secret env plans

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -213,6 +213,9 @@ jobs:
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to the selected runtime adapter.
 - `tool_profile` is the runtime-neutral tool policy input. The selected runtime adapter maps it into runtime-owned workflow fields. Deprecated compatibility alias: `tool_policy`.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. The generic workflow does not choose a provider plugin or secret for callers; provider dependencies and credential mappings are explicit caller inputs, and runtime manifests advertise provider-specific defaults/capabilities. Deprecated compatibility alias: `credentials`; generated config uses `provider_secret_env_mapping`.
+- `secret_env` declares canonical secret environment variable names required by the runtime. It accepts a JSON array or comma-separated list.
+- `secret_env_plan` accepts a `homeboy/secret-env-plan/v1` object and merges it into the generated runner config. The plan declares names and requirements only; secret values are never serialized.
+- `secret_env_map` maps canonical target env names to fallback source env names. Use it when a runner already exposes the source env name, such as a compatibility `PROVIDER_SECRET_n` slot. When `materialize_secret_env_from_github_secrets` is enabled, sources may also be GitHub secret names from the inherited secrets context. Values are names, not secret values.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - Bundle sources in `runtime_execution` are resolved relative to the consumer checkout unless the caller materializes external bundle sources through dependencies or validation checkouts.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`. Use it when the workflow needs app-token access to more than the target repository.
@@ -281,9 +284,10 @@ results copied into stable runner outputs.
 
 ## Provider plugin examples
 
-Provider plugins and credentials are explicit. Map each provider option to one
-of the generic provider secret env names, then pass that secret in the reusable
-workflow call:
+Provider plugins and credentials are explicit. New callers should declare
+canonical runtime secret names with `secret_env` or `secret_env_plan`. The
+reusable workflow can then forward those names through the Homeboy runner
+contract without serializing values:
 
 ```yaml
 jobs:
@@ -305,9 +309,39 @@ jobs:
           "path": ".",
           "register_function": "Example\\AiProvider\\register_provider",
           "provider_secret_env": {
-            "connectors_ai_example_api_key": "PROVIDER_SECRET_1"
+            "connectors_ai_example_api_key": "EXAMPLE_PROVIDER_API_KEY"
           }
         }
-    secrets:
-      PROVIDER_SECRET_1: ${{ secrets.EXAMPLE_PROVIDER_API_KEY }}
+      secret_env: '["EXAMPLE_PROVIDER_API_KEY"]'
+      secret_env_map: '{"EXAMPLE_PROVIDER_API_KEY":"EXAMPLE_PROVIDER_API_KEY"}'
+      materialize_secret_env_from_github_secrets: true
+    secrets: inherit
+```
+
+Enable `materialize_secret_env_from_github_secrets` only when the caller wants
+the reusable workflow to resolve `secret_env_map` sources from the GitHub secrets
+context. Prefer passing only the minimum required secrets to the workflow when
+the caller can avoid broad `secrets: inherit` access.
+
+`PROVIDER_SECRET_1` through `PROVIDER_SECRET_5` remain available for existing
+callers that cannot yet pass canonical names. Treat them as compatibility slots
+only. During migration, `secret_env_map` can fill a canonical env name from a
+numbered source while keeping the generated runner config canonical:
+
+```yaml
+with:
+  provider_plugin: |
+    {
+      "repo": "Example/example-ai-provider",
+      "ref": "main",
+      "path": ".",
+      "register_function": "Example\\AiProvider\\register_provider",
+      "provider_secret_env": {
+        "connectors_ai_example_api_key": "EXAMPLE_PROVIDER_API_KEY"
+      }
+    }
+  secret_env: '["EXAMPLE_PROVIDER_API_KEY"]'
+  secret_env_map: '{"EXAMPLE_PROVIDER_API_KEY":"PROVIDER_SECRET_1"}'
+secrets:
+  PROVIDER_SECRET_1: ${{ secrets.EXAMPLE_PROVIDER_API_KEY }}
 ```

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -80,6 +80,22 @@ name: Runtime Agent Full Run (reusable)
         description: JSON object describing an optional provider plugin checkout and credential env mapping.
         type: string
         default: '{}'
+      secret_env:
+        description: JSON array or comma-separated canonical secret env names required by the runtime. Prefer this over numbered provider secret slots for new callers.
+        type: string
+        default: ''
+      secret_env_map:
+        description: JSON object mapping canonical target secret env names to fallback source env names. Values are env names only, never secret values.
+        type: string
+        default: '{}'
+      secret_env_plan:
+        description: JSON homeboy/secret-env-plan/v1 declaration merged into the generated runner config. Values are never serialized.
+        type: string
+        default: '{}'
+      materialize_secret_env_from_github_secrets:
+        description: Opt-in bridge that resolves secret_env_map sources from the GitHub secrets context before the runner starts. Prefer explicit, minimal caller secrets when enabling.
+        type: boolean
+        default: false
       model:
         type: string
         default: ''
@@ -318,14 +334,19 @@ name: Runtime Agent Full Run (reusable)
       HOMEBOY_APP_PRIVATE_KEY:
         required: false
       PROVIDER_SECRET_1:
+        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
         required: false
       PROVIDER_SECRET_2:
+        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
         required: false
       PROVIDER_SECRET_3:
+        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
         required: false
       PROVIDER_SECRET_4:
+        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
         required: false
       PROVIDER_SECRET_5:
+        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
         required: false
     outputs:
       job_status:
@@ -499,6 +520,9 @@ jobs:
           PROMPT: ${{ inputs.prompt }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
+          SECRET_ENV: ${{ inputs.secret_env }}
+          SECRET_ENV_MAP: ${{ inputs.secret_env_map }}
+          SECRET_ENV_PLAN: ${{ inputs.secret_env_plan }}
           RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
           RUNTIME: ${{ inputs.runtime }}
           BACKEND: ${{ inputs.backend }}
@@ -572,6 +596,7 @@ jobs:
           PROVIDER_SECRET_3: ${{ secrets.PROVIDER_SECRET_3 }}
           PROVIDER_SECRET_4: ${{ secrets.PROVIDER_SECRET_4 }}
           PROVIDER_SECRET_5: ${{ secrets.PROVIDER_SECRET_5 }}
+          HOMEBOY_GITHUB_SECRETS_JSON: ${{ inputs.materialize_secret_env_from_github_secrets && toJson(secrets) || '{}' }}
           HOMEBOY_RUNTIME_AGENT_RUN_DIR: ${{ runner.temp }}/runtime-agent-run
           # Stream raw subprocess stdout/stderr live to the job log so a hard
           # crash or timeout inside the runtime agent is visible even when no

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -54,6 +54,9 @@ function buildConfig(env) {
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', true);
   const validationDependencies = validationPaths(workspace, providerPlugin, env.PROVIDER || '');
   const providerSecretEnvMapping = providerPlugin.provider_secret_env || {};
+  const declaredSecretEnv = normalizeSecretEnvInput(env.SECRET_ENV || '');
+  const inputSecretEnvPlan = parseJsonInput('secret_env_plan', env.SECRET_ENV_PLAN || '{}', 'object', {});
+  const inputSecretEnvMap = normalizeSecretEnvMap(parseJsonInput('secret_env_map', env.SECRET_ENV_MAP || '{}', 'object', {}));
   const providerBenchEnvNames = providerBenchEnvFromManifest(runtime, env.PROVIDER || '', env);
   // Provider-canonical secret env names advertised by the runtime manifest (e.g.
   // OPENAI_API_KEY for the openai provider). Captured before folding in the
@@ -75,6 +78,7 @@ function buildConfig(env) {
     githubRepositoryTokenEnv,
     providerCanonicalSecretEnvNames,
     providerCredentialSourceEnvNames,
+    secretEnvMap: inputSecretEnvMap,
   });
 
   const runtimeTask = runtimeTaskFromEnv(env);
@@ -129,6 +133,9 @@ function buildConfig(env) {
   });
 
   const secretEnv = uniqueStrings([
+    ...normalizeStringArray(inputSecretEnvPlan.secret_env_names),
+    ...secretEnvNamesFromRequirements(inputSecretEnvPlan.requirements),
+    ...declaredSecretEnv,
     ...normalizeStringArray(runtimeConfig.secret_env),
     githubRepositoryTokenEnv,
     githubTokenEnv,
@@ -182,7 +189,9 @@ function buildConfig(env) {
       runtimeEnv,
       providerSecretEnvMapping,
       secretEnvFallbacks,
+      basePlan: inputSecretEnvPlan,
     }),
+    ...(Object.keys(inputSecretEnvMap).length > 0 ? { secret_env_map: inputSecretEnvMap } : {}),
     // Fill a target secret env from a fallback source before the sandbox
     // preflight runs: the provider's canonical key (e.g. OPENAI_API_KEY) from
     // the caller's generic credential secret (PROVIDER_SECRET_n), and the
@@ -341,6 +350,48 @@ function normalizeStringArray(value) {
     return [value];
   }
   return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string' && entry.length > 0) : [];
+}
+
+function normalizeSecretEnvInput(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return [];
+  }
+  const trimmed = value.trim();
+  const entries = trimmed.startsWith('[') ? JSON.parse(trimmed) : splitCsv(trimmed);
+  if (!Array.isArray(entries)) {
+    throw new Error('secret_env must be a JSON array or comma-separated list');
+  }
+  for (const entry of entries) {
+    validateEnvName(entry, 'secret_env');
+  }
+  return entries;
+}
+
+function normalizeSecretEnvMap(map) {
+  const normalized = {};
+  for (const [target, sources] of Object.entries(map || {})) {
+    validateEnvName(target, 'secret_env_map target');
+    const sourceList = Array.isArray(sources) ? sources : [sources];
+    if (sourceList.length === 0) {
+      throw new Error(`secret_env_map.${target} requires at least one source env name`);
+    }
+    normalized[target] = sourceList.map((source) => validateEnvName(source, `secret_env_map.${target}`));
+  }
+  return normalized;
+}
+
+function secretEnvNamesFromRequirements(requirements) {
+  if (!Array.isArray(requirements)) {
+    return [];
+  }
+  return requirements.map((entry) => entry?.name).filter((name) => typeof name === 'string' && name.length > 0);
+}
+
+function validateEnvName(name, label) {
+  if (typeof name !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`${label} entries must be valid environment variable names`);
+  }
+  return name;
 }
 
 function uniqueStrings(values) {

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -21,12 +21,26 @@ const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
 
 // Local adapter seam for the secret materialization contract. Keep the emitted
 // shape stable until Homeboy core owns this schema and assembly.
-function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvFallbacks = {} } = {}) {
+function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvFallbacks = {}, basePlan = {} } = {}) {
+  const baseRequirements = Array.isArray(basePlan.requirements) ? basePlan.requirements.filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry)) : [];
+  const secretEnvNames = uniqueStrings([
+    ...normalizeStringArray(basePlan.secret_env_names),
+    ...baseRequirements.map((entry) => entry.name),
+    ...secretEnv,
+  ]);
+  const requirementNames = new Set(baseRequirements.map((entry) => entry.name).filter((name) => typeof name === 'string' && name.length > 0));
   return {
+    ...basePlan,
     schema: SECRET_ENV_PLAN_SCHEMA,
-    public_env: Object.fromEntries(Object.entries(runtimeEnv).filter(([, value]) => typeof value === 'string')),
-    secret_env_names: uniqueStrings(secretEnv),
-    requirements: uniqueStrings(secretEnv).map((name) => ({ name, required: true })),
+    public_env: {
+      ...(basePlan.public_env && typeof basePlan.public_env === 'object' && !Array.isArray(basePlan.public_env) ? basePlan.public_env : {}),
+      ...Object.fromEntries(Object.entries(runtimeEnv).filter(([, value]) => typeof value === 'string')),
+    },
+    secret_env_names: secretEnvNames,
+    requirements: [
+      ...baseRequirements,
+      ...secretEnvNames.filter((name) => !requirementNames.has(name)).map((name) => ({ name, required: true })),
+    ],
     env_name_mapping: Object.fromEntries(Object.entries({
       provider_secret_env: Object.values(providerSecretEnvMapping).filter((value) => typeof value === 'string' && value.length > 0),
       secret_env_fallbacks: Object.values(secretEnvFallbacks).flat().filter((value) => typeof value === 'string' && value.length > 0),
@@ -46,6 +60,7 @@ function buildSecretEnvFallbacks({
   githubRepositoryTokenEnv,
   providerCanonicalSecretEnvNames = [],
   providerCredentialSourceEnvNames = [],
+  secretEnvMap = {},
 } = {}) {
   const fallbacks = {};
   if (githubTokenEnv && githubRepositoryTokenEnv && githubTokenEnv !== githubRepositoryTokenEnv) {
@@ -59,7 +74,21 @@ function buildSecretEnvFallbacks({
       }
     }
   }
+  for (const [target, sources] of Object.entries(secretEnvMap || {})) {
+    const sourceList = Array.isArray(sources) ? sources : [sources];
+    const normalizedSources = sourceList.filter((name) => typeof name === 'string' && name.length > 0 && name !== target);
+    if (typeof target === 'string' && target.length > 0 && normalizedSources.length > 0) {
+      fallbacks[target] = uniqueStrings([...(fallbacks[target] || []), ...normalizedSources]);
+    }
+  }
   return fallbacks;
+}
+
+function normalizeStringArray(value) {
+  if (typeof value === 'string' && value.length > 0) {
+    return [value];
+  }
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string' && entry.length > 0) : [];
 }
 
 function uniqueStrings(values) {

--- a/runtime-agent-ci/scripts/run-headless-loop.cjs
+++ b/runtime-agent-ci/scripts/run-headless-loop.cjs
@@ -28,6 +28,7 @@ try {
   // the repository GITHUB_TOKEN when no app token is present. Forwarding still
   // happens through the secret-env-names-only boundary; only this process's env
   // is populated so the names resolve.
+  applySecretEnvMap(rawSpec.secret_env_map, parseGithubSecretsJson(process.env.HOMEBOY_GITHUB_SECRETS_JSON));
   applySecretEnvFallbacks(rawSpec.secret_env_fallbacks);
   const spec = materializeHeadlessProductionLoopSpec(rawSpec, {
     revolutions: args.revolutions || args.max_revolutions || process.env.HOMEBOY_HEADLESS_LOOP_REVOLUTIONS,
@@ -113,4 +114,34 @@ function applySecretEnvFallbacks(fallbacks) {
       }
     }
   }
+}
+
+function applySecretEnvMap(secretEnvMap, githubSecrets) {
+  if (!secretEnvMap || typeof secretEnvMap !== 'object' || Array.isArray(secretEnvMap)) {
+    return;
+  }
+  for (const [target, sources] of Object.entries(secretEnvMap)) {
+    if (typeof target !== 'string' || target === '' || process.env[target]) {
+      continue;
+    }
+    const sourceList = Array.isArray(sources) ? sources : [sources];
+    for (const source of sourceList) {
+      if (typeof source !== 'string' || source === '') {
+        continue;
+      }
+      const value = githubSecrets[source] || process.env[source];
+      if (typeof value === 'string' && value !== '') {
+        process.env[target] = value;
+        break;
+      }
+    }
+  }
+}
+
+function parseGithubSecretsJson(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return {};
+  }
+  const parsed = JSON.parse(raw);
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
 }

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -93,6 +93,61 @@ assert.deepEqual(mappedSecretEnvPlan.env_name_mapping, {
   secret_env_fallbacks: ['PROVIDER_SECRET_1'],
 });
 
+const plannedSecretEnv = buildSecretEnvPlan({
+  secretEnv: ['OPENAI_API_KEY'],
+  basePlan: {
+    schema: SECRET_ENV_PLAN_SCHEMA,
+    public_env: { EXISTING_PUBLIC_MODE: 'on' },
+    secret_env_names: ['ANTHROPIC_API_KEY'],
+    requirements: [{ name: 'ANTHROPIC_API_KEY', required: false, source: 'runner' }],
+  },
+});
+validateSecretEnvPlan(plannedSecretEnv);
+assert.deepEqual(plannedSecretEnv.public_env, { EXISTING_PUBLIC_MODE: 'on' });
+assert.deepEqual(plannedSecretEnv.secret_env_names, ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY']);
+assert.deepEqual(plannedSecretEnv.requirements, [
+  { name: 'ANTHROPIC_API_KEY', required: false, source: 'runner' },
+  { name: 'OPENAI_API_KEY', required: true },
+]);
+
+const canonicalSecretTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-build-runner-config-secret-env-'));
+try {
+  const canonicalSecretConfig = buildConfig({
+    ...process.env,
+    GITHUB_WORKSPACE: canonicalSecretTmpRoot,
+    RUNNER_TEMP: canonicalSecretTmpRoot,
+    WORKLOAD_ID: 'canonical-secret-fixture',
+    TARGET_REPO: 'Extra-Chill/example',
+    PROFILE: 'runtime-agent-ci',
+    RUNTIME_PROFILES: '{}',
+    RUNTIME: 'local-shell',
+    SECRET_ENV: 'OPENAI_API_KEY',
+    SECRET_ENV_MAP: '{"OPENAI_API_KEY":"PROVIDER_SECRET_1"}',
+    SECRET_ENV_PLAN: JSON.stringify({
+      schema: SECRET_ENV_PLAN_SCHEMA,
+      secret_env_names: ['ANTHROPIC_API_KEY'],
+      requirements: [{ name: 'ANTHROPIC_API_KEY', required: false, source: 'runner' }],
+    }),
+  });
+  validateSecretEnvPlan(canonicalSecretConfig.secret_env_plan);
+  assert.deepEqual(canonicalSecretConfig.secret_env, [
+    'ANTHROPIC_API_KEY',
+    'GITHUB_TOKEN',
+    'HOMEBOY_GITHUB_APP_TOKEN',
+    'OPENAI_API_KEY',
+  ]);
+  assert.deepEqual(canonicalSecretConfig.secret_env_fallbacks.OPENAI_API_KEY, ['PROVIDER_SECRET_1']);
+  assert.deepEqual(canonicalSecretConfig.secret_env_map, { OPENAI_API_KEY: ['PROVIDER_SECRET_1'] });
+  assert.deepEqual(canonicalSecretConfig.secret_env_plan.requirements, [
+    { name: 'ANTHROPIC_API_KEY', required: false, source: 'runner' },
+    { name: 'GITHUB_TOKEN', required: true },
+    { name: 'HOMEBOY_GITHUB_APP_TOKEN', required: true },
+    { name: 'OPENAI_API_KEY', required: true },
+  ]);
+} finally {
+  fs.rmSync(canonicalSecretTmpRoot, { recursive: true, force: true });
+}
+
 assert.deepEqual(
   normalizeProviderPlugin('{"providerSecretEnv":{"token":"PROVIDER_TOKEN"}}', 'fixture', true).provider_secret_env,
   { token: 'PROVIDER_TOKEN' }


### PR DESCRIPTION
## Summary
- Add canonical `secret_env`, `secret_env_map`, and `secret_env_plan` inputs to `runtime-agent-full-run.yml`.
- Merge caller-provided `homeboy/secret-env-plan/v1` declarations into generated runner config without serializing secret values.
- Add an explicit opt-in GitHub secrets-context materialization bridge for `secret_env_map` and document `PROVIDER_SECRET_1..5` as compatibility-only slots.
- Add regression coverage for plan merging, canonical secret declarations, and compatibility fallback maps.

## Tests
- `node --check runtime-agent-ci/lib/full-run-config.cjs && node --check runtime-agent-ci/lib/runtime-contracts.cjs && node --check runtime-agent-ci/scripts/run-headless-loop.cjs && node runtime-agent-ci/tests/build-runner-config.test.js`
- `npm test` from `runtime-agent-ci`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/runtime-agent-full-run.yml`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 via OpenCode\n- **Used for:** Implemented the workflow/runtime config changes, docs, tests, and local verification in collaboration with Chris.\n