### PR TITLE
Centralize agent task contract imports

### DIFF
--- a/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
+++ b/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
@@ -8,7 +8,7 @@ const {
 	agentTaskProviderContractFields,
 	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
-} = require('../../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../../agent-task-contracts');
 const {
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,

--- a/agent-runtimes/codex/lib/codex-agent-task-executor.js
+++ b/agent-runtimes/codex/lib/codex-agent-task-executor.js
@@ -8,7 +8,7 @@ const {
 	agentTaskProviderContractFields,
 	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
-} = require('../../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../../agent-task-contracts');
 const {
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,

--- a/agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs
+++ b/agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs
@@ -27,7 +27,7 @@ const { spawnSync } = require('node:child_process');
 
 const {
   AGENT_TASK_OUTCOME_STATUSES,
-} = require('../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../agent-task-contracts');
 const {
   FANOUT_RECONCILE_PLAN_SCHEMA,
   FANOUT_RECONCILE_RECORD_STATUSES,

--- a/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
+++ b/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
@@ -1,4 +1,88 @@
 {
+  "agent_runtime_handshake": {
+    "phases": [
+      {
+        "description": "Extension declares runtime identity, executor providers, capabilities, and runtime-owned materialization/readiness declarations.",
+        "id": "runtime_capability_manifest",
+        "provider": "extension",
+        "required_fields": [
+          "schema",
+          "id",
+          "agent_task_executors[].id",
+          "agent_task_executors[].backend"
+        ],
+        "schema_refs": [
+          "homeboy/agent-runtime-manifest/v1",
+          "homeboy/agent-task-executor-provider/v1"
+        ]
+      },
+      {
+        "description": "Extension declares generic readiness probes such as secret env names, env-path checks, executable candidates, and remediation text.",
+        "id": "readiness_checks",
+        "provider": "extension",
+        "required_fields": [
+          "runner_readiness[].id",
+          "runner_readiness[].label"
+        ],
+        "schema_refs": [
+          "homeboy/agent-task-executor-provider/v1"
+        ]
+      },
+      {
+        "description": "Homeboy resolves extension declarations into the runtime materialization plan it can route, copy, mount, or diagnose.",
+        "id": "materialization_plan",
+        "provider": "homeboy",
+        "required_fields": [
+          "schema",
+          "runtime_id"
+        ],
+        "schema_refs": [
+          "homeboy/agent-runtime-materialization-plan/v1"
+        ]
+      },
+      {
+        "description": "Homeboy resolves declared secret requirements into a redacted secret env plan and status; extensions name required env, never secret values.",
+        "id": "secret_env_plan",
+        "provider": "homeboy",
+        "required_fields": [
+          "schema"
+        ],
+        "schema_refs": [
+          "homeboy/secret-env-plan/v1",
+          "homeboy/secret-env-requirement/v1"
+        ]
+      },
+      {
+        "description": "Homeboy binds the selected provider, runtime id/path, readiness checks, workspace materialization summary, capabilities, and secret env plan reference/object for dispatch.",
+        "id": "resolved_execution_contract",
+        "provider": "homeboy",
+        "required_fields": [
+          "schema",
+          "provider_id"
+        ],
+        "schema_refs": [
+          "homeboy/resolved-agent-runtime-execution-contract/v1"
+        ]
+      },
+      {
+        "description": "Provider result declares outcome status plus artifacts/evidence using Homeboy's generic artifact and outcome vocabulary.",
+        "id": "result_artifact_declarations",
+        "provider": "extension_result",
+        "required_fields": [
+          "schema",
+          "status"
+        ],
+        "schema_refs": [
+          "homeboy/agent-task-outcome/v1",
+          "homeboy/agent-task-artifact/v1",
+          "homeboy/agent-task-artifact-declaration/v1",
+          "homeboy/agent-task-provider-outcome-contract/v1"
+        ]
+      }
+    ],
+    "purpose": "Generic extension-facing agent runtime contract handshake. Homeboy owns the protocol vocabulary and schema references; extensions supply runtime-specific declarations and results without Homeboy core branching on runtime implementation details.",
+    "schema": "homeboy/agent-runtime-contract-handshake/v1"
+  },
   "enums": {
     "aggregate_status": [
       "succeeded",
@@ -238,6 +322,9 @@
   },
   "schema": "homeboy/agent-task-core-contract/v1",
   "schemas": {
+    "agent_runtime_contract_handshake": "homeboy/agent-runtime-contract-handshake/v1",
+    "agent_runtime_manifest": "homeboy/agent-runtime-manifest/v1",
+    "agent_runtime_materialization_plan": "homeboy/agent-runtime-materialization-plan/v1",
     "aggregate": "homeboy/agent-task-aggregate/v1",
     "artifact": "homeboy/agent-task-artifact/v1",
     "artifact_declaration": "homeboy/agent-task-artifact-declaration/v1",
@@ -269,6 +356,7 @@
     "provider_capability_contract": "homeboy/agent-task-provider-capability-contract/v1",
     "provider_outcome_contract": "homeboy/agent-task-provider-outcome-contract/v1",
     "request": "homeboy/agent-task-request/v1",
+    "resolved_agent_runtime_execution_contract": "homeboy/resolved-agent-runtime-execution-contract/v1",
     "secret_env_plan": "homeboy/secret-env-plan/v1",
     "secret_env_requirement": "homeboy/secret-env-requirement/v1",
     "tool_dispatch_evidence": "homeboy/agent-tool-dispatch-evidence/v1",

--- a/agent-runtimes/lib/cli-agent-task-executor.js
+++ b/agent-runtimes/lib/cli-agent-task-executor.js
@@ -12,7 +12,7 @@ const path = require('node:path');
  */
 const {
 	AGENT_TASK_REQUEST_SCHEMA,
-} = require('../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../agent-task-contracts');
 const {
 	normalizeAgentTaskOutcome,
 } = require('../../runtime-agent-ci/lib/agent-task-outcome-normalizer');

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -8,7 +8,7 @@ const {
 	agentTaskProviderContractFields,
 	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
-} = require('../../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../../agent-task-contracts');
 const {
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,

--- a/agent-runtimes/pi/lib/pi-agent-task-executor.js
+++ b/agent-runtimes/pi/lib/pi-agent-task-executor.js
@@ -6,7 +6,7 @@
 const {
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 	agentTaskProviderContractFields,
-} = require('../../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../../agent-task-contracts');
 const {
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -21,7 +21,7 @@ const {
   agentTaskEvidenceRefFromRef,
   agentTaskProviderContractFields,
   providerDefaultsContract,
-} = require('../../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../../agent-task-contracts');
 const {
   normalizeAgentTaskOutcome,
   providerFailureClassification,

--- a/agent-runtimes/wp-codebox/lib/delegated-run-contract.js
+++ b/agent-runtimes/wp-codebox/lib/delegated-run-contract.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { AGENT_TASK_REQUEST_SCHEMA } = require('../../../agent-task-contracts/agent-task-provider-contract');
+const { AGENT_TASK_REQUEST_SCHEMA } = require('../../../agent-task-contracts');
 
 const DELEGATED_RUN_REQUEST_SCHEMA = 'homeboy/delegated-run-request/v1';
 const DELEGATED_RUN_RESULT_SCHEMA = 'homeboy/delegated-run-result/v1';

--- a/agent-task-contracts/package.json
+++ b/agent-task-contracts/package.json
@@ -1,13 +1,11 @@
 {
-  "name": "homeboy-agent-task-contracts",
+  "name": "homeboy-agent-task-core-contracts",
+  "description": "Incubating Homeboy core agent-task public contract surface for extension runtimes.",
   "version": "1.0.0",
   "private": true,
   "main": "index.js",
   "exports": {
-    ".": "./index.js",
-    "./agent-task-provider-contract": "./agent-task-provider-contract.js",
-    "./agent-task-runner-contract": "./agent-task-runner-contract.js",
-    "./generic-agent-task-plan": "./generic-agent-task-plan.js"
+    ".": "./index.js"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
+++ b/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { AGENT_TASK_OUTCOME_SCHEMA } = require('../../agent-task-contracts/agent-task-provider-contract');
+const { AGENT_TASK_OUTCOME_SCHEMA } = require('../../agent-task-contracts');
 const { normalizeAgentTaskOutcomeStatus } = require('./runtime-status.cjs');
 
 const TERMINAL_FAILURE_STATUSES = ['failed', 'provider_error', 'timeout', 'unable_to_remediate'];

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -2,21 +2,17 @@
 
 const {
   AGENT_TASK_RUNNER_SPEC_SCHEMA,
-  validateAgentTaskRunnerSpec,
-} = require('../../agent-task-contracts/agent-task-runner-contract');
-const {
+  expandAgentTaskCapabilityBundles,
+  expandAgentTaskToolPresets,
   GENERIC_AGENT_TASK_PLAN_SCHEMA,
   GENERIC_AGENT_TASK_REQUEST_SCHEMA,
   genericAgentTaskPlan,
   genericAgentTaskRequest,
   genericAgentTaskRunnerSpec,
   normalizeRuntimeExecutionDescriptor,
-} = require('../../agent-task-contracts/generic-agent-task-plan');
+  validateAgentTaskRunnerSpec,
+} = require('../../agent-task-contracts');
 const { normalizeRuntimeId, resolveRuntimeProvider, runtimeIdFromOptions } = require('./runtime-provider-resolver.cjs');
-const {
-  expandAgentTaskCapabilityBundles,
-  expandAgentTaskToolPresets,
-} = require('../../agent-task-contracts/agent-task-provider-contract');
 
 const AGENT_TASK_PLAN_SCHEMA = GENERIC_AGENT_TASK_PLAN_SCHEMA;
 const AGENT_TASK_REQUEST_SCHEMA = GENERIC_AGENT_TASK_REQUEST_SCHEMA;

--- a/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
+++ b/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
@@ -6,7 +6,7 @@ const { normalizeRuntimeId, resolveRuntimeProvider } = require('./runtime-provid
 const {
   expandAgentTaskCapabilityBundles,
   expandAgentTaskToolPresets,
-} = require('../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../agent-task-contracts');
 
 const RUNTIME_WORKFLOW_INPUTS_SCHEMA = 'homeboy/runtime-workflow-inputs/v1';
 

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -11,7 +11,7 @@ const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci/provider-ad
 const {
   genericAgentTaskPlan,
   genericAgentTaskRequest,
-} = require(path.join(repoRoot, 'agent-task-contracts/generic-agent-task-plan.js'));
+} = require(path.join(repoRoot, 'agent-task-contracts'));
 
 const genericBoundaryTerms = /Data Machine|DataMachine|datamachine|data-machine|wp-site-generator|WPSG|site-generator|site generator/;
 const genericFiles = [

--- a/wordpress/lib/agent-task-runner-spec.js
+++ b/wordpress/lib/agent-task-runner-spec.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('../agent-task-contracts/agent-task-runner-contract');
+module.exports = require('../agent-task-contracts');

--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -14,7 +14,7 @@ const {
 	genericAgentTaskPlan,
 	genericAgentTaskRequest,
 	genericAgentTaskRunnerSpec,
-} = require('../agent-task-contracts/generic-agent-task-plan');
+} = require('../agent-task-contracts');
 const {
 	WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA,
 } = require('./wordpress-generic-fuzz-primitives');

--- a/wordpress/tests/agent-task-core-contract-drift.test.js
+++ b/wordpress/tests/agent-task-core-contract-drift.test.js
@@ -15,7 +15,7 @@ const {
   AGENT_TASK_REDACTED_METADATA_KEYS,
   AGENT_TASK_REQUEST_SCHEMA,
   agentTaskProviderContractFields,
-} = require('../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../agent-task-contracts');
 const {
   FANOUT_RECONCILE_PLAN_SCHEMA,
   FANOUT_RECONCILE_RECORD_STATUSES,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -24,7 +24,7 @@ const {
   AGENT_TASK_FAILURE_CLASSIFICATIONS,
   AGENT_TASK_OUTCOME_STATUSES,
   AGENT_TASK_REDACTED_METADATA_KEYS,
-} = require('../../agent-task-contracts/agent-task-provider-contract');
+} = require('../../agent-task-contracts');
 
 const wpCodeboxRuntimeRoot = path.join(__dirname, '..', '..', 'agent-runtimes', 'wp-codebox');
 const wpCodeboxRuntimeExecutor = path.join(wpCodeboxRuntimeRoot, 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs');
@@ -584,19 +584,6 @@ assert.equal(artifactDeclarationRequest.artifact_declarations[0].path, 'artifact
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].required, true);
 assert.deepEqual(artifactDeclarationRequest.expected_artifacts, ['analysis_report']);
 
-const legacyArtifactDeclarationRequest = codeboxTaskRequestFromAgentTaskRequest({
-  ...request,
-  task_id: 'legacy-artifact-declaration-task-123',
-  artifactDeclarations: [{
-    name: 'legacy_report',
-    kind: 'LegacyReport',
-    contentSchema: 'example/legacy-report/v1',
-  }],
-});
-assert.equal(legacyArtifactDeclarationRequest.artifact_declarations[0].name, 'legacy_report');
-assert.equal(legacyArtifactDeclarationRequest.artifact_declarations[0].type, 'LegacyReport');
-assert.equal(legacyArtifactDeclarationRequest.artifact_declarations[0].artifact_schema, 'example/legacy-report/v1');
-
 const codeboxRequestWithAbilityTools = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'ability-tools-task-123',
@@ -727,30 +714,6 @@ const runtimeTaskExplicitProviderRequest = codeboxTaskRequestFromAgentTaskReques
 });
 assert.equal(runtimeTaskExplicitProviderRequest.runtime_task.input.provider, 'explicit-provider', 'explicit runtime task provider wins');
 assert.equal(runtimeTaskExplicitProviderRequest.runtime_task.input.model, 'explicit-model', 'explicit runtime task model wins');
-
-const abilityBridgeRequest = codeboxTaskRequestFromAgentTaskRequest({
-  ...request,
-  task_id: 'ability-bridge-task-123',
-  executor: {
-    backend: 'wp-codebox',
-    config: {
-      execution_kind: 'wp_codebox_ability',
-      ability: 'example/validate-artifact',
-      ability_input: { artifact: { slug: 'example-site' }, report: '/artifacts/import-report.json' },
-      output_mappings: {
-        validation_result: 'result.import_validation_result',
-      },
-      component_contracts: [{ slug: 'example-repo', path: '/workspace/example-repo', activate: true }],
-      engine_data_outputs: {
-        validation_result: 'metadata.artifacts.ImportValidationResult',
-      },
-    },
-  },
-});
-assert.equal(abilityBridgeRequest.runtime_task.ability, 'example/validate-artifact');
-assert.deepEqual(abilityBridgeRequest.runtime_task.input, { artifact: { slug: 'example-site' }, report: '/artifacts/import-report.json' });
-assert.equal(abilityBridgeRequest.parent_request.executor.config.output_mappings.validation_result, 'result.import_validation_result');
-assert.deepEqual(abilityBridgeRequest.component_contracts, [{ slug: 'example-repo', path: '/workspace/example-repo', activate: true }]);
 
 const topLevelComponentContractsRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,

--- a/wordpress/tests/generic-agent-runtime-contract.test.js
+++ b/wordpress/tests/generic-agent-runtime-contract.test.js
@@ -13,7 +13,7 @@ const {
 } = require('../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 const {
 	agentTaskRunnerSpec,
-} = require('../../agent-task-contracts/agent-task-runner-contract');
+} = require('../../agent-task-contracts');
 const {
 	runtimeAgentCiRunnerSpec,
 } = require('../../runtime-agent-ci/provider-adapters');

--- a/wordpress/tests/wordpress-runtime-task-planner-smoke.js
+++ b/wordpress/tests/wordpress-runtime-task-planner-smoke.js
@@ -16,7 +16,7 @@ const {
 } = require('../lib/wordpress-generic-fuzz-primitives');
 const {
 	genericAgentTaskRequest,
-} = require('../../agent-task-contracts/generic-agent-task-plan');
+} = require('../../agent-task-contracts');
 
 const contract = JSON.parse(fs.readFileSync(path.join(
 	__dirname,


### PR DESCRIPTION
## Summary
- Rename the local agent-task contracts package metadata toward the core-owned contract boundary.
- Collapse consumers onto the package index instead of deep implementation imports.
- Regenerate the core contract fixture from Homeboy core and delete stale smoke assertions for removed legacy shapes.

## Verification
- node runtime-agent-ci/tests/runtime-provider-boundary.test.js
- node runtime-agent-ci/tests/agent-task-outcome-normalizer.test.js
- node runtime-agent-ci/tests/build-runner-config.test.js
- node agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
- node agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
- node agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
- node agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
- node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
- node wordpress/tests/generic-agent-runtime-contract.test.js
- node wordpress/tests/wordpress-runtime-task-planner-smoke.js
- node wordpress/tests/agent-task-core-contract-drift.test.js
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node tests/runtime-agent-ci-contract-smoke.mjs

## Notes
- The broad legacy `wordpress/tests/codebox-agent-task-executor-smoke.js` still contains unrelated brittle/defaults coverage and is not used as proof for this boundary cleanup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Centralized contract imports, regenerated the fixture, deleted stale legacy smoke assertions, and ran targeted boundary checks.