### PR TITLE
Persist WP Codebox PHPUnit failure artifacts

### DIFF
--- a/wordpress/scripts/test/build-wp-codebox-phpunit-recipe.mjs
+++ b/wordpress/scripts/test/build-wp-codebox-phpunit-recipe.mjs
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 /**
  * Internal dependencies
@@ -11,9 +11,13 @@ import { loadCodeboxRecipeBuilder } from '../bench/wp-codebox-recipe-builder-loa
 import { applyWpCodeboxStepDiagnostics } from '../lib/wp-codebox-diagnostics-plan.mjs';
 
 const input = JSON.parse(readFileSync(0, 'utf8'));
-const { builder: buildWordPressPhpunitRecipe } = await loadCodeboxRecipeBuilder('buildWordPressPhpunitRecipe');
+const { builder: buildWordPressPhpunitRecipe, source } = await loadCodeboxRecipeBuilder('buildWordPressPhpunitRecipe');
 const options = input.options ?? input;
 const recipe = buildWordPressPhpunitRecipe(options);
 applyWpCodeboxStepDiagnostics(recipe, options);
+
+if (process.env.HOMEBOY_WP_CODEBOX_RECIPE_BUILDER_SOURCE_FILE) {
+	writeFileSync(process.env.HOMEBOY_WP_CODEBOX_RECIPE_BUILDER_SOURCE_FILE, `${source}\n`);
+}
 
 process.stdout.write(`${JSON.stringify(recipe, null, 2)}\n`);

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -958,12 +958,100 @@ fi
 
 RESULT_FILE="${PLUGIN_PATH}/.pg-test-result.txt"
 PHPUNIT_RESULT_CACHE_FILE="${PLUGIN_PATH}/.phpunit.result.cache"
+WP_CODEBOX_TMPFILE=""
+PHPUNIT_STDOUT_TMPFILE=""
+RECIPE_FILE=""
+RECIPE_OPTIONS_FILE=""
+RECIPE_BUILDER_SOURCE_FILE=""
+WP_CODEBOX_PHPUNIT_PERSIST_ON_FAILURE=0
 
 cleanup_wp_codebox_phpunit_runtime_files() {
     rm -f "$RESULT_FILE" "$PHPUNIT_RESULT_CACHE_FILE"
 }
 
-trap cleanup_wp_codebox_phpunit_runtime_files EXIT
+persist_wp_codebox_phpunit_failure_artifacts() {
+    [ "$WP_CODEBOX_PHPUNIT_PERSIST_ON_FAILURE" = "1" ] || return 0
+
+    mkdir -p "$ARTIFACTS_DIR"
+
+    [ -n "$RECIPE_FILE" ] && [ -f "$RECIPE_FILE" ] && cp "$RECIPE_FILE" "${ARTIFACTS_DIR}/wp-codebox-phpunit-recipe.json"
+    [ -n "$RECIPE_OPTIONS_FILE" ] && [ -f "$RECIPE_OPTIONS_FILE" ] && cp "$RECIPE_OPTIONS_FILE" "${ARTIFACTS_DIR}/wp-codebox-phpunit-recipe-options.json"
+
+    local resolved_bin
+    resolved_bin=$(homeboy_wp_codebox_resolved_bin_path "$WP_CODEBOX_BIN")
+    local command_json
+    command_json=$(printf '%s\0' "${wp_codebox_command[@]}" | php -r '
+        $raw = stream_get_contents(STDIN);
+        $parts = array_values(array_filter(explode("\0", $raw), static function ($value) { return $value !== ""; }));
+        echo json_encode($parts, JSON_UNESCAPED_SLASHES);
+    ' 2>/dev/null || printf '[]')
+    local recipe_builder_source=""
+    [ -n "$RECIPE_BUILDER_SOURCE_FILE" ] && [ -f "$RECIPE_BUILDER_SOURCE_FILE" ] && recipe_builder_source=$(cat "$RECIPE_BUILDER_SOURCE_FILE")
+
+    jq -n \
+        --arg schema "homeboy/wordpress-wp-codebox-phpunit-provenance/v1" \
+        --arg cliBin "$WP_CODEBOX_BIN" \
+        --arg resolvedCliPath "$resolved_bin" \
+        --argjson command "$command_json" \
+        --arg recipeBuilder "$PHPUNIT_RECIPE_BUILDER" \
+        --arg recipeBuilderSource "$recipe_builder_source" \
+        --arg artifactsDir "$ARTIFACTS_DIR" \
+        '{
+            schema: $schema,
+            wp_codebox: {
+                cli_bin: $cliBin,
+                resolved_cli_path: $resolvedCliPath,
+                command: $command,
+                recipe_builder: $recipeBuilder,
+                recipe_builder_source: $recipeBuilderSource
+            },
+            artifacts: {
+                directory: $artifactsDir,
+                recipe: "wp-codebox-phpunit-recipe.json",
+                recipe_options: "wp-codebox-phpunit-recipe-options.json",
+                profile: "wp-codebox-phpunit-profile.json"
+            }
+        }' > "${ARTIFACTS_DIR}/wp-codebox-phpunit-provenance.json"
+
+    jq -n \
+        --arg schema "homeboy/wordpress-wp-codebox-phpunit-profile/v1" \
+        --arg testRoot "$WP_CODEBOX_PHPUNIT_TEST_ROOT" \
+        --arg config "$WP_CODEBOX_PHPUNIT_CONFIG" \
+        --arg cwd "$WP_CODEBOX_PHPUNIT_CWD" \
+        --arg bootstrapMode "$WP_CODEBOX_PHPUNIT_BOOTSTRAP_MODE" \
+        --arg projectBootstrap "$WP_CODEBOX_PHPUNIT_PROJECT_BOOTSTRAP" \
+        --argjson extraMounts "$WP_CODEBOX_PHPUNIT_MOUNTS_JSON" \
+        --argjson passthroughArgs "$PHPUNIT_ARGS_JSON" \
+        '{
+            schema: $schema,
+            phpunit: {
+                test_root: $testRoot,
+                config: $config,
+                cwd: $cwd,
+                extra_mounts: $extraMounts,
+                bootstrap_mode: $bootstrapMode,
+                project_bootstrap: $projectBootstrap,
+                passthrough_args: $passthroughArgs
+            }
+        }' > "${ARTIFACTS_DIR}/wp-codebox-phpunit-profile.json"
+}
+
+cleanup_wp_codebox_phpunit_files() {
+    local status=$?
+    set +e
+    if [ "$status" -ne 0 ]; then
+        persist_wp_codebox_phpunit_failure_artifacts
+    fi
+    cleanup_wp_codebox_phpunit_runtime_files
+    [ -n "$WP_CODEBOX_TMPFILE" ] && rm -f "$WP_CODEBOX_TMPFILE"
+    [ -n "$PHPUNIT_STDOUT_TMPFILE" ] && rm -f "$PHPUNIT_STDOUT_TMPFILE"
+    [ -n "$RECIPE_FILE" ] && rm -f "$RECIPE_FILE"
+    [ -n "$RECIPE_OPTIONS_FILE" ] && rm -f "$RECIPE_OPTIONS_FILE"
+    [ -n "$RECIPE_BUILDER_SOURCE_FILE" ] && rm -f "$RECIPE_BUILDER_SOURCE_FILE"
+    exit "$status"
+}
+
+trap cleanup_wp_codebox_phpunit_files EXIT
 cleanup_wp_codebox_phpunit_runtime_files
 
 ARTIFACTS_DIR="${HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR:-}"
@@ -994,6 +1082,7 @@ WP_CODEBOX_TMPFILE=$(mktemp)
 PHPUNIT_STDOUT_TMPFILE=$(mktemp)
 RECIPE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-recipe.XXXXXX")
 RECIPE_OPTIONS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-recipe-options.XXXXXX")
+RECIPE_BUILDER_SOURCE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-recipe-builder-source.XXXXXX")
 homeboy_wp_codebox_set_command "$WP_CODEBOX_BIN"
 wp_codebox_command=("${HOMEBOY_WP_CODEBOX_COMMAND[@]}")
 
@@ -1039,12 +1128,14 @@ jq -n \
     + (if $phpunitCwd == "" then {} else {cwd: $phpunitCwd} end)
     + (if $diagnostics == null then {} else {diagnosticsCapture: $diagnostics} end))' > "$RECIPE_OPTIONS_FILE"
 
+WP_CODEBOX_PHPUNIT_PERSIST_ON_FAILURE=1
+
 if [ ! -f "$PHPUNIT_RECIPE_BUILDER" ]; then
     echo "Error: WP Codebox PHPUnit recipe builder not found: ${PHPUNIT_RECIPE_BUILDER}" >&2
     FAILED_STEP="WP Codebox PHPUnit recipe setup"
     exit 1
 fi
-node "$PHPUNIT_RECIPE_BUILDER" < "$RECIPE_OPTIONS_FILE" > "$RECIPE_FILE"
+HOMEBOY_WP_CODEBOX_RECIPE_BUILDER_SOURCE_FILE="$RECIPE_BUILDER_SOURCE_FILE" node "$PHPUNIT_RECIPE_BUILDER" < "$RECIPE_OPTIONS_FILE" > "$RECIPE_FILE"
 
 set +e
 "${wp_codebox_command[@]}" recipe-run \
@@ -1054,8 +1145,6 @@ set +e
     > "$WP_CODEBOX_TMPFILE" 2>&1
 wp_codebox_exit=$?
 set -e
-
-rm -f "$RECIPE_FILE" "$RECIPE_OPTIONS_FILE"
 
 WP_CODEBOX_OUTPUT=$(cat "$WP_CODEBOX_TMPFILE")
 PHPUNIT_OUTPUT=""

--- a/wordpress/tests/wp-codebox-phpunit-failure-artifacts-smoke.sh
+++ b/wordpress/tests/wp-codebox-phpunit-failure-artifacts-smoke.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RUNNER="${ROOT_DIR}/scripts/test/test-runner-wp-codebox.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PLUGIN_DIR="${TMPDIR}/sample-plugin"
+ARTIFACTS_DIR="${TMPDIR}/artifacts"
+FAKE_BIN="${TMPDIR}/wp-codebox"
+RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
+CORE_MODULE="${ROOT_DIR}/tests/fixtures/wp-codebox-core-recipe-builder.mjs"
+EXTRA_MOUNT="${TMPDIR}/extra.php"
+
+mkdir -p "${PLUGIN_DIR}/tests" "$ARTIFACTS_DIR"
+cat > "${PLUGIN_DIR}/sample-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Sample Plugin
+ */
+PHP
+cat > "${PLUGIN_DIR}/tests/SampleTest.php" <<'PHP'
+<?php
+
+class SampleTest extends WP_UnitTestCase {
+	public function test_sample(): void {
+		$this->assertTrue( true );
+	}
+}
+PHP
+printf '%s\n' '<?php // extra mount' > "$EXTRA_MOUNT"
+
+cat > "$FAKE_BIN" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "commands" ]; then
+	exit 0
+fi
+
+recipe=""
+artifacts=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--recipe)
+			shift
+			recipe="${1:-}"
+			;;
+		--artifacts)
+			shift
+			artifacts="${1:-}"
+			;;
+	esac
+	shift || true
+done
+
+[ -n "$recipe" ] || { echo "missing --recipe" >&2; exit 2; }
+[ -n "$artifacts" ] || { echo "missing --artifacts" >&2; exit 2; }
+mkdir -p "$artifacts"
+printf '%s\n' '{"executions":[{"stdout":"FAILURES!\nTests: 1, Assertions: 1, Failures: 1."}]}'
+exit 1
+SH
+chmod +x "$FAKE_BIN"
+
+cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
+#!/usr/bin/env bash
+homeboy_resolve_context() {
+	PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+	COMPONENT_ID="$HOMEBOY_COMPONENT_ID"
+	EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+SH
+chmod +x "$RESOLVE_CONTEXT_HELPER"
+
+set +e
+HOMEBOY_COMPONENT_ID="sample-plugin" \
+HOMEBOY_COMPONENT_PATH="$PLUGIN_DIR" \
+HOMEBOY_PROJECT_PATH="$PLUGIN_DIR" \
+HOMEBOY_EXTENSION_PATH="$ROOT_DIR" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
+HOMEBOY_WP_CODEBOX_CORE_MODULE="$CORE_MODULE" \
+HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="$ARTIFACTS_DIR" \
+HOMEBOY_SETTINGS_JSON='{"wp_codebox_phpunit_test_root":"tests","wp_codebox_phpunit_config":"phpunit.xml.dist","wp_codebox_phpunit_cwd":"tests","wp_codebox_phpunit_bootstrap_mode":"managed","wp_codebox_phpunit_mounts":[{"source":"'"$EXTRA_MOUNT"'","target":"/tmp/extra.php","mode":"readonly"}]}' \
+    bash "$RUNNER" --filter SampleFilter > "${TMPDIR}/runner.out" 2>&1
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+	echo "Expected WP Codebox PHPUnit runner to fail" >&2
+	exit 1
+fi
+
+node - "$ARTIFACTS_DIR" "$FAKE_BIN" "$CORE_MODULE" <<'NODE'
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const artifactsDir = process.argv[2];
+const fakeBin = process.argv[3];
+const coreModule = process.argv[4];
+
+const readJson = (name) => JSON.parse(fs.readFileSync(path.join(artifactsDir, name), 'utf8'));
+const recipe = readJson('wp-codebox-phpunit-recipe.json');
+const options = readJson('wp-codebox-phpunit-recipe-options.json');
+const provenance = readJson('wp-codebox-phpunit-provenance.json');
+const profile = readJson('wp-codebox-phpunit-profile.json');
+
+assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
+assert.equal(options.pluginSlug, 'sample-plugin');
+assert.equal(options.testRoot, 'tests');
+assert.equal(options.phpunitXml, 'phpunit.xml.dist');
+assert.equal(options.cwd, 'tests');
+assert.deepEqual(options.phpunitArgs, ['--filter', 'SampleFilter']);
+assert.equal(provenance.wp_codebox.cli_bin, fakeBin);
+assert.equal(provenance.wp_codebox.resolved_cli_path, fakeBin);
+assert.deepEqual(provenance.wp_codebox.command, [fakeBin]);
+assert.equal(provenance.wp_codebox.recipe_builder_source, `file://${coreModule}`);
+assert.equal(profile.phpunit.test_root, 'tests');
+assert.equal(profile.phpunit.config, 'phpunit.xml.dist');
+assert.equal(profile.phpunit.cwd, 'tests');
+assert.equal(profile.phpunit.bootstrap_mode, 'managed');
+assert.deepEqual(profile.phpunit.passthrough_args, ['--filter', 'SampleFilter']);
+assert.equal(profile.phpunit.extra_mounts[0].target, '/tmp/extra.php');
+NODE
+
+echo "WP Codebox PHPUnit failure artifacts smoke passed"


### PR DESCRIPTION
## Summary
- Persist generated WP Codebox PHPUnit recipe and options JSON on runner failure.
- Add failure provenance/profile artifacts for the resolved wp-codebox command, recipe-builder source, effective PHPUnit profile, and passthrough args.
- Add a fake wp-codebox smoke test for failure artifact persistence.

Fixes #2106

## Tests
- `bash wordpress/tests/wp-codebox-phpunit-failure-artifacts-smoke.sh`
- `bash wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh`
- `node wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/tests/wp-codebox-phpunit-failure-artifacts-smoke.sh`
- `node --check wordpress/scripts/test/build-wp-codebox-phpunit-recipe.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the runner artifact persistence change, added focused smoke coverage, and ran verification checks.