### PR TITLE
Guard pending Homeboy contract constants

### DIFF
--- a/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
+++ b/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
@@ -3,7 +3,8 @@
 const { spawnSync } = require('node:child_process');
 
 const {
-  LOCAL_RUNTIME_CONTRACT_CONSTANTS,
+  CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS,
+  PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS,
   runtimeContractConstantsFromHomeboyOutput,
 } = require('./runtime-contracts.cjs');
 
@@ -13,11 +14,9 @@ const CONTRACT_COMMANDS = Object.freeze([
   ['contract', 'constants', 'secret-env-plan'],
 ]);
 
-const LOCAL_ARTIFACT_MANIFEST_CONSTANTS = LOCAL_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest;
-const CORE_PUBLISHED_CONTRACT_CONSTANTS = Object.freeze({
-  artifact_manifest: LOCAL_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest,
-  secret_env_plan: LOCAL_RUNTIME_CONTRACT_CONSTANTS.secret_env_plan,
-});
+const LOCAL_ARTIFACT_MANIFEST_CONSTANTS = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest;
+const CORE_PUBLISHED_CONTRACT_CONSTANTS = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS;
+const VERSION_GATED_PENDING_CONTRACT_CONSTANTS = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS;
 
 function probeHomeboyContractSurface(options = {}) {
   const command = options.homeboyCommand || process.env.HOMEBOY_COMMAND || 'homeboy';
@@ -58,9 +57,7 @@ function probeHomeboyContractSurface(options = {}) {
 function validateRuntimeContractConstants({ contract, command, argv, attempts }) {
   const actualConstants = runtimeContractConstantsFromHomeboyOutput(contract);
   const expectedConstants = expectedConstantsForCommand(argv);
-  const comparableConstants = Object.fromEntries(
-    Object.entries(expectedConstants).filter(([contractName]) => actualConstants[contractName])
-  );
+  const comparableConstants = comparableConstantsForProbe(actualConstants, expectedConstants, argv);
   if (Object.keys(actualConstants).length === 0 || Object.keys(comparableConstants).length === 0) {
     return skip(`homeboy contract surface probe skipped: ${argv.join(' ')} did not expose runtime-agent constants`, attempts);
   }
@@ -93,10 +90,25 @@ function validateRuntimeContractConstants({ contract, command, argv, attempts })
   };
 }
 
+function comparableConstantsForProbe(actualConstants, expectedConstants, argv) {
+  const contractId = argv[2] || '';
+  return Object.fromEntries(
+    Object.entries(expectedConstants).filter(([contractName]) => {
+      if (actualConstants[contractName]) {
+        return true;
+      }
+      return contractId !== 'all' || !VERSION_GATED_PENDING_CONTRACT_CONSTANTS[contractName];
+    })
+  );
+}
+
 function expectedConstantsForCommand(argv) {
   const contractId = argv[2] || '';
   if (contractId === 'all') {
-    return CORE_PUBLISHED_CONTRACT_CONSTANTS;
+    return {
+      ...CORE_PUBLISHED_CONTRACT_CONSTANTS,
+      ...VERSION_GATED_PENDING_CONTRACT_CONSTANTS,
+    };
   }
   if (contractId === 'artifact-manifest') {
     return { artifact_manifest: CORE_PUBLISHED_CONTRACT_CONSTANTS.artifact_manifest };
@@ -119,5 +131,6 @@ module.exports = {
   CONTRACT_COMMANDS,
   CORE_PUBLISHED_CONTRACT_CONSTANTS,
   LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
+  VERSION_GATED_PENDING_CONTRACT_CONSTANTS,
   probeHomeboyContractSurface,
 };

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const LOCAL_RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
+const CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
   artifact_manifest: Object.freeze({
     file_name: 'homeboy-artifact-manifest.json',
     schema_id: 'homeboy/artifact-manifest/v1',
@@ -8,20 +8,48 @@ const LOCAL_RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
   secret_env_plan: Object.freeze({
     schema_id: 'homeboy/secret-env-plan/v1',
   }),
+  run_location_index: Object.freeze({
+    schema_id: 'homeboy/run-location-index/v1',
+  }),
+});
+
+// TODO(core-contract-export): remove these fallbacks once Homeboy core exports
+// these constants from `homeboy contract constants all`. The probe treats them
+// as optional until then, but validates them as soon as a current Homeboy binary
+// starts publishing the contract names.
+const PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
   artifact_paths: Object.freeze({
     schema_id: 'homeboy/runtime-agent-artifact-paths/v1',
   }),
   runner_artifact_manifest_ref: Object.freeze({
     schema_id: 'homeboy/runner-artifact-manifest-ref/v1',
   }),
+  runner_execution_record: Object.freeze({
+    schema_id: 'homeboy/runner-execution-record/v1',
+  }),
+  path_materialization_plan: Object.freeze({
+    schema_id: 'homeboy/path-materialization-plan/v1',
+  }),
+  run_outcome_envelope: Object.freeze({
+    schema_id: 'homeboy/run-outcome-envelope/v1',
+  }),
 });
 
-const ARTIFACT_MANIFEST_CONTRACT_CONSTANTS = LOCAL_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest;
+const RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
+  ...CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS,
+  ...PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS,
+});
+
+const ARTIFACT_MANIFEST_CONTRACT_CONSTANTS = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest;
 const ARTIFACT_MANIFEST_SCHEMA = ARTIFACT_MANIFEST_CONTRACT_CONSTANTS.schema_id;
 const ARTIFACT_MANIFEST_FILE = ARTIFACT_MANIFEST_CONTRACT_CONSTANTS.file_name;
-const SECRET_ENV_PLAN_SCHEMA = LOCAL_RUNTIME_CONTRACT_CONSTANTS.secret_env_plan.schema_id;
-const ARTIFACT_PATHS_SCHEMA = LOCAL_RUNTIME_CONTRACT_CONSTANTS.artifact_paths.schema_id;
-const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = LOCAL_RUNTIME_CONTRACT_CONSTANTS.runner_artifact_manifest_ref.schema_id;
+const SECRET_ENV_PLAN_SCHEMA = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.secret_env_plan.schema_id;
+const RUN_LOCATION_INDEX_SCHEMA = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.run_location_index.schema_id;
+const ARTIFACT_PATHS_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.artifact_paths.schema_id;
+const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.runner_artifact_manifest_ref.schema_id;
+const RUNNER_EXECUTION_RECORD_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.runner_execution_record.schema_id;
+const PATH_MATERIALIZATION_PLAN_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.path_materialization_plan.schema_id;
+const RUN_OUTCOME_ENVELOPE_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.run_outcome_envelope.schema_id;
 const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
   events: 'events.json',
   status: 'status.json',
@@ -118,6 +146,11 @@ function runtimeContractConstantsFromHomeboyOutput(output) {
   copyContractConstants(normalized, 'artifact_manifest', constants.artifact_manifest || constants.artifactManifest || constants, ['file_name', 'schema_id']);
   copyContractConstants(normalized, 'secret_env_plan', constants.secret_env_plan || constants.secretEnvPlan || constants, ['schema_id']);
   copyContractConstants(normalized, 'run_location_index', constants.run_location_index || constants.runLocationIndex, ['schema_id']);
+  copyContractConstants(normalized, 'artifact_paths', constants.artifact_paths || constants.artifactPaths, ['schema_id']);
+  copyContractConstants(normalized, 'runner_artifact_manifest_ref', constants.runner_artifact_manifest_ref || constants.runnerArtifactManifestRef, ['schema_id']);
+  copyContractConstants(normalized, 'runner_execution_record', constants.runner_execution_record || constants.runnerExecutionRecord, ['schema_id']);
+  copyContractConstants(normalized, 'path_materialization_plan', constants.path_materialization_plan || constants.pathMaterializationPlan, ['schema_id']);
+  copyContractConstants(normalized, 'run_outcome_envelope', constants.run_outcome_envelope || constants.runOutcomeEnvelope, ['schema_id']);
   return normalized;
 }
 
@@ -151,8 +184,14 @@ module.exports = {
   ARTIFACT_MANIFEST_SCHEMA,
   ARTIFACT_PATHS_SCHEMA,
   CANONICAL_RUN_ARTIFACT_FILES,
-  LOCAL_RUNTIME_CONTRACT_CONSTANTS,
+  CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS,
+  PATH_MATERIALIZATION_PLAN_SCHEMA,
+  PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS,
+  RUN_LOCATION_INDEX_SCHEMA,
+  RUN_OUTCOME_ENVELOPE_SCHEMA,
+  RUNNER_EXECUTION_RECORD_SCHEMA,
   RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
+  RUNTIME_CONTRACT_CONSTANTS,
   SECRET_ENV_PLAN_SCHEMA,
   buildSecretEnvFallbacks,
   buildSecretEnvPlan,

--- a/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
+++ b/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
@@ -5,8 +5,12 @@ const assert = require('node:assert/strict');
 const {
   CORE_PUBLISHED_CONTRACT_CONSTANTS,
   LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
+  VERSION_GATED_PENDING_CONTRACT_CONSTANTS,
   probeHomeboyContractSurface,
 } = require('../lib/homeboy-contract-surface-probe.cjs');
+const {
+  runtimeContractConstantsFromHomeboyOutput,
+} = require('../lib/runtime-contracts.cjs');
 const {
   checkHomeboyContractExportFixtures,
   compareSchemaCatalogFixture,
@@ -37,6 +41,46 @@ const releasedContractShape = probeHomeboyContractSurface({
 
 assert.equal(releasedContractShape.status, 'passed');
 assert.deepEqual(releasedContractShape.argv, ['contract', 'constants', 'all']);
+
+const pendingContractShape = probeHomeboyContractSurface({
+  homeboyCommand: 'homeboy',
+  spawnSync: () => ({
+    status: 0,
+    stdout: JSON.stringify({
+      success: true,
+      data: {
+        constants: {
+          ...CORE_PUBLISHED_CONTRACT_CONSTANTS,
+          runner_execution_record: VERSION_GATED_PENDING_CONTRACT_CONSTANTS.runner_execution_record,
+          path_materialization_plan: VERSION_GATED_PENDING_CONTRACT_CONSTANTS.path_materialization_plan,
+          run_outcome_envelope: VERSION_GATED_PENDING_CONTRACT_CONSTANTS.run_outcome_envelope,
+        },
+        contract_id: 'all',
+        schema: 'homeboy/contract-constants/v1',
+      },
+    }),
+    stderr: '',
+  }),
+});
+
+assert.equal(pendingContractShape.status, 'passed');
+assert.deepEqual(pendingContractShape.constants.runner_execution_record, { schema_id: 'homeboy/runner-execution-record/v1' });
+assert.deepEqual(pendingContractShape.constants.path_materialization_plan, { schema_id: 'homeboy/path-materialization-plan/v1' });
+assert.deepEqual(pendingContractShape.constants.run_outcome_envelope, { schema_id: 'homeboy/run-outcome-envelope/v1' });
+
+assert.deepEqual(runtimeContractConstantsFromHomeboyOutput({
+  data: {
+    constants: {
+      runnerExecutionRecord: { schema_id: 'homeboy/runner-execution-record/v1' },
+      pathMaterializationPlan: { schema_id: 'homeboy/path-materialization-plan/v1' },
+      runOutcomeEnvelope: { schema_id: 'homeboy/run-outcome-envelope/v1' },
+    },
+  },
+}), {
+  runner_execution_record: { schema_id: 'homeboy/runner-execution-record/v1' },
+  path_materialization_plan: { schema_id: 'homeboy/path-materialization-plan/v1' },
+  run_outcome_envelope: { schema_id: 'homeboy/run-outcome-envelope/v1' },
+});
 
 const singleContractShape = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',


### PR DESCRIPTION
## Summary
- split currently published Homeboy contract constants from pending core constants in runtime-agent-ci
- consume wave 1 runner contract constants when available
- validate pending constants only when the active Homeboy binary publishes them

## Verification
- node runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
- node runtime-agent-ci/tests/build-runner-config.test.js
- node runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
- node runtime-agent-ci/tests/generic-agent-loop-runner.test.js
- npm --prefix runtime-agent-ci test
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated core contract adoption seams, drafted the guarded constants cleanup, and coordinated verification.