### PR TITLE
Add WP Codebox runtime workflow wrapper

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,8 +49,8 @@ evidence.
 runtime-backed agent run. It owns the GitHub Actions orchestration that callers
 should not repeat: dependency materialization, provider/runtime setup, runner
 workspace lifecycle, transcript/replay artifact upload, PR comments,
-output/evidence projections, `callback_data_json`, before/after workload hooks,
-extra mounts, and runtime config defines. The runtime execution primitive is
+output/evidence projections, `callback_data_json`, selected-runtime setup, and
+host-side verification. The runtime execution primitive is
 `runtime-agent-ci/scripts/run-headless-loop.cjs`, which materializes task
 requests, runs the selected runtime provider, validates gates, and emits durable
 JSON results/events outside GitHub Actions.
@@ -58,8 +58,10 @@ JSON results/events outside GitHub Actions.
 The generic workflow requires callers to provide their domain runtime profile,
 runtime component dependencies, required abilities, and runtime task/execution
 descriptor. Homeboy Extensions assumes the runtime provider contract only.
-Domain ability names and component stacks are caller inputs. WordPress/WP Codebox
-callers should keep compatibility translation in a caller wrapper; see
+Domain ability names and component stacks are caller inputs. WP Codebox callers
+should prefer `.github/workflows/wp-codebox-runtime-agent-full-run.yml`, which
+keeps WordPress-specific defaults and input names at the runtime adapter boundary;
+see
 [`docs/wp-codebox-runtime-workflow.md`](../../docs/wp-codebox-runtime-workflow.md).
 
 ```yaml
@@ -89,11 +91,26 @@ jobs:
     secrets: inherit
 ```
 
+### Runtime-Specific Wrappers
+
+Runtime-specific reusable workflows may wrap `runtime-agent-full-run.yml` when a
+runtime has product vocabulary, compatibility aliases, or setup defaults that
+would make the generic workflow narrative less clear. The wrapper should pin the
+runtime id, translate product-specific input names, and then call the generic
+workflow with canonical inputs.
+
+`wp-codebox-runtime-agent-full-run.yml` is the WP Codebox wrapper. It sets
+`runtime: wp-codebox`, maps `wordpress_version` to `runtime_wordpress_version`,
+maps `wp_config_defines` to `extra_wp_config_defines`, and maps
+`wp_runtime_mounts` / `wp_runtime_overlays` to the selected-runtime mount and
+overlay inputs. Existing direct callers of `runtime-agent-full-run.yml` remain
+supported for compatibility.
+
 ### Migrating Old Wrapper Callers
 
 Removed domain-specific wrappers should migrate to `runtime-agent-full-run.yml`
 directly and provide their runtime stack as explicit generic inputs.
-WordPress runner-workspace publication wrappers have also been removed; callers
+Legacy runner-workspace publication wrappers have also been removed; callers
 that need host-runner publication should invoke
 `.github/scripts/runtime-agent-full-run/run-host-runner-lifecycle.cjs` or
 `.github/scripts/runtime-agent-full-run/update-runner-workspace-pr.cjs` through
@@ -103,7 +120,7 @@ Use this mapping when updating old wrapper workflow bodies:
 
 | Old wrapper concept | Generic `runtime-agent-full-run.yml` input |
 | --- | --- |
-| Runtime selection | `runtime`, `runtime_ref`; `runtime_wordpress_version` only applies to WordPress-capable runtimes. Deprecated compatibility alias: `runtime_provider`. |
+| Runtime selection | `runtime`, `runtime_ref`. Deprecated compatibility alias: `runtime_provider`. |
 | Flow identity | `workload_id`, `workload_label`, `callback_data` |
 | Bundle execution | `runtime_execution: {"kind":"bundle","source":"..."}` |
 | Direct ability execution | `runtime_task` or `ability_request` / `ability_input` |
@@ -111,7 +128,7 @@ Use this mapping when updating old wrapper workflow bodies:
 | Required abilities | `required_abilities` |
 | Output projection | `runtime_output_projections`, `evidence_projections` |
 | Artifacts | `expected_artifacts`, `artifact_declarations`, `artifact_export_config` |
-| WordPress setup | `extra_wp_config_defines`, `runtime_mounts`, `runtime_overlays`, `workload_run_before`, `workload_run_after` |
+| Selected-runtime setup | `runtime_mounts`, `runtime_overlays`, `runtime_config`, `workload_run_before`, `workload_run_after` |
 | Runner workspace | `runner_workspace`, `verification_commands`, `drift_checks`, `writable_paths`, `workspace_contract_checks` |
 | GitHub auth | `app_token_repos`, `require_homeboy_app_token`, `allowed_repos` |
 
@@ -128,9 +145,7 @@ the `homeboy-render-runtime-workflow-inputs` CLI, or
 `.github/actions/render-runtime-workflow-inputs`. These surfaces accept
 `runtime`, `runtime_profile` as either an id or JSON object,
 `runtime_profiles`, `tool_profile`, and runtime mount arrays, then emit
-selected-runtime workflow input JSON with a canonical `profile` output without
-exposing WP Codebox ability names, CLI paths, or schemas to the downstream
-workflow.
+selected-runtime workflow input JSON with a canonical `profile` output.
 
 ## GitHub auth modes
 
@@ -148,56 +163,6 @@ The workflow keeps two GitHub authentication modes:
 The run summary includes the selected auth mode, target repository, token scope,
 and whether the caller required a Homeboy App token. Tokens are never printed.
 
-## WP Codebox Runtime Bundle Examples
-
-WP Codebox-backed bundles are documented in
-[`docs/wp-codebox-runtime-workflow.md`](../../docs/wp-codebox-runtime-workflow.md). Keep WordPress sandbox configuration,
-pre-run bootstrap work, and WP Codebox-specific artifact schemas in a caller
-wrapper or caller workflow, then invoke this generic workflow with canonical
-runtime inputs.
-
-```yaml
-jobs:
-  run-example-agent:
-    uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
-    with:
-      runtime: wp-codebox
-      runtime_ref: main
-      profile: example-agent-ci
-      runtime_profiles: >-
-        {"example-agent-ci":{"id":"example-agent-ci","runtime_task_ability":"example/run-task","runtime_bundle_ability":"example/run-agent-bundle","capabilities":["ability_execution","agent_bundle_execution"],"runtime_execution_contracts":{"bundle":{"ability_field":"runtime_bundle_ability","required_capabilities":["agent_bundle_execution"]}},"ability_requirements":["example/run-agent-bundle"]}}
-      runtime_dependencies: '["Example/runtime-plugin@main"]'
-      workload_id: example-agent-flow
-      workload_label: Run example agent
-      target_repo: Example/project
-      prompt: ${{ inputs.prompt }}
-      runtime_execution: '{"kind":"bundle","source":"bundles/example-agent"}'
-      validation_dependencies: Example/project@main
-      runtime_wordpress_version: beta
-      max_turns: 16
-      step_budget: 20
-      time_budget_ms: 900000
-      extra_wp_config_defines: |
-        {
-          "EXAMPLE_RUNTIME_MODE": "primary"
-        }
-      runtime_mounts: |
-        [
-          "${{ github.workspace }}/.ci/example-runtime-plugin:/wordpress/wp-content/plugins/example-runtime-plugin:readonly"
-        ]
-      workload_run_before: |
-        [
-          { "type": "php", "file": "world-creator-bootstrap.php" }
-        ]
-      runtime_config: '{"daily_memory_enabled":true}'
-      required_abilities: |
-        ["example/create-artifact", "example/publish-result"]
-      success_requires_pr: true
-      runtime_output_projections: '{"example_pr_url":"metadata.engine_data.example.pr_url"}'
-      transcript_artifact_name: example-agent-transcript-${{ github.run_id }}
-    secrets: inherit
-```
-
 ## Inputs worth calling out
 
 - Agent CI runs through the selected `runtime`. Empty runtime input selects `local-shell`. Deprecated compatibility aliases remain available only for existing callers: `runtime_provider` and `backend` map to `runtime`. The legacy `codebox` value is not a generic runtime id; use `wp-codebox`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
@@ -208,11 +173,10 @@ jobs:
 - `ability_request` and `ability_input` are a shorthand for direct ability execution. `ability_input` is merged into `ability_request.input`.
 - `runtime_output_projections` maps named outputs to dotted paths in the provider runtime result.
 - Generic `runtime-agent-full-run.yml` callers can use `runtime_execution` for ability, bundle, or workflow descriptors and pass `runtime_output_projections` / `evidence_projections` through to the selected runtime config. Bundle and workflow descriptors derive the provider operation from the selected runtime profile's `runtime_execution_contracts`, so callers do not need to provide `runtime_task.ability` for generic package runs.
-- `component_contracts` forwards explicit runtime component/plugin contracts to the selected runtime adapter. WP Codebox maps them through its `wp-codebox/runtime-profile/v1` payload.
-- WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, tool profiles, and declarative runtime requirements through the generic runtime workflow input renderer. Domain policy belongs in caller inputs and runtime profiles, not in the generic WP Codebox provider manifest.
+- `component_contracts` forwards explicit runtime component/plugin contracts to the selected runtime adapter.
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to the selected runtime adapter.
 - `tool_profile` is the runtime-neutral tool policy input. The selected runtime adapter maps it into runtime-owned workflow fields. Deprecated compatibility alias: `tool_policy`.
-- `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. The generic workflow does not choose a provider plugin or secret for callers; provider dependencies and credential mappings are explicit caller inputs, and runtime manifests advertise provider-specific defaults/capabilities. Deprecated compatibility alias: `credentials`; generated config uses `provider_secret_env_mapping`.
+- `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. The generic workflow does not choose a provider plugin or secret for callers; provider dependencies and credential mappings are explicit caller inputs, and runtime manifests advertise provider-specific defaults/capabilities.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - Bundle sources in `runtime_execution` are resolved relative to the consumer checkout unless the caller materializes external bundle sources through dependencies or validation checkouts.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`. Use it when the workflow needs app-token access to more than the target repository.
@@ -221,13 +185,12 @@ jobs:
 - `engine_key` and `tool_results_key` control where built-in GitHub tool captures are written in `metadata.engine_data`.
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
-- `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
 - `runtime_mounts` adds selected-runtime mounts. It must be a JSON array.
-- `runtime_overlays` forwards runtime overlay entries to the Codebox runtime profile payload. It must be a JSON array; WP Codebox owns field-level overlay schema validation.
+- `runtime_overlays` forwards runtime overlay entries to the selected runtime adapter. It must be a JSON array; the runtime owns field-level overlay schema validation.
 - `workload_run_before`, `workload_run_after`, and `required_abilities` must be JSON arrays.
 - `proof_profile` controls controller-loop proof evidence. `artifact_only` is the generic default and does not require preview or PR/publication evidence, `cook_to_pr` requires durable preview plus pull-request evidence, and `none` declares no extra proof requirements. Explicit `controller_loop_proof` / `controller_loop_proof_policy` config still overrides profile fields.
-- `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
-- `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
+- `workload_run_after` runs post-agent verifier hooks through the selected runtime scenario.
+- `ability_tools` adds ability-backed tools to the agent loop. It must be a JSON array.
 - `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. Deprecated compatibility alias: `tool_recorders`, only for existing WP Codebox callers that still need forced-parameter behavior.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
 - `runner_workspace` provisions a selected-runtime runner workspace before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the selected runtime after completion.
@@ -239,14 +202,14 @@ jobs:
 
 Consumers can keep an agent bundle in one repository while
 running it against another repository. The reusable workflow handles the bundle
-checkout and passes tool recorder config to the WordPress runner.
+checkout and passes projection config to the selected runtime.
 
 ```yaml
 jobs:
   run-external-agent:
     uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
     with:
-      runtime: wp-codebox
+      runtime: local-shell
       runtime_ref: main
       profile: example-agent-ci
       runtime_profiles: >-
@@ -255,7 +218,7 @@ jobs:
       runtime_execution: '{"kind":"bundle","source":".ci/example-agent/bundles/example-agent"}'
       workload_id: example-agent-flow
       workload_label: Run example agent runtime bundle
-      target_repo: Automattic/agents-api
+      target_repo: ExampleOrg/target-repo
       validation_dependencies: ExampleOrg/example-agent@main
       app_token_repos: ExampleOrg/target-repo,ExampleOrg/example-agent
       require_homeboy_app_token: true
@@ -290,7 +253,7 @@ jobs:
   run-agent:
     uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
     with:
-      runtime: wp-codebox
+      runtime: local-shell
       profile: example-agent
       runtime_profiles: >-
         {"example-agent":{"id":"example-agent","runtime_task_ability":"example/run-task","ability_requirements":["example/run-task"]}}
@@ -303,7 +266,7 @@ jobs:
           "repo": "Example/example-ai-provider",
           "ref": "main",
           "path": ".",
-          "register_function": "Example\\AiProvider\\register_provider",
+          "register_function": "registerProvider",
           "provider_secret_env": {
             "connectors_ai_example_api_key": "PROVIDER_SECRET_1"
           }

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -16,7 +16,7 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: ''
       runtime:
-        description: Agent runtime id. Defaults to the neutral local-shell runtime; pass wp-codebox for WordPress/WP Codebox runs.
+        description: Agent runtime id. Defaults to the neutral local-shell runtime. WP Codebox callers should prefer wp-codebox-runtime-agent-full-run.yml.
         type: string
         default: ''
       backend:
@@ -28,7 +28,7 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: main
       runtime_wordpress_version:
-        description: WordPress version used by WordPress-capable runtimes.
+        description: Compatibility input consumed by WP Codebox-capable adapters. New WP Codebox callers should pass wordpress_version to the wrapper workflow.
         type: string
         default: '7.0'
       runtime_profile:
@@ -196,7 +196,7 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: '[]'
       artifact_declarations:
-        description: JSON array of artifact declaration DTOs. WP Codebox runtimes accept legacy Codebox declaration aliases.
+        description: JSON array of artifact declaration DTOs forwarded to the selected runtime adapter.
         type: string
         default: '[]'
       transcript_artifact_name:
@@ -253,7 +253,7 @@ name: Runtime Agent Full Run (reusable)
         type: boolean
         default: false
       extra_wp_config_defines:
-        description: JSON object merged into the runner config wp_config_defines.
+        description: Compatibility input consumed by the WP Codebox adapter. New WP Codebox callers should pass wp_config_defines to the wrapper workflow.
         type: string
         default: '{}'
       runtime_mounts:

--- a/.github/workflows/wp-codebox-runtime-agent-full-run.yml
+++ b/.github/workflows/wp-codebox-runtime-agent-full-run.yml
@@ -1,0 +1,404 @@
+name: WP Codebox Runtime Agent Full Run (reusable)
+
+'on':
+  workflow_call:
+    inputs:
+      homeboy_extensions_ref:
+        description: Ref of Extra-Chill/homeboy-extensions to check out for runner scripts.
+        type: string
+        default: main
+      run_agent:
+        description: When false, record a skipped run and bypass runtime setup/execution.
+        type: boolean
+        default: true
+      runtime_ref:
+        description: WP Codebox runtime provider ref.
+        type: string
+        default: main
+      wordpress_version:
+        description: WordPress version used by the WP Codebox runtime.
+        type: string
+        default: '7.0'
+      profile:
+        description: Runtime profile id selected from runtime_profiles.
+        type: string
+        default: ''
+      runtime_profiles:
+        description: JSON object keyed by runtime profile id.
+        type: string
+        required: true
+      runtime_dependencies:
+        description: JSON array or comma-separated OWNER/REPO@REF entries checked out under .ci.
+        type: string
+        default: ''
+      validation_dependencies:
+        description: Comma-separated additional OWNER/REPO or OWNER/REPO@REF entries checked out under .ci.
+        type: string
+        default: ''
+      context_repositories:
+        description: JSON array of read-only context repositories.
+        type: string
+        default: '[]'
+      workload_id:
+        description: Stable scenario/workload id used for result extraction.
+        type: string
+        required: true
+      workload_label:
+        description: Human-readable workload label.
+        type: string
+        default: ''
+      component_id:
+        description: Component id for runtime artifact paths. Defaults to the checkout basename.
+        type: string
+        default: ''
+      target_repo:
+        type: string
+        required: true
+      prompt:
+        type: string
+        default: ''
+      provider:
+        type: string
+        default: ''
+      provider_plugin:
+        description: JSON object describing an optional provider plugin checkout and credential env mapping.
+        type: string
+        default: '{}'
+      model:
+        type: string
+        default: ''
+      execution_kind:
+        description: Optional execution kind recorded in the runner config.
+        type: string
+        default: ''
+      runtime_task:
+        description: JSON object forwarded to the WP Codebox runtime task executor, typically {"ability":"example/process","input":{}}.
+        type: string
+        default: '{}'
+      runtime_execution:
+        description: JSON object describing a WP Codebox ability, bundle, or workflow execution.
+        type: string
+        default: '{}'
+      workload:
+        description: JSON workload DTO forwarded to the WP Codebox runtime config. Falls back to workload_id/workload_label when empty.
+        type: string
+        default: '{}'
+      tool_profile:
+        description: JSON generic runtime tool profile forwarded through the WP Codebox adapter.
+        type: string
+        default: '{}'
+      ability_request:
+        description: JSON object shorthand for runtime_task.
+        type: string
+        default: '{}'
+      ability_input:
+        description: JSON object merged into ability_request.input.
+        type: string
+        default: '{}'
+      runtime_components:
+        description: JSON object of runtime component paths forwarded to WP Codebox.
+        type: string
+        default: '{}'
+      component_contracts:
+        description: JSON array of runtime component contracts forwarded to the WP Codebox adapter.
+        type: string
+        default: '[]'
+      required_abilities:
+        description: JSON array of required ability/tool identifiers asserted before invocation.
+        type: string
+        default: '[]'
+      ability_requirements:
+        description: JSON array of declarative runtime requirements.
+        type: string
+        default: '[]'
+      ability_tools:
+        description: JSON array of ability-backed tool definitions.
+        type: string
+        default: '[]'
+      success_requires_pr:
+        type: boolean
+        default: true
+      proof_profile:
+        description: "Controller-loop proof profile: artifact_only, cook_to_pr, or none."
+        type: string
+        default: artifact_only
+      success_completion_outcomes:
+        description: JSON array of completion outcome names that may satisfy success without a PR.
+        type: string
+        default: '[]'
+      max_turns:
+        type: number
+        default: 12
+      step_budget:
+        type: number
+        default: 16
+      time_budget_ms:
+        type: number
+        default: 600000
+      loop_policy:
+        description: JSON generic loop policy forwarded to deterministic loop-capable runners.
+        type: string
+        default: '{}'
+      max_revolutions:
+        description: Optional deterministic loop revolution cap. Zero leaves existing single-run behavior unchanged.
+        type: number
+        default: 0
+      duration_ms:
+        description: Optional deterministic loop wall-clock duration budget in milliseconds.
+        type: number
+        default: 0
+      deadline_at:
+        description: Optional deterministic loop absolute deadline as epoch milliseconds or an ISO-8601 timestamp.
+        type: string
+        default: ''
+      output_mappings:
+        description: JSON object mapping workflow output names to dotted paths in the runtime task result.
+        type: string
+        default: '{}'
+      engine_data_outputs:
+        description: Legacy JSON map of output_name to result path, collected into engine_data_json.
+        type: string
+        default: '{}'
+      runtime_output_projections:
+        description: JSON map of output_name to provider runtime result path, collected into engine_data_json.
+        type: string
+        default: '{}'
+      evidence_projections:
+        description: JSON array mapping provider operation results to named runtime outputs or artifact refs.
+        type: string
+        default: '[]'
+      expected_artifacts:
+        description: JSON array of expected artifact names.
+        type: string
+        default: '[]'
+      artifact_declarations:
+        description: JSON array of artifact declaration DTOs. WP Codebox accepts legacy declaration aliases.
+        type: string
+        default: '[]'
+      transcript_artifact_name:
+        description: Empty string disables transcript artifact upload.
+        type: string
+        default: ''
+      replay_bundle_artifact_name:
+        description: Empty string disables replay bundle upload.
+        type: string
+        default: ''
+      artifact_export_config:
+        description: JSON config for exporting artifacts back to the target repo.
+        type: string
+        default: '{}'
+      rules:
+        type: string
+        default: '{}'
+      general_rules:
+        type: string
+        default: '[]'
+      task_rules:
+        type: string
+        default: '[]'
+      probes:
+        type: string
+        default: '{}'
+      callback_data:
+        description: JSON object preserved in the runner config and exposed as callback_data_json.
+        type: string
+        default: '{}'
+      comment_pr_summary:
+        type: boolean
+        default: false
+      app_token_repos:
+        description: Comma-separated OWNER/REPO entries for the Homeboy app token. Defaults to target_repo.
+        type: string
+        default: ''
+      require_homeboy_app_token:
+        description: Fail before running when Homeboy app credentials are unavailable.
+        type: boolean
+        default: false
+      allowed_repos:
+        description: JSON array of OWNER/REPO strings exposed to the injected GitHub profile.
+        type: string
+        default: '[]'
+      engine_key:
+        type: string
+        default: ''
+      tool_results_key:
+        type: string
+        default: tool_results
+      dry_run:
+        description: Build runner config and exercise the runner dry-run path without a live provider call.
+        type: boolean
+        default: false
+      wp_config_defines:
+        description: JSON object merged into the WP Codebox runner config wp_config_defines.
+        type: string
+        default: '{}'
+      wp_runtime_mounts:
+        description: JSON array appended to WP Codebox runtime mounts.
+        type: string
+        default: '[]'
+      wp_runtime_overlays:
+        description: JSON array of WP Codebox runtime overlay entries forwarded to the runner config.
+        type: string
+        default: '[]'
+      runtime_env:
+        description: JSON object forwarded to runtime profile construction.
+        type: string
+        default: '{}'
+      runtime_config:
+        description: JSON object merged into the generated runner config for caller-owned runtime fields.
+        type: string
+        default: '{}'
+      workload_run_before:
+        description: JSON array of pre-run hooks executed before the main WP Codebox workload.
+        type: string
+        default: '[]'
+      workload_run_after:
+        description: JSON array of post-run hooks executed after the main WP Codebox workload.
+        type: string
+        default: '[]'
+      runner_workspace:
+        description: JSON object for runner-owned workspace/worktree provisioning before execution.
+        type: string
+        default: '{}'
+      workspace_contract_checks:
+        description: JSON object of generic host-side post-run workspace checks.
+        type: string
+        default: '{}'
+      verification_commands:
+        description: JSON array of deterministic shell commands to run after execution.
+        type: string
+        default: '[]'
+      drift_checks:
+        description: JSON array of generated-output drift checks to run after verification.
+        type: string
+        default: '[]'
+      writable_paths:
+        description: Comma-separated or JSON array of target workspace paths the agent may change.
+        type: string
+        default: ''
+      ignored_workspace_paths:
+        description: JSON array of workspace paths ignored by drift/status checks.
+        type: string
+        default: '[]'
+      actions_artifact_downloads:
+        description: JSON array of GitHub Actions artifacts to download before the run.
+        type: string
+        default: '[]'
+      prepare_payload_command:
+        description: Optional shell command run after artifact downloads to build a runtime payload.
+        type: string
+        default: ''
+    secrets:
+      HOMEBOY_APP_ID:
+        required: false
+      HOMEBOY_APP_PRIVATE_KEY:
+        required: false
+      PROVIDER_SECRET_1:
+        required: false
+      PROVIDER_SECRET_2:
+        required: false
+      PROVIDER_SECRET_3:
+        required: false
+      PROVIDER_SECRET_4:
+        required: false
+      PROVIDER_SECRET_5:
+        required: false
+    outputs:
+      job_status:
+        value: ${{ jobs.run-wp-codebox-agent.outputs.job_status }}
+      transcript_json:
+        value: ${{ jobs.run-wp-codebox-agent.outputs.transcript_json }}
+      transcript_summary:
+        value: ${{ jobs.run-wp-codebox-agent.outputs.transcript_summary }}
+      engine_data_json:
+        value: ${{ jobs.run-wp-codebox-agent.outputs.engine_data_json }}
+      callback_data_json:
+        value: ${{ jobs.run-wp-codebox-agent.outputs.callback_data_json }}
+      auth_mode:
+        value: ${{ jobs.run-wp-codebox-agent.outputs.auth_mode }}
+
+jobs:
+  run-wp-codebox-agent:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    uses: ./.github/workflows/runtime-agent-full-run.yml
+    with:
+      homeboy_extensions_ref: ${{ inputs.homeboy_extensions_ref }}
+      run_agent: ${{ inputs.run_agent }}
+      runtime: wp-codebox
+      runtime_ref: ${{ inputs.runtime_ref }}
+      runtime_wordpress_version: ${{ inputs.wordpress_version }}
+      profile: ${{ inputs.profile }}
+      runtime_profiles: ${{ inputs.runtime_profiles }}
+      runtime_dependencies: ${{ inputs.runtime_dependencies }}
+      validation_dependencies: ${{ inputs.validation_dependencies }}
+      context_repositories: ${{ inputs.context_repositories }}
+      workload_id: ${{ inputs.workload_id }}
+      workload_label: ${{ inputs.workload_label }}
+      component_id: ${{ inputs.component_id }}
+      target_repo: ${{ inputs.target_repo }}
+      prompt: ${{ inputs.prompt }}
+      provider: ${{ inputs.provider }}
+      provider_plugin: ${{ inputs.provider_plugin }}
+      model: ${{ inputs.model }}
+      execution_kind: ${{ inputs.execution_kind }}
+      runtime_task: ${{ inputs.runtime_task }}
+      runtime_execution: ${{ inputs.runtime_execution }}
+      workload: ${{ inputs.workload }}
+      tool_profile: ${{ inputs.tool_profile }}
+      ability_request: ${{ inputs.ability_request }}
+      ability_input: ${{ inputs.ability_input }}
+      runtime_components: ${{ inputs.runtime_components }}
+      component_contracts: ${{ inputs.component_contracts }}
+      required_abilities: ${{ inputs.required_abilities }}
+      ability_requirements: ${{ inputs.ability_requirements }}
+      ability_tools: ${{ inputs.ability_tools }}
+      success_requires_pr: ${{ inputs.success_requires_pr }}
+      proof_profile: ${{ inputs.proof_profile }}
+      success_completion_outcomes: ${{ inputs.success_completion_outcomes }}
+      max_turns: ${{ inputs.max_turns }}
+      step_budget: ${{ inputs.step_budget }}
+      time_budget_ms: ${{ inputs.time_budget_ms }}
+      loop_policy: ${{ inputs.loop_policy }}
+      max_revolutions: ${{ inputs.max_revolutions }}
+      duration_ms: ${{ inputs.duration_ms }}
+      deadline_at: ${{ inputs.deadline_at }}
+      output_mappings: ${{ inputs.output_mappings }}
+      engine_data_outputs: ${{ inputs.engine_data_outputs }}
+      runtime_output_projections: ${{ inputs.runtime_output_projections }}
+      evidence_projections: ${{ inputs.evidence_projections }}
+      expected_artifacts: ${{ inputs.expected_artifacts }}
+      artifact_declarations: ${{ inputs.artifact_declarations }}
+      transcript_artifact_name: ${{ inputs.transcript_artifact_name }}
+      replay_bundle_artifact_name: ${{ inputs.replay_bundle_artifact_name }}
+      artifact_export_config: ${{ inputs.artifact_export_config }}
+      rules: ${{ inputs.rules }}
+      general_rules: ${{ inputs.general_rules }}
+      task_rules: ${{ inputs.task_rules }}
+      probes: ${{ inputs.probes }}
+      callback_data: ${{ inputs.callback_data }}
+      comment_pr_summary: ${{ inputs.comment_pr_summary }}
+      app_token_repos: ${{ inputs.app_token_repos }}
+      require_homeboy_app_token: ${{ inputs.require_homeboy_app_token }}
+      allowed_repos: ${{ inputs.allowed_repos }}
+      engine_key: ${{ inputs.engine_key }}
+      tool_results_key: ${{ inputs.tool_results_key }}
+      dry_run: ${{ inputs.dry_run }}
+      extra_wp_config_defines: ${{ inputs.wp_config_defines }}
+      runtime_mounts: ${{ inputs.wp_runtime_mounts }}
+      runtime_overlays: ${{ inputs.wp_runtime_overlays }}
+      runtime_env: ${{ inputs.runtime_env }}
+      runtime_config: ${{ inputs.runtime_config }}
+      workload_run_before: ${{ inputs.workload_run_before }}
+      workload_run_after: ${{ inputs.workload_run_after }}
+      runner_workspace: ${{ inputs.runner_workspace }}
+      workspace_contract_checks: ${{ inputs.workspace_contract_checks }}
+      verification_commands: ${{ inputs.verification_commands }}
+      drift_checks: ${{ inputs.drift_checks }}
+      writable_paths: ${{ inputs.writable_paths }}
+      ignored_workspace_paths: ${{ inputs.ignored_workspace_paths }}
+      actions_artifact_downloads: ${{ inputs.actions_artifact_downloads }}
+      prepare_payload_command: ${{ inputs.prepare_payload_command }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ runtime value is not accepted by the generic runtime registry; use `wp-codebox`.
 Do not add new callers or examples that depend on those aliases.
 
 Call `.github/workflows/runtime-agent-full-run.yml` directly for runtime-backed
-agent runs. Former domain-specific reusable workflow wrappers have been removed
-after active default-branch consumers migrated to the generic workflow.
+agent runs when the caller already speaks the generic runtime contract. WP
+Codebox callers should use `.github/workflows/wp-codebox-runtime-agent-full-run.yml`,
+which maps WordPress/WP Codebox workflow vocabulary onto the generic shell while
+preserving existing direct generic workflow inputs for migrated callers.
 See [`.github/workflows/README.md`](.github/workflows/README.md) for workflow
 inputs and integration examples, and
 [`docs/wp-codebox-runtime-workflow.md`](docs/wp-codebox-runtime-workflow.md) for

--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -55,6 +55,14 @@ and invokes the stable `run-agent-task` CLI.
 
 Runtime-package callers should invoke `wp-codebox/run-runtime-package`.
 
+GitHub Actions callers should prefer
+`.github/workflows/wp-codebox-runtime-agent-full-run.yml`. The wrapper pins the
+runtime id to `wp-codebox` and maps WP Codebox workflow vocabulary such as
+`wordpress_version`, `wp_config_defines`, `wp_runtime_mounts`, and
+`wp_runtime_overlays` onto the generic `runtime-agent-full-run.yml` inputs.
+Existing direct calls to the generic workflow remain supported for compatibility,
+but new WP Codebox examples and defaults belong in the wrapper docs.
+
 Provider credentials stay outside adapter payloads. The adapter forwards
 `secret_env` names and a `provider_credential_boundary` descriptor, and rejects
 raw credential fields such as `secret_env_values` or `credentials` before a task

--- a/docs/wp-codebox-runtime-workflow.md
+++ b/docs/wp-codebox-runtime-workflow.md
@@ -1,18 +1,23 @@
 # WP Codebox runtime workflow migration
 
-`runtime-agent-full-run.yml` is the runtime-neutral GitHub Actions shell. New
-WordPress/WP Codebox callers should keep WP-specific setup in their caller
-workflow or a local wrapper job, then invoke the generic shell with
-`runtime: wp-codebox` and canonical input names.
+`runtime-agent-full-run.yml` is the runtime-neutral GitHub Actions shell.
+`wp-codebox-runtime-agent-full-run.yml` is the WP Codebox wrapper over that
+shell. New WordPress/WP Codebox callers should use the wrapper so WordPress
+version selection, WP config defines, sandbox mounts, runtime overlays, and
+Codebox artifact declaration vocabulary stay at the WP Codebox adapter boundary.
+
+Existing callers that invoke `runtime-agent-full-run.yml` directly with
+`runtime: wp-codebox` remain supported. Treat that path as compatibility for
+migrated consumers or advanced callers that already compose generic runtime
+inputs themselves.
 
 ## Canonical call shape
 
 ```yaml
 jobs:
   run-wp-codebox-agent:
-    uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/wp-codebox-runtime-agent-full-run.yml@v4
     with:
-      runtime: wp-codebox
       runtime_ref: main
       profile: example-agent-ci
       runtime_profiles: >-
@@ -21,14 +26,33 @@ jobs:
       workload_id: example-agent-flow
       target_repo: Example/project
       runtime_execution: '{"kind":"bundle","source":"bundles/example-agent"}'
-      runtime_wordpress_version: beta
-      extra_wp_config_defines: '{"EXAMPLE_RUNTIME_MODE":"primary"}'
-      runtime_mounts: '["${{ github.workspace }}/.ci/example-runtime-plugin:/wordpress/wp-content/plugins/example-runtime-plugin:readonly"]'
+      wordpress_version: beta
+      wp_config_defines: '{"EXAMPLE_RUNTIME_MODE":"primary"}'
+      wp_runtime_mounts: '["${{ github.workspace }}/.ci/example-runtime-plugin:/wordpress/wp-content/plugins/example-runtime-plugin:readonly"]'
       required_abilities: '["example/run-agent-bundle"]'
       runtime_output_projections: '{"example_pr_url":"metadata.engine_data.example.pr_url"}'
       transcript_artifact_name: example-agent-transcript-${{ github.run_id }}
     secrets: inherit
 ```
+
+## Wrapper input mapping
+
+The wrapper pins `runtime: wp-codebox` and forwards the rest of the workflow to
+the generic shell. Its WP-specific names map to generic compatibility inputs as
+follows:
+
+| WP Codebox wrapper input | Generic workflow input |
+| --- | --- |
+| `wordpress_version` | `runtime_wordpress_version` |
+| `wp_config_defines` | `extra_wp_config_defines` |
+| `wp_runtime_mounts` | `runtime_mounts` |
+| `wp_runtime_overlays` | `runtime_overlays` |
+
+The wrapper keeps selected-runtime setup explicit without making the generic
+workflow docs carry WP Codebox examples. Generic inputs such as `runtime_profiles`,
+`component_contracts`, `runtime_execution`, `runtime_output_projections`,
+`runner_workspace`, `verification_commands`, and `artifact_declarations` pass
+through unchanged.
 
 ## Deprecated aliases
 

--- a/tests/wp-codebox-workflow-wrapper-boundary-smoke.mjs
+++ b/tests/wp-codebox-workflow-wrapper-boundary-smoke.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const wrapper = fs.readFileSync(path.join(repoRoot, '.github/workflows/wp-codebox-runtime-agent-full-run.yml'), 'utf8');
+const genericDocs = fs.readFileSync(path.join(repoRoot, '.github/workflows/README.md'), 'utf8');
+const wpDocs = fs.readFileSync(path.join(repoRoot, 'docs/wp-codebox-runtime-workflow.md'), 'utf8');
+
+assert.match(wrapper, /runtime: wp-codebox/);
+assert.match(wrapper, /runtime_wordpress_version: \$\{\{ inputs\.wordpress_version \}\}/);
+assert.match(wrapper, /extra_wp_config_defines: \$\{\{ inputs\.wp_config_defines \}\}/);
+assert.match(wrapper, /runtime_mounts: \$\{\{ inputs\.wp_runtime_mounts \}\}/);
+assert.match(wrapper, /runtime_overlays: \$\{\{ inputs\.wp_runtime_overlays \}\}/);
+
+assert.doesNotMatch(genericDocs, /runtime_wordpress_version: beta/);
+assert.doesNotMatch(genericDocs, /extra_wp_config_defines:/);
+assert.doesNotMatch(genericDocs, /wp-content\/plugins\/example-runtime-plugin/);
+assert.match(genericDocs, /wp-codebox-runtime-agent-full-run\.yml/);
+
+assert.match(wpDocs, /wp-codebox-runtime-agent-full-run\.yml/);
+assert.match(wpDocs, /wordpress_version: beta/);
+assert.match(wpDocs, /wp_config_defines:/);
+assert.match(wpDocs, /wp_runtime_mounts:/);
+
+console.log('wp-codebox workflow wrapper boundary smoke passed');


### PR DESCRIPTION
## Summary
- Add `wp-codebox-runtime-agent-full-run.yml` as the WP Codebox reusable workflow wrapper over the generic runtime full-run shell.
- Move WP Codebox workflow examples/input mapping into `docs/wp-codebox-runtime-workflow.md` and adapter docs while keeping direct generic workflow inputs compatible.
- Neutralize generic workflow docs so WP Codebox-specific setup/defaults are described as wrapper/adapter concerns.
- Add a smoke test that asserts the wrapper boundary and generic docs separation.

## Tests
- `node tests/wp-codebox-workflow-wrapper-boundary-smoke.mjs`
- `node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs`
- `node tests/runtime-workflow-input-renderer-smoke.mjs`
- `node tests/runtime-agent-full-run-provider-neutral-smoke.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runtime-agent-full-run.yml"); YAML.load_file(".github/workflows/wp-codebox-runtime-agent-full-run.yml"); puts "workflow yaml ok"'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the Wave 2 workflow/runtime docs, implemented the WP Codebox wrapper boundary and docs split, added targeted smoke coverage, and ran safe validation checks.
