### PR TITLE
Set WP Codebox test runner Node heap default

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -75,6 +75,7 @@ set -euo pipefail
 echo "WP_CODEBOX_STUB"
 echo "SELECTED=${HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE:-}"
 printf 'CHANGED=%s\n' "${HOMEBOY_CHANGED_TEST_FILES:-}"
+printf 'NODE_OPTIONS=%s\n' "${NODE_OPTIONS:-}"
 printf 'ARGS=%s\n' "$*"
 if [ -n "${WP_CODEBOX_ARGS_FILE:-}" ]; then
     printf '%s\n' "$@" > "${WP_CODEBOX_ARGS_FILE}"
@@ -380,6 +381,7 @@ HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builde
 
 assert_contains "${TMPDIR}/wp-codebox-file.out" "WP_CODEBOX_STUB"
 assert_contains "${TMPDIR}/wp-codebox-file.out" "Backend: wp-codebox"
+assert_contains "${TMPDIR}/wp-codebox-file.out" "NODE_OPTIONS=--max-old-space-size=8192"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "recipe-run"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "--recipe"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "wordpress.phpunit"

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -1224,6 +1224,17 @@ jq -n \
     + (if $diagnostics == null then {} else {diagnosticsCapture: $diagnostics} end))' > "$RECIPE_OPTIONS_FILE"
 
 WP_CODEBOX_PHPUNIT_PERSIST_ON_FAILURE=1
+WP_CODEBOX_NODE_OPTIONS="${HOMEBOY_WP_CODEBOX_NODE_OPTIONS:-${NODE_OPTIONS:-}}"
+case " $WP_CODEBOX_NODE_OPTIONS " in
+    *" --max-old-space-size="*) ;;
+    *)
+        if [ -n "$WP_CODEBOX_NODE_OPTIONS" ]; then
+            WP_CODEBOX_NODE_OPTIONS="${WP_CODEBOX_NODE_OPTIONS} --max-old-space-size=8192"
+        else
+            WP_CODEBOX_NODE_OPTIONS="--max-old-space-size=8192"
+        fi
+        ;;
+esac
 
 if [ ! -f "$PHPUNIT_RECIPE_BUILDER" ]; then
     fail_wp_codebox_phpunit_profile_setup "WP Codebox PHPUnit recipe builder not found: ${PHPUNIT_RECIPE_BUILDER}"
@@ -1240,7 +1251,7 @@ if ! validation_errors=$(validate_wp_codebox_phpunit_recipe_profile); then
 fi
 
 set +e
-"${wp_codebox_command[@]}" recipe-run \
+NODE_OPTIONS="$WP_CODEBOX_NODE_OPTIONS" "${wp_codebox_command[@]}" recipe-run \
     --recipe "$RECIPE_FILE" \
     --artifacts "$ARTIFACTS_DIR" \
     --json \


### PR DESCRIPTION
## Summary
- Give WP Codebox-backed WordPress PHPUnit runs a default `NODE_OPTIONS=--max-old-space-size=8192` when invoking `wp-codebox recipe-run`.
- Preserve explicit `HOMEBOY_WP_CODEBOX_NODE_OPTIONS`, existing `NODE_OPTIONS`, and any already-configured `--max-old-space-size`.
- Extend the file-routing smoke stub to verify the default reaches the WP Codebox process.

## Why
After the WP Codebox artifact collection fixes, the focused WPCOM PHPUnit target still exceeded Node/V8's default heap in the WP Codebox CLI process. The same command passed end-to-end when run with `NODE_OPTIONS=--max-old-space-size=8192`:

- Passing Homeboy run: `runner-exec-test-wpcom-homeboy-lab-55532def-049f-4cae-beaf-7e9af6a5c59a`
- Result: `35 passed, 0 failed`

This keeps the memory budget on the process that needs it, without changing Homeboy core or WP Codebox internals.

## Verification
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `HOMEBOY_RUNTIME_RUNNER_PRELUDE=/Users/chubes/Developer/homeboy/src/core/extension/runtime/runner-prelude.sh HOMEBOY_RUNTIME_RESOLVE_CONTEXT=/Users/chubes/Developer/homeboy/src/core/extension/runtime/resolve-context.sh HOMEBOY_RUNTIME_RUNNER_STEPS=/Users/chubes/Developer/homeboy/src/core/extension/runtime/runner-steps.sh HOMEBOY_RUNTIME_FAILURE_TRAP=/Users/chubes/Developer/homeboy/src/core/extension/runtime/failure-trap.sh bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosed the remaining WPCOM Node heap failure, confirmed the passing heap setting, implemented the durable WordPress extension default, and ran verification.