### PR TITLE
Use explicit secret env bindings

### DIFF
--- a/.github/scripts/runtime-agent-full-run/auth.cjs
+++ b/.github/scripts/runtime-agent-full-run/auth.cjs
@@ -88,9 +88,40 @@ function materializeSecretEnv(env) {
   const configPath = requireValue(env.CONFIG_FILE, 'CONFIG_FILE');
   const githubEnvPath = requireValue(env.GITHUB_ENV, 'GITHUB_ENV');
   const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  const bindings = normalizeSecretEnvBindings(env.HOMEBOY_SECRET_ENV_BINDINGS || '{}', config);
+  if (Object.keys(bindings).length === 0 && env.HOMEBOY_ALLOW_UNSAFE_BULK_GITHUB_SECRETS_JSON_BRIDGE !== 'true') {
+    throw new Error('materialize_secret_env_from_github_secrets requires non-empty secret_env_bindings.');
+  }
+
+  const materializedNames = Object.keys(bindings).length > 0
+    ? materializeExplicitSecretEnvBindings(bindings, env, githubEnvPath)
+    : materializeUnsafeGithubSecretsJson(config, env, githubEnvPath);
+
+  process.stdout.write(`Materialized ${materializedNames.length} declared secret env binding(s): ${materializedNames.join(', ') || 'none'}\n`);
+}
+
+function materializeExplicitSecretEnvBindings(bindings, env, githubEnvPath) {
+  const materializedNames = [];
+  const lines = [];
+  for (const [targetName, sourceName] of Object.entries(bindings)) {
+    const value = env[sourceName];
+    if (typeof value !== 'string' || value === '') {
+      throw new Error(`secret_env_bindings.${targetName} source env ${sourceName} is not set.`);
+    }
+    const delimiter = `HOMEBOY_SECRET_${randomUUID().replace(/-/g, '_')}`;
+    materializedNames.push(targetName);
+    lines.push(`${targetName}<<${delimiter}`, value, delimiter);
+  }
+  if (lines.length > 0) {
+    fs.appendFileSync(githubEnvPath, `${lines.join('\n')}\n`);
+  }
+  return materializedNames;
+}
+
+function materializeUnsafeGithubSecretsJson(config, env, githubEnvPath) {
   const secretEnvMap = config.secret_env_map;
   if (!secretEnvMap || typeof secretEnvMap !== 'object' || Array.isArray(secretEnvMap) || Object.keys(secretEnvMap).length === 0) {
-    throw new Error('materialize_secret_env_from_github_secrets requires a non-empty secret_env_map declaration.');
+    throw new Error('unsafe bulk GitHub secrets JSON bridge requires a non-empty secret_env_map declaration.');
   }
 
   const githubSecrets = parseGithubSecretsJson(env.HOMEBOY_GITHUB_SECRETS_JSON || '{}');
@@ -113,7 +144,45 @@ function materializeSecretEnv(env) {
   if (lines.length > 0) {
     fs.appendFileSync(githubEnvPath, `${lines.join('\n')}\n`);
   }
-  process.stdout.write(`Materialized ${materializedNames.length} declared GitHub secret env source(s): ${materializedNames.join(', ') || 'none'}\n`);
+  return materializedNames;
+}
+
+function normalizeSecretEnvBindings(raw, config) {
+  const parsed = JSON.parse(raw || '{}');
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('HOMEBOY_SECRET_ENV_BINDINGS must be a JSON object.');
+  }
+  const declaredNames = new Set([
+    ...(Array.isArray(config.secret_env) ? config.secret_env : []),
+    ...secretEnvPlanNames(config.secret_env_plan),
+  ]);
+  const normalized = {};
+  for (const [targetName, sourceName] of Object.entries(parsed)) {
+    validateBindingEnvName(targetName, 'secret_env_bindings target');
+    validateBindingEnvName(sourceName, `secret_env_bindings.${targetName}`);
+    if (!declaredNames.has(targetName)) {
+      throw new Error(`secret_env_bindings.${targetName} must target a declared secret env name.`);
+    }
+    normalized[targetName] = sourceName;
+  }
+  return normalized;
+}
+
+function secretEnvPlanNames(plan) {
+  if (!plan || typeof plan !== 'object' || Array.isArray(plan)) {
+    return [];
+  }
+  return [
+    ...(Array.isArray(plan.secret_env_names) ? plan.secret_env_names : []),
+    ...(Array.isArray(plan.requirements) ? plan.requirements.map((entry) => entry?.name) : []),
+  ].filter((name) => typeof name === 'string' && name.length > 0);
+}
+
+function validateBindingEnvName(name, label) {
+  if (typeof name !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`${label} entries must be valid environment variable names`);
+  }
+  return name;
 }
 
 function parseGithubSecretsJson(raw) {
@@ -131,9 +200,19 @@ function requireValue(value, name) {
   return value;
 }
 
-try {
-  main();
-} catch (error) {
-  process.stderr.write(`${error.message}\n`);
-  process.exit(1);
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
 }
+
+module.exports = {
+  materializeSecretEnv,
+  normalizeSecretEnvBindings,
+  parseGithubSecretsJson,
+  reportMode,
+  resolveTokenScope,
+};

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -76,8 +76,12 @@ name: Runtime Agent Full Run (reusable)
         description: JSON homeboy/secret-env-plan/v1 declaration merged into the generated runner config. Values are never serialized.
         type: string
         default: '{}'
+      secret_env_bindings:
+        description: JSON object mapping declared target secret env names to explicit source env names already present in the job environment. Values are env names only, never secret values.
+        type: string
+        default: '{}'
       materialize_secret_env_from_github_secrets:
-        description: Opt-in bridge that resolves only declared secret_env_map sources from the GitHub secrets context before the runner starts. Prefer explicit, minimal caller secrets when enabling.
+        description: Opt-in bridge that materializes declared secret_env_bindings before the runner starts. Unsafe bulk GitHub secrets JSON is not exposed by this reusable workflow.
         type: boolean
         default: false
       model:
@@ -532,7 +536,7 @@ jobs:
         if: ${{ inputs.run_agent && inputs.materialize_secret_env_from_github_secrets }}
         env:
           CONFIG_FILE: ${{ steps.config.outputs.config_path }}
-          HOMEBOY_GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}
+          HOMEBOY_SECRET_ENV_BINDINGS: ${{ inputs.secret_env_bindings }}
         run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/auth.cjs materialize-secret-env
 
       - name: Run runtime agent

--- a/runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js
+++ b/runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   normalizeArtifactDownloads,
@@ -8,6 +11,9 @@ const {
 const {
   projectCallbackData,
 } = require('../../.github/scripts/runtime-agent-full-run/project-callback-data.cjs');
+const {
+  materializeSecretEnv,
+} = require('../../.github/scripts/runtime-agent-full-run/auth.cjs');
 
 assert.deepEqual(normalizeArtifactDownloads(JSON.stringify([
   { runId: '123', artifactName: 'payload' },
@@ -38,5 +44,63 @@ assert.throws(
   () => projectCallbackData({ CALLBACK_DATA: '[]' }),
   /Invalid callback_data: expected JSON object/
 );
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-agent-auth-'));
+try {
+  const configPath = path.join(tmpRoot, 'config.json');
+  const githubEnvPath = path.join(tmpRoot, 'github-env');
+  fs.writeFileSync(configPath, JSON.stringify({
+    secret_env: ['OPENAI_API_KEY'],
+    secret_env_plan: {
+      secret_env_names: ['ANTHROPIC_API_KEY'],
+      requirements: [{ name: 'GITHUB_TOKEN', required: true }],
+    },
+  }));
+
+  materializeSecretEnv({
+    CONFIG_FILE: configPath,
+    GITHUB_ENV: githubEnvPath,
+    HOMEBOY_SECRET_ENV_BINDINGS: JSON.stringify({ OPENAI_API_KEY: 'UPSTREAM_OPENAI_API_KEY' }),
+    UPSTREAM_OPENAI_API_KEY: 'declared-secret-value',
+    UNDECLARED_SECRET: 'must-not-be-visible',
+  });
+
+  const githubEnv = fs.readFileSync(githubEnvPath, 'utf8');
+  assert.match(githubEnv, /OPENAI_API_KEY<<HOMEBOY_SECRET_/);
+  assert.match(githubEnv, /declared-secret-value/);
+  assert.doesNotMatch(githubEnv, /UPSTREAM_OPENAI_API_KEY/);
+  assert.doesNotMatch(githubEnv, /UNDECLARED_SECRET/);
+  assert.doesNotMatch(githubEnv, /must-not-be-visible/);
+
+  assert.throws(
+    () => materializeSecretEnv({
+      CONFIG_FILE: configPath,
+      GITHUB_ENV: githubEnvPath,
+      HOMEBOY_SECRET_ENV_BINDINGS: JSON.stringify({ UNDECLARED_SECRET: 'UNDECLARED_SECRET' }),
+      UNDECLARED_SECRET: 'must-not-be-visible',
+    }),
+    /secret_env_bindings\.UNDECLARED_SECRET must target a declared secret env name/
+  );
+
+  assert.throws(
+    () => materializeSecretEnv({
+      CONFIG_FILE: configPath,
+      GITHUB_ENV: githubEnvPath,
+      HOMEBOY_SECRET_ENV_BINDINGS: JSON.stringify({ ANTHROPIC_API_KEY: 'MISSING_ANTHROPIC_API_KEY' }),
+    }),
+    /secret_env_bindings\.ANTHROPIC_API_KEY source env MISSING_ANTHROPIC_API_KEY is not set/
+  );
+
+  assert.throws(
+    () => materializeSecretEnv({
+      CONFIG_FILE: configPath,
+      GITHUB_ENV: githubEnvPath,
+      HOMEBOY_GITHUB_SECRETS_JSON: JSON.stringify({ OPENAI_API_KEY: 'legacy-secret-value' }),
+    }),
+    /requires non-empty secret_env_bindings/
+  );
+} finally {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+}
 
 process.stdout.write('Runtime agent full-run control-plane projection checks passed\n');


### PR DESCRIPTION
## Summary
- Add explicit `secret_env_bindings` input.
- Remove normal-path bulk `${{ toJson(secrets) }}` exposure.
- Gate the legacy bulk secrets bridge behind an unsafe opt-in flag and fail closed for missing/undeclared bindings.

## Tests
- node runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js
- node runtime-agent-ci/tests/build-runner-config.test.js
- npm test from runtime-agent-ci
- git diff --check

## Dependencies
- Compatible with current flow; future tightening can consume Extra-Chill/homeboy#7353 secret handoff output.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Removed the unsafe normal-path secret bridge and added binding tests.