### PR TITLE
Fix Node.js project ecosystem adapter id

### DIFF
--- a/nodejs/scripts/lib/node-helpers.sh
+++ b/nodejs/scripts/lib/node-helpers.sh
@@ -8,7 +8,7 @@ source "$PROJECT_SCRIPTS_HELPER"
 # Verify the resolved component is actually a Node.js project.
 # Walks up to find package.json (so monorepo subpackages also pass).
 homeboy_require_package_json() {
-    homeboy_project_init --ecosystem node --path "${1:-$PROJECT_PATH}"
+    homeboy_project_init --ecosystem nodejs --path "${1:-$PROJECT_PATH}"
 }
 
 # Detect which package manager the project uses, in priority order:
@@ -16,7 +16,7 @@ homeboy_require_package_json() {
 # Sets PKG_MANAGER and PKG_RUN ("pnpm run", "yarn", "npm run", "npx").
 homeboy_detect_package_manager() {
     if [ -z "${HOMEBOY_PROJECT_ECOSYSTEM:-}" ]; then
-        homeboy_project_init --ecosystem node --path "${1:-$PROJECT_PATH}"
+        homeboy_project_init --ecosystem nodejs --path "${1:-$PROJECT_PATH}"
     fi
     PKG_MANAGER="$HOMEBOY_PROJECT_PACKAGE_MANAGER"
     PKG_RUN="$HOMEBOY_PROJECT_RUN_CMD"
@@ -26,7 +26,7 @@ homeboy_detect_package_manager() {
 # Prepare dependencies for clean runner snapshots. Lab offload intentionally
 # excludes node_modules, so package scripts need a deterministic install step.
 homeboy_ensure_node_dependencies() {
-    [ -n "${1:-}" ] && homeboy_project_init --ecosystem node --path "$1"
+    [ -n "${1:-}" ] && homeboy_project_init --ecosystem nodejs --path "$1"
     homeboy_project_ensure_dependencies
 }
 

--- a/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
+++ b/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
@@ -27,7 +27,7 @@ touch "$PNPM_PROJECT/pnpm-lock.yaml"
 
 bash -c '
     source "$1"
-    homeboy_project_init --ecosystem node --path "$2/subdir"
+    homeboy_project_init --ecosystem nodejs --path "$2/subdir"
     [ "$HOMEBOY_PROJECT_ROOT" = "$2" ]
     [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
     [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
@@ -46,7 +46,7 @@ touch "$WORKSPACE_PROJECT/pnpm-lock.yaml" "$WORKSPACE_PROJECT/pnpm-workspace.yam
 
 bash -c '
     source "$1"
-    homeboy_project_init --ecosystem node --path "$2/packages/plugin/subdir"
+    homeboy_project_init --ecosystem nodejs --path "$2/packages/plugin/subdir"
     [ "$HOMEBOY_PROJECT_ROOT" = "$2/packages/plugin" ]
     [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
     [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]


### PR DESCRIPTION
## Summary
- use the packaged `nodejs` dependency adapter id from Node.js helper scripts
- update the packaged project helper smoke coverage to match

## Testing
- `bash nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugged the Lab fixture-matrix failure, identified the stale Node.js ecosystem id, made the helper/test update, and ran targeted verification.