### PR TITLE
Document core fuzz plan boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ task boundary. HBX may describe WordPress targets, seeds, limits, coverage
 requests, and artifact expectations, but WP Codebox owns the fuzz execution
 loop and result envelope.
 
+Caller workflows should use core `homeboy fuzz plan` to compose the
+Homeboy-level fuzz execution request. HBX does not own `homeboy fuzz ...`
+command assembly; it only contributes WordPress-specific contracts that the
+core planner and WP Codebox runtime consume.
+
 Each extension also exposes a CLI binding for direct use against a project or component:
 
 ```bash

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -383,6 +383,24 @@ The manifest is intentionally product-agnostic. Product-specific target
 selection, fixture content, and assertions belong in caller-owned manifests or
 runtime inputs, not in the shared contract.
 
+Homeboy-level fuzz execution requests are composed by core `homeboy fuzz plan`,
+not by this extension. Use the core planner in workflows before handing the
+selected request to a runner:
+
+```bash
+homeboy fuzz plan my-wordpress-component \
+  --workload generic-rest-fuzz \
+  --run-id generic-rest-fuzz-20260702 \
+  --gate-profile evidence \
+  --case-budget 25 \
+  --output artifacts/fuzz/request.json
+```
+
+The WordPress extension boundary is the data contract: fuzz manifests, surface
+discovery, WordPress fuzz plans, runtime capabilities, and the Codebox-owned
+`wp-codebox/fuzz-suite/v1` payload. The extension does not assemble
+`homeboy fuzz ...` shell commands for workflow callers.
+
 ### Surface discovery and fuzz schemas
 
 The WordPress extension exposes product-agnostic data shapes for discovering

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -133,6 +133,7 @@
     "test:wordpress-runtime-surface-discovery": "node tests/wordpress-runtime-surface-discovery-smoke.js",
     "test:wordpress-live-surface-discovery": "node tests/wordpress-live-surface-discovery-smoke.js",
     "test:wordpress-fuzz-plan-from-surfaces": "node tests/wordpress-fuzz-plan-from-surfaces-smoke.js",
+    "test:core-fuzz-plan-boundary": "node tests/core-fuzz-plan-boundary-smoke.js",
     "test:wordpress-fuzz-campaign": "node tests/wordpress-fuzz-campaign-smoke.js",
     "test:wordpress-dependency-materialization-recipes": "node tests/wordpress-dependency-materialization-recipes-smoke.js",
     "test:wp-codebox-browser-metrics": "node tests/wp-codebox-browser-metrics-smoke.js",

--- a/wordpress/tests/core-fuzz-plan-boundary-smoke.js
+++ b/wordpress/tests/core-fuzz-plan-boundary-smoke.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.join(__dirname, '..', '..');
+
+const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+const readIfExists = (relativePath) => {
+	const filePath = path.join(repoRoot, relativePath);
+	return fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '';
+};
+
+const readDirectoryFiles = (directory, predicate) => {
+	const root = path.join(repoRoot, directory);
+	if (!fs.existsSync(root)) {
+		return [];
+	}
+	return fs.readdirSync(root)
+		.filter((entry) => predicate(entry))
+		.map((entry) => read(path.join(directory, entry)));
+};
+
+const readme = read('README.md');
+const wordpressDocs = read('docs/extensions/wordpress.md');
+
+assert(readme.includes('core `homeboy fuzz plan`'), 'README must route workflow fuzz request composition through core homeboy fuzz plan.');
+assert(wordpressDocs.includes('homeboy fuzz plan my-wordpress-component'), 'WordPress extension docs must include a core fuzz plan workflow example.');
+assert(wordpressDocs.includes('wp-codebox/fuzz-suite/v1'), 'WordPress extension docs must preserve the WP Codebox fuzz-suite runtime boundary.');
+
+const workflowAndScriptText = [
+	...readDirectoryFiles('.github/workflows', (entry) => entry.endsWith('.yml') || entry.endsWith('.yaml')),
+	...readDirectoryFiles('.github/scripts/runtime-agent-full-run', (entry) => entry.endsWith('.cjs') || entry.endsWith('.mjs') || entry.endsWith('.js')),
+	readIfExists('wordpress/package.json'),
+].join('\n');
+
+assert(!/homeboy\s+fuzz\s+run/.test(workflowAndScriptText), 'HBX workflows/scripts should not compose homeboy fuzz run commands; use core homeboy fuzz plan upstream.');
+
+const help = spawnSync('homeboy', ['fuzz', 'plan', '--help'], { encoding: 'utf8' });
+if (help.error && help.error.code === 'ENOENT') {
+	console.log('core fuzz plan boundary smoke skipped homeboy CLI probe because homeboy is not installed');
+} else {
+	assert.equal(help.status, 0, help.stderr || help.stdout);
+	assert((help.stdout || help.stderr).includes('Build a fuzz execution request without executing it'));
+}
+
+console.log('core fuzz plan boundary smoke passed');


### PR DESCRIPTION
## Summary
- Document that workflows should use core `homeboy fuzz plan` for Homeboy-level fuzz execution request composition.
- Clarify the WordPress extension boundary around data contracts and WP Codebox `wp-codebox/fuzz-suite/v1` runtime execution.
- Add a smoke test covering the documented core fuzz plan boundary and absence of HBX workflow-side `homeboy fuzz run` composition.

## Verification
- `npm run test:core-fuzz-plan-boundary`
- `npm run test:wp-codebox-fuzz-plan-recipe-builder`
- `npm run test:wordpress-fuzz-runner`

## Known existing failure
- `npm run test:wp-codebox-fuzz-suite` currently fails before this change's touched path due to a runtime contract source path expectation mismatch: expected cache `contracts.js`, resolved package `dist/index.js`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected the fuzz boundary, documented the core planner handoff, added the boundary smoke test, and ran verification.