### PR TITLE
feat: pass Node.js bench workload context

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -11,17 +11,23 @@
 //   HOMEBOY_BENCH_WARMUP_ITERATIONS — discarded warmups per workload (default 1)
 //   HOMEBOY_BENCH_RESULTS_FILE   — where to write the envelope
 //   HOMEBOY_BENCH_LIST_ONLY      — when 1, emit scenario inventory only
+//   HOMEBOY_BENCH_ARGS_JSON      — optional JSON array of passthrough args for workloads
 //   HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL — optional public URL base for artifacts
 //
 // Discovers `bench/**/*.bench.{ts,mjs,js}` under the project root.
-// Each workload file must export a default async function. The function may
-// return `{ metrics, artifacts, metadata }` to report workload-owned custom
-// metrics, artifacts, and scenario labels. Metrics are averaged across measured
-// iterations and merged beside the dispatcher-owned timing metrics; artifacts
-// and metadata are preserved under the scenario in the results envelope.
+// Each workload file must export a default async function. The runner calls it
+// as `fn(context)`, where context includes `{ args, artifactsDir,
+// publicArtifactBaseUrl, env }`. `args` is parsed from HOMEBOY_BENCH_ARGS_JSON;
+// artifactsDir and publicArtifactBaseUrl are present when their env-backed
+// values are available; env is process.env. The function may return `{ metrics,
+// artifacts, metadata }` to report workload-owned custom metrics, artifacts,
+// and scenario labels. Metrics are averaged across measured iterations and
+// merged beside the dispatcher-owned timing metrics; artifacts and metadata are
+// preserved under the scenario in the results envelope.
 //
 //     // bench/cold-boot.bench.ts
-//     export default async function () {
+//     export default async function (context) {
+//         console.log(context.args);
 //         await launchAppAndWaitForReady();
 //     }
 //
@@ -73,6 +79,13 @@ const ARTIFACTS_DIR = process.env.HOMEBOY_BENCH_ARTIFACTS_DIR
     ? resolve(process.env.HOMEBOY_BENCH_ARTIFACTS_DIR)
     : undefined;
 const PUBLIC_ARTIFACT_BASE_URL = publicArtifactBaseUrl();
+const WORKLOAD_ARGS = parseBenchArgs(process.env.HOMEBOY_BENCH_ARGS_JSON);
+const WORKLOAD_CONTEXT = {
+    args: WORKLOAD_ARGS,
+    artifactsDir: ARTIFACTS_DIR,
+    publicArtifactBaseUrl: PUBLIC_ARTIFACT_BASE_URL || undefined,
+    env: process.env,
+};
 
 const TIMING_METRIC_KEYS = new Set([
     'mean_ms',
@@ -99,6 +112,27 @@ function parseWarmupIterations(value) {
     }
 
     return Math.max(0, Number(value));
+}
+
+function parseBenchArgs(value) {
+    if (value === undefined || value === '') {
+        return [];
+    }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(value);
+    } catch (err) {
+        console.error(`FATAL: HOMEBOY_BENCH_ARGS_JSON must be a JSON array of strings: ${err.message}`);
+        process.exit(2);
+    }
+
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string')) {
+        console.error('FATAL: HOMEBOY_BENCH_ARGS_JSON must be a JSON array of strings');
+        process.exit(2);
+    }
+
+    return parsed;
 }
 
 function validateWorkloadResult(value, iterationLabel) {
@@ -351,7 +385,7 @@ async function runWorkload(file) {
     // Warmup pass — discarded.
     for (let i = 0; i < WARMUP; i++) {
         try {
-            validateWorkloadResult(await fn(), `warmup iteration ${i + 1}/${WARMUP}`);
+            validateWorkloadResult(await fn(WORKLOAD_CONTEXT), `warmup iteration ${i + 1}/${WARMUP}`);
         } catch (err) {
             return { error: `warmup iteration threw: ${err.message}` };
         }
@@ -365,7 +399,7 @@ async function runWorkload(file) {
     for (let i = 0; i < ITERATIONS; i++) {
         const start = performance.now();
         try {
-            const workloadResult = validateWorkloadResult(await fn(), `iteration ${i + 1}/${ITERATIONS}`);
+            const workloadResult = validateWorkloadResult(await fn(WORKLOAD_CONTEXT), `iteration ${i + 1}/${ITERATIONS}`);
             customMetrics.push(workloadResult.metrics);
             customArtifacts.push(workloadResult.artifacts);
             customMetadata.push(workloadResult.metadata);

--- a/nodejs/scripts/bench/nodejs-bench-workload-context-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-bench-workload-context-smoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-bench-workload-context.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+HELPER_JS="$TMP_DIR/bench-helper.mjs"
+cat > "$HELPER_JS" <<'EOF'
+import { basename } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+
+export function homeboyBenchPercentile(values, percentile) {
+  if (values.length === 0) return 0;
+  if (values.length === 1) return values[0];
+  const index = (values.length - 1) * percentile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return values[lower];
+  return values[lower] + (values[upper] - values[lower]) * (index - lower);
+}
+
+export function homeboyBenchScenarioId(file, suffixPattern) {
+  return basename(file).replace(suffixPattern, '');
+}
+
+export async function homeboyWriteBenchResults(file, componentId, iterations, scenarios) {
+  await writeFile(file, JSON.stringify({ component_id: componentId, iterations, scenarios }, null, 2));
+}
+EOF
+
+PROJECT_DIR="$TMP_DIR/project"
+mkdir -p "$PROJECT_DIR/bench"
+printf '{"name":"node-bench-workload-context-smoke"}\n' > "$PROJECT_DIR/package.json"
+
+cat > "$PROJECT_DIR/bench/context.bench.mjs" <<'EOF'
+export default async function (context) {
+  if (!context || typeof context !== 'object') throw new Error('missing workload context');
+  if (context.args.join('\n') !== 'first\n--flag=value\nspaced arg') throw new Error(`unexpected context args: ${JSON.stringify(context.args)}`);
+  if (!context.artifactsDir.endsWith('/artifacts')) throw new Error('missing artifactsDir');
+  if (context.publicArtifactBaseUrl !== 'https://artifacts.example.test/run-1') throw new Error('missing publicArtifactBaseUrl');
+  if (context.env.HOMEBOY_COMPONENT_ID !== 'node-bench-context-smoke') throw new Error('missing env passthrough');
+  return { metrics: { arg_count: context.args.length } };
+}
+EOF
+
+RESULTS_FILE="$TMP_DIR/bench-results.json"
+HOMEBOY_RUNTIME_BENCH_HELPER_JS="$HELPER_JS" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_COMPONENT_ID="node-bench-context-smoke" \
+    HOMEBOY_BENCH_ITERATIONS="1" \
+    HOMEBOY_BENCH_WARMUP_ITERATIONS="0" \
+    HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_FILE" \
+    HOMEBOY_BENCH_ARTIFACTS_DIR="$TMP_DIR/artifacts" \
+    HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL="https://artifacts.example.test/run-1" \
+    HOMEBOY_BENCH_ARGS_JSON='["first","--flag=value","spaced arg"]' \
+    node "$SCRIPT_DIR/bench-runner.mjs" >/dev/null
+
+node -e '
+const fs = require("fs");
+const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (data.scenarios[0].metrics.arg_count !== 3) throw new Error("workload did not receive context args");
+' "$RESULTS_FILE"
+
+set +e
+INVALID_OUTPUT="$(HOMEBOY_RUNTIME_BENCH_HELPER_JS="$HELPER_JS" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_COMPONENT_ID="node-bench-context-smoke" \
+    HOMEBOY_BENCH_RESULTS_FILE="$TMP_DIR/invalid-results.json" \
+    HOMEBOY_BENCH_ARGS_JSON='["ok",1]' \
+    node "$SCRIPT_DIR/bench-runner.mjs" 2>&1)"
+INVALID_EXIT=$?
+set -e
+if [ "$INVALID_EXIT" -eq 0 ]; then
+    echo "expected invalid HOMEBOY_BENCH_ARGS_JSON to fail" >&2
+    exit 1
+fi
+if [[ "$INVALID_OUTPUT" != *'HOMEBOY_BENCH_ARGS_JSON must be a JSON array of strings'* ]]; then
+    echo "expected clear HOMEBOY_BENCH_ARGS_JSON validation error" >&2
+    echo "$INVALID_OUTPUT" >&2
+    exit 1
+fi
+
+echo "Node.js bench workload context smoke passed."


### PR DESCRIPTION
## Summary
- Parse `HOMEBOY_BENCH_ARGS_JSON` as the generic bench passthrough args contract.
- Pass imported Node.js bench workloads a context object with `args`, `artifactsDir`, `publicArtifactBaseUrl`, and `env`.
- Keep existing zero-argument workloads compatible.
- Add a focused smoke covering `context.args` and invalid args JSON.

Depends on Homeboy core PR Extra-Chill/homeboy#7220 for the env producer; with older Homeboy, args default to `[]`.

## Verification
- `nodejs/scripts/bench/nodejs-bench-workload-context-smoke.sh`
- `node --check nodejs/scripts/bench/bench-runner.mjs`
- `nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode; subagent coding workflow
- **Used for:** Implementing the generic Node.js workload context and focused smoke coverage.
