### PR TITLE
Tighten runtime secret materialization

### DIFF
--- a/.github/scripts/runtime-agent-full-run/auth.cjs
+++ b/.github/scripts/runtime-agent-full-run/auth.cjs
@@ -2,6 +2,8 @@
 'use strict';
 
 const { normalizeContextRepositories, requireRepo, splitCsv, writeGithubOutput } = require('./lib/common.cjs');
+const fs = require('node:fs');
+const { randomUUID } = require('node:crypto');
 
 function main() {
   const command = process.argv[2];
@@ -16,6 +18,10 @@ function main() {
   }
   if (command === 'report-mode') {
     reportMode(process.env);
+    return;
+  }
+  if (command === 'materialize-secret-env') {
+    materializeSecretEnv(process.env);
     return;
   }
   throw new Error(`Unknown auth command: ${command || ''}`);
@@ -73,6 +79,72 @@ function reportMode(env) {
       ].join('\n')
     );
   }
+}
+
+function materializeSecretEnv(env) {
+  const configPath = requireValue(env.CONFIG_FILE, 'CONFIG_FILE');
+  const githubEnvPath = requireValue(env.GITHUB_ENV, 'GITHUB_ENV');
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  const secretEnvMap = config.secret_env_map;
+  if (!secretEnvMap || typeof secretEnvMap !== 'object' || Array.isArray(secretEnvMap) || Object.keys(secretEnvMap).length === 0) {
+    throw new Error('materialize_secret_env_from_github_secrets requires a non-empty secret_env_map declaration.');
+  }
+
+  const githubSecrets = parseGithubSecretsJson(env.HOMEBOY_GITHUB_SECRETS_JSON || '{}');
+  const sourceNames = secretEnvMapSourceNames(secretEnvMap);
+  if (sourceNames.length === 0) {
+    throw new Error('secret_env_map must declare at least one source env name.');
+  }
+
+  const materializedNames = [];
+  const lines = [];
+  for (const sourceName of sourceNames) {
+    const value = githubSecrets[sourceName];
+    if (typeof value !== 'string' || value === '') {
+      continue;
+    }
+    const delimiter = `HOMEBOY_SECRET_${randomUUID().replace(/-/g, '_')}`;
+    materializedNames.push(sourceName);
+    lines.push(`${sourceName}<<${delimiter}`, value, delimiter);
+  }
+  if (lines.length > 0) {
+    fs.appendFileSync(githubEnvPath, `${lines.join('\n')}\n`);
+  }
+  process.stdout.write(`Materialized ${materializedNames.length} declared GitHub secret env source(s): ${materializedNames.join(', ') || 'none'}\n`);
+}
+
+function secretEnvMapSourceNames(secretEnvMap) {
+  const names = new Set();
+  for (const [target, sources] of Object.entries(secretEnvMap)) {
+    validateEnvName(target, 'secret_env_map target');
+    const sourceList = Array.isArray(sources) ? sources : [sources];
+    for (const source of sourceList) {
+      names.add(validateEnvName(source, `secret_env_map.${target}`));
+    }
+  }
+  return Array.from(names).sort();
+}
+
+function parseGithubSecretsJson(raw) {
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('HOMEBOY_GITHUB_SECRETS_JSON must be a JSON object.');
+  }
+  return parsed;
+}
+
+function requireValue(value, name) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function validateEnvName(value, label) {
+  if (typeof value !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    throw new Error(`${label} must be a valid env name.`);
+  }
+  return value;
 }
 
 try {

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -77,7 +77,7 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: '{}'
       materialize_secret_env_from_github_secrets:
-        description: Opt-in bridge that resolves secret_env_map sources from the GitHub secrets context before the runner starts. Prefer explicit, minimal caller secrets when enabling.
+        description: Opt-in bridge that resolves only declared secret_env_map sources from the GitHub secrets context before the runner starts. Prefer explicit, minimal caller secrets when enabling.
         type: boolean
         default: false
       model:
@@ -528,12 +528,18 @@ jobs:
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
         run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
 
+      - name: Materialize declared GitHub secret env
+        if: ${{ inputs.run_agent && inputs.materialize_secret_env_from_github_secrets }}
+        env:
+          CONFIG_FILE: ${{ steps.config.outputs.config_path }}
+          HOMEBOY_GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}
+        run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/auth.cjs materialize-secret-env
+
       - name: Run runtime agent
         if: ${{ inputs.run_agent }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           HOMEBOY_GITHUB_APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          HOMEBOY_GITHUB_SECRETS_JSON: ${{ inputs.materialize_secret_env_from_github_secrets && toJson(secrets) || '{}' }}
           HOMEBOY_RUNTIME_AGENT_RUN_DIR: ${{ runner.temp }}/runtime-agent-run
           # Stream raw subprocess stdout/stderr live to the job log so a hard
           # crash or timeout inside the runtime agent is visible even when no

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -88,7 +88,11 @@ function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnv
     }).filter(([, names]) => names.length > 0)),
     inheritance: {
       require_declaration: true,
-      allowed_env_names: ['HOMEBOY_AGENT_RUNTIME_SECRET_ENV'],
+      allowed_env_names: uniqueStrings([
+        'HOMEBOY_AGENT_RUNTIME_SECRET_ENV',
+        ...Object.keys(secretEnvFallbacks || {}),
+        ...Object.values(secretEnvFallbacks || {}).flat(),
+      ]),
     },
   };
 }

--- a/runtime-agent-ci/scripts/run-headless-loop.cjs
+++ b/runtime-agent-ci/scripts/run-headless-loop.cjs
@@ -28,7 +28,6 @@ try {
   // the repository GITHUB_TOKEN when no app token is present. Forwarding still
   // happens through the secret-env-names-only boundary; only this process's env
   // is populated so the names resolve.
-  applySecretEnvMap(rawSpec.secret_env_map, parseGithubSecretsJson(process.env.HOMEBOY_GITHUB_SECRETS_JSON));
   applySecretEnvFallbacks(rawSpec.secret_env_fallbacks);
   const spec = materializeHeadlessProductionLoopSpec(rawSpec, {
     revolutions: args.revolutions || args.max_revolutions || process.env.HOMEBOY_HEADLESS_LOOP_REVOLUTIONS,
@@ -114,34 +113,4 @@ function applySecretEnvFallbacks(fallbacks) {
       }
     }
   }
-}
-
-function applySecretEnvMap(secretEnvMap, githubSecrets) {
-  if (!secretEnvMap || typeof secretEnvMap !== 'object' || Array.isArray(secretEnvMap)) {
-    return;
-  }
-  for (const [target, sources] of Object.entries(secretEnvMap)) {
-    if (typeof target !== 'string' || target === '' || process.env[target]) {
-      continue;
-    }
-    const sourceList = Array.isArray(sources) ? sources : [sources];
-    for (const source of sourceList) {
-      if (typeof source !== 'string' || source === '') {
-        continue;
-      }
-      const value = githubSecrets[source] || process.env[source];
-      if (typeof value === 'string' && value !== '') {
-        process.env[target] = value;
-        break;
-      }
-    }
-  }
-}
-
-function parseGithubSecretsJson(raw) {
-  if (typeof raw !== 'string' || raw.trim() === '') {
-    return {};
-  }
-  const parsed = JSON.parse(raw);
-  return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
 }

--- a/tests/runtime-agent-full-run-secret-bridge-smoke.mjs
+++ b/tests/runtime-agent-full-run-secret-bridge-smoke.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-secret-bridge-runner-'));
+const githubEnvPath = path.join(runnerTemp, 'github-env');
+const bridgeConfigPath = path.join(runnerTemp, 'secret-bridge-config.json');
+const emptyConfigPath = path.join(runnerTemp, 'secret-bridge-empty-config.json');
+
+fs.writeFileSync(bridgeConfigPath, `${JSON.stringify({
+  secret_env_map: {
+    OPENAI_API_KEY: ['PROVIDER_SECRET_1', 'UNSET_PROVIDER_SECRET'],
+  },
+}, null, 2)}\n`);
+
+const bridgeResult = spawnSync(process.execPath, [
+  path.join(repoRoot, '.github/scripts/runtime-agent-full-run/auth.cjs'),
+  'materialize-secret-env',
+], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    CONFIG_FILE: bridgeConfigPath,
+    GITHUB_ENV: githubEnvPath,
+    HOMEBOY_GITHUB_SECRETS_JSON: JSON.stringify({
+      PROVIDER_SECRET_1: 'github-secret-value',
+      UNDECLARED_SECRET: 'must-not-materialize',
+    }),
+  },
+  encoding: 'utf8',
+});
+
+assert.equal(bridgeResult.status, 0, bridgeResult.stderr || bridgeResult.stdout);
+const githubEnv = fs.readFileSync(githubEnvPath, 'utf8');
+assert.match(githubEnv, /PROVIDER_SECRET_1<</);
+assert.match(githubEnv, /github-secret-value/);
+assert.equal(githubEnv.includes('UNDECLARED_SECRET'), false);
+assert.equal(githubEnv.includes('must-not-materialize'), false);
+
+fs.writeFileSync(emptyConfigPath, `${JSON.stringify({}, null, 2)}\n`);
+const missingPlanResult = spawnSync(process.execPath, [
+  path.join(repoRoot, '.github/scripts/runtime-agent-full-run/auth.cjs'),
+  'materialize-secret-env',
+], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    CONFIG_FILE: emptyConfigPath,
+    GITHUB_ENV: path.join(runnerTemp, 'github-env-empty'),
+    HOMEBOY_GITHUB_SECRETS_JSON: '{}',
+  },
+  encoding: 'utf8',
+});
+assert.notEqual(missingPlanResult.status, 0, missingPlanResult.stderr || missingPlanResult.stdout);
+assert.match(missingPlanResult.stderr, /requires a non-empty secret_env_map/);
+
+console.log('runtime agent full-run secret bridge smoke passed');


### PR DESCRIPTION
## Summary
- Move GitHub secrets-context handling out of the runtime loop step and into a dedicated bridge step.
- Require a non-empty explicit `secret_env_map` before `materialize_secret_env_from_github_secrets` can materialize anything.
- Export only declared source secret env names to `GITHUB_ENV`, then let the existing secret fallback plan populate canonical runtime env names.
- Expand the secret env plan inheritance allowlist to include declared fallback source/target names.

## Staged migration note
GitHub Actions does not currently give this reusable workflow a clean way to dynamically materialize arbitrary caller-declared secret names without touching the `secrets` context. This PR reduces exposure now by confining `toJson(secrets)` to the small bridge step and removing raw all-secrets JSON from the runtime loop process. The next upstream dependency is a GitHub Actions/reusable-workflow capability for declared secret-name lookup or a first-class secret map input so the bridge step can be removed entirely.

## Verification
- `git diff --check`
- `node tests/runtime-agent-full-run-secret-bridge-smoke.mjs`
- `node tests/runtime-agent-full-run-local-shell-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Drafted and verified the workflow/script changes, focused smoke coverage, and PR text with Chris directing the task.