### PR TITLE
Remove deprecated runtime workflow inputs

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -10,7 +10,6 @@ const {
   providerBenchEnvFromManifest,
   runtimePathRequired,
   writeFullRunConfig,
-  workflowInputCompatibility,
 } = require('../../../runtime-agent-ci/provider-adapters');
 
 function main() {
@@ -26,4 +25,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, workflowInputCompatibility, writeFullRunConfig };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, writeFullRunConfig };

--- a/.github/scripts/runtime-agent-full-run/project-engine-data.cjs
+++ b/.github/scripts/runtime-agent-full-run/project-engine-data.cjs
@@ -5,9 +5,7 @@ const { findScenario, getByPath, parseJsonInput, readJsonFile, writeGithubOutput
 
 function main() {
   const runtimeOutputProjections = parseJsonInput('runtime_output_projections', process.env.RUNTIME_OUTPUT_PROJECTIONS || '{}', 'object', {});
-  const outputs = Object.keys(runtimeOutputProjections).length > 0
-    ? runtimeOutputProjections
-    : parseJsonInput('engine_data_outputs', process.env.ENGINE_DATA_OUTPUTS || '{}', 'object', {});
+  const outputs = runtimeOutputProjections;
   if (Object.keys(outputs).length === 0) {
     writeGithubOutput({ engine_data_json: '{}' });
     return;

--- a/.github/scripts/runtime-agent-full-run/render-runtime-workflow-inputs.cjs
+++ b/.github/scripts/runtime-agent-full-run/render-runtime-workflow-inputs.cjs
@@ -11,10 +11,10 @@ const {
 
 function main() {
 	const rendered = renderRuntimeWorkflowInputs({
-		runtime: process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND,
-		runtime_profile: parseRuntimeProfile(process.env.RUNTIME_PROFILE || process.env.PROFILE || ''),
+		runtime: process.env.RUNTIME,
+		runtime_profile: parseRuntimeProfile(process.env.PROFILE || ''),
 		runtime_profiles: parseJsonInput('runtime_profiles', process.env.RUNTIME_PROFILES || '{}', 'object', {}),
-		tool_profile: parseJsonInput('tool_profile', process.env.TOOL_PROFILE || process.env.TOOL_POLICY || '{}', 'object', {}),
+		tool_profile: parseJsonInput('tool_profile', process.env.TOOL_PROFILE || '{}', 'object', {}),
 		runtime_mounts: parseJsonInput('runtime_mounts', process.env.RUNTIME_MOUNTS || '[]', 'array', []),
 		runtime_state_mounts: parseJsonInput('runtime_state_mounts', process.env.RUNTIME_STATE_MOUNTS || '[]', 'array', []),
 		runtime_config_mounts: parseJsonInput('runtime_config_mounts', process.env.RUNTIME_CONFIG_MOUNTS || '[]', 'array', []),

--- a/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
+++ b/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
@@ -7,7 +7,7 @@ const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime
 
 function main() {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
-  const runtime = resolveRuntimeProvider(process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || DEFAULT_RUNTIME_ID, { workspace });
+  const runtime = resolveRuntimeProvider(process.env.RUNTIME || DEFAULT_RUNTIME_ID, { workspace });
   runRuntimeSetup(runtime, { phase: 'before_commands', workspace, env: process.env, run });
   for (const command of [...runtime.setupCommands, ...runtime.buildCommands]) {
     run(command.command, command.args, { cwd: path.join(workspace, command.cwd) });

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -99,8 +99,6 @@ workflow with canonical inputs.
 
 Runtime wrapper metadata lives with the runtime adapter manifest and docs. The
 generic workflow only relies on the canonical selected-runtime inputs it receives.
-Existing direct callers of `runtime-agent-full-run.yml` remain supported for
-compatibility.
 
 ### Migrating Old Wrapper Callers
 
@@ -115,11 +113,11 @@ Use this mapping when updating old wrapper workflow bodies:
 
 | Old wrapper concept | Generic `runtime-agent-full-run.yml` input |
 | --- | --- |
-| Runtime selection | `runtime`, `runtime_ref`. Deprecated compatibility alias: `runtime_provider`. |
+| Runtime selection | `runtime`, `runtime_ref` |
 | Flow identity | `workload_id`, `workload_label`, `callback_data` |
 | Bundle execution | `runtime_execution: {"kind":"bundle","source":"..."}` |
 | Direct ability execution | `runtime_task` or `ability_request` / `ability_input` |
-| Runtime stack | `runtime_dependencies`, `runtime_components`, `profile`, `runtime_profiles`. Deprecated compatibility alias: `runtime_profile`. |
+| Runtime stack | `runtime_dependencies`, `runtime_components`, `profile`, `runtime_profiles` |
 | Required abilities | `required_abilities` |
 | Output projection | `runtime_output_projections`, `evidence_projections` |
 | Artifacts | `expected_artifacts`, `artifact_declarations`, `artifact_export_config` |
@@ -138,7 +136,7 @@ Callers that compose workflow inputs before invoking `runtime-agent-full-run.yml
 can use the `homeboy-runtime-agent-ci/runtime-workflow-inputs` package export,
 the `homeboy-render-runtime-workflow-inputs` CLI, or
 `.github/actions/render-runtime-workflow-inputs`. These surfaces accept
-`runtime`, `runtime_profile` as either an id or JSON object,
+`runtime`, `profile` as either an id or JSON object,
 `runtime_profiles`, `tool_profile`, and runtime mount arrays, then emit
 selected-runtime workflow input JSON with a canonical `profile` output.
 
@@ -160,8 +158,8 @@ and whether the caller required a Homeboy App token. Tokens are never printed.
 
 ## Inputs worth calling out
 
-- Agent CI runs through the selected `runtime`. Empty runtime input selects `local-shell`. Deprecated compatibility aliases remain available only for existing callers: `runtime_provider` and `backend` map to `runtime`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
-- `profile` is the runtime profile selector. Deprecated compatibility alias: `runtime_profile`.
+- Agent CI runs through the selected `runtime`. Empty runtime input selects `local-shell`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
+- `profile` is the runtime profile selector.
 - `runtime_ref` controls the selected runtime ref.
 - `runtime_execution` declares bundle, workflow, or ability execution. When `runtime_task` or `ability_request` is supplied, the workflow builds a direct runtime task instead.
 - `runtime_task` forwards a generic `{ "ability", "input" }` object to the runtime task executor.
@@ -170,11 +168,11 @@ and whether the caller required a Homeboy App token. Tokens are never printed.
 - Generic `runtime-agent-full-run.yml` callers can use `runtime_execution` for ability, bundle, or workflow descriptors and pass `runtime_output_projections` / `evidence_projections` through to the selected runtime config. Bundle and workflow descriptors derive the provider operation from the selected runtime profile's `runtime_execution_contracts`, so callers do not need to provide `runtime_task.ability` for generic package runs.
 - `component_contracts` forwards explicit runtime component/plugin contracts to the selected runtime adapter.
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to the selected runtime adapter.
-- `tool_profile` is the runtime-neutral tool policy input. The selected runtime adapter maps it into runtime-owned workflow fields. Deprecated compatibility alias: `tool_policy`.
+- `tool_profile` is the runtime-neutral tool policy input. The selected runtime adapter maps it into runtime-owned workflow fields.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. The generic workflow does not choose a provider plugin or secret for callers; provider dependencies and credential mappings are explicit caller inputs, and runtime manifests advertise provider-specific defaults/capabilities. Deprecated compatibility alias: `credentials`; generated config uses `provider_secret_env_mapping`.
 - `secret_env` declares canonical secret environment variable names required by the runtime. It accepts a JSON array or comma-separated list.
 - `secret_env_plan` accepts a `homeboy/secret-env-plan/v1` object and merges it into the generated runner config. The plan declares names and requirements only; secret values are never serialized.
-- `secret_env_map` maps canonical target env names to fallback source env names. Use it when a runner already exposes the source env name, such as a compatibility `PROVIDER_SECRET_n` slot. When `materialize_secret_env_from_github_secrets` is enabled, sources may also be GitHub secret names from the inherited secrets context. Values are names, not secret values.
+- `secret_env_map` maps canonical target env names to fallback source env names. When `materialize_secret_env_from_github_secrets` is enabled, sources may also be GitHub secret names from the inherited secrets context. Values are names, not secret values.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - Bundle sources in `runtime_execution` are resolved relative to the consumer checkout unless the caller materializes external bundle sources through dependencies or validation checkouts.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`. Use it when the workflow needs app-token access to more than the target repository.
@@ -189,7 +187,7 @@ and whether the caller required a Homeboy App token. Tokens are never printed.
 - `proof_profile` controls controller-loop proof evidence. `artifact_only` is the generic default and does not require preview or PR/publication evidence, `cook_to_pr` requires durable preview plus pull-request evidence, and `none` declares no extra proof requirements. Explicit `controller_loop_proof` / `controller_loop_proof_policy` config still overrides profile fields.
 - `workload_run_after` runs post-agent verifier hooks through the selected runtime scenario.
 - `ability_tools` adds ability-backed tools to the agent loop. It must be a JSON array.
-- `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. Deprecated compatibility alias: `tool_recorders`, only for existing callers that still need forced-parameter behavior.
+- `evidence_projections` maps provider operation results to named runtime outputs or artifact refs.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
 - `runner_workspace` provisions a selected-runtime runner workspace before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the selected runtime after completion.
 - `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.
@@ -280,26 +278,3 @@ Enable `materialize_secret_env_from_github_secrets` only when the caller wants
 the reusable workflow to resolve `secret_env_map` sources from the GitHub secrets
 context. Prefer passing only the minimum required secrets to the workflow when
 the caller can avoid broad `secrets: inherit` access.
-
-`PROVIDER_SECRET_1` through `PROVIDER_SECRET_5` remain available for existing
-callers that cannot yet pass canonical names. Treat them as compatibility slots
-only. During migration, `secret_env_map` can fill a canonical env name from a
-numbered source while keeping the generated runner config canonical:
-
-```yaml
-with:
-  provider_plugin: |
-    {
-      "repo": "Example/example-ai-provider",
-      "ref": "main",
-      "path": ".",
-      "register_function": "Example\\AiProvider\\register_provider",
-      "provider_secret_env": {
-        "connectors_ai_example_api_key": "EXAMPLE_PROVIDER_API_KEY"
-      }
-    }
-  secret_env: '["EXAMPLE_PROVIDER_API_KEY"]'
-  secret_env_map: '{"EXAMPLE_PROVIDER_API_KEY":"PROVIDER_SECRET_1"}'
-secrets:
-  PROVIDER_SECRET_1: ${{ secrets.EXAMPLE_PROVIDER_API_KEY }}
-```

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -11,30 +11,14 @@ name: Runtime Agent Full Run (reusable)
         description: When false, record a skipped run and bypass runtime setup/execution.
         type: boolean
         default: true
-      runtime_provider:
-        description: Deprecated compatibility alias for runtime. Existing callers only; empty selects the neutral local-shell runtime.
-        type: string
-        default: ''
       runtime:
         description: Agent runtime id. Defaults to the neutral local-shell runtime. Runtime-specific callers should prefer a runtime wrapper when one is available.
-        type: string
-        default: ''
-      backend:
-        description: Deprecated compatibility alias for runtime. Existing callers only.
         type: string
         default: ''
       runtime_ref:
         description: Runtime provider ref.
         type: string
         default: main
-      runtime_wordpress_version:
-        description: Deprecated selected-runtime compatibility input. Runtime wrappers should expose runtime-owned names and pass canonical values explicitly.
-        type: string
-        default: ''
-      runtime_profile:
-        description: Deprecated compatibility alias for profile. Existing callers only.
-        type: string
-        default: ''
       profile:
         description: Runtime profile id selected from runtime_profiles.
         type: string
@@ -81,7 +65,7 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: '{}'
       secret_env:
-        description: JSON array or comma-separated canonical secret env names required by the runtime. Prefer this over numbered provider secret slots for new callers.
+        description: JSON array or comma-separated canonical secret env names required by the runtime.
         type: string
         default: ''
       secret_env_map:
@@ -113,10 +97,6 @@ name: Runtime Agent Full Run (reusable)
         default: '{}'
       workload:
         description: JSON workload DTO forwarded to the selected runtime config. Falls back to workload_id/workload_label when empty.
-        type: string
-        default: '{}'
-      tool_policy:
-        description: Deprecated compatibility alias for tool_profile. Existing callers only.
         type: string
         default: '{}'
       tool_profile:
@@ -191,20 +171,12 @@ name: Runtime Agent Full Run (reusable)
         description: JSON object mapping workflow output names to dotted paths in the runtime task result.
         type: string
         default: '{}'
-      engine_data_outputs:
-        description: Legacy JSON map of output_name to result path, collected into engine_data_json.
-        type: string
-        default: '{}'
       runtime_output_projections:
         description: JSON map of output_name to provider runtime result path, collected into engine_data_json.
         type: string
         default: '{}'
       evidence_projections:
         description: JSON array mapping provider operation results to named runtime outputs or artifact refs.
-        type: string
-        default: '[]'
-      tool_recorders:
-        description: Deprecated compatibility alias for evidence_projections with forced parameters. Existing callers only.
         type: string
         default: '[]'
       expected_artifacts:
@@ -268,10 +240,6 @@ name: Runtime Agent Full Run (reusable)
         description: Build runner config and exercise the runner dry-run path without a live provider call.
         type: boolean
         default: false
-      extra_wp_config_defines:
-        description: Deprecated selected-runtime compatibility input. Runtime wrappers should expose runtime-owned names and pass canonical values explicitly.
-        type: string
-        default: ''
       runtime_mounts:
         description: JSON array appended to selected runtime mounts.
         type: string
@@ -332,21 +300,6 @@ name: Runtime Agent Full Run (reusable)
       HOMEBOY_APP_ID:
         required: false
       HOMEBOY_APP_PRIVATE_KEY:
-        required: false
-      PROVIDER_SECRET_1:
-        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
-        required: false
-      PROVIDER_SECRET_2:
-        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
-        required: false
-      PROVIDER_SECRET_3:
-        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
-        required: false
-      PROVIDER_SECRET_4:
-        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
-        required: false
-      PROVIDER_SECRET_5:
-        description: Compatibility-only provider credential slot. Prefer canonical secret_env/secret_env_plan declarations for new callers.
         required: false
     outputs:
       job_status:
@@ -469,9 +422,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           VALIDATION_DEPENDENCIES: ${{ inputs.validation_dependencies }}
           RUNTIME_DEPENDENCIES: ${{ inputs.runtime_dependencies }}
-          RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
           RUNTIME: ${{ inputs.runtime }}
-          BACKEND: ${{ inputs.backend }}
           AGENT_RUNTIME_REF: ${{ inputs.runtime_ref }}
           PROVIDER: ${{ inputs.provider }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
@@ -496,9 +447,7 @@ jobs:
       - name: Install and build runtime dependencies
         if: ${{ inputs.run_agent }}
         env:
-          RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
           RUNTIME: ${{ inputs.runtime }}
-          BACKEND: ${{ inputs.backend }}
           AGENT_RUNTIME_REF: ${{ inputs.runtime_ref }}
           PROVIDER: ${{ inputs.provider }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
@@ -523,20 +472,15 @@ jobs:
           SECRET_ENV: ${{ inputs.secret_env }}
           SECRET_ENV_MAP: ${{ inputs.secret_env_map }}
           SECRET_ENV_PLAN: ${{ inputs.secret_env_plan }}
-          RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
           RUNTIME: ${{ inputs.runtime }}
-          BACKEND: ${{ inputs.backend }}
           AGENT_RUNTIME_REF: ${{ inputs.runtime_ref }}
           RUNTIME_REF: ${{ inputs.runtime_ref }}
-          RUNTIME_PROFILE: ${{ inputs.runtime_profile }}
           PROFILE: ${{ inputs.profile }}
           RUNTIME_PROFILES: ${{ inputs.runtime_profiles }}
-          RUNTIME_WORDPRESS_VERSION: ${{ inputs.runtime_wordpress_version }}
           EXECUTION_KIND: ${{ inputs.execution_kind }}
           RUNTIME_TASK: ${{ inputs.runtime_task }}
           RUNTIME_EXECUTION: ${{ inputs.runtime_execution }}
           WORKLOAD: ${{ inputs.workload }}
-          TOOL_POLICY: ${{ inputs.tool_policy }}
           TOOL_PROFILE: ${{ inputs.tool_profile }}
           ABILITY_REQUEST: ${{ inputs.ability_request }}
           ABILITY_INPUT: ${{ inputs.ability_input }}
@@ -564,7 +508,6 @@ jobs:
           PROBES: ${{ inputs.probes }}
           CALLBACK_DATA: ${{ inputs.callback_data }}
           DRY_RUN: ${{ inputs.dry_run }}
-          EXTRA_WP_CONFIG_DEFINES: ${{ inputs.extra_wp_config_defines }}
           RUNTIME_MOUNTS: ${{ inputs.runtime_mounts }}
           RUNTIME_OVERLAYS: ${{ inputs.runtime_overlays }}
           RUNTIME_ENV: ${{ inputs.runtime_env }}
@@ -578,7 +521,6 @@ jobs:
           ABILITY_TOOLS: ${{ inputs.ability_tools }}
           RUNTIME_OUTPUT_PROJECTIONS: ${{ inputs.runtime_output_projections }}
           EVIDENCE_PROJECTIONS: ${{ inputs.evidence_projections }}
-          TOOL_RECORDERS: ${{ inputs.tool_recorders }}
           RUNNER_WORKSPACE_CONFIG: ${{ inputs.runner_workspace }}
           IGNORED_WORKSPACE_PATHS: ${{ inputs.ignored_workspace_paths }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
@@ -591,11 +533,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           HOMEBOY_GITHUB_APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}
-          PROVIDER_SECRET_2: ${{ secrets.PROVIDER_SECRET_2 }}
-          PROVIDER_SECRET_3: ${{ secrets.PROVIDER_SECRET_3 }}
-          PROVIDER_SECRET_4: ${{ secrets.PROVIDER_SECRET_4 }}
-          PROVIDER_SECRET_5: ${{ secrets.PROVIDER_SECRET_5 }}
           HOMEBOY_GITHUB_SECRETS_JSON: ${{ inputs.materialize_secret_env_from_github_secrets && toJson(secrets) || '{}' }}
           HOMEBOY_RUNTIME_AGENT_RUN_DIR: ${{ runner.temp }}/runtime-agent-run
           # Stream raw subprocess stdout/stderr live to the job log so a hard
@@ -664,7 +601,6 @@ jobs:
         if: ${{ inputs.run_agent }}
         env:
           RESULTS_FILE: ${{ runner.temp }}/runtime-agent-run/results.json
-          ENGINE_DATA_OUTPUTS: ${{ inputs.engine_data_outputs }}
           RUNTIME_OUTPUT_PROJECTIONS: ${{ inputs.runtime_output_projections }}
           FLOW_SLUG: ${{ inputs.workload_id }}
         run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/project-engine-data.cjs

--- a/.github/workflows/wp-codebox-runtime-agent-full-run.yml
+++ b/.github/workflows/wp-codebox-runtime-agent-full-run.yml
@@ -15,10 +15,6 @@ name: WP Codebox Runtime Agent Full Run (reusable)
         description: WP Codebox runtime provider ref.
         type: string
         default: main
-      wordpress_version:
-        description: WordPress version used by the WP Codebox runtime.
-        type: string
-        default: ''
       profile:
         description: Runtime profile id selected from runtime_profiles.
         type: string
@@ -155,10 +151,6 @@ name: WP Codebox Runtime Agent Full Run (reusable)
         description: JSON object mapping workflow output names to dotted paths in the runtime task result.
         type: string
         default: '{}'
-      engine_data_outputs:
-        description: Legacy JSON map of output_name to result path, collected into engine_data_json.
-        type: string
-        default: '{}'
       runtime_output_projections:
         description: JSON map of output_name to provider runtime result path, collected into engine_data_json.
         type: string
@@ -228,10 +220,6 @@ name: WP Codebox Runtime Agent Full Run (reusable)
         description: Build runner config and exercise the runner dry-run path without a live provider call.
         type: boolean
         default: false
-      wp_config_defines:
-        description: JSON object merged into the WP Codebox runner config wp_config_defines.
-        type: string
-        default: ''
       wp_runtime_mounts:
         description: JSON array appended to WP Codebox runtime mounts.
         type: string
@@ -293,16 +281,6 @@ name: WP Codebox Runtime Agent Full Run (reusable)
         required: false
       HOMEBOY_APP_PRIVATE_KEY:
         required: false
-      PROVIDER_SECRET_1:
-        required: false
-      PROVIDER_SECRET_2:
-        required: false
-      PROVIDER_SECRET_3:
-        required: false
-      PROVIDER_SECRET_4:
-        required: false
-      PROVIDER_SECRET_5:
-        required: false
     outputs:
       job_status:
         value: ${{ jobs.run-wp-codebox-agent.outputs.job_status }}
@@ -329,7 +307,6 @@ jobs:
       run_agent: ${{ inputs.run_agent }}
       runtime: wp-codebox
       runtime_ref: ${{ inputs.runtime_ref }}
-      runtime_wordpress_version: ${{ inputs.wordpress_version }}
       profile: ${{ inputs.profile }}
       runtime_profiles: ${{ inputs.runtime_profiles }}
       runtime_dependencies: ${{ inputs.runtime_dependencies }}
@@ -366,7 +343,6 @@ jobs:
       duration_ms: ${{ inputs.duration_ms }}
       deadline_at: ${{ inputs.deadline_at }}
       output_mappings: ${{ inputs.output_mappings }}
-      engine_data_outputs: ${{ inputs.engine_data_outputs }}
       runtime_output_projections: ${{ inputs.runtime_output_projections }}
       evidence_projections: ${{ inputs.evidence_projections }}
       expected_artifacts: ${{ inputs.expected_artifacts }}
@@ -386,7 +362,6 @@ jobs:
       engine_key: ${{ inputs.engine_key }}
       tool_results_key: ${{ inputs.tool_results_key }}
       dry_run: ${{ inputs.dry_run }}
-      extra_wp_config_defines: ${{ inputs.wp_config_defines }}
       runtime_mounts: ${{ inputs.wp_runtime_mounts }}
       runtime_overlays: ${{ inputs.wp_runtime_overlays }}
       runtime_env: ${{ inputs.runtime_env }}

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -44,9 +44,8 @@ function buildConfig(env) {
   const targetRepo = required(env.TARGET_REPO, 'TARGET_REPO');
   const componentId = env.COMPONENT_ID || path.basename(workspace);
   const componentPath = env.COMPONENT_PATH || workspace;
-  const compatibility = workflowInputCompatibility(env);
-  const runtimeId = compatibility.runtimeId;
-  const runtimeProfile = required(compatibility.profile, 'PROFILE or RUNTIME_PROFILE');
+  const runtimeId = runtimeIdFromOptions({ runtime: env.RUNTIME }, env);
+  const runtimeProfile = required(env.PROFILE, 'PROFILE');
   const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
   const runtime = resolveRuntimeProvider(runtimeId, { workspace, env });
   const runtimeBin = runtime.paths.runtime_bin;
@@ -89,7 +88,7 @@ function buildConfig(env) {
   const runtimeTask = runtimeTaskFromEnv(env);
   const runtimeExecution = parseJsonInput('runtime_execution', env.RUNTIME_EXECUTION || '{}', 'object', {});
   const workload = runtimeWorkloadFromEnv(env, workloadId);
-  const toolProfile = parseJsonInput('tool_profile', compatibility.toolProfile, 'object', {});
+  const toolProfile = parseJsonInput('tool_profile', env.TOOL_PROFILE || '{}', 'object', {});
   const runtimeOutputProjections = parseJsonInput('runtime_output_projections', env.RUNTIME_OUTPUT_PROJECTIONS || '{}', 'object', {});
   const evidenceProjections = parseJsonInput('evidence_projections', env.EVIDENCE_PROJECTIONS || '[]', 'array', []);
   const runtimeComponents = parseJsonInput('runtime_components', env.RUNTIME_COMPONENTS || '{}', 'object', {});
@@ -198,10 +197,9 @@ function buildConfig(env) {
     }),
     ...(Object.keys(inputSecretEnvMap).length > 0 ? { secret_env_map: inputSecretEnvMap } : {}),
     // Fill a target secret env from a fallback source before the sandbox
-    // preflight runs: the provider's canonical key (e.g. OPENAI_API_KEY) from
-    // the caller's generic credential secret (PROVIDER_SECRET_n), and the
-    // Homeboy app token from the repository GITHUB_TOKEN when no app token is
-    // available. The run step applies these against its own environment.
+    // preflight runs, and allow the Homeboy app token to fall back to the
+    // repository GITHUB_TOKEN when no app token is available. The run step
+    // applies these against its own environment.
     ...(Object.keys(secretEnvFallbacks).length > 0 ? { secret_env_fallbacks: secretEnvFallbacks } : {}),
     github_profile_id: env.GITHUB_PROFILE_ID || `${workloadId}-ci`,
     target_repo: targetRepo,
@@ -230,7 +228,6 @@ function buildConfig(env) {
     ability_tools: parseJsonInput('ability_tools', env.ABILITY_TOOLS || '[]', 'array', []),
     ability_requirements: parseJsonInput('ability_requirements', env.ABILITY_REQUIREMENTS || '[]', 'array', []),
     evidence_projections: evidenceProjections,
-    tool_recorders: parseJsonInput('tool_recorders', env.TOOL_RECORDERS || '[]', 'array', []),
     runner_workspace: effectiveRunnerWorkspace,
     ignored_workspace_paths: parseJsonInput('ignored_workspace_paths', env.IGNORED_WORKSPACE_PATHS || '[]', 'array', []),
     callback_data: parseJsonInput('callback_data', env.CALLBACK_DATA || '{}', 'object', {}),
@@ -257,47 +254,7 @@ function buildConfig(env) {
       GITHUB_RUN_ID: env.GITHUB_RUN_ID_VALUE || '',
       GITHUB_RUN_ATTEMPT: env.GITHUB_RUN_ATTEMPT_VALUE || '',
     },
-    _workflowInputCompatibility: compatibility,
   };
-}
-
-function workflowInputCompatibility(env) {
-  const aliases = [];
-  const runtime = aliasValue(env, aliases, 'runtime', [
-    ['RUNTIME', 'runtime'],
-    ['RUNTIME_PROVIDER', 'runtime_provider'],
-    ['BACKEND', 'backend'],
-  ], '');
-  const profile = aliasValue(env, aliases, 'profile', [
-    ['PROFILE', 'profile'],
-    ['RUNTIME_PROFILE', 'runtime_profile'],
-  ], '');
-  const toolProfile = aliasValue(env, aliases, 'tool_profile', [
-    ['TOOL_PROFILE', 'tool_profile'],
-    ['TOOL_POLICY', 'tool_policy'],
-  ], '{}');
-
-  return {
-    runtimeId: runtimeIdFromOptions({ runtime }, env),
-    runtime,
-    profile,
-    toolProfile,
-    deprecated_aliases: aliases,
-  };
-}
-
-function aliasValue(env, aliases, canonicalName, candidates, fallback) {
-  for (let index = 0; index < candidates.length; index += 1) {
-    const [envName, inputName] = candidates[index];
-    if (env[envName] === undefined || env[envName] === '') {
-      continue;
-    }
-    if (index > 0) {
-      aliases.push({ input: inputName, canonical_input: canonicalName });
-    }
-    return env[envName];
-  }
-  return fallback;
 }
 
 function loopPolicyFromEnv(env) {
@@ -484,7 +441,6 @@ function projectRuntimeConfig({ env, runtime, workspace, componentId, componentP
     ),
     wp_config_defines: {
       ...(plainObject(projection.wp_config_defines) ? projection.wp_config_defines : {}),
-      ...parseJsonInput('extra_wp_config_defines', env.EXTRA_WP_CONFIG_DEFINES || '{}', 'object', {}),
     },
     runtime_fields: runtimeFieldsFromProjection(projection.runtime_fields, env),
   };
@@ -582,4 +538,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys, workflowInputCompatibility, writeFullRunConfig };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys, writeFullRunConfig };

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -247,20 +247,12 @@ function normalizeRuntimeId(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 }
 
 function runtimeIdFromOptions(options = {}, env = process.env) {
-	// Mirror the env precedence used by setup-runtime.cjs
-	// (RUNTIME || RUNTIME_PROVIDER || BACKEND). Consumers commonly set only
-	// RUNTIME_PROVIDER; without honoring it here, materialize-dependencies
-	// resolves DEFAULT_RUNTIME_ID instead of the real runtime and never checks
-	// out the runtime provider repo, so its setup_commands later fail on a
-	// missing cwd.
 	return firstString(
 		options.runtimeId,
 		options.runtime_id,
 		options.runtime,
 		env.RUNTIME_ID,
 		env.RUNTIME,
-		env.RUNTIME_PROVIDER,
-		env.BACKEND,
 		DEFAULT_RUNTIME_ID
 	);
 }

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -81,16 +81,16 @@ try {
 const mappedSecretEnvPlan = buildSecretEnvPlan({
   secretEnv: ['PRIVATE_TOKEN'],
   runtimeEnv: { PUBLIC_MODE: 'test', PRIVATE_MODE: false },
-  providerSecretEnvMapping: { token: 'PROVIDER_SECRET_1' },
-  secretEnvFallbacks: { PRIVATE_TOKEN: ['PROVIDER_SECRET_1'] },
+  providerSecretEnvMapping: { token: 'UPSTREAM_PROVIDER_TOKEN' },
+  secretEnvFallbacks: { PRIVATE_TOKEN: ['UPSTREAM_PROVIDER_TOKEN'] },
 });
 validateSecretEnvPlan(mappedSecretEnvPlan);
 assert.deepEqual(mappedSecretEnvPlan.public_env, { PUBLIC_MODE: 'test' });
 assert.deepEqual(mappedSecretEnvPlan.secret_env_names, ['PRIVATE_TOKEN']);
 assert.deepEqual(mappedSecretEnvPlan.requirements, [{ name: 'PRIVATE_TOKEN', required: true }]);
 assert.deepEqual(mappedSecretEnvPlan.env_name_mapping, {
-  provider_secret_env: ['PROVIDER_SECRET_1'],
-  secret_env_fallbacks: ['PROVIDER_SECRET_1'],
+  provider_secret_env: ['UPSTREAM_PROVIDER_TOKEN'],
+  secret_env_fallbacks: ['UPSTREAM_PROVIDER_TOKEN'],
 });
 
 const plannedSecretEnv = buildSecretEnvPlan({
@@ -122,7 +122,7 @@ try {
     RUNTIME_PROFILES: '{}',
     RUNTIME: 'local-shell',
     SECRET_ENV: 'OPENAI_API_KEY',
-    SECRET_ENV_MAP: '{"OPENAI_API_KEY":"PROVIDER_SECRET_1"}',
+    SECRET_ENV_MAP: '{"OPENAI_API_KEY":"UPSTREAM_OPENAI_API_KEY"}',
     SECRET_ENV_PLAN: JSON.stringify({
       schema: SECRET_ENV_PLAN_SCHEMA,
       secret_env_names: ['ANTHROPIC_API_KEY'],
@@ -136,8 +136,8 @@ try {
     'HOMEBOY_GITHUB_APP_TOKEN',
     'OPENAI_API_KEY',
   ]);
-  assert.deepEqual(canonicalSecretConfig.secret_env_fallbacks.OPENAI_API_KEY, ['PROVIDER_SECRET_1']);
-  assert.deepEqual(canonicalSecretConfig.secret_env_map, { OPENAI_API_KEY: ['PROVIDER_SECRET_1'] });
+  assert.deepEqual(canonicalSecretConfig.secret_env_fallbacks.OPENAI_API_KEY, ['UPSTREAM_OPENAI_API_KEY']);
+  assert.deepEqual(canonicalSecretConfig.secret_env_map, { OPENAI_API_KEY: ['UPSTREAM_OPENAI_API_KEY'] });
   assert.deepEqual(canonicalSecretConfig.secret_env_plan.requirements, [
     { name: 'ANTHROPIC_API_KEY', required: false, source: 'runner' },
     { name: 'GITHUB_TOKEN', required: true },

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -22,28 +22,12 @@ assert.equal(
   'wp-codebox'
 );
 
-// Regression guard: materialize-dependencies resolves the runtime id via
-// runtimeIdFromOptions while setup-runtime resolves it via
-// RUNTIME || RUNTIME_PROVIDER || BACKEND. When a consumer sets only
-// RUNTIME_PROVIDER (or BACKEND), both must resolve the SAME runtime so the
-// runtime provider repo is checked out into .ci/<runtime> before its npm
-// setup/build commands run there. Honoring only RUNTIME/RUNTIME_ID here makes
-// materialize fall back to DEFAULT_RUNTIME_ID (local-shell, no checkout), so
-// setup-runtime later spawns `npm install` in a never-created .ci/wp-codebox
-// and fails with a missing-cwd ENOENT.
-for (const env of [{ RUNTIME_PROVIDER: 'wp-codebox' }, { BACKEND: 'wp-codebox' }]) {
-  const materializeRuntimeId = runtimeIdFromOptions({}, env);
-  const setupRuntimeId = env.RUNTIME || env.RUNTIME_PROVIDER || env.BACKEND || DEFAULT_RUNTIME_ID;
-  assert.equal(
-    materializeRuntimeId,
-    setupRuntimeId,
-    `materialize and setup-runtime must resolve the same runtime for ${JSON.stringify(env)}`
-  );
-  assert.equal(materializeRuntimeId, 'wp-codebox');
-  const materializeCheckout = resolveRuntimeProvider(materializeRuntimeId, { env }).checkout;
-  assert.equal(materializeCheckout.repo, 'Automattic/wp-codebox');
-  assert.equal(materializeCheckout.target, '.ci/wp-codebox');
-}
+assert.equal(runtimeIdFromOptions({}, { RUNTIME: 'wp-codebox' }), 'wp-codebox');
+assert.equal(runtimeIdFromOptions({}, { RUNTIME_PROVIDER: 'wp-codebox' }), DEFAULT_RUNTIME_ID);
+assert.equal(runtimeIdFromOptions({}, { BACKEND: 'wp-codebox' }), DEFAULT_RUNTIME_ID);
+const materializeCheckout = resolveRuntimeProvider(runtimeIdFromOptions({}, { RUNTIME: 'wp-codebox' }), { env: { RUNTIME: 'wp-codebox' } }).checkout;
+assert.equal(materializeCheckout.repo, 'Automattic/wp-codebox');
+assert.equal(materializeCheckout.target, '.ci/wp-codebox');
 
 assert.equal(runtimeSetupAdapter({ manifest: { ci_materialization: {} } }), null);
 assert.equal(runtimeSetupAdapter({ manifest: { ci_materialization: { requires_wordpress_dependencies: true } } }), null);


### PR DESCRIPTION
## Summary
- Remove deprecated generic runtime workflow inputs and provider secret slots.
- Keep the full-run workflow on canonical runtime/profile/tool-profile/output-projection inputs.
- Update config builder logic, README, wrapper forwarding, and focused tests.

## Verification
- node runtime-agent-ci/tests/build-runner-config.test.js
- node runtime-agent-ci/tests/runtime-provider-boundary.test.js
- ruby YAML parse for runtime-agent-full-run.yml and wp-codebox-runtime-agent-full-run.yml
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Removed deprecated workflow compatibility inputs and updated the focused config tests.