### PR TITLE
Centralize runtime secret env planning

### DIFF
--- a/.github/scripts/runtime-agent-full-run/auth.cjs
+++ b/.github/scripts/runtime-agent-full-run/auth.cjs
@@ -2,6 +2,9 @@
 'use strict';
 
 const { normalizeContextRepositories, requireRepo, splitCsv, writeGithubOutput } = require('./lib/common.cjs');
+const {
+  secretEnvMapSourceNames,
+} = require('../../../runtime-agent-ci/lib/secret-env-plan.cjs');
 const fs = require('node:fs');
 const { randomUUID } = require('node:crypto');
 
@@ -113,18 +116,6 @@ function materializeSecretEnv(env) {
   process.stdout.write(`Materialized ${materializedNames.length} declared GitHub secret env source(s): ${materializedNames.join(', ') || 'none'}\n`);
 }
 
-function secretEnvMapSourceNames(secretEnvMap) {
-  const names = new Set();
-  for (const [target, sources] of Object.entries(secretEnvMap)) {
-    validateEnvName(target, 'secret_env_map target');
-    const sourceList = Array.isArray(sources) ? sources : [sources];
-    for (const source of sourceList) {
-      names.add(validateEnvName(source, `secret_env_map.${target}`));
-    }
-  }
-  return Array.from(names).sort();
-}
-
 function parseGithubSecretsJson(raw) {
   const parsed = JSON.parse(raw);
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -136,13 +127,6 @@ function parseGithubSecretsJson(raw) {
 function requireValue(value, name) {
   if (typeof value !== 'string' || value.length === 0) {
     throw new Error(`${name} is required.`);
-  }
-  return value;
-}
-
-function validateEnvName(value, label) {
-  if (typeof value !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
-    throw new Error(`${label} must be a valid env name.`);
   }
   return value;
 }

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -23,7 +23,11 @@ const {
 const {
   buildSecretEnvFallbacks,
   buildSecretEnvPlan,
-} = require('./runtime-contracts.cjs');
+  normalizeSecretEnvInput,
+  normalizeSecretEnvMap,
+  secretEnvNamesFromRequirements,
+  validateEnvName,
+} = require('./secret-env-plan.cjs');
 
 function main() {
   writeFullRunConfig(process.env);
@@ -312,48 +316,6 @@ function normalizeStringArray(value) {
     return [value];
   }
   return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string' && entry.length > 0) : [];
-}
-
-function normalizeSecretEnvInput(value) {
-  if (typeof value !== 'string' || value.trim() === '') {
-    return [];
-  }
-  const trimmed = value.trim();
-  const entries = trimmed.startsWith('[') ? JSON.parse(trimmed) : splitCsv(trimmed);
-  if (!Array.isArray(entries)) {
-    throw new Error('secret_env must be a JSON array or comma-separated list');
-  }
-  for (const entry of entries) {
-    validateEnvName(entry, 'secret_env');
-  }
-  return entries;
-}
-
-function normalizeSecretEnvMap(map) {
-  const normalized = {};
-  for (const [target, sources] of Object.entries(map || {})) {
-    validateEnvName(target, 'secret_env_map target');
-    const sourceList = Array.isArray(sources) ? sources : [sources];
-    if (sourceList.length === 0) {
-      throw new Error(`secret_env_map.${target} requires at least one source env name`);
-    }
-    normalized[target] = sourceList.map((source) => validateEnvName(source, `secret_env_map.${target}`));
-  }
-  return normalized;
-}
-
-function secretEnvNamesFromRequirements(requirements) {
-  if (!Array.isArray(requirements)) {
-    return [];
-  }
-  return requirements.map((entry) => entry?.name).filter((name) => typeof name === 'string' && name.length > 0);
-}
-
-function validateEnvName(name, label) {
-  if (typeof name !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
-    throw new Error(`${label} entries must be valid environment variable names`);
-  }
-  return name;
 }
 
 function uniqueStrings(values) {

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -49,6 +49,10 @@ const RUN_LOCATION_INDEX_SCHEMA = CORE_PUBLISHED_RUNTIME_CONTRACT_CONSTANTS.run_
 const RUN_OUTCOME_ENVELOPE_SCHEMA = RUNTIME_CONTRACT_CONSTANTS.run_outcome_envelope.schema_id;
 const ARTIFACT_PATHS_SCHEMA = EXTENSION_RUNTIME_CONTRACT_CONSTANTS.artifact_paths.schema_id;
 const RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA = EXTENSION_RUNTIME_CONTRACT_CONSTANTS.runner_artifact_manifest_ref.schema_id;
+const {
+  buildSecretEnvFallbacks,
+  buildSecretEnvPlan,
+} = require('./secret-env-plan.cjs');
 const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
   events: 'events.json',
   status: 'status.json',
@@ -59,86 +63,6 @@ const CANONICAL_RUN_ARTIFACT_FILES = Object.freeze({
   loop_result: 'loop-result.json',
   loop_policy: 'loop-policy.json',
 });
-
-// Local adapter seam for the secret materialization contract. Keep the emitted
-// shape stable until Homeboy core owns this schema and assembly.
-function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvFallbacks = {}, basePlan = {} } = {}) {
-  const baseRequirements = Array.isArray(basePlan.requirements) ? basePlan.requirements.filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry)) : [];
-  const secretEnvNames = uniqueStrings([
-    ...normalizeStringArray(basePlan.secret_env_names),
-    ...baseRequirements.map((entry) => entry.name),
-    ...secretEnv,
-  ]);
-  const requirementNames = new Set(baseRequirements.map((entry) => entry.name).filter((name) => typeof name === 'string' && name.length > 0));
-  return {
-    ...basePlan,
-    schema: SECRET_ENV_PLAN_SCHEMA,
-    public_env: {
-      ...(basePlan.public_env && typeof basePlan.public_env === 'object' && !Array.isArray(basePlan.public_env) ? basePlan.public_env : {}),
-      ...Object.fromEntries(Object.entries(runtimeEnv).filter(([, value]) => typeof value === 'string')),
-    },
-    secret_env_names: secretEnvNames,
-    requirements: [
-      ...baseRequirements,
-      ...secretEnvNames.filter((name) => !requirementNames.has(name)).map((name) => ({ name, required: true })),
-    ],
-    env_name_mapping: Object.fromEntries(Object.entries({
-      provider_secret_env: Object.values(providerSecretEnvMapping).filter((value) => typeof value === 'string' && value.length > 0),
-      secret_env_fallbacks: Object.values(secretEnvFallbacks).flat().filter((value) => typeof value === 'string' && value.length > 0),
-    }).filter(([, names]) => names.length > 0)),
-    inheritance: {
-      require_declaration: true,
-      allowed_env_names: uniqueStrings([
-        'HOMEBOY_AGENT_RUNTIME_SECRET_ENV',
-        ...Object.keys(secretEnvFallbacks || {}),
-        ...Object.values(secretEnvFallbacks || {}).flat(),
-      ]),
-    },
-  };
-}
-
-// Build the declarative secret-env fallback map consumed by the run step. Each
-// entry maps a target secret env name to an ordered list of source env names;
-// the run step sets target = first non-empty source when target is unset.
-function buildSecretEnvFallbacks({
-  githubTokenEnv,
-  githubRepositoryTokenEnv,
-  providerCanonicalSecretEnvNames = [],
-  providerCredentialSourceEnvNames = [],
-  secretEnvMap = {},
-} = {}) {
-  const fallbacks = {};
-  if (githubTokenEnv && githubRepositoryTokenEnv && githubTokenEnv !== githubRepositoryTokenEnv) {
-    fallbacks[githubTokenEnv] = [githubRepositoryTokenEnv];
-  }
-  if (providerCredentialSourceEnvNames.length > 0) {
-    for (const canonical of providerCanonicalSecretEnvNames) {
-      const sources = providerCredentialSourceEnvNames.filter((name) => name !== canonical);
-      if (sources.length > 0) {
-        fallbacks[canonical] = uniqueStrings([...(fallbacks[canonical] || []), ...sources]);
-      }
-    }
-  }
-  for (const [target, sources] of Object.entries(secretEnvMap || {})) {
-    const sourceList = Array.isArray(sources) ? sources : [sources];
-    const normalizedSources = sourceList.filter((name) => typeof name === 'string' && name.length > 0 && name !== target);
-    if (typeof target === 'string' && target.length > 0 && normalizedSources.length > 0) {
-      fallbacks[target] = uniqueStrings([...(fallbacks[target] || []), ...normalizedSources]);
-    }
-  }
-  return fallbacks;
-}
-
-function normalizeStringArray(value) {
-  if (typeof value === 'string' && value.length > 0) {
-    return [value];
-  }
-  return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string' && entry.length > 0) : [];
-}
-
-function uniqueStrings(values) {
-  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
-}
 
 function validatedLocalSchemaFallback(contractName, coreConstants, fallback) {
   if (coreConstants && typeof coreConstants.schema_id === 'string' && coreConstants.schema_id.length > 0) {

--- a/runtime-agent-ci/lib/secret-env-plan.cjs
+++ b/runtime-agent-ci/lib/secret-env-plan.cjs
@@ -1,0 +1,139 @@
+'use strict';
+
+const SECRET_ENV_PLAN_SCHEMA = 'homeboy/secret-env-plan/v1';
+
+function buildSecretEnvPlan({ secretEnv = [], runtimeEnv = {}, providerSecretEnvMapping = {}, secretEnvFallbacks = {}, basePlan = {} } = {}) {
+  const baseRequirements = Array.isArray(basePlan.requirements) ? basePlan.requirements.filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry)) : [];
+  const secretEnvNames = uniqueStrings([
+    ...normalizeStringArray(basePlan.secret_env_names),
+    ...baseRequirements.map((entry) => entry.name),
+    ...secretEnv,
+  ]);
+  const requirementNames = new Set(baseRequirements.map((entry) => entry.name).filter((name) => typeof name === 'string' && name.length > 0));
+  return {
+    ...basePlan,
+    schema: SECRET_ENV_PLAN_SCHEMA,
+    public_env: {
+      ...(basePlan.public_env && typeof basePlan.public_env === 'object' && !Array.isArray(basePlan.public_env) ? basePlan.public_env : {}),
+      ...Object.fromEntries(Object.entries(runtimeEnv).filter(([, value]) => typeof value === 'string')),
+    },
+    secret_env_names: secretEnvNames,
+    requirements: [
+      ...baseRequirements,
+      ...secretEnvNames.filter((name) => !requirementNames.has(name)).map((name) => ({ name, required: true })),
+    ],
+    env_name_mapping: Object.fromEntries(Object.entries({
+      provider_secret_env: Object.values(providerSecretEnvMapping).filter((value) => typeof value === 'string' && value.length > 0),
+      secret_env_fallbacks: Object.values(secretEnvFallbacks).flat().filter((value) => typeof value === 'string' && value.length > 0),
+    }).filter(([, names]) => names.length > 0)),
+    inheritance: {
+      require_declaration: true,
+      allowed_env_names: uniqueStrings([
+        'HOMEBOY_AGENT_RUNTIME_SECRET_ENV',
+        ...Object.keys(secretEnvFallbacks || {}),
+        ...Object.values(secretEnvFallbacks || {}).flat(),
+      ]),
+    },
+  };
+}
+
+function buildSecretEnvFallbacks({
+  githubTokenEnv,
+  githubRepositoryTokenEnv,
+  providerCanonicalSecretEnvNames = [],
+  providerCredentialSourceEnvNames = [],
+  secretEnvMap = {},
+} = {}) {
+  const fallbacks = {};
+  if (githubTokenEnv && githubRepositoryTokenEnv && githubTokenEnv !== githubRepositoryTokenEnv) {
+    fallbacks[githubTokenEnv] = [githubRepositoryTokenEnv];
+  }
+  if (providerCredentialSourceEnvNames.length > 0) {
+    for (const canonical of providerCanonicalSecretEnvNames) {
+      const sources = providerCredentialSourceEnvNames.filter((name) => name !== canonical);
+      if (sources.length > 0) {
+        fallbacks[canonical] = uniqueStrings([...(fallbacks[canonical] || []), ...sources]);
+      }
+    }
+  }
+  for (const [target, sources] of Object.entries(secretEnvMap || {})) {
+    const sourceList = Array.isArray(sources) ? sources : [sources];
+    const normalizedSources = sourceList.filter((name) => typeof name === 'string' && name.length > 0 && name !== target);
+    if (typeof target === 'string' && target.length > 0 && normalizedSources.length > 0) {
+      fallbacks[target] = uniqueStrings([...(fallbacks[target] || []), ...normalizedSources]);
+    }
+  }
+  return fallbacks;
+}
+
+function normalizeSecretEnvInput(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return [];
+  }
+  const trimmed = value.trim();
+  const entries = trimmed.startsWith('[') ? JSON.parse(trimmed) : trimmed.split(',').map((entry) => entry.trim()).filter(Boolean);
+  if (!Array.isArray(entries)) {
+    throw new Error('secret_env must be a JSON array or comma-separated list');
+  }
+  return entries.map((entry) => validateEnvName(entry, 'secret_env'));
+}
+
+function normalizeSecretEnvMap(map) {
+  const normalized = {};
+  for (const [target, sources] of Object.entries(map || {})) {
+    validateEnvName(target, 'secret_env_map target');
+    const sourceList = Array.isArray(sources) ? sources : [sources];
+    if (sourceList.length === 0) {
+      throw new Error(`secret_env_map.${target} requires at least one source env name`);
+    }
+    normalized[target] = sourceList.map((source) => validateEnvName(source, `secret_env_map.${target}`));
+  }
+  return normalized;
+}
+
+function secretEnvMapSourceNames(secretEnvMap) {
+  const names = new Set();
+  for (const [target, sources] of Object.entries(normalizeSecretEnvMap(secretEnvMap))) {
+    validateEnvName(target, 'secret_env_map target');
+    for (const source of sources) {
+      names.add(source);
+    }
+  }
+  return Array.from(names).sort();
+}
+
+function secretEnvNamesFromRequirements(requirements) {
+  if (!Array.isArray(requirements)) {
+    return [];
+  }
+  return requirements.map((entry) => entry?.name).filter((name) => typeof name === 'string' && name.length > 0);
+}
+
+function normalizeStringArray(value) {
+  if (typeof value === 'string' && value.length > 0) {
+    return [value];
+  }
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string' && entry.length > 0) : [];
+}
+
+function validateEnvName(name, label) {
+  if (typeof name !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`${label} entries must be valid environment variable names`);
+  }
+  return name;
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
+}
+
+module.exports = {
+  SECRET_ENV_PLAN_SCHEMA,
+  buildSecretEnvFallbacks,
+  buildSecretEnvPlan,
+  normalizeSecretEnvInput,
+  normalizeSecretEnvMap,
+  secretEnvMapSourceNames,
+  secretEnvNamesFromRequirements,
+  validateEnvName,
+};

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -25,6 +25,7 @@
     "./runtime-provider-resolver": "./lib/runtime-provider-resolver.cjs",
     "./artifact-paths": "./lib/artifact-paths.cjs",
     "./runtime-contracts": "./lib/runtime-contracts.cjs",
+    "./secret-env-plan": "./lib/secret-env-plan.cjs",
     "./loop-lifecycle": "./lib/loop-lifecycle.cjs",
     "./workspace-publication-lifecycle": "./lib/workspace-publication-lifecycle.cjs"
   },

--- a/runtime-agent-ci/provider-adapters.js
+++ b/runtime-agent-ci/provider-adapters.js
@@ -8,4 +8,5 @@ Object.assign(module.exports, require('./lib/runtime-workflow-inputs.cjs'));
 Object.assign(module.exports, require('./lib/preview-materialization'));
 Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));
 Object.assign(module.exports, require('./lib/runtime-contracts.cjs'));
+Object.assign(module.exports, require('./lib/secret-env-plan.cjs'));
 Object.assign(module.exports, require('./lib/full-run-config.cjs'));

--- a/tests/runtime-agent-full-run-secret-bridge-smoke.mjs
+++ b/tests/runtime-agent-full-run-secret-bridge-smoke.mjs
@@ -36,6 +36,10 @@ const bridgeResult = spawnSync(process.execPath, [
 });
 
 assert.equal(bridgeResult.status, 0, bridgeResult.stderr || bridgeResult.stdout);
+assert.equal(bridgeResult.stdout.includes('github-secret-value'), false);
+assert.equal(bridgeResult.stderr.includes('github-secret-value'), false);
+assert.equal(bridgeResult.stdout.includes('must-not-materialize'), false);
+assert.equal(bridgeResult.stderr.includes('must-not-materialize'), false);
 const githubEnv = fs.readFileSync(githubEnvPath, 'utf8');
 assert.match(githubEnv, /PROVIDER_SECRET_1<</);
 assert.match(githubEnv, /github-secret-value/);

--- a/tests/secret-env-plan-smoke.mjs
+++ b/tests/secret-env-plan-smoke.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  buildSecretEnvFallbacks,
+  buildSecretEnvPlan,
+  normalizeSecretEnvInput,
+  normalizeSecretEnvMap,
+  secretEnvMapSourceNames,
+} = require(path.join(repoRoot, 'runtime-agent-ci/lib/secret-env-plan.cjs'));
+
+assert.deepEqual(normalizeSecretEnvInput('OPENAI_API_KEY, PROVIDER_SECRET_1'), ['OPENAI_API_KEY', 'PROVIDER_SECRET_1']);
+assert.deepEqual(normalizeSecretEnvMap({ OPENAI_API_KEY: ['PROVIDER_SECRET_1', 'PROVIDER_SECRET_2'] }), {
+  OPENAI_API_KEY: ['PROVIDER_SECRET_1', 'PROVIDER_SECRET_2'],
+});
+assert.deepEqual(secretEnvMapSourceNames({ OPENAI_API_KEY: ['PROVIDER_SECRET_2', 'PROVIDER_SECRET_1'] }), ['PROVIDER_SECRET_1', 'PROVIDER_SECRET_2']);
+assert.throws(() => normalizeSecretEnvMap({ OPENAI_API_KEY: ['not-valid'] }), /valid environment variable names/);
+
+const secretEnvFallbacks = buildSecretEnvFallbacks({
+  githubTokenEnv: 'HOMEBOY_GITHUB_APP_TOKEN',
+  githubRepositoryTokenEnv: 'GITHUB_TOKEN',
+  providerCanonicalSecretEnvNames: ['OPENAI_API_KEY'],
+  providerCredentialSourceEnvNames: ['PROVIDER_SECRET_1'],
+  secretEnvMap: { ANTHROPIC_API_KEY: ['PROVIDER_SECRET_2'] },
+});
+assert.deepEqual(secretEnvFallbacks, {
+  ANTHROPIC_API_KEY: ['PROVIDER_SECRET_2'],
+  HOMEBOY_GITHUB_APP_TOKEN: ['GITHUB_TOKEN'],
+  OPENAI_API_KEY: ['PROVIDER_SECRET_1'],
+});
+
+const secretValue = 'sk-test-value-must-not-leak';
+const plan = buildSecretEnvPlan({
+  secretEnv: ['OPENAI_API_KEY', 'PROVIDER_SECRET_1'],
+  runtimeEnv: {
+    PUBLIC_FLAG: 'enabled',
+    NON_STRING: 1,
+  },
+  providerSecretEnvMapping: { connectors_ai_openai_api_key: 'PROVIDER_SECRET_1' },
+  secretEnvFallbacks,
+});
+
+assert.equal(plan.schema, 'homeboy/secret-env-plan/v1');
+assert.deepEqual(plan.public_env, {
+  PUBLIC_FLAG: 'enabled',
+});
+assert.deepEqual(plan.secret_env_names, ['OPENAI_API_KEY', 'PROVIDER_SECRET_1']);
+assert.deepEqual(plan.env_name_mapping.provider_secret_env, ['PROVIDER_SECRET_1']);
+assert.equal(JSON.stringify(plan).includes(secretValue), false);
+
+console.log('secret env plan smoke passed');


### PR DESCRIPTION
## Summary
- Add a shared Extension-local secret env plan helper for runtime-agent-ci secret plan assembly, fallback construction, env map validation, and source-name extraction.
- Wire runtime-agent-ci full-run config and the runtime-agent-full-run auth materializer through the shared helper.
- Add smoke coverage for secret env plan normalization and ensure secret bridge stdout/stderr do not leak materialized secret values.

## Tests
- `node tests/secret-env-plan-smoke.mjs`
- `node tests/runtime-agent-full-run-secret-bridge-smoke.mjs`
- `node tests/runtime-agent-ci-contract-smoke.mjs`

## Notes
- No Homeboy core PR dependency. This keeps provider/product credential readers in Extensions and only centralizes Extension-local secret/env planning.
- Broader pre-existing failures observed on origin/main: `node tests/runtime-agent-full-run-provider-neutral-smoke.mjs` fails because `workflowInputCompatibility` is not exported/defined; `npm test` in `runtime-agent-ci` fails in `agent-task-outcome-normalizer.test.js` expecting `provider.auth` but receiving `provider.error`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Drafted and verified the Extension-local secret/env planning refactor, targeted tests, commit, and PR.