### PR TITLE
Fix WP Codebox configured PHPUnit file routing

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -27,7 +27,7 @@ assert_not_contains() {
 }
 
 component="${TMPDIR}/component"
-mkdir -p "${component}/tests/Unit" "${component}/wordpress/tests" "${TMPDIR}/stubs"
+mkdir -p "${component}/tests/Unit" "${component}/wordpress/tests" "${component}/bin/tests/i18n-tools" "${TMPDIR}/stubs"
 
 cat > "${component}/tests/import-agent-ability-smoke.php" <<'PHP'
 <?php
@@ -57,6 +57,11 @@ JS
 cat > "${component}/tests/Unit/ImportAgentAbilityTest.php" <<'PHP'
 <?php
 // PHPUnit-shaped file; the WP Codebox backend owns execution.
+PHP
+
+cat > "${component}/bin/tests/i18n-tools/ExtractTest.php" <<'PHP'
+<?php
+// PHPUnit-shaped file under a configured non-default test root.
 PHP
 
 cat > "${component}/tests/helper.php" <<'PHP'
@@ -105,6 +110,7 @@ const recipe = {
     `wp-config-defines-json=${JSON.stringify(options.wpConfigDefines || {})}`,
     `autoload-file=${options.autoloadFile}`,
     `tests-dir=${options.testsDir}`,
+    `test-root=${options.testRoot || ''}`,
     `dependency-mounts=${(options.dependencyMounts || []).filter(Boolean).join(',')}`,
     `multisite=${options.multisite ? '1' : '0'}`,
   ] }] },
@@ -165,6 +171,7 @@ const recipe = {
     `wp-config-defines-json=${JSON.stringify(options.wpConfigDefines || {})}`,
     `autoload-file=${options.autoloadFile}`,
     `tests-dir=${options.testsDir}`,
+    `test-root=${options.testRoot || ''}`,
     `dependency-mounts=${(options.dependencyMounts || []).filter(Boolean).join(',')}`,
     `multisite=${options.multisite ? '1' : '0'}`,
   ] }] },
@@ -383,6 +390,20 @@ if [ -e "${component}/.phpunit.result.cache" ]; then
     echo "Expected WP Codebox runner to clean PHPUnit result cache" >&2
     exit 1
 fi
+
+WP_CODEBOX_ARGS_FILE="${TMPDIR}/wp-codebox-configured-root-args.txt" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_SETTINGS_JSON='{"wp_codebox_phpunit_mounts":[{"source":"'"${component}"'","target":"/home/example/public_html","mode":"readwrite"}],"wp_codebox_phpunit_test_root":"/home/example/public_html/bin/tests/i18n-tools"}' \
+HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file /home/example/public_html/bin/tests/i18n-tools/ExtractTest.php > "${TMPDIR}/wp-codebox-configured-root-file.out"
+
+assert_contains "${TMPDIR}/wp-codebox-configured-root-file.out" "WP_CODEBOX_STUB"
+assert_contains "${TMPDIR}/wp-codebox-configured-root-args.txt" "test-file=ExtractTest.php"
+assert_contains "${TMPDIR}/wp-codebox-configured-root-args.txt" '"target": "/home/example/public_html"'
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -667,6 +667,30 @@ detect_phpunit_project_bootstrap() {
     return 1
 }
 
+resolve_wp_codebox_sandbox_host_path() {
+    local settings_json="$1"
+    local sandbox_path="$2"
+
+    if [ -e "$sandbox_path" ]; then
+        printf '%s\n' "$sandbox_path"
+        return 0
+    fi
+
+    printf '%s' "$settings_json" | jq -r --arg sandboxPath "$sandbox_path" '
+        (.wp_codebox_phpunit_mounts // [])[]
+        | select((.source // "") != "" and (.target // "") != "")
+        | (.target | rtrimstr("/")) as $target
+        | (.source | rtrimstr("/")) as $source
+        | select($sandboxPath == $target or ($sandboxPath | startswith($target + "/")))
+        | $source + ($sandboxPath | sub("^" + ($target | gsub("([][\\.^$*+?{}|()-])"; "\\\\\\1")); ""))
+    ' 2>/dev/null | while IFS= read -r candidate; do
+        if [ -e "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+}
+
 validate_project_bootstrap_ref() {
     local bootstrap_ref="$1"
 
@@ -802,24 +826,34 @@ PHPUNIT_ARGS_JSON=$(printf '%s\0' "${PASSTHROUGH_ARGS[@]}" | php -r '
 
 SELECTED_TEST_FILE_REL=""
 if [ -n "$SELECTED_TEST_FILE" ]; then
+    SELECTED_TEST_ROOT_HOST=""
+    if [ -n "$WP_CODEBOX_PHPUNIT_TEST_ROOT" ]; then
+        SELECTED_TEST_ROOT_HOST=$(resolve_wp_codebox_sandbox_host_path "${HOMEBOY_SETTINGS_JSON:-{}}" "$WP_CODEBOX_PHPUNIT_TEST_ROOT" || true)
+    fi
+    if [ -z "$SELECTED_TEST_ROOT_HOST" ]; then
+        SELECTED_TEST_ROOT_HOST="${PLUGIN_PATH}/tests"
+    fi
+
     if [ "${SELECTED_TEST_FILE#/}" != "$SELECTED_TEST_FILE" ]; then
-        selected_abs="$SELECTED_TEST_FILE"
+        selected_abs=$(resolve_wp_codebox_sandbox_host_path "${HOMEBOY_SETTINGS_JSON:-{}}" "$SELECTED_TEST_FILE" || true)
+        [ -n "$selected_abs" ] || selected_abs="$SELECTED_TEST_FILE"
     else
         selected_abs="${PLUGIN_PATH}/${SELECTED_TEST_FILE}"
+        if [ ! -f "$selected_abs" ]; then
+            selected_abs="${SELECTED_TEST_ROOT_HOST%/}/${SELECTED_TEST_FILE}"
+        fi
     fi
     if [ ! -f "$selected_abs" ]; then
         echo "ERROR: requested PHPUnit test file not found: ${SELECTED_TEST_FILE}" >&2
         exit 2
     fi
-    case "$selected_abs" in
-        "${PLUGIN_PATH}"/tests/*.php|"${PLUGIN_PATH}"/tests/*/*.php|"${PLUGIN_PATH}"/tests/*/*/*.php|"${PLUGIN_PATH}"/tests/*/*/*/*.php)
-            SELECTED_TEST_FILE_REL="${selected_abs#"${PLUGIN_PATH}/"}"
-            ;;
-        *)
-            echo "ERROR: requested PHPUnit test file must live under tests/: ${SELECTED_TEST_FILE}" >&2
-            exit 2
-            ;;
-    esac
+    selected_root_real=$(php -r 'echo realpath($argv[1]) ?: "";' "$SELECTED_TEST_ROOT_HOST" 2>/dev/null || true)
+    selected_abs_real=$(php -r 'echo realpath($argv[1]) ?: "";' "$selected_abs" 2>/dev/null || true)
+    if [ -z "$selected_root_real" ] || [ -z "$selected_abs_real" ] || [ "${selected_abs_real#"${selected_root_real%/}/"}" = "$selected_abs_real" ]; then
+        echo "ERROR: requested PHPUnit test file must live under configured test root: ${SELECTED_TEST_FILE}" >&2
+        exit 2
+    fi
+    SELECTED_TEST_FILE_REL="${selected_abs_real#"${selected_root_real%/}/"}"
 fi
 
 MOUNTS_JSON="[]"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -160,6 +160,10 @@ homeboy_wordpress_rel_test_file() {
         abs_path="${PLUGIN_PATH}/${raw_path#wordpress/}"
     fi
 
+    if [ ! -f "$abs_path" ] && [ "${raw_path#/}" != "$raw_path" ]; then
+        abs_path=$(homeboy_wordpress_resolve_wp_codebox_sandbox_path "$raw_path" || true)
+    fi
+
     if [ ! -f "$abs_path" ]; then
         return 1
     fi
@@ -167,6 +171,60 @@ homeboy_wordpress_rel_test_file() {
     case "$abs_path" in
         "${PLUGIN_PATH}"/*)
             printf '%s\n' "${abs_path#"${PLUGIN_PATH}/"}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+homeboy_wordpress_resolve_wp_codebox_sandbox_path() {
+    local sandbox_path="$1"
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    [ -n "$settings_json" ] || settings_json="{}"
+
+    if [ -e "$sandbox_path" ]; then
+        printf '%s\n' "$sandbox_path"
+        return 0
+    fi
+
+    printf '%s' "$settings_json" | jq -r --arg sandboxPath "$sandbox_path" '
+        (.wp_codebox_phpunit_mounts // [])[]
+        | select((.source // "") != "" and (.target // "") != "")
+        | (.target | rtrimstr("/")) as $target
+        | (.source | rtrimstr("/")) as $source
+        | select($sandboxPath == $target or ($sandboxPath | startswith($target + "/")))
+        | $source + ($sandboxPath | sub("^" + ($target | gsub("([][\\.^$*+?{}|()-])"; "\\\\\\1")); ""))
+    ' 2>/dev/null | while IFS= read -r candidate; do
+        if [ -e "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+}
+
+homeboy_wordpress_configured_phpunit_test_root() {
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    local test_root
+    [ -n "$settings_json" ] || settings_json="{}"
+
+    test_root=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_phpunit_test_root // empty' 2>/dev/null || true)
+    [ -n "$test_root" ] || return 1
+
+    homeboy_wordpress_resolve_wp_codebox_sandbox_path "$test_root"
+}
+
+homeboy_wordpress_is_configured_phpunit_file() {
+    local target_rel="$1"
+    local test_root
+    local target_abs="${PLUGIN_PATH}/${target_rel}"
+
+    test_root=$(homeboy_wordpress_configured_phpunit_test_root || true)
+    [ -n "$test_root" ] || return 1
+
+    case "$target_abs" in
+        "${test_root%/}"/*.php|"${test_root%/}"/*/*.php|"${test_root%/}"/*/*/*.php|"${test_root%/}"/*/*/*/*.php)
+            return 0
             ;;
         *)
             return 1
@@ -365,6 +423,26 @@ if [ -n "$TARGET_FILE" ]; then
     if homeboy_wordpress_is_shell_smoke_file "$target_rel"; then
         homeboy_wordpress_run_shell_smoke_files "$target_rel"
         exit 0
+    fi
+
+    if homeboy_wordpress_is_configured_phpunit_file "$target_rel"; then
+        configured_phpunit_root=$(homeboy_wordpress_configured_phpunit_test_root || true)
+        configured_phpunit_target="${PLUGIN_PATH}/${target_rel}"
+        configured_phpunit_rel="${configured_phpunit_target#"${configured_phpunit_root%/}/"}"
+        if [ -z "$configured_phpunit_root" ] || [ "$configured_phpunit_rel" = "$configured_phpunit_target" ]; then
+            configured_phpunit_rel="$target_rel"
+        fi
+        case "$target_base" in
+            *Test.php|test-*.php)
+                WORDPRESS_RUNTIME_RUNNER="$(homeboy_wordpress_runtime_runner)" || exit $?
+                HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE="$configured_phpunit_rel" exec bash "$WORDPRESS_RUNTIME_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+                ;;
+            *)
+                echo "ERROR: cannot classify requested WordPress test file under configured PHPUnit test root: ${target_rel}" >&2
+                echo "  PHPUnit files must match *Test.php or test-*.php." >&2
+                exit 2
+                ;;
+        esac
     fi
 
     case "$target_rel" in


### PR DESCRIPTION
## Summary
- Map absolute WP Codebox sandbox `--file` paths back to host paths using configured PHPUnit mounts in the WordPress router.
- Allow selected PHPUnit files under `wp_codebox_phpunit_test_root` to be passed relative to that configured root.
- Add smoke coverage for a non-default configured PHPUnit test root.

## Verification
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `HOMEBOY_RUNTIME_RUNNER_PRELUDE=/Users/chubes/Developer/homeboy/src/core/extension/runtime/runner-prelude.sh HOMEBOY_RUNTIME_RESOLVE_CONTEXT=/Users/chubes/Developer/homeboy/src/core/extension/runtime/resolve-context.sh HOMEBOY_RUNTIME_RUNNER_STEPS=/Users/chubes/Developer/homeboy/src/core/extension/runtime/runner-steps.sh HOMEBOY_RUNTIME_FAILURE_TRAP=/Users/chubes/Developer/homeboy/src/core/extension/runtime/failure-trap.sh bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigated the WPCOM selected-file routing failure, split the focused Homeboy Extensions fix from a dirty worktree, implemented the shell routing changes, and ran verification.