### PR TITLE
Classify WP Codebox PHPUnit profile failures

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -992,10 +992,71 @@ fi
 
 WP_CODEBOX_TMPFILE=$(mktemp)
 PHPUNIT_STDOUT_TMPFILE=$(mktemp)
+PHPUNIT_RECIPE_BUILDER_STDERR=$(mktemp)
 RECIPE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-recipe.XXXXXX")
 RECIPE_OPTIONS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-recipe-options.XXXXXX")
 homeboy_wp_codebox_set_command "$WP_CODEBOX_BIN"
 wp_codebox_command=("${HOMEBOY_WP_CODEBOX_COMMAND[@]}")
+
+fail_wp_codebox_phpunit_profile_setup() {
+    local message="$1"
+    local detail="${2:-}"
+
+    FAILED_STEP="WP Codebox PHPUnit profile setup"
+    FAILURE_OUTPUT="$message"
+    echo ""
+    echo "============================================"
+    echo "WP CODEBOX PHPUNIT PROFILE CONFIGURATION FAILURE"
+    echo "============================================"
+    echo "$message" >&2
+    if [ -n "$detail" ]; then
+        echo "" >&2
+        echo "$detail" >&2
+    fi
+    write_phpunit_discovery_result failed "wp-codebox-phpunit-profile-configuration" "$message"
+    rm -f "$WP_CODEBOX_TMPFILE" "$PHPUNIT_STDOUT_TMPFILE" "$PHPUNIT_RECIPE_BUILDER_STDERR" "$RECIPE_FILE" "$RECIPE_OPTIONS_FILE"
+    exit 1
+}
+
+validate_wp_codebox_phpunit_recipe_profile() {
+    local validation_output
+
+    validation_output=$(jq -r \
+        --argjson requestedMounts "$WP_CODEBOX_PHPUNIT_MOUNTS_JSON" \
+        --arg requestedCwd "$WP_CODEBOX_PHPUNIT_CWD" \
+        --arg requestedTestRoot "$WP_CODEBOX_PHPUNIT_TEST_ROOT" \
+        --arg requestedConfig "$WP_CODEBOX_PHPUNIT_CONFIG" \
+        '
+        def arg_present($args; $name; $value):
+            ($value == "") or (($args // []) | index(($name + "=" + $value)) != null);
+        def mount_mode($mount): ($mount.mode // "readonly");
+
+        . as $recipe
+        | ($recipe.inputs.mounts // []) as $recipeMounts
+        | (if ($requestedMounts | type == "array") then $requestedMounts else [] end) as $requestedMountsArray
+        | ($recipe.workflow.steps // [] | map(select((.command // "") | test("(^|\\.)wordpress\\.phpunit$"))) | .[0]) as $phpunitStep
+        | [
+            (if $phpunitStep == null then "generated recipe does not include a wordpress.phpunit workflow step" else empty end),
+            (if ($requestedMounts | type == "array") then empty else "wp_codebox_phpunit_mounts must be an array" end),
+            ($requestedMountsArray[] as $mount
+                | select(($recipeMounts | any(.source == $mount.source and .target == $mount.target and mount_mode(.) == mount_mode($mount))) | not)
+                | "wp_codebox_phpunit_mounts entry missing from generated recipe inputs: " + (($mount.source // "") + " -> " + ($mount.target // "") + " (" + mount_mode($mount) + ")")),
+            (if $phpunitStep == null then empty elif arg_present($phpunitStep.args; "cwd"; $requestedCwd) then empty else "wp_codebox_phpunit_cwd missing from generated wordpress.phpunit args: " + $requestedCwd end),
+            (if $phpunitStep == null then empty elif arg_present($phpunitStep.args; "test-root"; $requestedTestRoot) then empty else "wp_codebox_phpunit_test_root missing from generated wordpress.phpunit args: " + $requestedTestRoot end),
+            (if $phpunitStep == null then empty elif arg_present($phpunitStep.args; "phpunit-xml"; $requestedConfig) then empty else "wp_codebox_phpunit_config missing from generated wordpress.phpunit args: " + $requestedConfig end)
+        ] | map(select(. != null and . != "")) | .[]
+        ' "$RECIPE_FILE" 2>&1) || {
+        printf '%s\n' "$validation_output"
+        return 1
+    }
+
+    if [ -n "$validation_output" ]; then
+        printf '%s\n' "$validation_output"
+        return 1
+    fi
+
+    return 0
+}
 
 jq -n \
     --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \
@@ -1040,11 +1101,18 @@ jq -n \
     + (if $diagnostics == null then {} else {diagnosticsCapture: $diagnostics} end))' > "$RECIPE_OPTIONS_FILE"
 
 if [ ! -f "$PHPUNIT_RECIPE_BUILDER" ]; then
-    echo "Error: WP Codebox PHPUnit recipe builder not found: ${PHPUNIT_RECIPE_BUILDER}" >&2
-    FAILED_STEP="WP Codebox PHPUnit recipe setup"
-    exit 1
+    fail_wp_codebox_phpunit_profile_setup "WP Codebox PHPUnit recipe builder not found: ${PHPUNIT_RECIPE_BUILDER}"
 fi
-node "$PHPUNIT_RECIPE_BUILDER" < "$RECIPE_OPTIONS_FILE" > "$RECIPE_FILE"
+set +e
+node "$PHPUNIT_RECIPE_BUILDER" < "$RECIPE_OPTIONS_FILE" > "$RECIPE_FILE" 2> "$PHPUNIT_RECIPE_BUILDER_STDERR"
+recipe_builder_exit=$?
+set -e
+if [ $recipe_builder_exit -ne 0 ]; then
+    fail_wp_codebox_phpunit_profile_setup "WP Codebox PHPUnit recipe generation failed before WP Codebox runtime execution." "$(cat "$PHPUNIT_RECIPE_BUILDER_STDERR")"
+fi
+if ! validation_errors=$(validate_wp_codebox_phpunit_recipe_profile); then
+    fail_wp_codebox_phpunit_profile_setup "Requested WP Codebox PHPUnit profile settings were not represented in the generated recipe." "$validation_errors"
+fi
 
 set +e
 "${wp_codebox_command[@]}" recipe-run \
@@ -1055,7 +1123,7 @@ set +e
 wp_codebox_exit=$?
 set -e
 
-rm -f "$RECIPE_FILE" "$RECIPE_OPTIONS_FILE"
+rm -f "$RECIPE_FILE" "$RECIPE_OPTIONS_FILE" "$PHPUNIT_RECIPE_BUILDER_STDERR"
 
 WP_CODEBOX_OUTPUT=$(cat "$WP_CODEBOX_TMPFILE")
 PHPUNIT_OUTPUT=""

--- a/wordpress/scripts/test/wp-codebox-core-module-setting-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-core-module-setting-smoke.sh
@@ -37,12 +37,20 @@ cat > "$FAKE_BUILDER" <<'JS'
 import fs from 'node:fs';
 
 fs.readFileSync(0, 'utf8');
-process.stdout.write(JSON.stringify({ steps: [] }));
+process.stdout.write(JSON.stringify({
+  schema: 'wp-codebox/workspace-recipe/v1',
+  inputs: { mounts: [] },
+  workflow: { steps: [{ command: 'wordpress.phpunit', args: ['plugin-slug=sample-plugin'] }] },
+}));
 JS
 
 cat > "$FAKE_BIN" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${1:-}" = "commands" ]; then
+    printf '%s\n' 'recipe-run'
+    exit 0
+fi
 
 printf '%s' "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" > "$CAPTURED_CORE_MODULE"
 printf '%s\n' 'NO_TEST_FILES' > "${HOMEBOY_PLUGIN_PATH}/.pg-test-result.txt"

--- a/wordpress/scripts/test/wp-codebox-phpunit-profile-validation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-phpunit-profile-validation-smoke.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/test-runner-wp-codebox.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PLUGIN_DIR="${TMPDIR}/sample-plugin"
+EXTRA_MOUNT="${TMPDIR}/extra-config"
+FAKE_BIN="${TMPDIR}/wp-codebox"
+FAKE_BUILDER="${TMPDIR}/build-recipe.mjs"
+RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
+WP_CODEBOX_RAN_FILE="${TMPDIR}/wp-codebox-ran.txt"
+
+mkdir -p "$PLUGIN_DIR/tests" "$EXTRA_MOUNT"
+printf '<?php /*\nPlugin Name: Sample Plugin\n*/\n' > "${PLUGIN_DIR}/sample-plugin.php"
+printf '<?php class SampleTest extends WP_UnitTestCase {}\n' > "${PLUGIN_DIR}/tests/SampleTest.php"
+printf 'custom config\n' > "${EXTRA_MOUNT}/phpunit.ini"
+
+cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
+#!/usr/bin/env bash
+homeboy_resolve_context() {
+    PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+    COMPONENT_ID="$HOMEBOY_COMPONENT_ID"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+SH
+chmod +x "$RESOLVE_CONTEXT_HELPER"
+
+cat > "$FAKE_BUILDER" <<'JS'
+import fs from 'node:fs';
+
+const options = JSON.parse(fs.readFileSync(0, 'utf8'));
+const omitProfile = process.env.OMIT_PHPUNIT_PROFILE === '1';
+const recipe = {
+  schema: 'wp-codebox/workspace-recipe/v1',
+  inputs: {
+    mounts: omitProfile ? [] : (options.mounts || []),
+  },
+  workflow: {
+    steps: [{
+      command: 'wordpress.phpunit',
+      args: [
+        `plugin-slug=${options.pluginSlug}`,
+        ...(omitProfile ? [] : [
+          `cwd=${options.cwd || ''}`,
+          `test-root=${options.testRoot || ''}`,
+          `phpunit-xml=${options.phpunitXml || ''}`,
+        ]),
+      ],
+    }],
+  },
+};
+
+process.stdout.write(`${JSON.stringify(recipe, null, 2)}\n`);
+JS
+
+cat > "$FAKE_BIN" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "commands" ]; then
+    printf '%s\n' 'recipe-run'
+    exit 0
+fi
+printf 'ran\n' > "${WP_CODEBOX_RAN_FILE:?}"
+printf 'NO_TEST_FILES\n' > "${HOMEBOY_PLUGIN_PATH}/.pg-test-result.txt"
+printf '%s\n' '{"executions":[{"stdout":"NO_TEST_FILES"}]}'
+SH
+chmod +x "$FAKE_BIN"
+
+settings_json=$(jq -nc \
+    --arg mountSource "$EXTRA_MOUNT" \
+    '{
+        phpunit_no_tests: "skip",
+        wp_codebox_phpunit_mounts: [{source: $mountSource, target: "/wordpress/custom/phpunit", mode: "readonly"}],
+        wp_codebox_phpunit_cwd: "/wordpress/custom/cwd",
+        wp_codebox_phpunit_test_root: "/wordpress/custom/tests/phpunit",
+        wp_codebox_phpunit_config: "/wordpress/custom/phpunit.xml.dist"
+    }')
+
+run_runner() {
+    HOMEBOY_COMPONENT_ID="sample-plugin" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_DIR" \
+    HOMEBOY_PROJECT_PATH="$PLUGIN_DIR" \
+    HOMEBOY_EXTENSION_PATH="${SCRIPT_DIR}/../.." \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
+    HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
+    HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="$FAKE_BUILDER" \
+    HOMEBOY_SETTINGS_JSON="$settings_json" \
+    WP_CODEBOX_RAN_FILE="$WP_CODEBOX_RAN_FILE" \
+    bash "$RUNNER"
+}
+
+set +e
+valid_output=$(run_runner 2>&1)
+valid_status=$?
+set -e
+if [ "$valid_status" -ne 0 ]; then
+    echo "Expected valid profile recipe to pass" >&2
+    echo "$valid_output" >&2
+    exit 1
+fi
+if [ ! -f "$WP_CODEBOX_RAN_FILE" ]; then
+    echo "Expected WP Codebox to run after valid profile recipe generation" >&2
+    echo "$valid_output" >&2
+    exit 1
+fi
+
+rm -f "$WP_CODEBOX_RAN_FILE"
+set +e
+output=$(OMIT_PHPUNIT_PROFILE=1 run_runner 2>&1)
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    echo "Expected profile validation to fail when generated recipe omits requested settings" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+if [ -f "$WP_CODEBOX_RAN_FILE" ]; then
+    echo "Expected WP Codebox not to run after profile validation failure" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+for expected in \
+    "WP CODEBOX PHPUNIT PROFILE CONFIGURATION FAILURE" \
+    "wp_codebox_phpunit_mounts entry missing" \
+    "wp_codebox_phpunit_cwd missing" \
+    "wp_codebox_phpunit_test_root missing" \
+    "wp_codebox_phpunit_config missing"; do
+    if [[ "$output" != *"$expected"* ]]; then
+        echo "Expected diagnostic containing: $expected" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+done
+
+echo "WP Codebox PHPUnit profile validation smoke passed"


### PR DESCRIPTION
## Summary
- classify WP Codebox PHPUnit recipe/profile generation failures before runtime workload execution
- validate requested custom PHPUnit mounts and cwd/test-root/phpunit-config against generated recipes before calling WP Codebox
- add a shell smoke using fake builder and wp-codebox paths for valid and invalid profile recipes

Fixes #2105.

## Tests
- bash wordpress/scripts/test/wp-codebox-phpunit-profile-validation-smoke.sh
- node wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
- bash wordpress/scripts/test/wp-codebox-core-module-setting-smoke.sh
- bash -n scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-phpunit-profile-validation-smoke.sh scripts/test/wp-codebox-core-module-setting-smoke.sh
- npm run test:wp-codebox-phpunit-recipe-builder

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the runner validation, smoke coverage, targeted verification, and PR preparation.