### PR TITLE
Consume finalization outcome for workspace publication

### DIFF
--- a/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
+++ b/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
@@ -721,6 +721,13 @@ function parseHomeboyJsonOutput(stdout) {
   return plainObject(parsed?.data) ? parsed.data : parsed;
 }
 
+function requireFinalizationOutcome(report) {
+  if (!plainObject(report.finalization_outcome)) {
+    throw new Error('homeboy agent-task finalize-pr did not return finalization_outcome; upgrade Homeboy core before using runner workspace publication finalization');
+  }
+  return report.finalization_outcome;
+}
+
 function finalizeWorkspaceReview(config, workspace, publication, delta, lifecycle = {}, hooks = {}) {
   const gateArgs = finalizationGateArgs({
     ...lifecycle,
@@ -776,24 +783,23 @@ function finalizeWorkspaceReview(config, workspace, publication, delta, lifecycl
     throw new Error((result.stderr || result.stdout || 'homeboy agent-task finalize-pr failed').trim());
   }
   const report = parseHomeboyJsonOutput(result.stdout) || {};
-  const publicationProof = plainObject(report.publication_proof) ? report.publication_proof : {};
-  const target = plainObject(publicationProof.target) ? publicationProof.target : {};
-  const url = report.pr_url || publicationProof.adapter_ref || target.url || '';
-  const action = report.pr_action || publicationProof.adapter_action || '';
+  const finalizationOutcome = requireFinalizationOutcome(report);
+  const target = plainObject(finalizationOutcome.target) ? finalizationOutcome.target : {};
+  const changedFiles = Array.isArray(finalizationOutcome.changed_files) ? finalizationOutcome.changed_files : [];
   return {
     report,
-    changed: Array.isArray(report.changed_files) ? report.changed_files.length > 0 : delta.changed,
-    head: report.head || publication.branch,
-    base: report.base || publication.base,
-    url,
-    action,
-    pr_number: report.pr_number ?? null,
-    pr_state: url ? 'OPEN' : '',
-    files: Array.isArray(report.changed_files) ? report.changed_files : delta.staged,
-    // TODO(homeboy-core): pass these through when finalize-pr exposes explicit
-    // publication_intent/publication_proof fields in its JSON report.
-    publication_intent: report.publication_intent || null,
-    publication_proof: report.publication_proof || null,
+    outcome: finalizationOutcome,
+    changed: changedFiles.length > 0,
+    head: finalizationOutcome.head || target.head || publication.branch,
+    base: finalizationOutcome.base || target.base || publication.base,
+    url: finalizationOutcome.pr_url || target.url || '',
+    action: finalizationOutcome.publication_action || '',
+    publication_status: finalizationOutcome.publication_status || finalizationOutcome.status || '',
+    published: finalizationOutcome.published === true,
+    pr_number: finalizationOutcome.pr_number ?? null,
+    files: changedFiles,
+    publication_intent: report.publication_intent,
+    publication_proof: report.publication_proof,
   };
 }
 
@@ -817,31 +823,32 @@ function publishWorkspace(config, results, scenario, workspace, files, hooks = {
   const evidenceRef = publicationEvidenceRef({
     repo: publication.repo,
     head: finalization.head,
-    base: publication.base,
+    base: finalization.base,
     url,
     action: finalization.action,
     number: finalization.pr_number,
-    state: finalization.pr_state,
+    state: finalization.publication_status,
     files: finalization.files,
   });
 
 
   return {
-    opened: Boolean(url),
+    opened: finalization.published,
     changed: true,
     tool_name: 'host_runner_workspace_publication',
     source: 'host_runner_lifecycle',
-    success: Boolean(url),
+    success: finalization.published,
     repo: publication.repo,
     head: finalization.head,
-    base: publication.base,
+    base: finalization.base,
     url,
     action: finalization.action,
+    publication_status: finalization.publication_status,
     pr_number: finalization.pr_number,
-    pr_state: finalization.pr_state,
     files: finalization.files,
     publication_evidence_ref: evidenceRef,
     finalization: finalization.report,
+    finalization_outcome: finalization.outcome,
     publication_intent: finalization.publication_intent,
     publication_proof: finalization.publication_proof,
   };
@@ -1011,6 +1018,7 @@ module.exports = {
   publishWorkspace,
   prepareRunnerCommand,
   recordLifecycle,
+  requireFinalizationOutcome,
   runDeterministicWorkspaceLifecycle,
   runShellCommand,
   scenarioById,

--- a/runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
+++ b/runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
@@ -17,6 +17,7 @@ const {
   preparePublication,
   publicationTemplates,
   publishWorkspace,
+  requireFinalizationOutcome,
   validateWritablePaths,
 } = require('../lib/workspace-publication-lifecycle.cjs');
 
@@ -132,6 +133,53 @@ try {
           pr_number: 1291,
           pr_url: 'https://github.com/owner/repo/pull/1291',
           changed_files: ['docs/generated.md'],
+          publication_intent: {
+            schema: 'homeboy/agent-task-publication-intent/v1',
+            run_id: '12345',
+            action: 'review_request',
+            target: {
+              kind: 'code_review',
+              adapter: 'github_pull_request',
+              base: 'trunk',
+              head: 'agent-artifacts/fixture-agent-12345',
+            },
+          },
+          publication_proof: {
+            schema: 'homeboy/agent-task-publication-proof/v1',
+            run_id: '12345',
+            status: 'review_ready',
+            adapter_action: 'created',
+            adapter_ref: 'https://github.com/owner/repo/pull/1291',
+            target: {
+              kind: 'code_review',
+              adapter: 'github_pull_request',
+              base: 'trunk',
+              head: 'agent-artifacts/fixture-agent-12345',
+              url: 'https://github.com/owner/repo/pull/1291',
+            },
+          },
+          finalization_outcome: {
+            schema: 'homeboy/agent-task-pr-finalization-outcome/v1',
+            run_id: '12345',
+            status: 'review_ready',
+            publication_status: 'review_ready',
+            publication_action: 'created',
+            target: {
+              kind: 'code_review',
+              adapter: 'github_pull_request',
+              base: 'trunk',
+              head: 'agent-artifacts/fixture-agent-12345',
+              url: 'https://github.com/owner/repo/pull/1291',
+            },
+            base: 'trunk',
+            head: 'agent-artifacts/fixture-agent-12345',
+            pr_number: 1291,
+            pr_url: 'https://github.com/owner/repo/pull/1291',
+            changed_files: ['docs/generated.md'],
+            committed: true,
+            pushed: true,
+            published: true,
+          },
           proof: { schema: 'homeboy/proof/v1' },
         })}\n`,
         stderr: '',
@@ -169,11 +217,13 @@ try {
   assert.equal(publication.base, 'trunk');
   assert.equal(publication.url, 'https://github.com/owner/repo/pull/1291');
   assert.equal(publication.action, 'created');
+  assert.equal(publication.publication_status, 'review_ready');
   assert.equal(publication.pr_number, 1291);
   assert.deepEqual(publication.files, ['docs/generated.md']);
   assert.equal(publication.finalization.schema, 'homeboy/agent-task-pr-finalization/v1');
-  assert.equal(publication.publication_intent, null);
-  assert.equal(publication.publication_proof, null);
+  assert.equal(publication.finalization_outcome.schema, 'homeboy/agent-task-pr-finalization-outcome/v1');
+  assert.equal(publication.publication_intent.schema, 'homeboy/agent-task-publication-intent/v1');
+  assert.equal(publication.publication_proof.schema, 'homeboy/agent-task-publication-proof/v1');
   assert.deepEqual(publication.publication_evidence_ref, {
     type: 'pull_request',
     provider: 'github',
@@ -183,7 +233,7 @@ try {
     url: 'https://github.com/owner/repo/pull/1291',
     action: 'created',
     pr_number: 1291,
-    pr_state: 'OPEN',
+    pr_state: 'review_ready',
     files: ['docs/generated.md'],
   });
   const finalizationCall = calls.find((call) => call.command === 'homeboy' && call.args[0] === 'agent-task' && call.args[1] === 'finalize-pr');
@@ -198,5 +248,10 @@ try {
 } finally {
   fs.rmSync(tmp, { recursive: true, force: true });
 }
+
+assert.throws(
+  () => requireFinalizationOutcome({ schema: 'homeboy/agent-task-pr-finalization/v1' }),
+  /did not return finalization_outcome/,
+);
 
 process.stdout.write('Workspace publication lifecycle primitive checks passed\n');


### PR DESCRIPTION
## Summary
- require Homeboy core `finalization_outcome` from `agent-task finalize-pr` before accepting workspace publication finalization
- propagate outcome-owned publication status/action/target/files instead of deriving opened/success from PR URL presence
- update workspace publication lifecycle tests for the new core report shape and stale-core blocker

## Verification
- `npm test` in `runtime-agent-ci`
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `node tests/wp-codebox-runtime-contract-source-smoke.mjs`
- `node tests/wp-codebox-provider-plugin-defaults-smoke.mjs`

## Notes
- Requires Homeboy core with `homeboy/agent-task-pr-finalization-outcome/v1`. Stale core output now fails loudly instead of using local inference.
- Not run to completion: `node tests/wp-codebox-runtime-contract-built-module-canary.mjs` requires `HOMEBOY_WP_CODEBOX_CORE_MODULE`/`WP_CODEBOX_CORE_MODULE`; `node tests/wp-codebox-bundled-agents-api-smoke.mjs` currently throws on missing `component_contracts` in the smoke fixture.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI `openai/gpt-5.5` via OpenCode
- **Used for:** Implemented the outcome consumption change, updated tests, ran verification, and drafted this PR description.