### PR TITLE
Tighten Codebox artifact result boundary

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -39,7 +39,6 @@ const {
 } = require('./codebox-artifact-contract');
 const {
   codeboxPublicResultEnvelope,
-  privateCodeboxRuntimeResultShapeNames,
   publicEnvelopeBoundaryDiagnostic,
 } = require('./codebox-result-boundary');
 const {
@@ -2356,9 +2355,6 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
 
 function normalizeStatus(result, exitStatus = 0) {
   const publicEnvelope = codeboxPublicResultEnvelope(result);
-  if (!publicEnvelope && privateCodeboxRuntimeResultShapeNames(result).length > 0) {
-    return 'failed';
-  }
   if (recipeRunFailedPhase(recipeRunFromResult(result))) {
     return 'failed';
   }

--- a/agent-runtimes/wp-codebox/lib/codebox-result-boundary.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-result-boundary.js
@@ -9,32 +9,11 @@ function codeboxPublicResultEnvelope(result, options = {}) {
   return options.publicResultEnvelope || options.public_result_envelope || normalizeCodeboxPublicResultEnvelope(result, options);
 }
 
-function privateCodeboxRuntimeResultShapeNames(result = {}) {
-  const names = [];
-  if (result?.run?.agentResult) {
-    names.push('run.agentResult');
-  }
-  if (result?.agentResult) {
-    names.push('agentResult');
-  }
-  if (result?.agent_result) {
-    names.push('agent_result');
-  }
-  if (result?.metadata?.agent_runtime) {
-    names.push('metadata.agent_runtime');
-  }
-  if (result?.engine_data || result?.metadata?.engine_data) {
-    names.push('engine_data');
-  }
-  return names;
-}
-
 function publicEnvelopeBoundaryDiagnostic(result, options = {}) {
   if (codeboxPublicResultEnvelope(result, options)) {
     return null;
   }
-  const privateShapes = privateCodeboxRuntimeResultShapeNames(result);
-  if (privateShapes.length === 0) {
+  if (!result) {
     return null;
   }
   return {
@@ -42,13 +21,11 @@ function publicEnvelopeBoundaryDiagnostic(result, options = {}) {
     message: 'WP Codebox result used private runtime fields without the canonical public artifact result envelope.',
     data: {
       required_schema: WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
-      private_shapes: privateShapes,
     },
   };
 }
 
 module.exports = {
   codeboxPublicResultEnvelope,
-  privateCodeboxRuntimeResultShapeNames,
   publicEnvelopeBoundaryDiagnostic,
 };

--- a/agent-runtimes/wp-codebox/lib/runtime-agent-outcome-adapter.js
+++ b/agent-runtimes/wp-codebox/lib/runtime-agent-outcome-adapter.js
@@ -1,15 +1,7 @@
 'use strict';
 
 function scenarioResultsFromOutcome(outcome) {
-  const codebox = outcome?.metadata?.codebox || {};
-  const workload = codebox?.raw?.agent_runtime?.result
-    || codebox?.agent_runtime?.workload
-    || codebox?.agent_runtime?.result
-    || codebox?.metadata?.agent_runtime?.workload
-    || codebox?.metadata?.agent_runtime?.result
-    || codebox?.agentResult
-    || codebox?.agent_result
-    || null;
+  const workload = outcome?.metadata?.codebox?.artifact_result?.result || null;
 
   if (workload && Array.isArray(workload.scenarios)) {
     return workload;

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -172,7 +172,7 @@ assert.equal(privateRuntimeShapeOutcome.failure_classification, 'execution_faile
 assert.equal(privateRuntimeShapeOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.public_result_envelope_missing'), true);
 assert.equal(privateRuntimeShapeOutcome.outputs.reply, undefined);
 assert.equal(privateRuntimeShapeOutcome.metadata.dispatch_identity, undefined);
-assert.deepEqual(publicEnvelopeBoundaryDiagnostic({ run: { agentResult: { reply: 'private' } } }).data.private_shapes, ['run.agentResult']);
+assert.equal(publicEnvelopeBoundaryDiagnostic({ run: { agentResult: { reply: 'private' } } }).data.required_schema, 'wp-codebox/artifact-result-envelope/v1');
 const dispatchIdentityOutcome = agentTaskOutcomeFromCodeboxResult({
   ...privateRuntimeShapeRequest,
   task_id: 'dispatch-identity-boundary',


### PR DESCRIPTION
## Summary
- Remove private Codebox runtime result shape enumeration from the public result boundary.
- Stop the agent-task executor from using the private-shape helper as a status shortcut.
- Read scenario workload data from the canonical Codebox artifact result envelope only.

## Verification
- npm run test:codebox-agent-task-executor-boundary
- node --check agent-runtimes/wp-codebox/lib/runtime-agent-outcome-adapter.js && node --check agent-runtimes/wp-codebox/lib/codebox-result-boundary.js && node --check agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js && node --check wordpress/tests/codebox-agent-task-executor-boundary.test.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Implemented the artifact/result boundary cleanup, ran targeted verification, and drafted this PR description.