### PR TITLE
Move PHP dependency setup into wp-codebox adapter

### DIFF
--- a/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
+++ b/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
@@ -161,4 +161,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { assertSafeDependencyTargetPath, dependencyEntries, resolveDependencyTarget, resolvePlan };
+module.exports = { assertSafeDependencyTargetPath, dependencyEntries, resolveDependencyTarget, resolvePlan, runtimeDependencyEntries };

--- a/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
+++ b/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('node:fs');
 const path = require('node:path');
-const { normalizeProviderPlugin, run } = require('./lib/common.cjs');
+const { run } = require('./lib/common.cjs');
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 
 function main() {
@@ -13,7 +12,7 @@ function main() {
   for (const command of [...runtime.setupCommands, ...runtime.buildCommands]) {
     run(command.command, command.args, { cwd: path.join(workspace, command.cwd) });
   }
-  runRuntimeSetup(runtime, { phase: 'after_commands', workspace, env: process.env, run, installCheckedOutPhpDependencies });
+  runRuntimeSetup(runtime, { phase: 'after_commands', workspace, env: process.env, run });
 }
 
 try {
@@ -48,36 +47,7 @@ function runtimeSetupAdapter(runtime) {
   return loaded[exportName];
 }
 
-function installCheckedOutPhpDependencies(workspace) {
-  const ciDir = path.join(workspace, '.ci');
-  if (!fs.existsSync(ciDir)) {
-    return;
-  }
-  for (const entry of fs.readdirSync(ciDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const componentDir = path.join(ciDir, entry.name);
-    if (componentDir === path.join(workspace, '.ci/homeboy-extensions')) {
-      continue;
-    }
-    if (fs.existsSync(path.join(componentDir, 'composer.json'))) {
-      run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: componentDir });
-    }
-  }
-
-  const providerPlugin = normalizeProviderPlugin(process.env.PROVIDER_PLUGIN || '{}', process.env.PROVIDER || '', false);
-  if (!providerPlugin.repo) {
-    return;
-  }
-  const providerPluginDir = path.join(ciDir, providerPlugin.repo.split('/')[1], providerPlugin.path || '.');
-  if (fs.existsSync(path.join(providerPluginDir, 'composer.json'))) {
-    run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: providerPluginDir });
-  }
-}
-
 module.exports = {
-  installCheckedOutPhpDependencies,
   main,
   runRuntimeSetup,
   runtimeSetupAdapter,

--- a/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
+++ b/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
@@ -2,8 +2,10 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { normalizeProviderPlugin } = require('../../../.github/scripts/runtime-agent-full-run/lib/common.cjs');
+const { resolveDependencyTarget, runtimeDependencyEntries } = require('../../../.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs');
 
-function setupRuntime({ phase, workspace, env = process.env, run, installCheckedOutPhpDependencies }) {
+function setupRuntime({ phase, workspace, env = process.env, run }) {
   // After the runtime's build commands run, the wp-codebox CLI exists in the
   // checkout (packages/cli/dist/index.js, made executable by the build) but is
   // not on PATH and HOMEBOY_WP_CODEBOX_BIN is unset, so the downstream
@@ -22,8 +24,59 @@ function setupRuntime({ phase, workspace, env = process.env, run, installChecked
     return;
   }
   if (phase === 'after_commands') {
-    installCheckedOutPhpDependencies(workspace);
+    installCheckedOutPhpDependencies({ workspace, env, run });
   }
+}
+
+function installCheckedOutPhpDependencies({ workspace, env = process.env, run }) {
+  for (const dependencyDir of checkedOutPhpDependencyDirs({ workspace, env })) {
+    run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: dependencyDir });
+  }
+}
+
+function checkedOutPhpDependencyDirs({ workspace, env = process.env }) {
+  const dirs = [];
+  for (const entry of runtimeDependencyEntries(env.RUNTIME_DEPENDENCIES || '')) {
+    const dir = checkedOutDependencyDir(entry, workspace);
+    if (dir && fs.existsSync(path.join(dir, 'composer.json'))) {
+      dirs.push(dir);
+    }
+  }
+
+  const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', false);
+  if (providerPlugin.repo) {
+    const providerPluginDir = safeDependencySubdir(path.join('.ci', providerPlugin.repo.split('/')[1]), providerPlugin.path || '.', workspace);
+    if (fs.existsSync(path.join(providerPluginDir, 'composer.json'))) {
+      dirs.push(providerPluginDir);
+    }
+  }
+
+  return [...new Set(dirs)];
+}
+
+function checkedOutDependencyDir(rawEntry, workspace) {
+  if (rawEntry && !Array.isArray(rawEntry) && typeof rawEntry === 'object') {
+    if (!rawEntry.repo) {
+      return '';
+    }
+    return safeDependencySubdir(rawEntry.target || path.join('.ci', rawEntry.repo.split('/')[1]), rawEntry.path || '.', workspace);
+  }
+  const entry = String(rawEntry || '').trim();
+  if (!entry) {
+    return '';
+  }
+  const repo = entry.includes('@') ? entry.slice(0, entry.lastIndexOf('@')) : entry;
+  return resolveDependencyTarget(path.join('.ci', repo.split('/')[1]), workspace).targetPath;
+}
+
+function safeDependencySubdir(target, subdir, workspace) {
+  const targetPath = resolveDependencyTarget(target, workspace).targetPath;
+  const resolved = path.resolve(targetPath, subdir);
+  const relative = path.relative(targetPath, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Dependency subdirectory must resolve inside dependency checkout: ${subdir}`);
+  }
+  return resolved;
 }
 
 function exportRuntimeBin(workspace, env = process.env) {
@@ -95,7 +148,11 @@ function requiresWordPressDependencies(env = process.env) {
 }
 
 module.exports = {
+  checkedOutPhpDependencyDirs,
+  checkedOutDependencyDir,
   envPathIsInsideWorkspace,
+  installCheckedOutPhpDependencies,
   requiresWordPressDependencies,
+  safeDependencySubdir,
   setupRuntime,
 };

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -8,7 +8,7 @@ const path = require('node:path');
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider, runtimeIdFromOptions } = require('../lib/runtime-provider-resolver.cjs');
 const { runtimeAgentCiRunnerSpec } = require('..');
 const { runRuntimeSetup, runtimeSetupAdapter } = require('../../.github/scripts/runtime-agent-full-run/setup-runtime.cjs');
-const { envPathIsInsideWorkspace, requiresWordPressDependencies, setupRuntime } = require('../../agent-runtimes/wp-codebox/lib/runtime-setup.cjs');
+const { checkedOutPhpDependencyDirs, envPathIsInsideWorkspace, requiresWordPressDependencies, safeDependencySubdir, setupRuntime } = require('../../agent-runtimes/wp-codebox/lib/runtime-setup.cjs');
 
 assert.equal(DEFAULT_RUNTIME_ID, 'local-shell');
 
@@ -96,17 +96,46 @@ assert.deepEqual(codeboxSetupCalls.map(([command, args, options]) => ({ command,
   },
 ]);
 
-let installedCheckedOutDependencies = false;
+const dependencyWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-dependencies-'));
+const providerComposerJson = path.join(dependencyWorkspace, '.ci/ai-provider-for-openai/composer.json');
+const runtimeDependencyComposerJson = path.join(dependencyWorkspace, '.ci/dependencies/runtime-helper-plugin/plugin/composer.json');
+const arbitraryComposerJson = path.join(dependencyWorkspace, '.ci/arbitrary/composer.json');
+fs.mkdirSync(path.dirname(providerComposerJson), { recursive: true });
+fs.mkdirSync(path.dirname(runtimeDependencyComposerJson), { recursive: true });
+fs.mkdirSync(path.dirname(arbitraryComposerJson), { recursive: true });
+fs.writeFileSync(providerComposerJson, '{}\n');
+fs.writeFileSync(runtimeDependencyComposerJson, '{}\n');
+fs.writeFileSync(arbitraryComposerJson, '{}\n');
+
+assert.deepEqual(checkedOutPhpDependencyDirs({
+  workspace: dependencyWorkspace,
+  env: {
+    PROVIDER_PLUGIN: JSON.stringify({ repo: 'WordPress/ai-provider-for-openai', path: '.' }),
+    RUNTIME_DEPENDENCIES: JSON.stringify([{ repo: 'Extra-Chill/runtime-helper-plugin', ref: 'main', target: '.ci/dependencies/runtime-helper-plugin', path: 'plugin' }]),
+  },
+}), [
+  path.join(dependencyWorkspace, '.ci/dependencies/runtime-helper-plugin/plugin'),
+  path.join(dependencyWorkspace, '.ci/ai-provider-for-openai'),
+]);
+assert.throws(
+  () => safeDependencySubdir('.ci/dependencies/runtime-helper-plugin', '../escape', dependencyWorkspace),
+  /Dependency subdirectory must resolve inside dependency checkout/
+);
+
+const installedDependencyDirs = [];
 setupRuntime({
   phase: 'after_commands',
-  workspace: '/tmp/workspace',
-  env: {},
-  run: () => {},
-  installCheckedOutPhpDependencies: (workspace) => {
-    installedCheckedOutDependencies = workspace === '/tmp/workspace';
+  workspace: dependencyWorkspace,
+  env: {
+    PROVIDER_PLUGIN: JSON.stringify({ repo: 'WordPress/ai-provider-for-openai', path: '.' }),
+    RUNTIME_DEPENDENCIES: JSON.stringify([{ repo: 'Extra-Chill/runtime-helper-plugin', ref: 'main', target: '.ci/dependencies/runtime-helper-plugin', path: 'plugin' }]),
   },
+  run: (command, args, options) => installedDependencyDirs.push({ command, args, cwd: options.cwd }),
 });
-assert.equal(installedCheckedOutDependencies, true);
+assert.deepEqual(installedDependencyDirs.map((call) => call.cwd), [
+  path.join(dependencyWorkspace, '.ci/dependencies/runtime-helper-plugin/plugin'),
+  path.join(dependencyWorkspace, '.ci/ai-provider-for-openai'),
+]);
 
 const runtimeWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-runtime-'));
 const githubEnvPath = path.join(runtimeWorkspace, 'github-env');
@@ -129,7 +158,6 @@ setupRuntime({
     HOMEBOY_WP_CODEBOX_CORE_MODULE: '/home/chubes/Developer/wp-codebox@main-fuzz-proof-20260625/packages/runtime-core/dist/index.js',
   },
   run: () => {},
-  installCheckedOutPhpDependencies: () => {},
 });
 const githubEnv = fs.readFileSync(githubEnvPath, 'utf8');
 assert.match(githubEnv, new RegExp(`HOMEBOY_WP_CODEBOX_BIN=${escapeRegExp(builtCliPath)}`));
@@ -145,7 +173,6 @@ setupRuntime({
     HOMEBOY_WP_CODEBOX_CORE_MODULE: builtContractsPath,
   },
   run: () => {},
-  installCheckedOutPhpDependencies: () => {},
 });
 assert.equal(fs.readFileSync(githubEnvPath, 'utf8'), '');
 


### PR DESCRIPTION
## Summary
- Remove generic setup-runtime Composer scanning across arbitrary .ci checkouts.
- Move checked-out PHP dependency installs into the wp-codebox runtime setup adapter.
- Limit Composer installs to declared runtime dependencies and provider plugin checkouts, including explicit target/path handling with .ci bounds checks.

## Verification
- node runtime-agent-ci/tests/runtime-provider-boundary.test.js
- node tests/runtime-agent-full-run-provider-neutral-smoke.mjs
- node tests/dependency-adapter-manifests-smoke.mjs
- bash tests/project-scripts-pnpm-workspace-smoke.sh
- bash tests/runtime-helpers-smoke.sh
- npm test (runtime-agent-ci)
- node wordpress/tests/wordpress-dependency-materialization-recipes-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated the dependency materialization workflow, implemented the adapter-bound cleanup, ran verification, and drafted this PR.