### PR TITLE
Support local runtime package adapter overlays

### DIFF
--- a/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
+++ b/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
@@ -3,7 +3,7 @@
 
 const path = require('node:path');
 const { run } = require('./lib/common.cjs');
-const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
+const { DEFAULT_RUNTIME_ID, resolveRuntimeModulePath, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 
 function main() {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
@@ -38,7 +38,7 @@ function runtimeSetupAdapter(runtime) {
     return null;
   }
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
-  const adapterPath = path.resolve(repoRoot, adapter.module);
+  const adapterPath = resolveRuntimeModulePath(adapter.module, runtime, { repoRoot });
   const loaded = require(adapterPath);
   const exportName = adapter.export || 'setupRuntime';
   if (typeof loaded[exportName] !== 'function') {

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -137,7 +137,39 @@ function explicitRuntimePackages(options = {}) {
 }
 
 function runtimePackageBasePaths(options = {}) {
-	return normalizeStringList(options.packageBasePaths, options.package_base_paths, options.packageBasePath, options.package_base_path, process.cwd());
+	return normalizeStringList(
+		options.packageBasePaths,
+		options.package_base_paths,
+		options.packageBasePath,
+		options.package_base_path,
+		options.env?.AGENT_RUNTIME_PACKAGE_BASE_PATHS,
+		options.env?.AGENT_RUNTIME_PACKAGE_BASE_PATH,
+		process.env.AGENT_RUNTIME_PACKAGE_BASE_PATHS,
+		process.env.AGENT_RUNTIME_PACKAGE_BASE_PATH,
+		process.cwd()
+	);
+}
+
+function resolveRuntimeModulePath(modulePath, runtime = {}, options = {}) {
+	if (typeof modulePath !== 'string' || modulePath.trim() === '') {
+		throw new Error('Runtime module path is required.');
+	}
+	const requestedPath = modulePath.trim();
+	if (path.isAbsolute(requestedPath)) {
+		return requestedPath;
+	}
+	const repoRoot = options.repoRoot || repoRootFromHere();
+	const sourcePath = runtime?.source?.source_path;
+	const candidates = [
+		...(sourcePath ? [path.resolve(sourcePath, requestedPath)] : []),
+		path.resolve(repoRoot, requestedPath),
+	];
+	for (const candidate of [...new Set(candidates)]) {
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+	return candidates[0];
 }
 
 function normalizeStringList(...values) {
@@ -607,4 +639,5 @@ module.exports = {
 	resolveRuntimeProvider,
 	runtimeManifestPath,
 	runtimeRegistry,
+	resolveRuntimeModulePath,
 };

--- a/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
+++ b/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
@@ -2,7 +2,7 @@
 
 const path = require('node:path');
 
-const { normalizeRuntimeId, resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
+const { normalizeRuntimeId, resolveRuntimeModulePath, resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
 const {
   expandAgentTaskCapabilityBundles,
   expandAgentTaskToolPresets,
@@ -63,8 +63,9 @@ function runtimeWorkflowInputAdapter(runtime, options = {}) {
 	if (!isPlainObject(adapter) || !adapter.module) {
 		return renderDefaultWorkflowInputs;
 	}
-	const repoRoot = options.repoRoot || path.resolve(__dirname, '..', '..');
-	const adapterPath = path.resolve(repoRoot, adapter.module);
+	const adapterPath = resolveRuntimeModulePath(adapter.module, runtime, {
+		repoRoot: options.repoRoot || path.resolve(__dirname, '..', '..'),
+	});
 	const loaded = require(adapterPath);
 	const exportName = adapter.export || 'renderRuntimeWorkflowInputs';
 	if (typeof loaded[exportName] !== 'function') {

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider, runtimeIdFromOptions } = require('../lib/runtime-provider-resolver.cjs');
+const { renderRuntimeWorkflowInputs } = require('../lib/runtime-workflow-inputs.cjs');
 const { runtimeAgentCiRunnerSpec } = require('../provider-adapters');
 const { runRuntimeSetup, runtimeSetupAdapter } = require('../../.github/scripts/runtime-agent-full-run/setup-runtime.cjs');
 const { checkedOutPhpDependencyDirs, envPathIsInsideWorkspace, requiresWordPressDependencies, safeDependencySubdir, setupRuntime } = require('../../agent-runtimes/wp-codebox/lib/runtime-setup.cjs');
@@ -31,6 +32,49 @@ assert.equal(materializeCheckout.target, '.ci/wp-codebox');
 
 assert.equal(runtimeSetupAdapter({ manifest: { ci_materialization: {} } }), null);
 assert.equal(runtimeSetupAdapter({ manifest: { ci_materialization: { requires_wordpress_dependencies: true } } }), null);
+
+const overlayRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-overlay-'));
+const overlayPackageRoot = path.join(overlayRoot, 'node_modules/@example/runtime-overlay');
+fs.mkdirSync(path.join(overlayPackageRoot, 'lib'), { recursive: true });
+fs.writeFileSync(path.join(overlayPackageRoot, 'package.json'), JSON.stringify({
+  name: '@example/runtime-overlay',
+  version: '1.0.0',
+  homeboy: { agent_runtime_manifest: 'runtime.json' },
+}, null, 2));
+fs.writeFileSync(path.join(overlayPackageRoot, 'runtime.json'), JSON.stringify({
+  schema: 'homeboy/agent-runtime-manifest/v1',
+  id: 'overlay-runtime',
+  agent_task_executors: [{ id: 'overlay-executor', backend: 'local', invocation: { command: 'node', argv: ['node', '{{runtime_path}}/executor.js'] } }],
+  workload_profiles: { default: { runtime_profile: 'default' } },
+  workflow_input_projection: { adapter: { module: 'lib/workflow-inputs.cjs', export: 'renderInputs' } },
+  ci_materialization: { setup_adapter: { module: 'lib/setup.cjs', export: 'setupOverlay' } },
+}, null, 2));
+fs.writeFileSync(path.join(overlayPackageRoot, 'lib/workflow-inputs.cjs'), `
+'use strict';
+exports.renderInputs = ({ runtime, profileId }) => ({
+  runtime_requirements: { id: profileId, overlay: true },
+  workflow_inputs: { runtime_source: runtime.source.source_path },
+});
+`);
+fs.writeFileSync(path.join(overlayPackageRoot, 'lib/setup.cjs'), `
+'use strict';
+exports.setupOverlay = ({ runtime, run }) => run('overlay-setup', [runtime.source.source_path], { cwd: runtime.source.source_path });
+`);
+
+const overlayRuntime = resolveRuntimeProvider('overlay-runtime', {
+  runtimePackages: ['@example/runtime-overlay'],
+  env: { AGENT_RUNTIME_PACKAGE_BASE_PATHS: overlayRoot },
+});
+const expectedOverlayPackageRoot = fs.realpathSync(overlayPackageRoot);
+assert.equal(overlayRuntime.source.source_path, expectedOverlayPackageRoot);
+assert.deepEqual(renderRuntimeWorkflowInputs({
+  runtime: overlayRuntime,
+  runtime_profile: 'default',
+  workload_profile: 'default',
+}).workflow_inputs, { runtime_source: expectedOverlayPackageRoot });
+const overlaySetupCalls = [];
+runtimeSetupAdapter(overlayRuntime)({ runtime: overlayRuntime, run: (...args) => overlaySetupCalls.push(args) });
+assert.deepEqual(overlaySetupCalls, [['overlay-setup', [expectedOverlayPackageRoot], { cwd: expectedOverlayPackageRoot }]]);
 
 const setupCalls = [];
 runRuntimeSetup({ manifest: { ci_materialization: {} } }, {


### PR DESCRIPTION
## Summary
- Resolve runtime adapter modules from the runtime manifest source path before falling back to the Extensions repo root.
- Accept env-provided runtime package base paths for local package overlay iteration.
- Add boundary coverage for package-provided workflow/setup adapters loaded from a local overlay package.

## Verification
- `node runtime-agent-ci/tests/runtime-provider-boundary.test.js`
- `node runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Implemented the small runtime loader change, added targeted boundary coverage, and ran safe verification checks.