### PR TITLE
Remove pending runtime contract fallbacks

### DIFF
--- a/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
+++ b/runtime-agent-ci/lib/homeboy-contract-surface-probe.cjs
@@ -4,7 +4,6 @@ const { spawnSync } = require('node:child_process');
 
 const {
   CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS,
-  PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS,
   runtimeContractConstantsFromHomeboyOutput,
 } = require('./runtime-contracts.cjs');
 
@@ -16,7 +15,6 @@ const CONTRACT_COMMANDS = Object.freeze([
 
 const LOCAL_ARTIFACT_MANIFEST_CONSTANTS = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest;
 const CORE_PUBLISHED_CONTRACT_CONSTANTS = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS;
-const VERSION_GATED_PENDING_CONTRACT_CONSTANTS = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS;
 
 function probeHomeboyContractSurface(options = {}) {
   const command = options.homeboyCommand || process.env.HOMEBOY_COMMAND || 'homeboy';
@@ -93,22 +91,14 @@ function validateRuntimeContractConstants({ contract, command, argv, attempts })
 function comparableConstantsForProbe(actualConstants, expectedConstants, argv) {
   const contractId = argv[2] || '';
   return Object.fromEntries(
-    Object.entries(expectedConstants).filter(([contractName]) => {
-      if (actualConstants[contractName]) {
-        return true;
-      }
-      return contractId !== 'all' || !VERSION_GATED_PENDING_CONTRACT_CONSTANTS[contractName];
-    })
+    Object.entries(expectedConstants).filter(([contractName]) => actualConstants[contractName] || contractId !== 'all')
   );
 }
 
 function expectedConstantsForCommand(argv) {
   const contractId = argv[2] || '';
   if (contractId === 'all') {
-    return {
-      ...CORE_PUBLISHED_CONTRACT_CONSTANTS,
-      ...VERSION_GATED_PENDING_CONTRACT_CONSTANTS,
-    };
+    return CORE_PUBLISHED_CONTRACT_CONSTANTS;
   }
   if (contractId === 'artifact-manifest') {
     return { artifact_manifest: CORE_PUBLISHED_CONTRACT_CONSTANTS.artifact_manifest };
@@ -131,6 +121,5 @@ module.exports = {
   CONTRACT_COMMANDS,
   CORE_PUBLISHED_CONTRACT_CONSTANTS,
   LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
-  VERSION_GATED_PENDING_CONTRACT_CONSTANTS,
   probeHomeboyContractSurface,
 };

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -13,31 +13,22 @@ const CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
   }),
 });
 
-// TODO(core-contract-export): remove these fallbacks once Homeboy core exports
-// these constants from `homeboy contract constants all`. The probe treats them
-// as optional until then, but validates them as soon as a current Homeboy binary
-// starts publishing the contract names.
-const PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
+// Extension-local artifact schemas. These remain here until Homeboy core exports
+// contract constants for the runtime artifact path/ref boundary.
+const EXTENSION_RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
   artifact_paths: Object.freeze({
     schema_id: 'homeboy/runtime-agent-artifact-paths/v1',
   }),
   runner_artifact_manifest_ref: Object.freeze({
     schema_id: 'homeboy/runner-artifact-manifest-ref/v1',
   }),
-  runner_execution_record: Object.freeze({
-    schema_id: 'homeboy/runner-execution-record/v1',
-  }),
-  path_materialization_plan: Object.freeze({
-    schema_id: 'homeboy/path-materialization-plan/v1',
-  }),
-  run_outcome_envelope: Object.freeze({
-    schema_id: 'homeboy/run-outcome-envelope/v1',
-  }),
 });
+
+const CORE_RUNTIME_CONTRACT_EXPORT_BLOCKERS = Object.freeze(Object.keys(EXTENSION_RUNTIME_CONTRACT_CONSTANTS));
 
 const RUNTIME_CONTRACT_CONSTANTS = Object.freeze({
   ...CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS,
-  ...PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS,
+  ...EXTENSION_RUNTIME_CONTRACT_CONSTANTS,
 });
 
 const ARTIFACT_MANIFEST_CONTRACT_CONSTANTS = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.artifact_manifest;
@@ -45,11 +36,8 @@ const ARTIFACT_MANIFEST_SCHEMA = ARTIFACT_MANIFEST_CONTRACT_CONSTANTS.schema_id;
 const ARTIFACT_MANIFEST_FILE = ARTIFACT_MANIFEST_CONTRACT_CONSTANTS.file_name;
 const SECRET_ENV_PLAN_SCHEMA = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.secret_env_plan.schema_id;
 const RUN_LOCATION_INDEX_SCHEMA = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.run_location_index.schema_id;
-const ARTIFACT_PATHS_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.artifact_paths.schema_id;
-const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.runner_artifact_manifest_ref.schema_id;
-const RUNNER_EXECUTION_RECORD_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.runner_execution_record.schema_id;
-const PATH_MATERIALIZATION_PLAN_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.path_materialization_plan.schema_id;
-const RUN_OUTCOME_ENVELOPE_SCHEMA = PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS.run_outcome_envelope.schema_id;
+const ARTIFACT_PATHS_SCHEMA = EXTENSION_RUNTIME_CONTRACT_CONSTANTS.artifact_paths.schema_id;
+const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = EXTENSION_RUNTIME_CONTRACT_CONSTANTS.runner_artifact_manifest_ref.schema_id;
 const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
   events: 'events.json',
   status: 'status.json',
@@ -184,12 +172,10 @@ module.exports = {
   ARTIFACT_MANIFEST_SCHEMA,
   ARTIFACT_PATHS_SCHEMA,
   CANONICAL_RUN_ARTIFACT_FILES,
+  CORE_RUNTIME_CONTRACT_EXPORT_BLOCKERS,
   CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS,
-  PATH_MATERIALIZATION_PLAN_SCHEMA,
-  PENDING_CORE_RUNTIME_CONTRACT_CONSTANTS,
+  EXTENSION_RUNTIME_CONTRACT_CONSTANTS,
   RUN_LOCATION_INDEX_SCHEMA,
-  RUN_OUTCOME_ENVELOPE_SCHEMA,
-  RUNNER_EXECUTION_RECORD_SCHEMA,
   RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
   RUNTIME_CONTRACT_CONSTANTS,
   SECRET_ENV_PLAN_SCHEMA,

--- a/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
+++ b/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
@@ -5,7 +5,6 @@ const assert = require('node:assert/strict');
 const {
   CORE_PUBLISHED_CONTRACT_CONSTANTS,
   LOCAL_ARTIFACT_MANIFEST_CONSTANTS,
-  VERSION_GATED_PENDING_CONTRACT_CONSTANTS,
   probeHomeboyContractSurface,
 } = require('../lib/homeboy-contract-surface-probe.cjs');
 const {
@@ -41,32 +40,6 @@ const releasedContractShape = probeHomeboyContractSurface({
 
 assert.equal(releasedContractShape.status, 'passed');
 assert.deepEqual(releasedContractShape.argv, ['contract', 'constants', 'all']);
-
-const pendingContractShape = probeHomeboyContractSurface({
-  homeboyCommand: 'homeboy',
-  spawnSync: () => ({
-    status: 0,
-    stdout: JSON.stringify({
-      success: true,
-      data: {
-        constants: {
-          ...CORE_PUBLISHED_CONTRACT_CONSTANTS,
-          runner_execution_record: VERSION_GATED_PENDING_CONTRACT_CONSTANTS.runner_execution_record,
-          path_materialization_plan: VERSION_GATED_PENDING_CONTRACT_CONSTANTS.path_materialization_plan,
-          run_outcome_envelope: VERSION_GATED_PENDING_CONTRACT_CONSTANTS.run_outcome_envelope,
-        },
-        contract_id: 'all',
-        schema: 'homeboy/contract-constants/v1',
-      },
-    }),
-    stderr: '',
-  }),
-});
-
-assert.equal(pendingContractShape.status, 'passed');
-assert.deepEqual(pendingContractShape.constants.runner_execution_record, { schema_id: 'homeboy/runner-execution-record/v1' });
-assert.deepEqual(pendingContractShape.constants.path_materialization_plan, { schema_id: 'homeboy/path-materialization-plan/v1' });
-assert.deepEqual(pendingContractShape.constants.run_outcome_envelope, { schema_id: 'homeboy/run-outcome-envelope/v1' });
 
 assert.deepEqual(runtimeContractConstantsFromHomeboyOutput({
   data: {


### PR DESCRIPTION
## Summary
- Remove the pending/version-gated runtime contract fallback map from Extensions.
- Keep only active extension-local artifact path/ref schemas under an explicit extension-local boundary.
- Tighten the Homeboy contract surface probe so it validates only core-published constants from Homeboy core.

## Verification
- `node tests/homeboy-contract-surface-probe.test.js`
- `node -e "require('./lib/runtime-contracts.cjs'); require('./lib/homeboy-contract-surface-probe.cjs'); require('./lib/artifact-paths.cjs')"`
- `npm test`

## Blockers
- Homeboy core currently does not export `artifact_paths` or `runner_artifact_manifest_ref` from `homeboy contract constants all`; those remain explicitly extension-local until core owns that artifact boundary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Implemented the scoped runtime contract boundary cleanup, ran verification, and drafted this PR description.
