### PR TITLE
Consume core runtime contract constants

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('node:fs');
-const path = require('node:path');
 const {
   buildConfig,
   buildSecretEnvFallbacks,
@@ -11,16 +9,12 @@ const {
   projectRuntimeConfig,
   providerBenchEnvFromManifest,
   runtimePathRequired,
-  withoutInternalKeys,
+  writeFullRunConfig,
   workflowInputCompatibility,
 } = require('../../../runtime-agent-ci/provider-adapters');
-const { writeGithubOutput } = require('../../../runtime-agent-ci/lib/full-run-inputs.cjs');
 
 function main() {
-  const config = buildConfig(process.env);
-  fs.mkdirSync(path.dirname(config._configPath), { recursive: true });
-  fs.writeFileSync(config._configPath, `${JSON.stringify(withoutInternalKeys(config), null, 2)}\n`);
-  writeGithubOutput({ config_path: config._configPath, transcript_host_dir: config.transcript_host_dir });
+  writeFullRunConfig(process.env);
 }
 
 if (require.main === module) {
@@ -32,4 +26,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, workflowInputCompatibility };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, workflowInputCompatibility, writeFullRunConfig };

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -26,10 +26,15 @@ const {
 } = require('./runtime-contracts.cjs');
 
 function main() {
-  const config = buildConfig(process.env);
+  writeFullRunConfig(process.env);
+}
+
+function writeFullRunConfig(env = process.env) {
+  const config = buildConfig(env);
   fs.mkdirSync(path.dirname(config._configPath), { recursive: true });
   fs.writeFileSync(config._configPath, `${JSON.stringify(withoutInternalKeys(config), null, 2)}\n`);
   writeGithubOutput({ config_path: config._configPath, transcript_host_dir: config.transcript_host_dir });
+  return config;
 }
 
 function buildConfig(env) {
@@ -577,4 +582,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys, workflowInputCompatibility };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys, workflowInputCompatibility, writeFullRunConfig };

--- a/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
+++ b/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
@@ -3,15 +3,20 @@
 const { spawnSync } = require('node:child_process');
 
 const {
-  ARTIFACT_MANIFEST_CONTRACT_CONSTANTS,
+  LOCAL_RUNTIME_CONTRACT_CONSTANTS,
+  runtimeContractConstantsFromHomeboyOutput,
 } = require('./runtime-contracts.cjs');
 
 const CONTRACT_COMMANDS = Object.freeze([
+  ['contract', 'constants', 'all'],
   ['contract', 'constants', 'artifact-manifest'],
+  ['contract', 'constants', 'secret-env-plan'],
 ]);
 
-const LOCAL_ARTIFACT_MANIFEST_CONSTANTS = Object.freeze({
-  ...ARTIFACT_MANIFEST_CONTRACT_CONSTANTS,
+const LOCAL_ARTIFACT_MANIFEST_CONSTANTS = LOCAL_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest;
+const CORE_PUBLISHED_CONTRACT_CONSTANTS = Object.freeze({
+  artifact_manifest: LOCAL_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest,
+  secret_env_plan: LOCAL_RUNTIME_CONTRACT_CONSTANTS.secret_env_plan,
 });
 
 function probeHomeboyContractSurface(options = {}) {
@@ -41,21 +46,36 @@ function probeHomeboyContractSurface(options = {}) {
       return fail(`homeboy contract surface probe failed: ${argv.join(' ')} did not emit JSON (${error.message})`, attempts);
     }
 
-    return validateArtifactManifestConstants({ contract, command, argv, attempts });
+    const validation = validateRuntimeContractConstants({ contract, command, argv, attempts });
+    if (validation.status === 'passed' || validation.status === 'failed') {
+      return validation;
+    }
   }
 
   return skip('homeboy contract surface probe skipped: no supported Homeboy contract command is available yet', attempts);
 }
 
-function validateArtifactManifestConstants({ contract, command, argv, attempts }) {
+function validateRuntimeContractConstants({ contract, command, argv, attempts }) {
+  const actualConstants = runtimeContractConstantsFromHomeboyOutput(contract);
+  const expectedConstants = expectedConstantsForCommand(argv);
+  const comparableConstants = Object.fromEntries(
+    Object.entries(expectedConstants).filter(([contractName]) => actualConstants[contractName])
+  );
+  if (Object.keys(actualConstants).length === 0 || Object.keys(comparableConstants).length === 0) {
+    return skip(`homeboy contract surface probe skipped: ${argv.join(' ')} did not expose runtime-agent constants`, attempts);
+  }
+
   const errors = [];
 
-  for (const [name, expected] of Object.entries(LOCAL_ARTIFACT_MANIFEST_CONSTANTS)) {
-    const actual = contractValue(contract, name);
-    if (typeof actual !== 'string' || actual.length === 0) {
-      errors.push(`${name} is missing from Homeboy contract output`);
-    } else if (actual !== expected) {
-      errors.push(`${name} expected ${expected}, got ${actual}`);
+  for (const [contractName, expectedContract] of Object.entries(comparableConstants)) {
+    const actualContract = actualConstants[contractName] || {};
+    for (const [name, expected] of Object.entries(expectedContract)) {
+      const actual = actualContract[name];
+      if (typeof actual !== 'string' || actual.length === 0) {
+        errors.push(`${contractName}.${name} is missing from Homeboy contract output`);
+      } else if (actual !== expected) {
+        errors.push(`${contractName}.${name} expected ${expected}, got ${actual}`);
+      }
     }
   }
 
@@ -68,70 +88,23 @@ function validateArtifactManifestConstants({ contract, command, argv, attempts }
     message: `homeboy contract surface probe passed via ${command} ${argv.join(' ')}`,
     command,
     argv,
-    constants: LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
+    constants: actualConstants,
     attempts,
   };
 }
 
-function contractValue(contract, name) {
-  const candidates = valueCandidates(name);
-  for (const path of candidates) {
-    const value = readPath(contract, path);
-    if (typeof value === 'string' && value.length > 0) {
-      return value;
-    }
+function expectedConstantsForCommand(argv) {
+  const contractId = argv[2] || '';
+  if (contractId === 'all') {
+    return CORE_PUBLISHED_CONTRACT_CONSTANTS;
   }
-  return '';
-}
-
-function valueCandidates(name) {
-  const camel = name.toLowerCase().replace(/_([a-z])/g, (_match, letter) => letter.toUpperCase());
-  const lower = name.toLowerCase();
-
-  const candidates = [
-    ['data', 'constants', name],
-    ['data', 'constants', lower],
-    ['data', 'constants', camel],
-    ['constants', name],
-    ['constants', lower],
-    ['constants', camel],
-    [name],
-    [lower],
-    [camel],
-  ];
-
-  if (name === 'schema_id') {
-    candidates.push(
-      ['data', 'constants', 'schema'],
-      ['data', 'constants', 'schemaId'],
-      ['constants', 'schema'],
-      ['constants', 'schemaId'],
-      ['artifact_manifest', 'schema'],
-      ['artifactManifest', 'schema']
-    );
-  } else if (name === 'file_name') {
-    candidates.push(
-      ['data', 'constants', 'file'],
-      ['data', 'constants', 'fileName'],
-      ['constants', 'file'],
-      ['constants', 'fileName'],
-      ['artifact_manifest', 'file'],
-      ['artifactManifest', 'file']
-    );
+  if (contractId === 'artifact-manifest') {
+    return { artifact_manifest: CORE_PUBLISHED_CONTRACT_CONSTANTS.artifact_manifest };
   }
-
-  return candidates;
-}
-
-function readPath(value, path) {
-  let current = value;
-  for (const segment of path) {
-    if (!current || typeof current !== 'object' || Array.isArray(current) || !Object.hasOwn(current, segment)) {
-      return undefined;
-    }
-    current = current[segment];
+  if (contractId === 'secret-env-plan') {
+    return { secret_env_plan: CORE_PUBLISHED_CONTRACT_CONSTANTS.secret_env_plan };
   }
-  return current;
+  return {};
 }
 
 function skip(message, attempts) {
@@ -144,6 +117,7 @@ function fail(message, attempts, extra = {}) {
 
 module.exports = {
   CONTRACT_COMMANDS,
+  CORE_PUBLISHED_CONTRACT_CONSTANTS,
   LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
   probeHomeboyContractSurface,
 };

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -1,14 +1,27 @@
 'use strict';
 
-const SECRET_ENV_PLAN_SCHEMA = 'homeboy/secret-env-plan/v1';
-const ARTIFACT_PATHS_SCHEMA = 'homeboy/runtime-agent-artifact-paths/v1';
-const ARTIFACT_MANIFEST_CONTRACT_CONSTANTS = Object.freeze({
-  file_name: 'homeboy-artifact-manifest.json',
-  schema_id: 'homeboy/artifact-manifest/v1',
+const LOCAL_RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
+  artifact_manifest: Object.freeze({
+    file_name: 'homeboy-artifact-manifest.json',
+    schema_id: 'homeboy/artifact-manifest/v1',
+  }),
+  secret_env_plan: Object.freeze({
+    schema_id: 'homeboy/secret-env-plan/v1',
+  }),
+  artifact_paths: Object.freeze({
+    schema_id: 'homeboy/runtime-agent-artifact-paths/v1',
+  }),
+  runner_artifact_manifest_ref: Object.freeze({
+    schema_id: 'homeboy/runner-artifact-manifest-ref/v1',
+  }),
 });
+
+const ARTIFACT_MANIFEST_CONTRACT_CONSTANTS = LOCAL_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest;
 const ARTIFACT_MANIFEST_SCHEMA = ARTIFACT_MANIFEST_CONTRACT_CONSTANTS.schema_id;
 const ARTIFACT_MANIFEST_FILE = ARTIFACT_MANIFEST_CONTRACT_CONSTANTS.file_name;
-const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = 'homeboy/runner-artifact-manifest-ref/v1';
+const SECRET_ENV_PLAN_SCHEMA = LOCAL_RUNTIME_CONTRACT_CONSTANTS.secret_env_plan.schema_id;
+const ARTIFACT_PATHS_SCHEMA = LOCAL_RUNTIME_CONTRACT_CONSTANTS.artifact_paths.schema_id;
+const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = LOCAL_RUNTIME_CONTRACT_CONSTANTS.runner_artifact_manifest_ref.schema_id;
 const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
   events: 'events.json',
   status: 'status.json',
@@ -95,14 +108,53 @@ function uniqueStrings(values) {
   return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
 }
 
+function runtimeContractConstantsFromHomeboyOutput(output) {
+  const constants = contractConstantsPayload(output);
+  if (!constants) {
+    return {};
+  }
+
+  const normalized = {};
+  copyContractConstants(normalized, 'artifact_manifest', constants.artifact_manifest || constants.artifactManifest || constants, ['file_name', 'schema_id']);
+  copyContractConstants(normalized, 'secret_env_plan', constants.secret_env_plan || constants.secretEnvPlan || constants, ['schema_id']);
+  copyContractConstants(normalized, 'run_location_index', constants.run_location_index || constants.runLocationIndex, ['schema_id']);
+  return normalized;
+}
+
+function contractConstantsPayload(output) {
+  if (!output || typeof output !== 'object' || Array.isArray(output)) {
+    return null;
+  }
+  const data = output.data && typeof output.data === 'object' && !Array.isArray(output.data) ? output.data : output;
+  return data.constants && typeof data.constants === 'object' && !Array.isArray(data.constants) ? data.constants : null;
+}
+
+function copyContractConstants(target, contractName, source, names) {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    return;
+  }
+  const values = {};
+  for (const name of names) {
+    const value = source[name];
+    if (typeof value === 'string' && value.length > 0) {
+      values[name] = value;
+    }
+  }
+  if (Object.keys(values).length > 0) {
+    target[contractName] = values;
+  }
+}
+
 module.exports = {
   ARTIFACT_MANIFEST_CONTRACT_CONSTANTS,
   ARTIFACT_MANIFEST_FILE,
   ARTIFACT_MANIFEST_SCHEMA,
   ARTIFACT_PATHS_SCHEMA,
   CANONICAL_RUN_ARTIFACT_FILES,
+  LOCAL_RUNTIME_CONTRACT_CONSTANTS,
   RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
   SECRET_ENV_PLAN_SCHEMA,
   buildSecretEnvFallbacks,
   buildSecretEnvPlan,
+  runtimeContractConstantsFromHomeboyOutput,
 };

--- a/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
+++ b/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 
 const {
+  CORE_PUBLISHED_CONTRACT_CONSTANTS,
   LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
   probeHomeboyContractSurface,
 } = require('../lib/homeboy-contract-surface-probe.cjs');
@@ -10,12 +11,6 @@ const {
   checkHomeboyContractExportFixtures,
   compareSchemaCatalogFixture,
 } = require('../scripts/check-homeboy-contract-export-fixtures.cjs');
-const {
-  ARTIFACT_MANIFEST_FILE,
-  ARTIFACT_MANIFEST_SCHEMA,
-  RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
-} = require('../lib/runtime-contracts.cjs');
-
 const missing = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',
   spawnSync: () => ({ status: 2, stdout: '', stderr: "error: unrecognized subcommand 'constants'" }),
@@ -31,8 +26,8 @@ const releasedContractShape = probeHomeboyContractSurface({
     stdout: JSON.stringify({
       success: true,
       data: {
-        constants: LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
-        contract_id: 'artifact-manifest',
+        constants: CORE_PUBLISHED_CONTRACT_CONSTANTS,
+        contract_id: 'all',
         schema: 'homeboy/contract-constants/v1',
       },
     }),
@@ -41,29 +36,26 @@ const releasedContractShape = probeHomeboyContractSurface({
 });
 
 assert.equal(releasedContractShape.status, 'passed');
-assert.deepEqual(releasedContractShape.argv, ['contract', 'constants', 'artifact-manifest']);
+assert.deepEqual(releasedContractShape.argv, ['contract', 'constants', 'all']);
 
-const nestedContractShape = probeHomeboyContractSurface({
+const singleContractShape = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',
-  spawnSync: () => ({
-    status: 0,
-    stdout: JSON.stringify({
-      artifact_manifest: {
-        schema: ARTIFACT_MANIFEST_SCHEMA,
-        file: ARTIFACT_MANIFEST_FILE,
+  spawnSync: (_command, argv) => ({
+    status: argv[2] === 'artifact-manifest' ? 0 : 2,
+    stdout: argv[2] === 'artifact-manifest' ? JSON.stringify({
+      success: true,
+      data: {
+        constants: LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
+        contract_id: 'artifact-manifest',
+        schema: 'homeboy/contract-constants/v1',
       },
-      artifact_paths: {
-        schema: 'homeboy/runtime-agent-artifact-paths/v1',
-      },
-      runner_artifact_manifest_ref: {
-        schema: RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
-      },
-    }),
+    }) : '',
     stderr: '',
   }),
 });
 
-assert.equal(nestedContractShape.status, 'passed');
+assert.equal(singleContractShape.status, 'passed');
+assert.deepEqual(singleContractShape.argv, ['contract', 'constants', 'artifact-manifest']);
 
 const drift = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',
@@ -71,6 +63,7 @@ const drift = probeHomeboyContractSurface({
     status: 0,
     stdout: JSON.stringify({
       constants: {
+        secret_env_plan: CORE_PUBLISHED_CONTRACT_CONSTANTS.secret_env_plan,
         ...LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
         schema_id: 'homeboy/artifact-manifest/v2',
       },
@@ -80,7 +73,7 @@ const drift = probeHomeboyContractSurface({
 });
 
 assert.equal(drift.status, 'failed');
-assert.match(drift.message, /schema_id expected homeboy\/artifact-manifest\/v1/);
+assert.match(drift.message, /artifact_manifest\.schema_id expected homeboy\/artifact-manifest\/v1/);
 
 const fixtureDrift = compareSchemaCatalogFixture({
   schema: 'homeboy/contract-schema-catalog/v1',


### PR DESCRIPTION
## Summary
- centralize runtime contract constants in runtime-agent-ci
- prefer Homeboy core contract constants when available
- simplify runner config generation through the shared runtime-agent-ci writer
- remove old loose probe compatibility shape from tests

## Verification
- npm test in runtime-agent-ci
- npm run probe:homeboy-contract in runtime-agent-ci
- npm run test:homeboy-contract-export in runtime-agent-ci
- node tests/generic-agent-runtime-contract.test.js in wordpress

## Notes
- Core still needs to publish runtime-agent artifact path constants, runner artifact manifest ref constants, and canonical runtime artifact filenames before local fallbacks can be deleted.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated duplicated contract constants, drafted the adoption cleanup, and coordinated verification.