### PR TITLE
Deduplicate WP Codebox runtime schemas

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-result-boundary.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-result-boundary.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
   normalizeCodeboxPublicResultEnvelope,
 } = require('./codebox-artifact-contract');
 
@@ -40,7 +41,7 @@ function publicEnvelopeBoundaryDiagnostic(result, options = {}) {
     class: 'codebox.public_result_envelope_missing',
     message: 'WP Codebox result used private runtime fields without the canonical public artifact result envelope.',
     data: {
-      required_schema: 'wp-codebox/artifact-result-envelope/v1',
+      required_schema: WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
       private_shapes: privateShapes,
     },
   };

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -130,7 +130,7 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
   },
   {
     id: 'runtime-profile',
-    schema: 'wp-codebox/runtime-profile/v1',
+    schema: RUNTIME_CONTRACT_SCHEMAS.runtimeBoundary.profile,
     owner: 'wp-codebox',
     adapter_behavior: 'forward_profile_payload',
     requirement: 'Consume generic runtime dependencies, provider plugins, overlays, env, and mounts through the public runtime profile payload Homeboy forwards.',

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -23,6 +23,7 @@ const {
   providerCredentialSecretEnvNames,
 } = require('../../lib/provider-credential-boundary');
 const {
+  WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
   artifactNameFromDeclaration,
   artifactPath,
   normalizeTypedArtifactEntry,
@@ -1535,7 +1536,7 @@ function resultExecutions(result) {
 
 function publicArtifactResultPayload(result) {
   const envelope = plainObject(result?.artifact_result) ? result.artifact_result : (plainObject(result?.artifactResult) ? result.artifactResult : null);
-  if (!envelope || envelope.schema !== 'wp-codebox/artifact-result-envelope/v1' || !plainObject(envelope.result)) {
+  if (!envelope || envelope.schema !== WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA || !plainObject(envelope.result)) {
     return null;
   }
   return envelope.result;

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -140,6 +140,7 @@ const {
 const {
   WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA,
   WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+  WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
   WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
   WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
   wpCodeboxProviderRuntimeInvocationContract,
@@ -167,6 +168,14 @@ assert.equal(WP_CODEBOX_RUNTIME_PROFILE_SCHEMA, schemas.runtimeBoundary.profile)
 assert.equal(WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA, schemas.artifact.resultEnvelope);
 assert.equal(WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA, schemas.agentTask.runResult);
 assert.equal(WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.workspace_capture, schemas.runnerWorkspace.captureResult);
+assert.equal(
+  WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.find((requirement) => requirement.id === 'runtime-profile').schema,
+  schemas.runtimeBoundary.profile
+);
+assert.equal(
+  WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.find((requirement) => requirement.id === 'artifact-result-envelope').schema,
+  schemas.artifact.resultEnvelope
+);
 assert.deepEqual(wpCodeboxProviderRuntimeInvocationContract(), {
   ...canonicalManifest.providerRuntime,
   result_schemas: {


### PR DESCRIPTION
## Summary
- Load WP Codebox runtime-profile and artifact-result-envelope schema values from the canonical runtime contract source instead of repeating literals in adapter/runtime boundary code.
- Extend the runtime contract source smoke test so upstream primitive requirement metadata follows a fake canonical manifest.

## Tests
- PASS: npm run test:wp-codebox-runtime-contract-source
- PASS: npm run test:wp-codebox-adapter-contract
- PASS: node tests/wp-codebox-provider-plugin-env-override-smoke.mjs
- FAIL: node tests/wp-codebox-artifact-contract-smoke.mjs (pre-existing failure: typedArtifactFileRefs({ fileRefs: [...] }) returns [] before this patch's changed paths)
- FAIL: node tests/wp-codebox-callback-data-smoke.mjs (fake WP Codebox fixture receives no runtime_env and throws reading HOMEBOY_CALLBACK_DATA_PATH)
- FAIL: node tests/wp-codebox-bundled-agents-api-smoke.mjs (fixture captured runtimeRequirements has no component_contracts)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected the WP Codebox runtime contract/adapters, made the focused schema source-of-truth cleanup, ran JS smoke tests, and prepared this PR.