### PR TITLE
Move dependency behavior into adapter manifests

### DIFF
--- a/dependency-adapters/examples/composer.json
+++ b/dependency-adapters/examples/composer.json
@@ -1,11 +1,12 @@
 {
   "schema": "homeboy-extension/dependency-adapter-manifest/v1",
   "id": "composer-package-manager",
-  "version": 1,
+  "version": 2,
   "ecosystem": "php",
   "description": "Declarative Composer dependency materialization outputs for PHP projects.",
   "project_signals": {
     "root_files": ["composer.json"],
+    "root_match": "any",
     "optional_files": ["composer.lock"]
   },
   "capabilities": {
@@ -21,6 +22,7 @@
       "id": "composer",
       "selection": {
         "priority": 1,
+        "search": "project-root",
         "default": true,
         "files": ["composer.json", "composer.lock"]
       },

--- a/dependency-adapters/examples/nodejs.json
+++ b/dependency-adapters/examples/nodejs.json
@@ -1,7 +1,7 @@
 {
   "schema": "homeboy-extension/dependency-adapter-manifest/v1",
   "id": "nodejs-package-managers",
-  "version": 1,
+  "version": 2,
   "ecosystem": "nodejs",
   "description": "Declarative Node.js package manager selection and dependency materialization outputs.",
   "project_signals": {
@@ -21,6 +21,7 @@
       "id": "pnpm",
       "selection": {
         "priority": 1,
+        "search": "upward",
         "files": ["pnpm-workspace.yaml", "pnpm-lock.yaml"]
       },
       "install": {
@@ -38,6 +39,7 @@
       "id": "yarn",
       "selection": {
         "priority": 2,
+        "search": "project-root",
         "files": ["yarn.lock"]
       },
       "install": {
@@ -55,6 +57,7 @@
       "id": "npm",
       "selection": {
         "priority": 3,
+        "search": "project-root",
         "default": true,
         "files": ["package-lock.json"]
       },

--- a/dependency-adapters/examples/wordpress.json
+++ b/dependency-adapters/examples/wordpress.json
@@ -1,11 +1,12 @@
 {
   "schema": "homeboy-extension/dependency-adapter-manifest/v1",
   "id": "wordpress-dependency-helpers",
-  "version": 1,
+  "version": 2,
   "ecosystem": "wordpress",
   "description": "WordPress extension helper surface for composing PHP, JavaScript, and WP-CLI dependency preparation.",
   "project_signals": {
     "root_files": ["wp-content", "wp-includes"],
+    "root_match": "all",
     "optional_files": ["composer.json", "package.json", "wp-cli.yml"]
   },
   "capabilities": {

--- a/dependency-adapters/schema.json
+++ b/dependency-adapters/schema.json
@@ -34,6 +34,10 @@
           "minItems": 1,
           "items": { "type": "string" }
         },
+        "root_match": {
+          "type": "string",
+          "enum": ["any", "all"]
+        },
         "optional_files": {
           "type": "array",
           "items": { "type": "string" }
@@ -80,6 +84,10 @@
             "files": {
               "type": "array",
               "items": { "type": "string" }
+            },
+            "search": {
+              "type": "string",
+              "enum": ["project-root", "upward"]
             },
             "default": { "type": "boolean" }
           }

--- a/docs/project-script-runtime.md
+++ b/docs/project-script-runtime.md
@@ -39,9 +39,14 @@ The helper exposes these generic functions:
 
 ## Current Adapters
 
-The current adapter is `node` / `nodejs`. It finds the nearest `package.json` at
-or above the input path and selects the package manager from committed project
-signals in this order:
+The current adapters are declared in
+[`../dependency-adapters/examples/`](../dependency-adapters/examples/). The
+helper loads those manifests to discover project roots, select package managers,
+build script/exec commands, and choose install commands.
+
+`node` / `nodejs` finds the nearest `package.json` at or above the input path and
+selects the package manager from committed project signals in manifest priority
+order:
 
 1. `pnpm-lock.yaml` -> `pnpm`
 2. `yarn.lock` -> `yarn`
@@ -51,12 +56,18 @@ Lockfiles are authoritative even when the corresponding executable is missing on
 the current host. That keeps discovery deterministic; execution then fails with a
 normal missing-tool error instead of silently running the wrong package manager.
 
-The declarative version of this package-manager knowledge lives in
-[`../dependency-adapters/examples/nodejs.json`](../dependency-adapters/examples/nodejs.json).
-Composer and WordPress helper examples live beside it. These manifests are the
-extension-owned seam for dependency materialization adapters; they document
-capabilities and outputs without adding package-manager knowledge to Homeboy
-core.
+The pnpm adapter uses manifest-declared upward search so a package inside a pnpm
+workspace runs scripts from the package root while installing dependencies from
+the workspace root.
+
+`composer` / `php` finds `composer.json`, exposes `composer run-script` and
+`composer exec`, and materializes `vendor/` from the Composer adapter manifest.
+
+`wordpress` requires the manifest-declared WordPress root signals
+(`wp-content` and `wp-includes`) and composes helper behavior from the Composer
+and Node.js adapters when `composer.json` or `package.json` are present. The
+WordPress adapter describes the helper surface without embedding package-manager
+behavior in Homeboy core.
 
 ## Homeboy Core Seam
 

--- a/scripts/lib/project-scripts.sh
+++ b/scripts/lib/project-scripts.sh
@@ -18,16 +18,129 @@ homeboy_project_find_file_upward() {
     return 1
 }
 
-homeboy_project_find_pnpm_root_upward() {
+homeboy_project_adapter_manifest_file() {
+    local _ecosystem="$1"
+    local _base_dir="${HOMEBOY_DEPENDENCY_ADAPTERS_PATH:-}"
+    if [ -z "$_base_dir" ]; then
+        _base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/dependency-adapters/examples"
+    fi
+
+    case "$_ecosystem" in
+        node|nodejs)
+            printf '%s\n' "$_base_dir/nodejs.json"
+            ;;
+        composer|php)
+            printf '%s\n' "$_base_dir/composer.json"
+            ;;
+        wordpress|wp)
+            printf '%s\n' "$_base_dir/wordpress.json"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+homeboy_project_manifest_value() {
+    local _manifest="$1"
+    local _path="$2"
+    MANIFEST_FILE="$_manifest" MANIFEST_PATH="$_path" node -e '
+        const fs = require("fs");
+        let value = JSON.parse(fs.readFileSync(process.env.MANIFEST_FILE, "utf8"));
+        for (const part of process.env.MANIFEST_PATH.split(".")) {
+            value = value && value[part];
+        }
+        if (value === undefined || value === null) process.exit(1);
+        if (Array.isArray(value)) console.log(value.join("\n"));
+        else console.log(String(value));
+    '
+}
+
+homeboy_project_find_manifest_root_upward() {
     local _dir="$1"
+    local _manifest="$2"
+    local _match
+    local _files
+    _match="$(homeboy_project_manifest_value "$_manifest" "project_signals.root_match" 2>/dev/null || printf 'any')"
+    _files="$(homeboy_project_manifest_value "$_manifest" "project_signals.root_files")" || return 1
+
     while [ "$_dir" != "/" ] && [ "$_dir" != "." ]; do
-        if [ -f "$_dir/pnpm-workspace.yaml" ] || [ -f "$_dir/pnpm-lock.yaml" ]; then
+        local _found=0
+        local _missing=0
+        while IFS= read -r _file; do
+            [ -z "$_file" ] && continue
+            if [ -e "$_dir/$_file" ]; then
+                _found=1
+            else
+                _missing=1
+            fi
+        done <<EOF
+$_files
+EOF
+        if { [ "$_match" = "all" ] && [ "$_missing" -eq 0 ]; } || { [ "$_match" != "all" ] && [ "$_found" -eq 1 ]; }; then
             printf '%s\n' "$_dir"
             return 0
         fi
         _dir="$(dirname "$_dir")"
     done
     return 1
+}
+
+homeboy_project_select_package_manager() {
+    local _manifest="$1"
+    local _root="$2"
+    MANIFEST_FILE="$_manifest" PROJECT_ROOT="$_root" node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_FILE, 'utf8'));
+const root = process.env.PROJECT_ROOT;
+const managers = [...(manifest.package_managers || [])].sort((a, b) => a.selection.priority - b.selection.priority);
+
+function findUpward(files) {
+    let dir = root;
+    while (dir && dir !== path.dirname(dir)) {
+        if (files.some((file) => fs.existsSync(path.join(dir, file)))) return dir;
+        dir = path.dirname(dir);
+    }
+    return null;
+}
+
+let fallback = null;
+for (const manager of managers) {
+    const selection = manager.selection || {};
+    if (selection.default) fallback = manager;
+    const files = selection.files || [];
+    const selectedRoot = selection.search === 'upward' ? findUpward(files) : (files.some((file) => fs.existsSync(path.join(root, file))) ? root : null);
+    if (selectedRoot) {
+        console.log(`${manager.id}\t${selectedRoot}`);
+        process.exit(0);
+    }
+}
+
+if (fallback) {
+    console.log(`${fallback.id}\t${root}`);
+    process.exit(0);
+}
+
+process.exit(1);
+NODE
+}
+
+homeboy_project_package_manager_value() {
+    local _manifest="$1"
+    local _manager="$2"
+    local _path="$3"
+    MANIFEST_FILE="$_manifest" PACKAGE_MANAGER="$_manager" MANAGER_PATH="$_path" node -e '
+        const fs = require("fs");
+        const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_FILE, "utf8"));
+        const manager = (manifest.package_managers || []).find((item) => item.id === process.env.PACKAGE_MANAGER);
+        let value = manager;
+        for (const part of process.env.MANAGER_PATH.split(".")) {
+            value = value && value[part];
+        }
+        if (value === undefined || value === null) process.exit(1);
+        console.log(String(value));
+    '
 }
 
 homeboy_project_init() {
@@ -51,53 +164,58 @@ homeboy_project_init() {
         esac
     done
 
-    case "$_ecosystem" in
-        node|nodejs)
-            homeboy_project_init_node "$_dir"
-            ;;
-        "")
+    if [ -z "$_ecosystem" ]; then
             echo "Error: homeboy_project_init requires --ecosystem" >&2
             return 1
-            ;;
-        *)
-            echo "Error: Unsupported Homeboy project ecosystem: $_ecosystem" >&2
-            return 1
-            ;;
-    esac
+    fi
+
+    homeboy_project_init_manifest "$_ecosystem" "$_dir"
 }
 
-homeboy_project_init_node() {
-    local _dir="$1"
+homeboy_project_init_manifest() {
+    local _ecosystem="$1"
+    local _dir="$2"
+    local _manifest
     local _root
-    local _pnpm_root
+    local _selection
+    local _script_manifest
 
-    if ! _root="$(homeboy_project_find_file_upward "$_dir" "package.json")"; then
-        echo "Error: No package.json found at or above ${_dir}" >&2
-        echo "Not a Node.js project -- cannot run." >&2
+    if ! _manifest="$(homeboy_project_adapter_manifest_file "$_ecosystem")" || [ ! -f "$_manifest" ]; then
+        echo "Error: Unsupported Homeboy project ecosystem: $_ecosystem" >&2
         return 1
     fi
 
-    HOMEBOY_PROJECT_ECOSYSTEM="node"
+    if ! _root="$(homeboy_project_find_manifest_root_upward "$_dir" "$_manifest")"; then
+        echo "Error: No $(homeboy_project_manifest_value "$_manifest" "project_signals.root_files" | tr '\n' '/' | sed 's:/$::') found at or above ${_dir}" >&2
+        echo "Not a $(homeboy_project_manifest_value "$_manifest" "ecosystem") project -- cannot run." >&2
+        return 1
+    fi
+
+    HOMEBOY_PROJECT_ADAPTER_MANIFEST="$_manifest"
+    HOMEBOY_PROJECT_ECOSYSTEM="$(homeboy_project_manifest_value "$_manifest" "ecosystem")"
     HOMEBOY_PROJECT_ROOT="$_root"
     HOMEBOY_PROJECT_DEPENDENCY_ROOT="$_root"
-    HOMEBOY_PROJECT_SCRIPT_FILE="${_root}/package.json"
 
-    if _pnpm_root="$(homeboy_project_find_pnpm_root_upward "$_root")"; then
-        HOMEBOY_PROJECT_DEPENDENCY_ROOT="$_pnpm_root"
-        HOMEBOY_PROJECT_PACKAGE_MANAGER="pnpm"
-        HOMEBOY_PROJECT_RUN_CMD="pnpm run"
-        HOMEBOY_PROJECT_EXEC_CMD="pnpm exec"
-    elif [ -f "$_root/yarn.lock" ]; then
-        HOMEBOY_PROJECT_PACKAGE_MANAGER="yarn"
-        HOMEBOY_PROJECT_RUN_CMD="yarn"
-        HOMEBOY_PROJECT_EXEC_CMD="yarn"
+    if _selection="$(homeboy_project_select_package_manager "$_manifest" "$_root")"; then
+        HOMEBOY_PROJECT_PACKAGE_MANAGER="${_selection%%$'\t'*}"
+        HOMEBOY_PROJECT_DEPENDENCY_ROOT="${_selection#*$'\t'}"
+        _script_manifest="$(homeboy_project_package_manager_value "$_manifest" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "scripts.manifest" 2>/dev/null || true)"
+        HOMEBOY_PROJECT_RUN_CMD="$(homeboy_project_package_manager_value "$_manifest" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "scripts.run_command" 2>/dev/null || true)"
+        HOMEBOY_PROJECT_EXEC_CMD="$(homeboy_project_package_manager_value "$_manifest" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "scripts.exec_command" 2>/dev/null || true)"
+        if [ -n "$_script_manifest" ]; then
+            HOMEBOY_PROJECT_SCRIPT_FILE="${_root}/${_script_manifest}"
+        else
+            HOMEBOY_PROJECT_SCRIPT_FILE=""
+        fi
     else
-        HOMEBOY_PROJECT_PACKAGE_MANAGER="npm"
-        HOMEBOY_PROJECT_RUN_CMD="npm run"
-        HOMEBOY_PROJECT_EXEC_CMD="npx"
+        HOMEBOY_PROJECT_PACKAGE_MANAGER=""
+        HOMEBOY_PROJECT_RUN_CMD=""
+        HOMEBOY_PROJECT_EXEC_CMD=""
+        HOMEBOY_PROJECT_SCRIPT_FILE=""
     fi
 
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: Dependency adapter manifest: $HOMEBOY_PROJECT_ADAPTER_MANIFEST" >&2
         echo "DEBUG: Project ecosystem: $HOMEBOY_PROJECT_ECOSYSTEM" >&2
         echo "DEBUG: Project root: $HOMEBOY_PROJECT_ROOT" >&2
         echo "DEBUG: Dependency root: $HOMEBOY_PROJECT_DEPENDENCY_ROOT" >&2
@@ -117,11 +235,11 @@ homeboy_project_has_script() {
     homeboy_project_require_script_file || return 1
 
     case "${HOMEBOY_PROJECT_ECOSYSTEM:-}" in
-        node)
+        nodejs|php)
             HOMEBOY_PROJECT_SCRIPT_NAME="$_script" \
-            HOMEBOY_PROJECT_PACKAGE_JSON="$HOMEBOY_PROJECT_SCRIPT_FILE" \
+            HOMEBOY_PROJECT_SCRIPT_JSON="$HOMEBOY_PROJECT_SCRIPT_FILE" \
                 node -e '
-                    const pkg = require(process.env.HOMEBOY_PROJECT_PACKAGE_JSON);
+                    const pkg = require(process.env.HOMEBOY_PROJECT_SCRIPT_JSON);
                     const script = process.env.HOMEBOY_PROJECT_SCRIPT_NAME;
                     process.exit(pkg.scripts && pkg.scripts[script] ? 0 : 1);
                 ' 2>/dev/null
@@ -173,43 +291,58 @@ homeboy_project_exec() {
 }
 
 homeboy_project_ensure_dependencies() {
-    if [ "${HOMEBOY_PROJECT_ECOSYSTEM:-}" != "node" ]; then
-        echo "Error: Dependency installation is not implemented for ecosystem: ${HOMEBOY_PROJECT_ECOSYSTEM:-}" >&2
-        return 1
-    fi
-
     local _dir="${HOMEBOY_PROJECT_DEPENDENCY_ROOT:-${HOMEBOY_PROJECT_ROOT:-}}"
     if [ -z "$_dir" ]; then
         echo "Error: homeboy_project_init must be called before dependency helpers" >&2
         return 1
     fi
 
-    if [ -d "$_dir/node_modules" ]; then
+    if [ "${HOMEBOY_PROJECT_ECOSYSTEM:-}" = "wordpress" ]; then
+        local _status=0
+        if [ -f "$_dir/composer.json" ]; then
+            (homeboy_project_init --ecosystem composer --path "$_dir" && homeboy_project_ensure_dependencies) || _status=$?
+        fi
+        if [ -f "$_dir/package.json" ]; then
+            (homeboy_project_init --ecosystem nodejs --path "$_dir" && homeboy_project_ensure_dependencies) || _status=$?
+        fi
+        return "$_status"
+    fi
+
+    if [ -z "${HOMEBOY_PROJECT_ADAPTER_MANIFEST:-}" ] || [ -z "${HOMEBOY_PROJECT_PACKAGE_MANAGER:-}" ]; then
+        echo "Error: Dependency installation is not implemented for ecosystem: ${HOMEBOY_PROJECT_ECOSYSTEM:-}" >&2
+        return 1
+    fi
+
+    local _output_path
+    _output_path="$(homeboy_project_package_manager_value "$HOMEBOY_PROJECT_ADAPTER_MANIFEST" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "outputs.0.path" 2>/dev/null || true)"
+    if [ -n "$_output_path" ] && [ -e "$_dir/$_output_path" ]; then
         return 0
     fi
 
-    echo "Installing Node.js dependencies..."
-    case "${HOMEBOY_PROJECT_PACKAGE_MANAGER:-npm}" in
-        pnpm)
-            (cd "$_dir" && pnpm install --frozen-lockfile)
-            ;;
-        yarn)
-            (cd "$_dir" && yarn install --frozen-lockfile)
-            ;;
-        npm|*)
-            # `npm ci` only makes sense for a committed, authoritative
-            # lockfile. A gitignored/untracked package-lock.json is a local
-            # artifact that nothing keeps in sync with package.json, so a stale
-            # leftover would make `npm ci` fail on an unfixable desync. Use
-            # `npm install` to refresh it in that case.
-            if [ -f "$_dir/package-lock.json" ] \
-                && command -v git >/dev/null 2>&1 \
-                && git -C "$_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-                && git -C "$_dir" ls-files --error-unmatch package-lock.json >/dev/null 2>&1; then
-                (cd "$_dir" && npm ci)
-            else
-                (cd "$_dir" && npm install)
-            fi
-            ;;
-    esac
+    local _intent
+    local _command
+    local _fallback_command
+    _intent="$(homeboy_project_package_manager_value "$HOMEBOY_PROJECT_ADAPTER_MANIFEST" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "install.intent")"
+    _command="$(homeboy_project_package_manager_value "$HOMEBOY_PROJECT_ADAPTER_MANIFEST" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "install.command" 2>/dev/null || true)"
+    _fallback_command="$(homeboy_project_package_manager_value "$HOMEBOY_PROJECT_ADAPTER_MANIFEST" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "install.fallback_command" 2>/dev/null || true)"
+
+    echo "Installing ${HOMEBOY_PROJECT_ECOSYSTEM} dependencies with ${HOMEBOY_PROJECT_PACKAGE_MANAGER}..."
+    if [ "$_intent" = "locked-or-refresh" ] && [ -n "$_fallback_command" ]; then
+        local _lockfile=""
+        case "$HOMEBOY_PROJECT_PACKAGE_MANAGER" in
+            npm) _lockfile="package-lock.json" ;;
+            composer) _lockfile="composer.lock" ;;
+        esac
+        if [ -n "$_lockfile" ] \
+            && [ -f "$_dir/$_lockfile" ] \
+            && command -v git >/dev/null 2>&1 \
+            && git -C "$_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+            && git -C "$_dir" ls-files --error-unmatch "$_lockfile" >/dev/null 2>&1; then
+            (cd "$_dir" && $_command)
+        else
+            (cd "$_dir" && $_fallback_command)
+        fi
+    else
+        (cd "$_dir" && $_command)
+    fi
 }

--- a/tests/project-scripts-pnpm-workspace-smoke.sh
+++ b/tests/project-scripts-pnpm-workspace-smoke.sh
@@ -22,5 +22,84 @@ bash -c '
     [ "$HOMEBOY_PROJECT_ROOT" = "$2/packages/plugin" ]
     [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
     [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
+    [ "$(basename "$HOMEBOY_PROJECT_ADAPTER_MANIFEST")" = "nodejs.json" ]
     [ "$(homeboy_project_run_script_command test)" = "pnpm run test" ]
 ' _ "$PROJECT_SCRIPTS" "$WORKSPACE_PROJECT"
+
+COMPOSER_PROJECT="$TMP_DIR/composer-project"
+mkdir -p "$COMPOSER_PROJECT/src"
+cat > "$COMPOSER_PROJECT/composer.json" <<'EOF'
+{"scripts":{"test":"phpunit"}}
+EOF
+
+bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem composer --path "$2/src"
+    [ "$HOMEBOY_PROJECT_ECOSYSTEM" = "php" ]
+    [ "$HOMEBOY_PROJECT_ROOT" = "$2" ]
+    [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
+    [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "composer" ]
+    [ "$(basename "$HOMEBOY_PROJECT_ADAPTER_MANIFEST")" = "composer.json" ]
+    [ "$(homeboy_project_run_script_command test)" = "composer run-script test" ]
+    [ "$(homeboy_project_exec_command phpunit --filter Example)" = "composer exec phpunit --filter Example" ]
+    homeboy_project_has_script test
+    ! homeboy_project_has_script build
+' _ "$PROJECT_SCRIPTS" "$COMPOSER_PROJECT"
+
+FAKE_BIN="$TMP_DIR/bin"
+COMMAND_LOG="$TMP_DIR/dependency-commands.log"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/npm" <<'EOF'
+#!/usr/bin/env bash
+printf 'npm %s\n' "$*" >> "$HOMEBOY_DEPENDENCY_COMMAND_LOG"
+EOF
+cat > "$FAKE_BIN/composer" <<'EOF'
+#!/usr/bin/env bash
+printf 'composer %s\n' "$*" >> "$HOMEBOY_DEPENDENCY_COMMAND_LOG"
+EOF
+chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/composer"
+
+NPM_PROJECT="$TMP_DIR/npm-project"
+mkdir -p "$NPM_PROJECT"
+cat > "$NPM_PROJECT/package.json" <<'EOF'
+{"scripts":{}}
+EOF
+
+PATH="$FAKE_BIN:$PATH" HOMEBOY_DEPENDENCY_COMMAND_LOG="$COMMAND_LOG" bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem nodejs --path "$2"
+    homeboy_project_ensure_dependencies
+' _ "$PROJECT_SCRIPTS" "$NPM_PROJECT"
+grep -q '^npm install$' "$COMMAND_LOG"
+
+PATH="$FAKE_BIN:$PATH" HOMEBOY_DEPENDENCY_COMMAND_LOG="$COMMAND_LOG" bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem composer --path "$2"
+    homeboy_project_ensure_dependencies
+' _ "$PROJECT_SCRIPTS" "$COMPOSER_PROJECT"
+grep -q '^composer update$' "$COMMAND_LOG"
+
+WORDPRESS_PROJECT="$TMP_DIR/wordpress-project"
+mkdir -p "$WORDPRESS_PROJECT/wp-content/plugins/example" "$WORDPRESS_PROJECT/wp-includes"
+cat > "$WORDPRESS_PROJECT/package.json" <<'EOF'
+{"scripts":{"build":"wp-scripts build"}}
+EOF
+cat > "$WORDPRESS_PROJECT/composer.json" <<'EOF'
+{"scripts":{"lint":"phpcs"}}
+EOF
+
+bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem wordpress --path "$2/wp-content/plugins/example"
+    [ "$HOMEBOY_PROJECT_ECOSYSTEM" = "wordpress" ]
+    [ "$HOMEBOY_PROJECT_ROOT" = "$2" ]
+    [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
+    [ "$(basename "$HOMEBOY_PROJECT_ADAPTER_MANIFEST")" = "wordpress.json" ]
+' _ "$PROJECT_SCRIPTS" "$WORDPRESS_PROJECT"
+
+WORDPRESS_INCOMPLETE="$TMP_DIR/wordpress-incomplete"
+mkdir -p "$WORDPRESS_INCOMPLETE/wp-content/plugins/example"
+if bash -c 'source "$1"; homeboy_project_init --ecosystem wordpress --path "$2/wp-content/plugins/example"' _ "$PROJECT_SCRIPTS" "$WORDPRESS_INCOMPLETE" 2>/dev/null; then
+    echo "WordPress adapter should require all root signals from the manifest" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Load dependency adapter manifests from the shared project script helper instead of hardcoding Node package-manager behavior.
- Add manifest fields for root matching and package-manager search scope, with version bumps for Node.js, Composer, and WordPress adapter examples.
- Add Composer and WordPress helper coverage plus fake-install assertions for manifest-driven npm/composer install behavior.

## Tests
- `node tests/dependency-adapter-manifests-smoke.mjs`
- `bash tests/project-scripts-pnpm-workspace-smoke.sh`
- `bash nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the manifest-backed helper behavior, tests, docs, verification, and PR preparation with Chris reviewing the requested scope.