### PR TITLE
Trim runtime agent CI root barrel

### DIFF
--- a/.github/scripts/runtime-agent-full-run/run-runtime-agent-task.cjs
+++ b/.github/scripts/runtime-agent-full-run/run-runtime-agent-task.cjs
@@ -12,12 +12,12 @@ const path = require('node:path');
 /**
  * Internal dependencies
  */
-const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
+const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../../../runtime-agent-ci/provider-adapters');
 const {
   genericAgentLoopStdoutSummary,
   runGenericAgentLoop,
   writeGenericAgentLoopArtifacts,
-} = require('../../../runtime-agent-ci');
+} = require('../../../runtime-agent-ci/generic-orchestration');
 const { resolveControllerLoopProofPolicy } = require('./lib/proof-profile.cjs');
 
 const SCRIPT_DIR = __dirname;

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ helper contract.
 Generic runtime loop, fanout/reconcile, proof, and lifecycle primitives are
 exported from `homeboy-runtime-agent-ci/generic-orchestration`; provider and
 workflow adapters are exported from `homeboy-runtime-agent-ci/provider-adapters`.
-The legacy `homeboy-runtime-agent-ci` root export is a deprecated compatibility
-barrel and should not be used by new callers. Module internals live in
+The legacy `homeboy-runtime-agent-ci` root export is a deprecated provider-adapter
+compatibility barrel and should not be used by new callers. Module internals live in
 
 Declarative dependency adapter manifests live in
 [`dependency-adapters/`](dependency-adapters/). They describe extension-owned

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -88,6 +88,7 @@ const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be object
 const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 const AGENT_TASK_EVENT_SCHEMA = 'homeboy/agent-task-event/v1';
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
+const HOMEBOY_RUN_RUNTIME_PACKAGE_ABILITY = 'homeboy/run-runtime-package';
 const WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY = 'wp-codebox/run-runtime-package';
 const WP_CODEBOX_RUNTIME_PACKAGE_TASK_SCHEMA = 'wp-codebox/runtime-package-task/v1';
 
@@ -1390,7 +1391,8 @@ function runtimeTaskWithExecutionDefaults(runtimeTask, defaults = {}) {
   }
   const normalizedRuntimeTask = { ...runtimeTask };
   const requestedAbility = normalizedRuntimeTask.ability;
-  const normalizedAbility = normalizedRuntimeTask.ability;
+  const normalizedAbility = requestedAbility === HOMEBOY_RUN_RUNTIME_PACKAGE_ABILITY ? WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY : requestedAbility;
+  normalizedRuntimeTask.ability = normalizedAbility;
   const abilityNormalization = runtimeTask.ability_normalization || runtimeTaskAbilityNormalization({ requestedAbility, normalizedAbility });
   if (abilityNormalization) {
     normalizedRuntimeTask.ability_normalization = abilityNormalization;

--- a/docs/generic-fanout-reconcile-workflow.md
+++ b/docs/generic-fanout-reconcile-workflow.md
@@ -62,7 +62,7 @@ For Homeboy agent-task fanout, keep record status host-owned: map provider outco
 
 ## Finding Packets
 
-`runtime-agent-ci` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` export helpers for diagnostic/finding packet inputs.
+`runtime-agent-ci/generic-orchestration` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` export helpers for diagnostic/finding packet inputs.
 
 - `normalizeFindingPacketItems(packets, policy)` flattens packet-level `findings` or `diagnostics` arrays into generic items with stable packet/finding IDs.
 - `materializeFindingPacketFanoutConfig({ packets, policy, ...config })` applies policy-driven grouping and returns the generic config/groups/items needed by the planner.

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// Deprecated compatibility barrel. New imports should use the narrower
-// ./generic-orchestration or ./provider-adapters package boundaries.
-Object.assign(module.exports, require('./generic-orchestration'));
+// Deprecated compatibility barrel. New imports should use ./provider-adapters;
+// executor-neutral helpers live behind ./generic-orchestration only.
 Object.assign(module.exports, require('./provider-adapters'));

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -23,6 +23,7 @@ const AGENT_TASK_REQUEST_SCHEMA = GENERIC_AGENT_TASK_REQUEST_SCHEMA;
 const RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID = 'runtime-agent-ci';
 
 function runtimeAgentCiRuntimeTaskRequest(options = {}, context = {}) {
+  options = normalizeRuntimeAgentCiOptions(options);
   const taskId = requiredString(options.task_id, 'task_id');
   const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile(options);
   const runtimeExecution = normalizeRuntimeExecutionDescriptor(options.runtime_execution, runtimeProfile);
@@ -40,6 +41,7 @@ function runtimeAgentCiRuntimeTaskRequest(options = {}, context = {}) {
 }
 
 function runtimeAgentCiAbilityTaskRequest(options = {}, context = {}) {
+  options = normalizeRuntimeAgentCiOptions(options);
   const taskId = requiredString(options.task_id, 'task_id');
   const ability = requiredString(options.ability, 'ability');
   const runnerSpec = runtimeAgentCiRunnerSpec({
@@ -65,6 +67,7 @@ function runtimeAgentCiAbilityTaskRequest(options = {}, context = {}) {
 }
 
 function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
+  options = normalizeRuntimeAgentCiOptions(options);
   const taskExecutorConfig = context.taskExecutorConfig || runtimeAgentCiTaskExecutorConfig;
   const config = taskExecutorConfig(options);
   // The executor runtime is only populated from an explicit runtime selector; a
@@ -96,6 +99,7 @@ function runtimeBackendForRuntime(runtime) {
 }
 
 function runtimeAgentCiTaskExecutorConfig(options = {}) {
+  options = normalizeRuntimeAgentCiOptions(options);
   const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile(options);
   const runtimeId = runtimeIdFromOptions(options, {});
   const runtimeExecution = normalizeRuntimeExecutionDescriptor(options.runtime_execution, runtimeProfile);
@@ -235,6 +239,7 @@ function runtimeAgentCiTaskFromRequest(runtimeTask = {}, abilityRequest = {}, ab
 }
 
 function resolveRuntimeAgentCiRuntimeProfile(options = {}) {
+  options = normalizeRuntimeAgentCiOptions(options);
   const runtimeProfiles = options.runtime_profiles || options.config?.runtime_profiles || {};
   const runtimeProfilePresets = options.runtime_profile_presets || options.config?.runtime_profile_presets || {};
   const requestedProfile = options.runtime_profile || options.config?.runtime_profile || RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID;
@@ -267,6 +272,7 @@ function runtimeAgentCiRuntimeProfilesForOptions(options, runtimeProfile) {
 const runtimeProfilesForOptions = runtimeAgentCiRuntimeProfilesForOptions;
 
 function runtimeAgentCiPlan(options = {}) {
+  options = normalizeRuntimeAgentCiOptions(options);
   return genericAgentTaskPlan({
     schema: AGENT_TASK_PLAN_SCHEMA,
     plan_id: options.plan_id,
@@ -274,6 +280,36 @@ function runtimeAgentCiPlan(options = {}) {
     options: options.options,
     metadata: options.metadata,
   });
+}
+
+function normalizeRuntimeAgentCiOptions(options = {}) {
+  return {
+    ...options,
+    ability_input: options.ability_input ?? options.abilityInput,
+    ability_tools: options.ability_tools ?? options.abilityTools,
+    artifact_declarations: options.artifact_declarations ?? options.artifactDeclarations,
+    artifact_slots: options.artifact_slots ?? options.artifactSlots,
+    callback_data: options.callback_data ?? options.callbackData,
+    capability_bundles: options.capability_bundles ?? options.capabilityBundles,
+    evidence_projections: options.evidence_projections ?? options.evidenceProjections,
+    expected_artifacts: options.expected_artifacts ?? options.expectedArtifacts,
+    group_key: options.group_key ?? options.groupKey,
+    ignored_workspace_paths: options.ignored_workspace_paths ?? options.ignoredWorkspacePaths,
+    parent_plan_id: options.parent_plan_id ?? options.parentPlanId,
+    plan_id: options.plan_id ?? options.planId,
+    runtime_component_paths: options.runtime_component_paths ?? options.runtimeComponentPaths,
+    runtime_execution: options.runtime_execution ?? options.runtimeExecution,
+    runtime_invocation: options.runtime_invocation ?? options.runtimeInvocation,
+    runtime_output_projections: options.runtime_output_projections ?? options.runtimeOutputProjections,
+    runtime_profile: options.runtime_profile ?? options.runtimeProfile,
+    runtime_profile_config: options.runtime_profile_config ?? options.runtimeProfileConfig,
+    runtime_profile_presets: options.runtime_profile_presets ?? options.runtimeProfilePresets,
+    runtime_profiles: options.runtime_profiles ?? options.runtimeProfiles,
+    sandbox_tool_policy: options.sandbox_tool_policy ?? options.toolPolicy,
+    task_id: options.task_id ?? options.taskId,
+    task_timeout_seconds: options.task_timeout_seconds ?? options.taskTimeoutSeconds,
+    transcript_slots: options.transcript_slots ?? options.transcriptSlots,
+  };
 }
 
 function normalizeArray(value) {

--- a/runtime-agent-ci/tests/fixtures/headless-deterministic-loop-fixture.cjs
+++ b/runtime-agent-ci/tests/fixtures/headless-deterministic-loop-fixture.cjs
@@ -55,7 +55,7 @@ function createHeadlessDeterministicLoopFixture(options = {}) {
 async function runHeadlessDeterministicLoopFixture(options = {}) {
   const fixture = createHeadlessDeterministicLoopFixture(options);
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
-  const { runHeadlessDeterministicLoop } = require(path.join(repoRoot, 'runtime-agent-ci'));
+  const { runHeadlessDeterministicLoop } = require(path.join(repoRoot, 'runtime-agent-ci/generic-orchestration'));
   const result = await runHeadlessDeterministicLoop({
     spec: fixture.spec,
     repoRoot: fixture.root,

--- a/runtime-agent-ci/tests/gate-plan-evaluator.test.js
+++ b/runtime-agent-ci/tests/gate-plan-evaluator.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const runtimeAgentCi = require('..');
+const runtimeAgentCi = require('../generic-orchestration');
 const {
   GATE_PLAN_SCHEMA,
   GATE_RESULT_SCHEMA,

--- a/tests/controller-loop-proof-validator.test.mjs
+++ b/tests/controller-loop-proof-validator.test.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
-const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci'));
+const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci/generic-orchestration'));
 const validator = require(path.join(repoRoot, 'runtime-agent-ci/lib/controller-loop-proof-validator'));
 
 assert.equal(typeof runtimeAgentCi.validateControllerLoopProof, 'function');

--- a/tests/preview-materialization-contract-smoke.mjs
+++ b/tests/preview-materialization-contract-smoke.mjs
@@ -11,7 +11,7 @@ const {
 	PREVIEW_MATERIALIZATION_REQUEST_SCHEMA,
 	materializePreview,
 	normalizePreviewMaterializationRequest,
-} = require(path.join(rootDir, 'runtime-agent-ci', 'index.js'));
+} = require(path.join(rootDir, 'runtime-agent-ci', 'provider-adapters.js'));
 
 const request = normalizePreviewMaterializationRequest({
 	id: 'preview-1',

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -131,14 +131,6 @@ assert.deepEqual(
   ),
   { ability: 'example/process', input: { source: 'artifact.json', mode: 'typed' } }
 );
-assert.deepEqual(
-  runtimeAgentCi.runtimeAgentCiFirstNonEmptyObject({}, { legacy: true }),
-  { legacy: true }
-);
-assert.deepEqual(
-  runtimeAgentCi.runtimeAgentCiFirstNonEmptyArray([], [{ legacy: true }]),
-  [{ legacy: true }]
-);
 
 const genericBundleConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
   runtimeProfile: runtimeProfile.id,
@@ -262,7 +254,7 @@ assert.deepEqual(
     expectedArtifacts: ['packet'],
   }),
   genericAgentTaskRequest({
-    taskId: 'equivalent-task',
+    task_id: 'equivalent-task',
     instructions: '',
     inputs: {},
     runnerSpec: runtimeAgentCi.runtimeAgentCiRunnerSpec({
@@ -285,7 +277,7 @@ assert.deepEqual(
     metadata: { preset: 'runtime-agent-ci' },
   }),
   genericAgentTaskPlan({
-    planId: 'equivalent-plan',
+    plan_id: 'equivalent-plan',
     tasks: [genericRequest],
     options: { concurrency: 1 },
     metadata: { preset: 'runtime-agent-ci' },

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -26,7 +26,7 @@ const {
   runtimeContractSchemas,
   typedArtifactsFromCodeboxResult,
 } = require('../../agent-runtimes/wp-codebox');
-const runtimeAgentCi = require('../../runtime-agent-ci');
+const runtimeAgentCi = require('../../runtime-agent-ci/provider-adapters');
 
 const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-agent-boundary-'));
 const codexSecretEnv = [

--- a/wordpress/tests/codebox-native-run-agent-task-smoke.js
+++ b/wordpress/tests/codebox-native-run-agent-task-smoke.js
@@ -30,7 +30,7 @@ const path = require('node:path');
 process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(__dirname, '..', '..', 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 
 const { codeboxTaskRequestFromAgentTaskRequest } = require('../../agent-runtimes/wp-codebox');
-const runtimeAgentCi = require('../../runtime-agent-ci');
+const runtimeAgentCi = require('../../runtime-agent-ci/provider-adapters');
 
 const workspaceRoot = path.join(__dirname, 'fixtures');
 

--- a/wordpress/tests/generic-agent-runtime-contract.test.js
+++ b/wordpress/tests/generic-agent-runtime-contract.test.js
@@ -16,7 +16,7 @@ const {
 } = require('../../agent-task-contracts/agent-task-runner-contract');
 const {
 	runtimeAgentCiRunnerSpec,
-} = require('../../runtime-agent-ci');
+} = require('../../runtime-agent-ci/provider-adapters');
 const {
 	buildConfig,
 } = require('../../.github/scripts/runtime-agent-full-run/build-runner-config.cjs');


### PR DESCRIPTION
## Summary
- Migrate remaining internal runtime-agent-ci root imports to generic-orchestration or provider-adapters.
- Reduce the deprecated root export to the provider-adapter compatibility surface only.
- Preserve provider-adapter camelCase option aliases used by internal callers and normalize generic runtime-package tasks for WP Codebox.

## Tests
- npm test (runtime-agent-ci)
- node tests/controller-loop-proof-validator.test.mjs && node tests/generic-fanout-reconcile-boundary.test.mjs && node tests/runtime-agent-ci-contract-smoke.mjs && node tests/preview-materialization-contract-smoke.mjs && node tests/generic-agent-loop-runner-smoke.mjs && node tests/runtime-provider-resolver-smoke.mjs && node tests/wp-codebox-preview-materialization-contract-smoke.mjs
- node wordpress/tests/generic-agent-runtime-contract.test.js && node wordpress/tests/codebox-native-run-agent-task-smoke.js && node wordpress/tests/codebox-agent-task-executor-boundary.test.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Migrated internal imports, trimmed the deprecated compatibility barrel, fixed exposed provider/Codebox contract gaps, and ran verification.