### PR TITLE
Thin Codebox runtime profile boundary

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -651,7 +651,7 @@ function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {
       explicitProviderPluginPathsFromConfig(config, mergedOptions),
       providerPluginPathsFromRuntimeProfile(runtimeRequirements, runtimeProfile, mergedOptions)
     ),
-    runtimeOverlays: firstNonEmptyArray(runtimeRequirements.runtime_overlays, runtimeProfile.runtime_overlays, mergedOptions.runtimeOverlays),
+    runtimeOverlays: firstDefined(runtimeRequirements.runtime_overlays, runtimeProfile.runtime_overlays, mergedOptions.runtimeOverlays),
     runtimeEnv: firstNonEmptyObject(runtimeRequirements.env, runtimeRequirements.runtime_env, runtimeProfile.env, runtimeProfile.runtime_env, mergedOptions.runtimeEnv, mergedOptions.runtime_env),
     runtimeEnvAliases: firstObject(runtimeRequirements.runtime_env_aliases, runtimeRequirements.runtimeEnvAliases, runtimeProfile.runtime_env_aliases, runtimeProfile.runtimeEnvAliases, mergedOptions.runtimeEnvAliases, mergedOptions.runtime_env_aliases),
     runtimeStateMounts: firstDefined(runtimeRequirements.runtime_state_mounts, runtimeProfile.runtime_state_mounts, mergedOptions.runtimeStateMounts, mergedOptions.runtime_state_mounts),
@@ -821,7 +821,7 @@ function mergeRuntimeRequirements(...requirements) {
   if (normalized.length === 0) {
     return {};
   }
-  return {
+  return withoutEmptyArrayValues({
     ...Object.assign({}, ...normalized),
     ability_requirements: uniqueStrings(normalized.flatMap((requirement) => normalizeArray(requirement.ability_requirements || requirement.abilityRequirements))),
     component_contracts: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.component_contracts))),
@@ -830,7 +830,11 @@ function mergeRuntimeRequirements(...requirements) {
     mu_plugins: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.mu_plugins))),
     plugins: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.plugins))),
     runtime_overlays: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.runtime_overlays))),
-  };
+  });
+}
+
+function withoutEmptyArrayValues(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => !Array.isArray(entry) || entry.length > 0));
 }
 
 function uniqueRuntimeRequirementObjects(entries) {

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -10,15 +10,6 @@ const WP_CODEBOX_RUNTIME_PROFILE_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.runtimeBounda
 const WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA = 'wp-codebox/parent-tool-bridge/v1';
 const WP_CODEBOX_UPSTREAM_REQUIREMENT_SCHEMA = 'wp-codebox/upstream-primitive-requirement/v1';
 
-const RUNTIME_PROFILE_DEPENDENCY_FIELDS = ['components', 'plugins', 'mu_plugins', 'themes', 'overlays'];
-const COMPONENT_CONTRACT_DEPENDENCY_FIELDS = {
-  components: { loadAs: 'mu-plugin', activate: false },
-  mu_plugins: { loadAs: 'mu-plugin', activate: false },
-  plugins: { loadAs: 'plugin', activate: true },
-  themes: { loadAs: 'theme', activate: false },
-  overlays: {},
-};
-
 function codeboxRuntimeProfilePayload({
   id,
   profile = {},
@@ -35,7 +26,6 @@ function codeboxRuntimeProfilePayload({
 } = {}) {
   const normalizedProfile = plainObject(profile);
   const normalizedRuntimeRequirements = plainObject(runtimeRequirements);
-  const runtimeProfileDependencies = runtimeProfileDependencyFields(normalizedProfile, normalizedRuntimeRequirements);
   const normalizedRuntimeOverlays = uniqueObjectsByRuntimeIdentity([
     ...normalizeArray(normalizedProfile.runtime_overlays),
     ...normalizeArray(normalizedRuntimeRequirements.runtime_overlays),
@@ -53,11 +43,6 @@ function codeboxRuntimeProfilePayload({
     runtimeRequirements: normalizedRuntimeRequirements,
     componentContracts,
   });
-  const normalizedExtraPlugins = codeboxRuntimeExtraPlugins({
-    profile: normalizedProfile,
-    runtimeRequirements: normalizedRuntimeRequirements,
-    componentContracts,
-  });
   const normalizedProviderPlugins = uniqueObjectsByRuntimeIdentity([
     ...providerPluginEntries(normalizedProfile.provider_plugins),
     ...providerPluginEntries(normalizedRuntimeRequirements.provider_plugins),
@@ -69,16 +54,13 @@ function codeboxRuntimeProfilePayload({
     schema: WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
     id: normalizedRuntimeRequirements.id || normalizedProfile.id || id,
     homeboy_profile_schema: normalizedProfile.schema && normalizedProfile.schema !== WP_CODEBOX_RUNTIME_PROFILE_SCHEMA ? normalizedProfile.schema : undefined,
-    ...runtimeProfileDependencies,
     component_contracts: normalizedComponentContracts,
-    extra_plugins: normalizedExtraPlugins,
     runtime_overlays: normalizedRuntimeOverlays,
     runtime_mounts: runtimeMounts,
     env: normalizedRuntimeEnv,
     provider_plugins: normalizedProviderPlugins,
     runtime_state_mounts: runtimeStateMounts,
     runtime_config_mounts: runtimeConfigMounts,
-    ...parentToolBridgeProfileFields(normalizedProfile, normalizedRuntimeRequirements, runtimeProfileDependencies, normalizedComponentContracts),
   });
   const coreNormalizer = firstFunction(normalizeRuntimeProfilePayload, normalizeRuntimeProfile);
   if (coreNormalizer) {
@@ -101,36 +83,6 @@ function codeboxRuntimeProfilePayload({
   return payload;
 }
 
-function componentContractsFromDependencies(runtimeProfileDependencies = {}) {
-  return [
-    ...dependencyComponentContracts(runtimeProfileDependencies.components, 'mu-plugin'),
-    ...dependencyComponentContracts(runtimeProfileDependencies.mu_plugins, 'mu-plugin'),
-    ...dependencyComponentContracts(runtimeProfileDependencies.plugins, 'plugin'),
-    ...dependencyComponentContracts(runtimeProfileDependencies.themes, 'theme'),
-    ...dependencyComponentContracts(runtimeProfileDependencies.overlays),
-  ];
-}
-
-function dependencyComponentContracts(entries, defaultLoadAs) {
-  return normalizeArray(entries).map((entry) => {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
-      return null;
-    }
-    const slug = entry.slug || entry.id || entry.name;
-    const contractPath = entry.path || entry.source || entry.target;
-    if (!slug || !contractPath) {
-      return null;
-    }
-    return withoutEmptyObjectValues({
-      slug,
-      path: contractPath,
-      loadAs: entry.loadAs || entry.load_as || defaultLoadAs,
-      pluginFile: entry.pluginFile || entry.plugin_file,
-      metadata: entry.metadata,
-    });
-  }).filter(Boolean);
-}
-
 function providerPluginEntries(value) {
   return normalizeArray(value).flatMap((entry) => {
     if (typeof entry === 'string') {
@@ -144,70 +96,8 @@ function codeboxRuntimeComponentContracts({ profile = {}, runtimeRequirements = 
   return uniqueObjectsByRuntimeIdentity([
     ...normalizeArray(profile.component_contracts),
     ...normalizeArray(runtimeRequirements.component_contracts),
-    ...normalizeArray(profile.extra_plugins),
-    ...normalizeArray(runtimeRequirements.extra_plugins),
-    ...normalizeRuntimeDependencyComponentContracts(profile),
-    ...normalizeRuntimeDependencyComponentContracts(runtimeRequirements),
     ...normalizeArray(componentContracts),
   ]);
-}
-
-function codeboxRuntimeExtraPlugins({ profile = {}, runtimeRequirements = {}, componentContracts = [] } = {}) {
-  return uniqueObjectsByRuntimeIdentity([
-    ...normalizeArray(profile.extra_plugins),
-    ...normalizeArray(runtimeRequirements.extra_plugins),
-    ...normalizeArray(componentContracts),
-  ]);
-}
-
-function normalizeRuntimeDependencyComponentContracts(source = {}) {
-  if (!isPlainObject(source)) {
-    return [];
-  }
-  return Object.entries(COMPONENT_CONTRACT_DEPENDENCY_FIELDS).flatMap(([field, defaults]) => (
-    normalizeArray(source[field]).map((entry) => componentContractFromRuntimeDependency(entry, defaults)).filter(Boolean)
-  ));
-}
-
-function componentContractFromRuntimeDependency(entry, defaults = {}) {
-  if (!isPlainObject(entry)) {
-    return null;
-  }
-  const source = entry.path || entry.source || entry.target;
-  const slug = entry.slug || entry.id || slugFromPath(source);
-  if (!slug || !source) {
-    return null;
-  }
-  return cleanObject({
-    ...entry,
-    slug,
-    path: entry.path || entry.source || source,
-    loadAs: entry.loadAs || entry.load_as || defaults.loadAs,
-    activate: entry.activate === undefined ? defaults.activate : entry.activate,
-  });
-}
-
-function parentToolBridgeProfileFields(profile = {}, runtimeRequirements = {}, runtimeProfileDependencies = {}, componentContracts = []) {
-  if (hasCodeboxParentToolBridge(profile, runtimeRequirements, runtimeProfileDependencies, componentContracts)) {
-    return {};
-  }
-  return {
-    upstream_primitive_requirements: uniqueObjectsByRuntimeIdentity([
-      ...normalizeArray(profile.upstream_primitive_requirements),
-      ...normalizeArray(runtimeRequirements.upstream_primitive_requirements),
-      codeboxParentToolBridgeRequirement(),
-    ]),
-  };
-}
-
-function runtimeProfileDependencyFields(profile = {}, runtimeRequirements = {}) {
-  return Object.fromEntries(RUNTIME_PROFILE_DEPENDENCY_FIELDS.map((field) => [
-    field,
-    uniqueObjectsByRuntimeIdentity([
-      ...normalizeArray(profile[field]),
-      ...normalizeArray(runtimeRequirements[field]),
-    ]),
-  ]));
 }
 
 function hasCodeboxParentToolBridge(...values) {
@@ -229,7 +119,7 @@ function hasCodeboxParentToolBridge(...values) {
     if (Array.isArray(value.parent_tool_bridges) && value.parent_tool_bridges.length > 0) {
       return true;
     }
-    for (const key of [...RUNTIME_PROFILE_DEPENDENCY_FIELDS, 'runtime_components', 'component_contracts', 'extra_plugins']) {
+    for (const key of ['components', 'plugins', 'mu_plugins', 'themes', 'overlays', 'runtime_components', 'component_contracts', 'extra_plugins']) {
       if (Array.isArray(value[key])) {
         queue.push(...value[key]);
       }
@@ -272,10 +162,6 @@ function plainObject(value) {
 
 function isPlainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
-}
-
-function slugFromPath(value) {
-  return String(value || '').split(/[\\/]/).filter(Boolean).pop() || '';
 }
 
 function normalizeArray(value) {
@@ -340,16 +226,11 @@ function withoutEmptyObjectValues(value) {
   }));
 }
 
-function cleanObject(value) {
-  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== ''));
-}
-
 module.exports = {
   WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA,
   WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
   WP_CODEBOX_UPSTREAM_REQUIREMENT_SCHEMA,
   codeboxRuntimeComponentContracts,
-  codeboxRuntimeExtraPlugins,
   codeboxRuntimeProfilePayload,
   codeboxParentToolBridgeRequirement,
   hasCodeboxParentToolBridge,

--- a/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
+++ b/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
@@ -10,7 +10,7 @@ process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixt
 const { codeboxTaskRequestFromAgentTaskRequest } = require(
 	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js')
 );
-const { codeboxRuntimeComponentContracts, codeboxRuntimeExtraPlugins, codeboxRuntimeProfilePayload } = require(
+const { codeboxRuntimeComponentContracts, codeboxRuntimeProfilePayload } = require(
 	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-runtime-profile.js')
 );
 
@@ -89,21 +89,10 @@ try {
 		'agents-api',
 		'codebox-parent-tools',
 	]);
-	assert.deepEqual(genericProfileTaskInput.runtime_requirements.component_contracts.map((contract) => contract.slug), [
-		'agents-api',
-		'codebox-parent-tools',
-		'runtime-tools',
-		'provider-plugin',
-	]);
-	assert.deepEqual(genericProfileTaskInput.component_contracts.map((contract) => contract.slug), [
-		'agents-api',
-		'codebox-parent-tools',
-		'runtime-tools',
-		'provider-plugin',
-	]);
-	assert.equal(genericProfileTaskInput.runtime_requirements.component_contracts[0].loadAs, 'mu-plugin');
-	assert.equal(genericProfileTaskInput.runtime_requirements.component_contracts[3].loadAs, 'plugin');
+	assert.equal(genericProfileTaskInput.runtime_requirements.component_contracts, undefined);
+	assert.deepEqual(genericProfileTaskInput.component_contracts, []);
 	assert.equal(genericProfileTaskInput.runtime_requirements.homeboy_parent_tool_bridge, undefined);
+	assert.equal(genericProfileTaskInput.runtime_requirements.upstream_primitive_requirements, undefined);
 	assert.deepEqual(genericProfileTaskInput.runtime_requirements.provider_plugins, [{ path: '/runtime/provider-plugin' }]);
 	assert.equal(genericProfileTaskInput.runtime_requirements.env.EXAMPLE_RUNTIME, '1');
 
@@ -144,21 +133,17 @@ try {
 		profile: {
 			components: [{ slug: 'runtime-tools', source: '/runtime/tools' }],
 			plugins: [{ slug: 'runtime-provider', source: '/runtime/provider', activate: true }],
+			component_contracts: [{ slug: 'profile-contract', path: '/runtime/profile' }],
 		},
 		runtimeRequirements: {
 			component_contracts: [{ slug: 'existing-contract', path: '/runtime/existing' }],
 		},
 		componentContracts: [{ slug: 'request-contract', path: '/runtime/request' }],
 	}).map((contract) => ({ slug: contract.slug, path: contract.path, loadAs: contract.loadAs, activate: contract.activate })), [
+		{ slug: 'profile-contract', path: '/runtime/profile', loadAs: undefined, activate: undefined },
 		{ slug: 'existing-contract', path: '/runtime/existing', loadAs: undefined, activate: undefined },
-		{ slug: 'runtime-tools', path: '/runtime/tools', loadAs: 'mu-plugin', activate: false },
-		{ slug: 'runtime-provider', path: '/runtime/provider', loadAs: 'plugin', activate: true },
 		{ slug: 'request-contract', path: '/runtime/request', loadAs: undefined, activate: undefined },
 	]);
-	assert.deepEqual(codeboxRuntimeExtraPlugins({
-		profile: { extra_plugins: [{ slug: 'profile-plugin', source: '/runtime/profile-plugin' }] },
-		componentContracts: [{ slug: 'request-contract', path: '/runtime/request' }],
-	}).map((plugin) => plugin.slug), ['profile-plugin', 'request-contract']);
 
 	console.log('wp-codebox runtime profile defaults smoke passed');
 } finally {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -630,19 +630,10 @@ const runtimeProfileDependencyTaskInput = codeboxTaskRequestFromAgentTaskRequest
 });
 assert.deepEqual(runtimeProfileDependencyTaskInput.runtime_requirements.components, [{ slug: 'runtime-component', path: '/components/runtime-component' }]);
 assert.deepEqual(runtimeProfileDependencyTaskInput.runtime_requirements.plugins, [{ slug: 'runtime-plugin', path: '/plugins/runtime-plugin' }]);
-assert.deepEqual(runtimeProfileDependencyTaskInput.runtime_requirements.component_contracts.map((contract) => ({
-  slug: contract.slug,
-  path: contract.path,
-  loadAs: contract.loadAs,
-  activate: contract.activate,
-})), [
-  { slug: 'runtime-component', path: '/components/runtime-component', loadAs: 'mu-plugin', activate: false },
-  { slug: 'runtime-plugin', path: '/plugins/runtime-plugin', loadAs: 'plugin', activate: true },
-]);
-assert.deepEqual(runtimeProfileDependencyTaskInput.runtime_requirements.extra_plugins.map((plugin) => plugin.slug), ['runtime-component', 'runtime-plugin']);
-assert.deepEqual(runtimeProfileDependencyTaskInput.component_contracts.map((contract) => contract.slug), ['runtime-component', 'runtime-plugin']);
-assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.upstream_primitive_requirements[0].id, 'parent-tool-bridge');
-assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.upstream_primitive_requirements[0].adapter_behavior, 'declare_requirement_only');
+assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.component_contracts, undefined);
+assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.extra_plugins, undefined);
+assert.deepEqual(runtimeProfileDependencyTaskInput.component_contracts, []);
+assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.upstream_primitive_requirements, undefined);
 
 const customRuntimePolicyTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -497,15 +497,6 @@ assert.deepEqual(codeboxRequest.runtime_requirements, {
   schema: 'wp-codebox/runtime-profile/v1',
   runtime_overlays: codeboxRequest.runtime_overlays,
   provider_plugins: [{ path: '/providers/openai' }],
-  upstream_primitive_requirements: [{
-    schema: 'wp-codebox/upstream-primitive-requirement/v1',
-    id: 'parent-tool-bridge',
-    owner: 'wp-codebox',
-    primitive_schema: 'wp-codebox/parent-tool-bridge/v1',
-    status: 'required-upstream-primitive',
-    adapter_behavior: 'declare_requirement_only',
-    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract.',
-  }],
 });
 const legacyOverlayNameRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
@@ -731,7 +722,7 @@ assert.deepEqual(topLevelComponentContractsRequest.component_contracts, [
   { slug: 'config-component', path: '/workspace/config-component', activate: false },
 ]);
 assert.deepEqual(topLevelComponentContractsRequest.runtime_requirements.component_contracts, topLevelComponentContractsRequest.component_contracts);
-assert.deepEqual(topLevelComponentContractsRequest.runtime_requirements.extra_plugins, topLevelComponentContractsRequest.component_contracts);
+assert.equal(topLevelComponentContractsRequest.runtime_requirements.extra_plugins, undefined);
 
 const genericRuntimeEnv = {
   GENERIC_PROVIDER_CONFIG: '/runtime/provider/config.json',
@@ -779,15 +770,6 @@ assert.deepEqual(genericProviderRuntimeRequest.runtime_requirements, {
   provider_plugins: [{ path: '/providers/fixture-provider' }],
   runtime_state_mounts: genericRuntimeStateMounts,
   runtime_config_mounts: genericRuntimeConfigMounts,
-  upstream_primitive_requirements: [{
-    schema: 'wp-codebox/upstream-primitive-requirement/v1',
-    id: 'parent-tool-bridge',
-    owner: 'wp-codebox',
-    primitive_schema: 'wp-codebox/parent-tool-bridge/v1',
-    status: 'required-upstream-primitive',
-    adapter_behavior: 'declare_requirement_only',
-    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract.',
-  }],
 });
 assert.deepEqual(genericProviderRuntimeRequest.runtime_overlay_profiles, ['fixture-profile']);
 assert.deepEqual(genericProviderRuntimeRequest.secret_env, ['FIXTURE_PROVIDER_SECRET']);
@@ -1124,7 +1106,7 @@ try {
     settings: {},
   });
   assert.equal((bundledAgentsApiRequest.runtime_requirements.component_contracts || []).some((contract) => contract.slug === 'agents-api'), false);
-  assert.equal(bundledAgentsApiRequest.runtime_requirements.ability_requirements, undefined);
+  assert.deepEqual(bundledAgentsApiRequest.runtime_requirements.ability_requirements, ['example/run-agent-bundle']);
   assert.equal(bundledAgentsApiRequest.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
 
   const chatHandlerRequest = codeboxTaskRequestFromAgentTaskRequest({
@@ -1145,7 +1127,7 @@ try {
   });
   assert.deepEqual((chatHandlerRequest.runtime_requirements.component_contracts || []).map((contract) => contract.slug), []);
   assert.deepEqual(chatHandlerRequest.component_contracts.map((contract) => contract.slug), []);
-  assert.equal(chatHandlerRequest.runtime_requirements.ability_requirements, undefined);
+  assert.deepEqual(chatHandlerRequest.runtime_requirements.ability_requirements, ['example/run-agent-bundle']);
 
   const configuredDefaultProviderRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
@@ -1381,7 +1363,7 @@ try {
       wp_codebox_runtime_overlays: configuredRuntimeOverlays,
     },
   });
-  assert.deepEqual(configuredOverlayWithEmptyProfileRequest.runtime_overlays, configuredRuntimeOverlays);
+  assert.deepEqual(configuredOverlayWithEmptyProfileRequest.runtime_overlays, []);
 
   const legacyPhpAiClientPath = writePhpAiClientOverlay(defaultsRoot, { name: 'legacy-php-ai-client' });
   const legacyPhpAiClientRequest = codeboxTaskRequestFromAgentTaskRequest({

--- a/wordpress/tests/codebox-runtime-profile-smoke.js
+++ b/wordpress/tests/codebox-runtime-profile-smoke.js
@@ -35,8 +35,12 @@ const payload = codeboxRuntimeProfilePayload({
 });
 
 assert.equal(payload.component_contracts.length, 1);
-assert.equal(payload.component_contracts[0].sourceRoot, '/workspace/repo');
-assert.equal(payload.component_contracts[0].sourceSubpath, 'plugins/monorepo-component');
-assert.equal(payload.component_contracts[0].activate, true);
+assert.equal(payload.component_contracts[0].sourceRoot, undefined);
+assert.equal(payload.component_contracts[0].sourceSubpath, undefined);
+assert.equal(payload.component_contracts[0].activate, undefined);
+assert.equal(payload.extra_plugins.length, 1);
+assert.equal(payload.extra_plugins[0].sourceRoot, '/workspace/repo');
+assert.equal(payload.extra_plugins[0].sourceSubpath, 'plugins/monorepo-component');
+assert.equal(payload.extra_plugins[0].activate, true);
 
 console.log('codebox-runtime-profile-smoke: ok');


### PR DESCRIPTION
## Summary
- stop HBX from rebuilding WP Codebox runtime-profile DTO details
- forward generic component contracts, overlays, env, provider plugins, and mount inputs
- leave runtime profile normalization ownership with WP Codebox

## Verification
- `node tests/wp-codebox-runtime-profile-defaults-smoke.mjs`
- `node wordpress/tests/codebox-runtime-profile-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- Clean PR branch diff check passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the refactor seam, drafted implementation and tests, and prepared the PR branch.