### PR TITLE
Trim workspace publication git lifecycle

### DIFF
--- a/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
+++ b/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
@@ -572,57 +572,6 @@ function publicationTemplates(config, values, hooks = {}) {
   };
 }
 
-function copyFile(source, destination) {
-  fs.mkdirSync(path.dirname(destination), { recursive: true });
-  fs.copyFileSync(source, destination);
-}
-
-function preserveWorkspaceFiles(workspace, files, hooks = {}) {
-  const adapter = lifecycleHooks(hooks);
-  const temp = fs.mkdtempSync(path.join(
-    adapter.tmpdir,
-    'homeboy-runner-workspace.',
-  ));
-  const entries = [];
-  for (const file of files) {
-    const source = path.join(workspace, file);
-    const backup = path.join(temp, file);
-    if (fs.existsSync(source) && fs.statSync(source).isFile()) {
-      copyFile(source, backup);
-      entries.push({ file, backup, deleted: false });
-    } else {
-      entries.push({ file, deleted: true });
-    }
-  }
-  return { temp, entries };
-}
-
-function restoreWorkspaceFiles(workspace, preserved) {
-  for (const entry of preserved.entries) {
-    const target = path.join(workspace, entry.file);
-    if (entry.deleted) {
-      fs.rmSync(target, { force: true });
-      continue;
-    }
-    copyFile(entry.backup, target);
-  }
-  fs.rmSync(preserved.temp, { recursive: true, force: true });
-}
-
-function resetPublicationBranch(workspace, branch, base, files, hooks = {}) {
-  const preserved = preserveWorkspaceFiles(workspace, files, hooks);
-  const fetch = git(
-    workspace,
-    ['fetch', 'origin', `+refs/heads/${base}:refs/remotes/origin/${base}`],
-    { check: false, hooks },
-  );
-  const baseRef = fetch.status === 0 ? `origin/${base}` : base;
-  git(workspace, ['reset', '--hard', 'HEAD'], { hooks });
-  git(workspace, ['clean', '-fd'], { hooks });
-  git(workspace, ['checkout', '-B', branch, baseRef], { hooks });
-  restoreWorkspaceFiles(workspace, preserved);
-}
-
 function publicationEvidenceRef(input = {}) {
   return {
     type: input.url ? 'pull_request' : 'branch',
@@ -679,10 +628,9 @@ function preparePublication(config, results, scenario, files, hooks = {}) {
 }
 
 function captureWorkspaceDelta(config, workspace, publication, hooks = {}) {
-  resetPublicationBranch(workspace, publication.branch, publication.base, publication.files, hooks);
-  const files = changedFiles(workspace, config, hooks);
-  git(workspace, ['add', '--', ...files], { hooks });
-  const staged = git(workspace, ['diff', '--cached', '--name-only'], { check: false, hooks }).stdout.trim().split('\n').filter(Boolean);
+  const workspaceFiles = new Set(changedFiles(workspace, config, hooks).map(normalizePathPattern));
+  const files = publication.files.map(normalizePathPattern).filter(Boolean);
+  const staged = files.filter((file) => workspaceFiles.has(file));
   return {
     changed: staged.length > 0,
     workspace,

--- a/runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
+++ b/runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
@@ -229,6 +229,9 @@ try {
   assert.equal(finalizationCall.args.includes('--changed-file'), true);
   assert.equal(finalizationCall.args.includes('docs/generated.md'), true);
   assert.equal(calls.some((call) => call.command === 'gh'), false);
+  assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'checkout'), false);
+  assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'reset'), false);
+  assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'add'), false);
   assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'push'), false);
   assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'commit'), false);
 } finally {


### PR DESCRIPTION
## Summary
- Remove extension-side branch reset/checkout/preserve/stage ceremony from workspace publication.
- Keep Homeboy Extensions focused on the domain-specific publish set, gate results, templates, and evidence passed to Homeboy core finalization.
- Add unit coverage that publication delegates review finalization without local git checkout/reset/add/commit/push operations.

## Verification
- npm run test:workspace-publication-lifecycle

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Drafted the small lifecycle cleanup, updated targeted unit coverage, and ran verification.