### PR TITLE
Consume path materialization plans

### DIFF
--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -256,6 +256,10 @@ name: Runtime Agent Full Run (reusable)
         description: JSON object merged into the generated runner config for caller-owned runtime fields.
         type: string
         default: '{}'
+      path_materialization_plan:
+        description: JSON homeboy/path-materialization-plan/v1 declaration for runner/workload paths and runtime mounts.
+        type: string
+        default: '{}'
       workload_run_before:
         description: JSON array of pre-run hooks executed before the main workload.
         type: string
@@ -512,6 +516,7 @@ jobs:
           RUNTIME_OVERLAYS: ${{ inputs.runtime_overlays }}
           RUNTIME_ENV: ${{ inputs.runtime_env }}
           RUNTIME_CONFIG: ${{ inputs.runtime_config }}
+          PATH_MATERIALIZATION_PLAN: ${{ inputs.path_materialization_plan }}
           WORKLOAD_RUN_BEFORE: ${{ inputs.workload_run_before }}
           WORKLOAD_RUN_AFTER: ${{ inputs.workload_run_after }}
           APP_TOKEN_REPOS: ${{ inputs.app_token_repos }}

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -28,6 +28,9 @@ const {
   secretEnvNamesFromRequirements,
   validateEnvName,
 } = require('./secret-env-plan.cjs');
+const {
+  parsePathMaterializationPlan,
+} = require('./path-materialization-plan.cjs');
 
 function main() {
   writeFullRunConfig(process.env);
@@ -101,6 +104,7 @@ function buildConfig(env) {
   const componentContracts = parseJsonInput('component_contracts', env.COMPONENT_CONTRACTS || '[]', 'array', []);
   const runtimeEnv = parseJsonInput('runtime_env', env.RUNTIME_ENV || '{}', 'object', {});
   const runtimeConfig = parseJsonInput('runtime_config', env.RUNTIME_CONFIG || '{}', 'object', {});
+  const pathMaterializationPlan = parsePathMaterializationPlan(env.PATH_MATERIALIZATION_PLAN || '', { workspace });
   const loopPolicy = loopPolicyFromEnv(env);
   const providerPluginPaths = validationDependencies.providerPluginHostPath ? [validationDependencies.providerPluginHostPath] : [];
   const renderedRuntimeInputs = renderRuntimeWorkflowInputs({
@@ -119,7 +123,7 @@ function buildConfig(env) {
   const effectiveRuntimeProfiles = renderedRuntimeInputs.runtime_profiles;
   const runnerWorkspace = parseJsonInput('runner_workspace', env.RUNNER_WORKSPACE_CONFIG || '{}', 'object', {});
   const runnerWorkspaceRepo = targetRepo.split('/')[1].replace(/\.git$/, '');
-  const runnerWorkspaceGuestCheckout = `/workspace/${runnerWorkspaceRepo}`;
+  const runnerWorkspaceGuestCheckout = pathMaterializationPlan.runner_workspace_guest_checkout || `/workspace/${runnerWorkspaceRepo}`;
   const runnerWorkspaceMounts = runnerWorkspace.enabled === true ? [{
     type: 'directory',
     source: workspace,
@@ -127,6 +131,7 @@ function buildConfig(env) {
     mode: 'readwrite',
     metadata: { kind: 'runner-workspace', artifactExcludePaths: ['.ci/**'] },
   }] : [];
+  const pathMaterializationMounts = pathMaterializationPlan.runtime_mounts || [];
   const effectiveRunnerWorkspace = runnerWorkspace.enabled === true ? { ...runnerWorkspace, checkout_path: runnerWorkspaceGuestCheckout } : runnerWorkspace;
   const appTokenRepos = splitCsv(env.APP_TOKEN_REPOS || targetRepo);
   const allowedRepos = parseJsonInput('allowed_repos', env.ALLOWED_REPOS || '[]', 'array', []);
@@ -167,7 +172,7 @@ function buildConfig(env) {
     execution_kind: env.EXECUTION_KIND || (runtimeTask ? 'runtime_task' : 'runtime_execution'),
     runtime_mounts: [
       ...runtimeMounts,
-      ...runnerWorkspaceMounts,
+      ...(pathMaterializationMounts.length > 0 ? pathMaterializationMounts : runnerWorkspaceMounts),
     ],
     wp_config_defines: runtimeProjection.wp_config_defines,
     runtime_overlays: runtimeOverlays,
@@ -232,6 +237,7 @@ function buildConfig(env) {
     ability_tools: parseJsonInput('ability_tools', env.ABILITY_TOOLS || '[]', 'array', []),
     ability_requirements: parseJsonInput('ability_requirements', env.ABILITY_REQUIREMENTS || '[]', 'array', []),
     evidence_projections: evidenceProjections,
+    ...(Object.keys(pathMaterializationPlan).length > 0 ? { path_materialization_plan: pathMaterializationPlan } : {}),
     runner_workspace: effectiveRunnerWorkspace,
     ignored_workspace_paths: parseJsonInput('ignored_workspace_paths', env.IGNORED_WORKSPACE_PATHS || '[]', 'array', []),
     callback_data: parseJsonInput('callback_data', env.CALLBACK_DATA || '{}', 'object', {}),
@@ -382,6 +388,7 @@ function executableInPath(command, searchPath) {
 function projectRuntimeConfig({ env, runtime, workspace, componentId, componentPath, workloadId, runnerWorkspaceGuestCheckout }) {
   const projection = runtime?.manifest?.runner_config_projection || {};
   const artifactDeclarations = parseJsonInput('artifact_declarations', env.ARTIFACT_DECLARATIONS || '[]', 'array', []);
+  const pathMaterializationPlan = parsePathMaterializationPlan(env.PATH_MATERIALIZATION_PLAN || '', { workspace });
   const context = {
     component_id: componentId,
     component_path: componentPath,
@@ -394,12 +401,12 @@ function projectRuntimeConfig({ env, runtime, workspace, componentId, componentP
     transcript_host_dir: renderTemplate(
       projection.transcript_host_dir_template,
       context,
-      path.join(workspace, 'runtime-agent-artifacts', workloadId)
+      pathMaterializationPlan.transcript_host_dir || path.join(workspace, 'runtime-agent-artifacts', workloadId)
     ),
     transcript_dir: renderTemplate(
       projection.transcript_guest_dir_template,
       context,
-      `${runnerWorkspaceGuestCheckout}/runtime-agent-artifacts/${workloadId}`
+      pathMaterializationPlan.transcript_dir || `${runnerWorkspaceGuestCheckout}/runtime-agent-artifacts/${workloadId}`
     ),
     wp_config_defines: {
       ...(plainObject(projection.wp_config_defines) ? projection.wp_config_defines : {}),
@@ -408,7 +415,7 @@ function projectRuntimeConfig({ env, runtime, workspace, componentId, componentP
   };
   const adapter = runtimeProjectionAdapter(runtime, projection);
   if (!adapter) {
-    return manifestProjection;
+    return applyPathMaterializationProjection(manifestProjection, pathMaterializationPlan);
   }
   const adapterProjection = adapter({
     env,
@@ -421,7 +428,15 @@ function projectRuntimeConfig({ env, runtime, workspace, componentId, componentP
     artifactDeclarations,
     manifestProjection,
   });
-  return mergeProjection(manifestProjection, adapterProjection);
+  return applyPathMaterializationProjection(mergeProjection(manifestProjection, adapterProjection), pathMaterializationPlan);
+}
+
+function applyPathMaterializationProjection(projection, pathMaterializationPlan) {
+  return {
+    ...projection,
+    ...(pathMaterializationPlan.transcript_host_dir ? { transcript_host_dir: pathMaterializationPlan.transcript_host_dir } : {}),
+    ...(pathMaterializationPlan.transcript_dir ? { transcript_dir: pathMaterializationPlan.transcript_dir } : {}),
+  };
 }
 
 function runtimeProjectionAdapter(runtime, projection) {

--- a/runtime-agent-ci/lib/path-materialization-plan.cjs
+++ b/runtime-agent-ci/lib/path-materialization-plan.cjs
@@ -1,0 +1,151 @@
+'use strict';
+
+const path = require('node:path');
+
+const PATH_MATERIALIZATION_PLAN_SCHEMA = 'homeboy/path-materialization-plan/v1';
+
+function parsePathMaterializationPlan(rawInput, options = {}) {
+  const raw = String(rawInput || '').trim();
+  if (raw === '') {
+    return {};
+  }
+  const plan = JSON.parse(raw);
+  return normalizePathMaterializationPlan(plan, options);
+}
+
+function normalizePathMaterializationPlan(plan, options = {}) {
+  if (!plainObject(plan)) {
+    throw new Error('path_materialization_plan must be a JSON object');
+  }
+  if (Object.keys(plan).length === 0) {
+    return {};
+  }
+  if (plan.schema !== PATH_MATERIALIZATION_PLAN_SCHEMA) {
+    throw new Error(`path_materialization_plan.schema must be ${PATH_MATERIALIZATION_PLAN_SCHEMA}`);
+  }
+
+  const workspace = requiredString(options.workspace, 'workspace');
+  const paths = plainObject(plan.paths) ? plan.paths : {};
+
+  return stripUndefined({
+    schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
+    runner_workspace_guest_checkout: optionalGuestPath(
+      paths.runner_workspace_guest_checkout,
+      'path_materialization_plan.paths.runner_workspace_guest_checkout'
+    ),
+    transcript_host_dir: optionalHostPath(
+      paths.transcript_host_dir,
+      workspace,
+      'path_materialization_plan.paths.transcript_host_dir'
+    ),
+    transcript_dir: optionalGuestPath(
+      paths.transcript_dir,
+      'path_materialization_plan.paths.transcript_dir'
+    ),
+    runtime_mounts: normalizeMounts(plan.runtime_mounts || [], workspace),
+  });
+}
+
+function normalizeMounts(mounts, workspace) {
+  if (!Array.isArray(mounts)) {
+    throw new Error('path_materialization_plan.runtime_mounts must be an array');
+  }
+  return mounts.map((mount, index) => {
+    if (!plainObject(mount)) {
+      throw new Error(`path_materialization_plan.runtime_mounts[${index}] must be an object`);
+    }
+    const source = requiredHostPath(mount.source, workspace, `path_materialization_plan.runtime_mounts[${index}].source`, { allowWorkspaceRoot: true });
+    const target = requiredGuestPath(mount.target, `path_materialization_plan.runtime_mounts[${index}].target`);
+    return stripUndefined({
+      type: mount.type || 'directory',
+      source,
+      target,
+      mode: mount.mode || 'readwrite',
+      metadata: plainObject(mount.metadata) ? mount.metadata : undefined,
+    });
+  });
+}
+
+function requiredHostPath(value, workspace, name, options = {}) {
+  const normalized = optionalHostPath(value, workspace, name, options);
+  if (!normalized) {
+    throw new Error(`${name} is required`);
+  }
+  return normalized;
+}
+
+function optionalHostPath(value, workspace, name, options = {}) {
+  const raw = firstString(value);
+  if (!raw) {
+    return '';
+  }
+  if (path.win32.isAbsolute(raw)) {
+    throw new Error(`${name} must be a workspace-relative path or absolute path under GITHUB_WORKSPACE: ${raw}`);
+  }
+  const relativeRaw = path.isAbsolute(raw) ? path.relative(path.resolve(workspace), raw) : raw;
+  if ((relativeRaw === '' || relativeRaw === '.') && options.allowWorkspaceRoot === true) {
+    return path.resolve(workspace);
+  }
+  if (relativeRaw === '' || relativeRaw === '.' || relativeRaw === '..' || relativeRaw.split(/[\\/]+/).some((segment) => segment === '' || segment === '..')) {
+    throw new Error(`${name} must not contain empty or parent-directory segments: ${raw}`);
+  }
+  const resolved = path.resolve(workspace, raw);
+  const relative = path.relative(path.resolve(workspace), resolved);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${name} must resolve under GITHUB_WORKSPACE: ${raw}`);
+  }
+  return resolved;
+}
+
+function requiredGuestPath(value, name) {
+  const normalized = optionalGuestPath(value, name);
+  if (!normalized) {
+    throw new Error(`${name} is required`);
+  }
+  return normalized;
+}
+
+function optionalGuestPath(value, name) {
+  const raw = firstString(value);
+  if (!raw) {
+    return '';
+  }
+  if (!raw.startsWith('/') || raw.startsWith('//') || raw.includes('\\')) {
+    throw new Error(`${name} must be an absolute POSIX path: ${raw}`);
+  }
+  const normalized = path.posix.normalize(raw);
+  if (normalized !== raw || normalized === '/' || normalized.split('/').includes('..')) {
+    throw new Error(`${name} must be a normalized absolute POSIX path without parent-directory segments: ${raw}`);
+  }
+  return normalized;
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value.trim();
+    }
+  }
+  return '';
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stripUndefined(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== ''));
+}
+
+module.exports = {
+  PATH_MATERIALIZATION_PLAN_SCHEMA,
+  normalizePathMaterializationPlan,
+  parsePathMaterializationPlan,
+};

--- a/runtime-agent-ci/provider-adapters.js
+++ b/runtime-agent-ci/provider-adapters.js
@@ -9,4 +9,5 @@ Object.assign(module.exports, require('./lib/preview-materialization'));
 Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));
 Object.assign(module.exports, require('./lib/runtime-contracts.cjs'));
 Object.assign(module.exports, require('./lib/secret-env-plan.cjs'));
+Object.assign(module.exports, require('./lib/path-materialization-plan.cjs'));
 Object.assign(module.exports, require('./lib/full-run-config.cjs'));

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -10,6 +10,8 @@ const {
   buildConfig,
   buildSecretEnvPlan,
   loopPolicyFromEnv,
+  normalizePathMaterializationPlan,
+  PATH_MATERIALIZATION_PLAN_SCHEMA,
   SECRET_ENV_PLAN_SCHEMA,
 } = require('../provider-adapters');
 const { normalizeProviderPlugin } = require('../lib/full-run-inputs.cjs');
@@ -46,6 +48,53 @@ assert.deepEqual(loopPolicyFromEnv({
   deadline_at: '2030-01-01T00:00:00.000Z',
 });
 
+const pathPlanWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-path-plan-'));
+try {
+  const pathPlan = normalizePathMaterializationPlan({
+    schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
+    paths: {
+      runner_workspace_guest_checkout: '/runtime/workspace/example',
+      transcript_host_dir: 'artifacts/transcript',
+      transcript_dir: '/runtime/workspace/example/artifacts/transcript',
+    },
+    runtime_mounts: [{ source: '.', target: '/runtime/workspace/example', metadata: { kind: 'runner-workspace' } }],
+  }, { workspace: pathPlanWorkspace });
+  assert.equal(pathPlan.runner_workspace_guest_checkout, '/runtime/workspace/example');
+  assert.equal(pathPlan.transcript_host_dir, path.join(pathPlanWorkspace, 'artifacts/transcript'));
+  assert.equal(pathPlan.transcript_dir, '/runtime/workspace/example/artifacts/transcript');
+  assert.deepEqual(pathPlan.runtime_mounts, [{
+    type: 'directory',
+    source: pathPlanWorkspace,
+    target: '/runtime/workspace/example',
+    mode: 'readwrite',
+    metadata: { kind: 'runner-workspace' },
+  }]);
+
+  assert.throws(
+    () => normalizePathMaterializationPlan({
+      schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
+      paths: { transcript_host_dir: '../outside' },
+    }, { workspace: pathPlanWorkspace }),
+    /transcript_host_dir.*parent-directory|transcript_host_dir.*under GITHUB_WORKSPACE/
+  );
+  assert.throws(
+    () => normalizePathMaterializationPlan({
+      schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
+      paths: { transcript_dir: 'relative/transcript' },
+    }, { workspace: pathPlanWorkspace }),
+    /transcript_dir must be an absolute POSIX path/
+  );
+  assert.throws(
+    () => normalizePathMaterializationPlan({
+      schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
+      runtime_mounts: [{ source: '.', target: '/runtime/../escape' }],
+    }, { workspace: pathPlanWorkspace }),
+    /runtime_mounts\[0\]\.target.*normalized absolute POSIX path/
+  );
+} finally {
+  fs.rmSync(pathPlanWorkspace, { recursive: true, force: true });
+}
+
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-build-runner-config-'));
 try {
   const config = buildConfig({
@@ -76,6 +125,43 @@ try {
   assert.deepEqual(config.secret_env_plan.secret_env_names, config.secret_env);
 } finally {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
+}
+
+const materializedTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-build-runner-config-path-plan-'));
+try {
+  const config = buildConfig({
+    ...process.env,
+    GITHUB_WORKSPACE: materializedTmpRoot,
+    RUNNER_TEMP: materializedTmpRoot,
+    WORKLOAD_ID: 'path-plan-fixture',
+    TARGET_REPO: 'Extra-Chill/example',
+    PROFILE: 'runtime-agent-ci',
+    RUNTIME_PROFILES: '{}',
+    RUNTIME: 'local-shell',
+    RUNNER_WORKSPACE_CONFIG: '{"enabled":true}',
+    PATH_MATERIALIZATION_PLAN: JSON.stringify({
+      schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
+      paths: {
+        runner_workspace_guest_checkout: '/runtime/workspace/example',
+        transcript_host_dir: 'runtime-artifacts/path-plan-fixture',
+        transcript_dir: '/runtime/workspace/example/runtime-artifacts/path-plan-fixture',
+      },
+      runtime_mounts: [{ source: '.', target: '/runtime/workspace/example', mode: 'readwrite' }],
+    }),
+  });
+
+  assert.equal(config.runner_workspace.checkout_path, '/runtime/workspace/example');
+  assert.equal(config.transcript_host_dir, path.join(materializedTmpRoot, 'runtime-artifacts/path-plan-fixture'));
+  assert.equal(config.transcript_dir, '/runtime/workspace/example/runtime-artifacts/path-plan-fixture');
+  assert.deepEqual(config.runtime_mounts, [{
+    type: 'directory',
+    source: materializedTmpRoot,
+    target: '/runtime/workspace/example',
+    mode: 'readwrite',
+  }]);
+  assert.equal(config.path_materialization_plan.schema, PATH_MATERIALIZATION_PLAN_SCHEMA);
+} finally {
+  fs.rmSync(materializedTmpRoot, { recursive: true, force: true });
 }
 
 const mappedSecretEnvPlan = buildSecretEnvPlan({


### PR DESCRIPTION
## Summary
- Add parser for `homeboy/path-materialization-plan/v1`.
- Add full-run workflow input for path materialization plans.
- Prefer planned checkout, transcript, and runtime mount paths when provided.

## Tests
- node runtime-agent-ci/tests/build-runner-config.test.js
- node runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js
- node tests/runtime-agent-full-run-projection-boundary-smoke.mjs
- node tests/runtime-agent-full-run-local-shell-smoke.mjs
- for test_file in runtime-agent-ci/tests/*.test.js; do node "$test_file"; done
- git diff --check

## Dependencies
- Depends on path materialization contract publication from Extra-Chill/homeboy#7356.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Added typed materialization plan consumption and tests.