### PR TITLE
Remove runtime agent CI root barrel internals

### DIFF
--- a/.github/workflows/runtime-agent-ci.yml
+++ b/.github/workflows/runtime-agent-ci.yml
@@ -155,7 +155,7 @@ jobs:
           const path = require('node:path');
           const {
             runtimeAgentCiTaskExecutorConfig,
-          } = require('./runtime-agent-ci');
+          } = require('./runtime-agent-ci/provider-adapters');
           const { normalizeRuntimeId } = require('./runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 
           function parseJson(name, fallback) {

--- a/README.md
+++ b/README.md
@@ -22,16 +22,15 @@ helper contract.
 Generic runtime loop, fanout/reconcile, proof, and lifecycle primitives are
 exported from `homeboy-runtime-agent-ci/generic-orchestration`; provider and
 workflow adapters are exported from `homeboy-runtime-agent-ci/provider-adapters`.
-The legacy `homeboy-runtime-agent-ci` root export is a deprecated provider-adapter
-compatibility barrel and should not be used by new callers. Module internals live in
+The legacy `homeboy-runtime-agent-ci` root export is intentionally empty and
+only emits a deprecation warning. Module internals live in `runtime-agent-ci/lib/`
+and are documented in
+[`docs/generic-fanout-reconcile-workflow.md`](docs/generic-fanout-reconcile-workflow.md).
 
 Declarative dependency adapter manifests live in
 [`dependency-adapters/`](dependency-adapters/). They describe extension-owned
 Node.js, Composer, and WordPress dependency materialization surfaces without
 teaching Homeboy core ecosystem-specific package-manager behavior.
-
-`runtime-agent-ci/lib/` and are documented in
-[`docs/generic-fanout-reconcile-workflow.md`](docs/generic-fanout-reconcile-workflow.md).
 Use `.github/workflows/runtime-agent-full-run.yml` for the standard single-task
 path: injectable runtime execution, workspace verification, dry-run or PR
 publication evidence, and one final green/red proof envelope.
@@ -196,7 +195,9 @@ loop, fanout, and review publication primitives. Use
 `homeboy-runtime-agent-ci/generic-fanout-reconcile-workflow`,
 `homeboy-runtime-agent-ci/fanout-reconcile-runner`,
 `runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs`, and the
-`.github/scripts/runtime-agent-full-run/*` workflow helpers directly.
+`.github/scripts/runtime-agent-full-run/*` workflow helpers directly. The
+deprecated `homeboy-runtime-agent-ci` root export is intentionally empty and
+only emits a deprecation warning for compatibility discovery.
 
 WP Codebox is expected to consume a `wp-codebox/runtime-profile/v1` payload with
 generic runtime dependencies such as `components`, `plugins`, `mu_plugins`,

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
-// Deprecated compatibility barrel. New imports should use ./provider-adapters;
-// executor-neutral helpers live behind ./generic-orchestration only.
-Object.assign(module.exports, require('./provider-adapters'));
+process.emitWarning(
+  'homeboy-runtime-agent-ci root export is deprecated and intentionally empty. Use homeboy-runtime-agent-ci/generic-orchestration or homeboy-runtime-agent-ci/provider-adapters.',
+  { code: 'HOMEBOY_RUNTIME_AGENT_CI_ROOT_EXPORT_DEPRECATED', type: 'DeprecationWarning' }
+);

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -11,7 +11,7 @@ const {
   buildSecretEnvPlan,
   loopPolicyFromEnv,
   SECRET_ENV_PLAN_SCHEMA,
-} = require('..');
+} = require('../provider-adapters');
 const { normalizeProviderPlugin } = require('../lib/full-run-inputs.cjs');
 
 assert.equal(typeof buildConfig, 'function');

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -6,7 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider, runtimeIdFromOptions } = require('../lib/runtime-provider-resolver.cjs');
-const { runtimeAgentCiRunnerSpec } = require('..');
+const { runtimeAgentCiRunnerSpec } = require('../provider-adapters');
 const { runRuntimeSetup, runtimeSetupAdapter } = require('../../.github/scripts/runtime-agent-full-run/setup-runtime.cjs');
 const { envPathIsInsideWorkspace, requiresWordPressDependencies, setupRuntime } = require('../../agent-runtimes/wp-codebox/lib/runtime-setup.cjs');
 

--- a/tests/generic-fanout-reconcile-boundary.test.mjs
+++ b/tests/generic-fanout-reconcile-boundary.test.mjs
@@ -45,6 +45,10 @@ assert.equal(packageJson.exports['./generic-fanout-reconcile-workflow'], './lib/
 assert.equal(packageJson.bin['homeboy-controller-loop-proof-validate'], './scripts/homeboy-controller-loop-proof-validate.cjs');
 assert.equal(packageJson.bin['homeboy-generic-fanout-reconcile'], './scripts/homeboy-generic-fanout-reconcile.cjs');
 
+const rootExportSource = fs.readFileSync(path.join(repoRoot, 'runtime-agent-ci/index.js'), 'utf8');
+assert.match(rootExportSource, /emitWarning/);
+assert.doesNotMatch(rootExportSource, /require\(/);
+
 const runtimeSources = [
   'runtime-agent-ci/index.js',
   'runtime-agent-ci/generic-orchestration.js',

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
-const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci/index.js'));
+const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci/provider-adapters.js'));
 const {
   genericAgentTaskPlan,
   genericAgentTaskRequest,
@@ -15,7 +15,7 @@ const {
 
 const genericBoundaryTerms = /Data Machine|DataMachine|datamachine|data-machine|wp-site-generator|WPSG|site-generator|site generator/;
 const genericFiles = [
-  'runtime-agent-ci/index.js',
+  'runtime-agent-ci/provider-adapters.js',
   'runtime-agent-ci/lib/runtime-agent-ci-plan.js',
   'agent-task-contracts/generic-agent-task-plan.js',
   '.github/workflows/runtime-agent-ci.yml',

--- a/tests/wp-codebox-preview-materialization-contract-smoke.mjs
+++ b/tests/wp-codebox-preview-materialization-contract-smoke.mjs
@@ -10,7 +10,7 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const {
 	materializePreview,
-} = require(path.join(rootDir, 'runtime-agent-ci', 'index.js'));
+} = require(path.join(rootDir, 'runtime-agent-ci', 'provider-adapters.js'));
 const {
 	WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA,
 	WP_CODEBOX_BROWSER_CONTAINED_SITE_STATUS_SCHEMA,


### PR DESCRIPTION
## Summary
- shrink the deprecated homeboy-runtime-agent-ci root export to a warning-only empty compatibility surface
- migrate remaining runtime-agent-ci internal/workflow/test callers to provider-adapters
- document the explicit import boundary and add a regression assertion that the root export does not require internals

## Tests
- npm test (in runtime-agent-ci)
- node tests/runtime-agent-ci-contract-smoke.mjs && node tests/generic-fanout-reconcile-boundary.test.mjs && node tests/wp-codebox-preview-materialization-contract-smoke.mjs && node tests/preview-materialization-contract-smoke.mjs
- Broader top-level JS loop run with setopt null_glob; for test in tests/*.js tests/*.mjs; do node "$test"; done. This surfaced existing WP Codebox smoke failures in wp-codebox-artifact-contract-smoke.mjs, wp-codebox-bundled-agents-api-smoke.mjs, wp-codebox-callback-data-smoke.mjs, and wp-codebox-runtime-contract-built-module-canary.mjs; affected runtime-agent-ci contract tests passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implemented the runtime-agent-ci root barrel shrink, migrated internal callers, ran tests, and prepared this PR.