### PR TITLE
Thin WP Codebox workflow wrapper

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,11 +58,9 @@ JSON results/events outside GitHub Actions.
 The generic workflow requires callers to provide their domain runtime profile,
 runtime component dependencies, required abilities, and runtime task/execution
 descriptor. Homeboy Extensions assumes the runtime provider contract only.
-Domain ability names and component stacks are caller inputs. WP Codebox callers
-should prefer `.github/workflows/wp-codebox-runtime-agent-full-run.yml`, which
-keeps WordPress-specific defaults and input names at the runtime adapter boundary;
-see
-[`docs/wp-codebox-runtime-workflow.md`](../../docs/wp-codebox-runtime-workflow.md).
+Domain ability names and component stacks are caller inputs. Runtime-specific
+defaults and product vocabulary belong in wrapper workflows declared by runtime
+adapter manifests; see the runtime adapter docs for wrapper-specific inputs.
 
 ```yaml
 jobs:
@@ -99,12 +97,10 @@ would make the generic workflow narrative less clear. The wrapper should pin the
 runtime id, translate product-specific input names, and then call the generic
 workflow with canonical inputs.
 
-`wp-codebox-runtime-agent-full-run.yml` is the WP Codebox wrapper. It sets
-`runtime: wp-codebox`, maps `wordpress_version` to `runtime_wordpress_version`,
-maps `wp_config_defines` to `extra_wp_config_defines`, and maps
-`wp_runtime_mounts` / `wp_runtime_overlays` to the selected-runtime mount and
-overlay inputs. Existing direct callers of `runtime-agent-full-run.yml` remain
-supported for compatibility.
+Runtime wrapper metadata lives with the runtime adapter manifest and docs. The
+generic workflow only relies on the canonical selected-runtime inputs it receives.
+Existing direct callers of `runtime-agent-full-run.yml` remain supported for
+compatibility.
 
 ### Migrating Old Wrapper Callers
 
@@ -165,7 +161,7 @@ and whether the caller required a Homeboy App token. Tokens are never printed.
 
 ## Inputs worth calling out
 
-- Agent CI runs through the selected `runtime`. Empty runtime input selects `local-shell`. Deprecated compatibility aliases remain available only for existing callers: `runtime_provider` and `backend` map to `runtime`. The legacy `codebox` value is not a generic runtime id; use `wp-codebox`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
+- Agent CI runs through the selected `runtime`. Empty runtime input selects `local-shell`. Deprecated compatibility aliases remain available only for existing callers: `runtime_provider` and `backend` map to `runtime`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
 - `profile` is the runtime profile selector. Deprecated compatibility alias: `runtime_profile`.
 - `runtime_ref` controls the selected runtime ref.
 - `runtime_execution` declares bundle, workflow, or ability execution. When `runtime_task` or `ability_request` is supplied, the workflow builds a direct runtime task instead.
@@ -194,7 +190,7 @@ and whether the caller required a Homeboy App token. Tokens are never printed.
 - `proof_profile` controls controller-loop proof evidence. `artifact_only` is the generic default and does not require preview or PR/publication evidence, `cook_to_pr` requires durable preview plus pull-request evidence, and `none` declares no extra proof requirements. Explicit `controller_loop_proof` / `controller_loop_proof_policy` config still overrides profile fields.
 - `workload_run_after` runs post-agent verifier hooks through the selected runtime scenario.
 - `ability_tools` adds ability-backed tools to the agent loop. It must be a JSON array.
-- `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. Deprecated compatibility alias: `tool_recorders`, only for existing WP Codebox callers that still need forced-parameter behavior.
+- `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. Deprecated compatibility alias: `tool_recorders`, only for existing callers that still need forced-parameter behavior.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
 - `runner_workspace` provisions a selected-runtime runner workspace before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the selected runtime after completion.
 - `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -16,7 +16,7 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: ''
       runtime:
-        description: Agent runtime id. Defaults to the neutral local-shell runtime. WP Codebox callers should prefer wp-codebox-runtime-agent-full-run.yml.
+        description: Agent runtime id. Defaults to the neutral local-shell runtime. Runtime-specific callers should prefer a runtime wrapper when one is available.
         type: string
         default: ''
       backend:
@@ -28,9 +28,9 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: main
       runtime_wordpress_version:
-        description: Compatibility input consumed by WP Codebox-capable adapters. New WP Codebox callers should pass wordpress_version to the wrapper workflow.
+        description: Deprecated selected-runtime compatibility input. Runtime wrappers should expose runtime-owned names and pass canonical values explicitly.
         type: string
-        default: '7.0'
+        default: ''
       runtime_profile:
         description: Deprecated compatibility alias for profile. Existing callers only.
         type: string
@@ -269,9 +269,9 @@ name: Runtime Agent Full Run (reusable)
         type: boolean
         default: false
       extra_wp_config_defines:
-        description: Compatibility input consumed by the WP Codebox adapter. New WP Codebox callers should pass wp_config_defines to the wrapper workflow.
+        description: Deprecated selected-runtime compatibility input. Runtime wrappers should expose runtime-owned names and pass canonical values explicitly.
         type: string
-        default: '{}'
+        default: ''
       runtime_mounts:
         description: JSON array appended to selected runtime mounts.
         type: string

--- a/.github/workflows/wp-codebox-runtime-agent-full-run.yml
+++ b/.github/workflows/wp-codebox-runtime-agent-full-run.yml
@@ -18,7 +18,7 @@ name: WP Codebox Runtime Agent Full Run (reusable)
       wordpress_version:
         description: WordPress version used by the WP Codebox runtime.
         type: string
-        default: '7.0'
+        default: ''
       profile:
         description: Runtime profile id selected from runtime_profiles.
         type: string
@@ -231,15 +231,15 @@ name: WP Codebox Runtime Agent Full Run (reusable)
       wp_config_defines:
         description: JSON object merged into the WP Codebox runner config wp_config_defines.
         type: string
-        default: '{}'
+        default: ''
       wp_runtime_mounts:
         description: JSON array appended to WP Codebox runtime mounts.
         type: string
-        default: '[]'
+        default: ''
       wp_runtime_overlays:
         description: JSON array of WP Codebox runtime overlay entries forwarded to the runner config.
         type: string
-        default: '[]'
+        default: ''
       runtime_env:
         description: JSON object forwarded to runtime profile construction.
         type: string

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -71,6 +71,22 @@
     "adapter": {
       "module": "agent-runtimes/wp-codebox/lib/runtime-workflow-input-projection.js",
       "export": "renderRuntimeWorkflowInputs"
+    },
+    "wrapper": {
+      "workflow": ".github/workflows/wp-codebox-runtime-agent-full-run.yml",
+      "description": "Thin WP Codebox wrapper over runtime-agent-full-run.yml. It pins runtime=wp-codebox and translates WordPress/WP Codebox input names into generic selected-runtime inputs.",
+      "input_defaults": {
+        "wordpress_version": "7.0",
+        "wp_config_defines": {},
+        "wp_runtime_mounts": [],
+        "wp_runtime_overlays": []
+      },
+      "input_mapping": {
+        "wordpress_version": "runtime_wordpress_version",
+        "wp_config_defines": "extra_wp_config_defines",
+        "wp_runtime_mounts": "runtime_mounts",
+        "wp_runtime_overlays": "runtime_overlays"
+      }
     }
   },
   "runner_config_projection": {

--- a/docs/wp-codebox-runtime-workflow.md
+++ b/docs/wp-codebox-runtime-workflow.md
@@ -5,6 +5,9 @@
 shell. New WordPress/WP Codebox callers should use the wrapper so WordPress
 version selection, WP config defines, sandbox mounts, runtime overlays, and
 Codebox artifact declaration vocabulary stay at the WP Codebox adapter boundary.
+The wrapper default and mapping contract is declared in
+`agent-runtimes/wp-codebox/wp-codebox.json` under `workflow_input_projection.wrapper`;
+empty wrapper inputs fall back to the manifest/runtime adapter defaults.
 
 Existing callers that invoke `runtime-agent-full-run.yml` directly with
 `runtime: wp-codebox` remain supported. Treat that path as compatibility for
@@ -53,6 +56,15 @@ workflow docs carry WP Codebox examples. Generic inputs such as `runtime_profile
 `component_contracts`, `runtime_execution`, `runtime_output_projections`,
 `runner_workspace`, `verification_commands`, and `artifact_declarations` pass
 through unchanged.
+
+The adapter manifest owns these wrapper defaults:
+
+| Wrapper input | Default |
+| --- | --- |
+| `wordpress_version` | `7.0` |
+| `wp_config_defines` | `{}` |
+| `wp_runtime_mounts` | `[]` |
+| `wp_runtime_overlays` | `[]` |
 
 ## Deprecated aliases
 

--- a/tests/runtime-agent-full-run-projection-boundary-smoke.mjs
+++ b/tests/runtime-agent-full-run-projection-boundary-smoke.mjs
@@ -83,4 +83,18 @@ assert.equal(codeboxConfig.transcript_dir, '/wordpress/wp-content/plugins/exampl
 assert.deepEqual(codeboxConfig.wp_config_defines, { CODEBOX_DEFINE: true });
 assert.equal(codeboxConfig.runtime_wordpress_version, '7.0');
 
+const codeboxOverrideConfig = buildConfig({
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  WORKLOAD_ID: 'codebox-projection-override',
+  COMPONENT_ID: 'example',
+  TARGET_REPO: 'Extra-Chill/example',
+  RUNTIME: 'wp-codebox',
+  PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
+  PROFILE: 'codebox-profile',
+  RUNTIME_WORDPRESS_VERSION: 'nightly',
+});
+
+assert.equal(codeboxOverrideConfig.runtime_wordpress_version, 'nightly');
+
 console.log('runtime agent full-run projection boundary smoke passed');

--- a/tests/wp-codebox-workflow-wrapper-boundary-smoke.mjs
+++ b/tests/wp-codebox-workflow-wrapper-boundary-smoke.mjs
@@ -6,23 +6,44 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const wrapper = fs.readFileSync(path.join(repoRoot, '.github/workflows/wp-codebox-runtime-agent-full-run.yml'), 'utf8');
+const genericWorkflow = fs.readFileSync(path.join(repoRoot, '.github/workflows/runtime-agent-full-run.yml'), 'utf8');
 const genericDocs = fs.readFileSync(path.join(repoRoot, '.github/workflows/README.md'), 'utf8');
 const wpDocs = fs.readFileSync(path.join(repoRoot, 'docs/wp-codebox-runtime-workflow.md'), 'utf8');
+const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'agent-runtimes/wp-codebox/wp-codebox.json'), 'utf8'));
 
 assert.match(wrapper, /runtime: wp-codebox/);
 assert.match(wrapper, /runtime_wordpress_version: \$\{\{ inputs\.wordpress_version \}\}/);
 assert.match(wrapper, /extra_wp_config_defines: \$\{\{ inputs\.wp_config_defines \}\}/);
 assert.match(wrapper, /runtime_mounts: \$\{\{ inputs\.wp_runtime_mounts \}\}/);
 assert.match(wrapper, /runtime_overlays: \$\{\{ inputs\.wp_runtime_overlays \}\}/);
+assert.match(wrapper, /wordpress_version:[\s\S]*?default: ''/);
+assert.match(wrapper, /wp_config_defines:[\s\S]*?default: ''/);
+assert.match(wrapper, /wp_runtime_mounts:[\s\S]*?default: ''/);
+assert.match(wrapper, /wp_runtime_overlays:[\s\S]*?default: ''/);
 
+assert.match(genericWorkflow, /runtime_wordpress_version:[\s\S]*?default: ''/);
+assert.match(genericWorkflow, /extra_wp_config_defines:[\s\S]*?default: ''/);
 assert.doesNotMatch(genericDocs, /runtime_wordpress_version: beta/);
 assert.doesNotMatch(genericDocs, /extra_wp_config_defines:/);
 assert.doesNotMatch(genericDocs, /wp-content\/plugins\/example-runtime-plugin/);
-assert.match(genericDocs, /wp-codebox-runtime-agent-full-run\.yml/);
+assert.doesNotMatch(genericDocs, /wp-codebox-runtime-agent-full-run\.yml/);
 
 assert.match(wpDocs, /wp-codebox-runtime-agent-full-run\.yml/);
 assert.match(wpDocs, /wordpress_version: beta/);
 assert.match(wpDocs, /wp_config_defines:/);
 assert.match(wpDocs, /wp_runtime_mounts:/);
+assert.equal(manifest.workflow_input_projection.wrapper.workflow, '.github/workflows/wp-codebox-runtime-agent-full-run.yml');
+assert.deepEqual(manifest.workflow_input_projection.wrapper.input_defaults, {
+  wordpress_version: '7.0',
+  wp_config_defines: {},
+  wp_runtime_mounts: [],
+  wp_runtime_overlays: [],
+});
+assert.deepEqual(manifest.workflow_input_projection.wrapper.input_mapping, {
+  wordpress_version: 'runtime_wordpress_version',
+  wp_config_defines: 'extra_wp_config_defines',
+  wp_runtime_mounts: 'runtime_mounts',
+  wp_runtime_overlays: 'runtime_overlays',
+});
 
 console.log('wp-codebox workflow wrapper boundary smoke passed');


### PR DESCRIPTION
## Summary
- Move WP Codebox wrapper defaults and input mapping into the WP Codebox adapter manifest/docs.
- Make generic workflow WP compatibility inputs empty by default so runtime manifests own effective provider defaults.
- Keep generic workflow docs provider-neutral while preserving direct-call compatibility.
- Extend workflow boundary tests for wrapper defaults, manifest mapping, and effective WP Codebox runtime version fallback/override.

## Testing
- `ruby -e 'require "psych"; ARGV.each { |f| Psych.load_file(f) }; puts "YAML parse passed"' ".github/workflows/runtime-agent-full-run.yml" ".github/workflows/wp-codebox-runtime-agent-full-run.yml"`
- `node tests/wp-codebox-workflow-wrapper-boundary-smoke.mjs`
- `node tests/runtime-workflow-input-renderer-smoke.mjs`
- `node tests/runtime-agent-full-run-projection-boundary-smoke.mjs`
- `npm test` in `runtime-agent-ci`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafted and validated the workflow/docs/manifest/test changes with Chris's requested scope.