### PR TITLE
Promote runtime materialization helpers

### DIFF
--- a/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
+++ b/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
@@ -2,9 +2,14 @@
 'use strict';
 
 const fs = require('node:fs');
-const path = require('node:path');
-const { capture, normalizeProviderPlugin, parseJsonInput, requireRepo, run, splitCsv } = require('./lib/common.cjs');
-const { resolveRuntimeProvider, runtimeIdFromOptions } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
+const { run } = require('./lib/common.cjs');
+const {
+  assertSafeDependencyTargetPath,
+  dependencyEntries,
+  resolveDependencyTarget,
+  resolvePlan,
+  runtimeDependencyEntries,
+} = require('../../../runtime-agent-ci/lib/materialize-dependencies.cjs');
 
 function main() {
   const printPlan = process.argv.includes('--print-plan');
@@ -22,134 +27,6 @@ function main() {
     run('git', ['-C', item.targetPath, 'fetch', '--depth=1', 'origin', item.ref]);
     run('git', ['-C', item.targetPath, 'checkout', '--quiet', 'FETCH_HEAD']);
   }
-}
-
-function dependencyEntries(env) {
-  const runtimeId = runtimeIdFromOptions({}, env);
-  const runtime = resolveRuntimeProvider(runtimeId, { env });
-  const entries = runtime.checkout.repo ? [{ repo: runtime.checkout.repo, ref: runtime.checkout.ref, target: runtime.checkout.target }] : [];
-  const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', true);
-  const runtimeDependencies = runtimeDependencyEntries(env.RUNTIME_DEPENDENCIES || '');
-  if (runtimeDependencies.length > 0) {
-    entries.push(...runtimeDependencies);
-  }
-  if (providerPlugin.repo) {
-    entries.push(providerPlugin.ref ? `${providerPlugin.repo}@${providerPlugin.ref}` : providerPlugin.repo);
-  }
-  entries.push(...splitCsv(env.VALIDATION_DEPENDENCIES || ''));
-  return entries;
-}
-
-function runtimeDependencyEntries(value) {
-  if (!value || String(value).trim() === '') {
-    return [];
-  }
-  if (String(value).trim().startsWith('[')) {
-    return parseJsonInput('runtime_dependencies', value, 'array', []);
-  }
-  return splitCsv(value);
-}
-
-function resolvePlan(entries, offline, options = {}) {
-  const workspace = options.workspace || process.env.GITHUB_WORKSPACE || process.cwd();
-  const seen = new Set();
-  const plan = [];
-  for (const rawEntry of entries) {
-    const entry = normalizeDependencyEntry(rawEntry);
-    if (!entry.repo) {
-      continue;
-    }
-    const { repo, target } = entry;
-    let { ref } = entry;
-    requireRepo(repo, 'validation_dependencies entries');
-    if (!ref) {
-      if (offline) {
-        ref = '<default-branch>';
-      } else {
-        ref = capture('gh', ['repo', 'view', repo, '--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name']);
-        if (!ref) {
-          throw new Error(`Could not resolve default branch for validation dependency: ${repo}`);
-        }
-      }
-    }
-    const key = `${repo}@${ref}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    const safeTarget = resolveDependencyTarget(target || path.join('.ci', repo.split('/')[1]), workspace);
-    plan.push({ repo, ref, target: safeTarget.target, targetPath: safeTarget.targetPath });
-  }
-  return plan;
-}
-
-function resolveDependencyTarget(rawTarget, workspace) {
-  const target = String(rawTarget || '').trim();
-  if (!target || target === '.' || target === '..' || path.isAbsolute(target) || path.win32.isAbsolute(target)) {
-    throw new Error(`Dependency target must be a relative path under .ci/: ${target || '(empty)'}`);
-  }
-
-  const segments = target.split(/[\\/]+/);
-  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
-    throw new Error(`Dependency target must not contain empty, current-directory, or parent-directory segments: ${target}`);
-  }
-
-  const normalized = path.normalize(target);
-  const safeRoot = path.resolve(workspace, '.ci');
-  const targetPath = path.resolve(workspace, normalized);
-  const relativeToSafeRoot = path.relative(safeRoot, targetPath);
-  // Dependency materialization deletes the target before cloning; keep that write bounded to .ci/*.
-  if (relativeToSafeRoot === '' || relativeToSafeRoot.startsWith('..') || path.isAbsolute(relativeToSafeRoot)) {
-    throw new Error(`Dependency target must resolve under .ci/: ${target}`);
-  }
-
-  return { target: normalized, targetPath };
-}
-
-function assertSafeDependencyTargetPath(targetPath, workspace) {
-  const safeRoot = path.resolve(workspace, '.ci');
-  fs.mkdirSync(safeRoot, { recursive: true });
-  const workspaceRealPath = fs.realpathSync(path.resolve(workspace));
-  const safeRootRealPath = fs.realpathSync(safeRoot);
-  if (safeRootRealPath !== path.join(workspaceRealPath, '.ci')) {
-    throw new Error(`Dependency safe root must be a workspace-owned directory: ${safeRoot}`);
-  }
-
-  let existingParent = targetPath;
-  while (!fs.existsSync(existingParent)) {
-    const parent = path.dirname(existingParent);
-    if (parent === existingParent) {
-      break;
-    }
-    existingParent = parent;
-  }
-
-  const parentRealPath = fs.realpathSync(existingParent);
-  const relativeToSafeRoot = path.relative(safeRootRealPath, parentRealPath);
-  if (relativeToSafeRoot.startsWith('..') || path.isAbsolute(relativeToSafeRoot)) {
-    throw new Error(`Dependency target parent must resolve under .ci/: ${targetPath}`);
-  }
-}
-
-function normalizeDependencyEntry(rawEntry) {
-  if (rawEntry && !Array.isArray(rawEntry) && typeof rawEntry === 'object') {
-    return {
-      repo: rawEntry.repo || '',
-      ref: rawEntry.ref || '',
-      target: rawEntry.target || '',
-    };
-  }
-  const entry = String(rawEntry || '').trim();
-  if (!entry) {
-    return { repo: '', ref: '', target: '' };
-  }
-  const atIndex = entry.lastIndexOf('@');
-  const repo = atIndex === -1 ? entry : entry.slice(0, atIndex);
-  const ref = atIndex === -1 ? '' : entry.slice(atIndex + 1);
-  if (atIndex !== -1 && !ref) {
-    throw new Error(`validation_dependencies entries must include a non-empty ref after @: ${entry}`);
-  }
-  return { repo, ref, target: '' };
 }
 
 if (require.main === module) {

--- a/agent-runtimes/opencode/README.md
+++ b/agent-runtimes/opencode/README.md
@@ -48,8 +48,8 @@ OPENCODE_CONFIG_CONTENT='{"model":"opencode-go/kimi-k2.7-code","agent":{"build":
 ```
 
 The OpenCode binary is resolved from `executor.config.runtime_bin`,
-`executor.config.command`, `HOMEBOY_OPENCODE_COMMAND`, or `opencode` in that
-order. Additional leading command args may be supplied with
+`executor.config.command`, or `opencode` in that order. Additional leading
+command args may be supplied with
 `executor.config.command_args` or `HOMEBOY_OPENCODE_COMMAND_ARGS` as a JSON array.
 
 The outcome includes status, diagnostics, and bounded metadata. It intentionally

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -63,7 +63,6 @@ const OPENCODE_PROCESS_ENV_ALLOWLIST = [
 	'SHELL',
 	'TMPDIR',
 	'USER',
-	'HOMEBOY_OPENCODE_COMMAND',
 	'HOMEBOY_OPENCODE_COMMAND_ARGS',
 ];
 
@@ -81,12 +80,11 @@ const OPENCODE_RUNNER_READINESS = [
 		id: 'opencode.executable',
 		label: 'OpenCode executable',
 		executable: {
-			env: ['HOMEBOY_OPENCODE_COMMAND'],
 			candidates: ['opencode'],
 			version_command: ['--version'],
-			install_hint: 'Install OpenCode or set the generic runtime_bin executor config; HOMEBOY_OPENCODE_COMMAND remains a legacy compatibility env alias.',
+			install_hint: 'Install OpenCode or set the generic runtime_bin executor config.',
 		},
-		remediation: 'Install OpenCode or set the generic runtime_bin executor config; HOMEBOY_OPENCODE_COMMAND remains a legacy compatibility env alias.',
+		remediation: 'Install OpenCode or set the generic runtime_bin executor config.',
 	},
 ];
 
@@ -508,7 +506,7 @@ function objectValue(value) {
 }
 
 function resolveCommandSpec(config = {}, options = {}) {
-	const configuredCommand = options.command || config.runtime_bin || config.runtimeBin || config.command || process.env.HOMEBOY_OPENCODE_COMMAND || 'opencode';
+	const configuredCommand = options.command || config.runtime_bin || config.runtimeBin || config.command || 'opencode';
 	const configuredArgs = options.commandArgs || config.command_args || parseEnvCommandArgs();
 	if (typeof configuredCommand !== 'string' || configuredCommand.trim() === '') {
 		return { error: 'executor.config.command must be a non-empty string when provided.' };

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -116,12 +116,11 @@
           "id": "opencode.executable",
           "label": "OpenCode executable",
           "executable": {
-            "env": ["HOMEBOY_OPENCODE_COMMAND"],
             "candidates": ["opencode"],
             "version_command": ["--version"],
-            "install_hint": "Install OpenCode or set the generic runtime_bin executor config; HOMEBOY_OPENCODE_COMMAND remains a legacy compatibility env alias."
+            "install_hint": "Install OpenCode or set the generic runtime_bin executor config."
           },
-          "remediation": "Install OpenCode or set the generic runtime_bin executor config; HOMEBOY_OPENCODE_COMMAND remains a legacy compatibility env alias."
+          "remediation": "Install OpenCode or set the generic runtime_bin executor config."
         }
       ],
       "workspace_tools": {

--- a/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
+++ b/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
@@ -2,8 +2,8 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { normalizeProviderPlugin } = require('../../../.github/scripts/runtime-agent-full-run/lib/common.cjs');
-const { resolveDependencyTarget, runtimeDependencyEntries } = require('../../../.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs');
+const { normalizeProviderPlugin } = require('../../../runtime-agent-ci/lib/full-run-inputs.cjs');
+const { resolveDependencyTarget, runtimeDependencyEntries } = require('../../../runtime-agent-ci/lib/materialize-dependencies.cjs');
 
 function setupRuntime({ phase, workspace, env = process.env, run }) {
   // After the runtime's build commands run, the wp-codebox CLI exists in the

--- a/runtime-agent-ci/lib/materialize-dependencies.cjs
+++ b/runtime-agent-ci/lib/materialize-dependencies.cjs
@@ -1,0 +1,143 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { capture, normalizeProviderPlugin, parseJsonInput, requireRepo, splitCsv } = require('./full-run-inputs.cjs');
+const { resolveRuntimeProvider, runtimeIdFromOptions } = require('./runtime-provider-resolver.cjs');
+
+function dependencyEntries(env) {
+  const runtimeId = runtimeIdFromOptions({}, env);
+  const runtime = resolveRuntimeProvider(runtimeId, { env });
+  const entries = runtime.checkout.repo ? [{ repo: runtime.checkout.repo, ref: runtime.checkout.ref, target: runtime.checkout.target }] : [];
+  const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', true);
+  const runtimeDependencies = runtimeDependencyEntries(env.RUNTIME_DEPENDENCIES || '');
+  if (runtimeDependencies.length > 0) {
+    entries.push(...runtimeDependencies);
+  }
+  if (providerPlugin.repo) {
+    entries.push(providerPlugin.ref ? `${providerPlugin.repo}@${providerPlugin.ref}` : providerPlugin.repo);
+  }
+  entries.push(...splitCsv(env.VALIDATION_DEPENDENCIES || ''));
+  return entries;
+}
+
+function runtimeDependencyEntries(value) {
+  if (!value || String(value).trim() === '') {
+    return [];
+  }
+  if (String(value).trim().startsWith('[')) {
+    return parseJsonInput('runtime_dependencies', value, 'array', []);
+  }
+  return splitCsv(value);
+}
+
+function resolvePlan(entries, offline, options = {}) {
+  const workspace = options.workspace || process.env.GITHUB_WORKSPACE || process.cwd();
+  const seen = new Set();
+  const plan = [];
+  for (const rawEntry of entries) {
+    const entry = normalizeDependencyEntry(rawEntry);
+    if (!entry.repo) {
+      continue;
+    }
+    const { repo, target } = entry;
+    let { ref } = entry;
+    requireRepo(repo, 'validation_dependencies entries');
+    if (!ref) {
+      if (offline) {
+        ref = '<default-branch>';
+      } else {
+        ref = capture('gh', ['repo', 'view', repo, '--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name']);
+        if (!ref) {
+          throw new Error(`Could not resolve default branch for validation dependency: ${repo}`);
+        }
+      }
+    }
+    const key = `${repo}@${ref}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const safeTarget = resolveDependencyTarget(target || path.join('.ci', repo.split('/')[1]), workspace);
+    plan.push({ repo, ref, target: safeTarget.target, targetPath: safeTarget.targetPath });
+  }
+  return plan;
+}
+
+function resolveDependencyTarget(rawTarget, workspace) {
+  const target = String(rawTarget || '').trim();
+  if (!target || target === '.' || target === '..' || path.isAbsolute(target) || path.win32.isAbsolute(target)) {
+    throw new Error(`Dependency target must be a relative path under .ci/: ${target || '(empty)'}`);
+  }
+
+  const segments = target.split(/[\\/]+/);
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    throw new Error(`Dependency target must not contain empty, current-directory, or parent-directory segments: ${target}`);
+  }
+
+  const normalized = path.normalize(target);
+  const safeRoot = path.resolve(workspace, '.ci');
+  const targetPath = path.resolve(workspace, normalized);
+  const relativeToSafeRoot = path.relative(safeRoot, targetPath);
+  // Dependency materialization deletes the target before cloning; keep that write bounded to .ci/*.
+  if (relativeToSafeRoot === '' || relativeToSafeRoot.startsWith('..') || path.isAbsolute(relativeToSafeRoot)) {
+    throw new Error(`Dependency target must resolve under .ci/: ${target}`);
+  }
+
+  return { target: normalized, targetPath };
+}
+
+function assertSafeDependencyTargetPath(targetPath, workspace) {
+  const safeRoot = path.resolve(workspace, '.ci');
+  fs.mkdirSync(safeRoot, { recursive: true });
+  const workspaceRealPath = fs.realpathSync(path.resolve(workspace));
+  const safeRootRealPath = fs.realpathSync(safeRoot);
+  if (safeRootRealPath !== path.join(workspaceRealPath, '.ci')) {
+    throw new Error(`Dependency safe root must be a workspace-owned directory: ${safeRoot}`);
+  }
+
+  let existingParent = targetPath;
+  while (!fs.existsSync(existingParent)) {
+    const parent = path.dirname(existingParent);
+    if (parent === existingParent) {
+      break;
+    }
+    existingParent = parent;
+  }
+
+  const parentRealPath = fs.realpathSync(existingParent);
+  const relativeToSafeRoot = path.relative(safeRootRealPath, parentRealPath);
+  if (relativeToSafeRoot.startsWith('..') || path.isAbsolute(relativeToSafeRoot)) {
+    throw new Error(`Dependency target parent must resolve under .ci/: ${targetPath}`);
+  }
+}
+
+function normalizeDependencyEntry(rawEntry) {
+  if (rawEntry && !Array.isArray(rawEntry) && typeof rawEntry === 'object') {
+    return {
+      repo: rawEntry.repo || '',
+      ref: rawEntry.ref || '',
+      target: rawEntry.target || '',
+    };
+  }
+  const entry = String(rawEntry || '').trim();
+  if (!entry) {
+    return { repo: '', ref: '', target: '' };
+  }
+  const atIndex = entry.lastIndexOf('@');
+  const repo = atIndex === -1 ? entry : entry.slice(0, atIndex);
+  const ref = atIndex === -1 ? '' : entry.slice(atIndex + 1);
+  if (atIndex !== -1 && !ref) {
+    throw new Error(`validation_dependencies entries must include a non-empty ref after @: ${entry}`);
+  }
+  return { repo, ref, target: '' };
+}
+
+module.exports = {
+  assertSafeDependencyTargetPath,
+  dependencyEntries,
+  normalizeDependencyEntry,
+  resolveDependencyTarget,
+  resolvePlan,
+  runtimeDependencyEntries,
+};

--- a/runtime-agent-ci/provider-adapters.js
+++ b/runtime-agent-ci/provider-adapters.js
@@ -10,4 +10,5 @@ Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));
 Object.assign(module.exports, require('./lib/runtime-contracts.cjs'));
 Object.assign(module.exports, require('./lib/secret-env-plan.cjs'));
 Object.assign(module.exports, require('./lib/path-materialization-plan.cjs'));
+Object.assign(module.exports, require('./lib/materialize-dependencies.cjs'));
 Object.assign(module.exports, require('./lib/full-run-config.cjs'));

--- a/runtime-agent-ci/tests/materialize-dependencies.test.js
+++ b/runtime-agent-ci/tests/materialize-dependencies.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  assertSafeDependencyTargetPath,
+  normalizeDependencyEntry,
+  resolveDependencyTarget,
+  resolvePlan,
+  runtimeDependencyEntries,
+} = require('../lib/materialize-dependencies.cjs');
+
+const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-materialize-deps-'));
+try {
+  assert.deepEqual(runtimeDependencyEntries('Extra-Chill/runtime-a@main, Extra-Chill/runtime-b'), [
+    'Extra-Chill/runtime-a@main',
+    'Extra-Chill/runtime-b',
+  ]);
+  assert.deepEqual(runtimeDependencyEntries('[{"repo":"Extra-Chill/runtime-a","ref":"main","target":".ci/runtime-a"}]'), [{
+    repo: 'Extra-Chill/runtime-a',
+    ref: 'main',
+    target: '.ci/runtime-a',
+  }]);
+
+  assert.deepEqual(normalizeDependencyEntry('Extra-Chill/runtime-a@trunk'), {
+    repo: 'Extra-Chill/runtime-a',
+    ref: 'trunk',
+    target: '',
+  });
+  assert.throws(() => normalizeDependencyEntry('Extra-Chill/runtime-a@'), /non-empty ref/);
+
+  assert.deepEqual(resolveDependencyTarget('.ci/runtime-a', workspace), {
+    target: path.normalize('.ci/runtime-a'),
+    targetPath: path.join(workspace, '.ci/runtime-a'),
+  });
+  assert.throws(() => resolveDependencyTarget('runtime-a', workspace), /under \.ci\//);
+  assert.throws(() => resolveDependencyTarget('.ci/../runtime-a', workspace), /parent-directory/);
+
+  assert.deepEqual(resolvePlan([
+    { repo: 'Extra-Chill/runtime-a', ref: 'main', target: '.ci/runtime-a' },
+    'Extra-Chill/runtime-a@main',
+    'Extra-Chill/runtime-b@trunk',
+  ], true, { workspace }), [
+    { repo: 'Extra-Chill/runtime-a', ref: 'main', target: path.normalize('.ci/runtime-a'), targetPath: path.join(workspace, '.ci/runtime-a') },
+    { repo: 'Extra-Chill/runtime-b', ref: 'trunk', target: path.normalize('.ci/runtime-b'), targetPath: path.join(workspace, '.ci/runtime-b') },
+  ]);
+
+  assertSafeDependencyTargetPath(path.join(workspace, '.ci/runtime-a'), workspace);
+  assert.throws(
+    () => assertSafeDependencyTargetPath(path.join(workspace, 'outside-runtime'), workspace),
+    /parent must resolve under \.ci\//
+  );
+} finally {
+  fs.rmSync(workspace, { recursive: true, force: true });
+}
+
+process.stdout.write('Runtime dependency materialization helper passed\n');

--- a/wordpress/tests/generic-agent-runtime-contract.test.js
+++ b/wordpress/tests/generic-agent-runtime-contract.test.js
@@ -22,7 +22,7 @@ const {
 } = require('../../.github/scripts/runtime-agent-full-run/build-runner-config.cjs');
 const {
 	dependencyEntries,
-} = require('../../.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs');
+} = require('../../runtime-agent-ci/lib/materialize-dependencies.cjs');
 
 const repoRoot = path.join(__dirname, '..', '..');
 const registry = runtimeRegistry({ repoRoot });


### PR DESCRIPTION
## Summary
- Move dependency/path materialization helpers into public `runtime-agent-ci/lib/materialize-dependencies.cjs`.
- Keep the GitHub workflow script as a thin wrapper over the public helper.
- Update WP Codebox runtime setup to import the public helper.
- Remove the `HOMEBOY_OPENCODE_COMMAND` legacy alias from OpenCode runtime config/docs.

## Verification
- `node runtime-agent-ci/tests/materialize-dependencies.test.js`
- Direct WP Codebox runtime setup import/assertion via `node -e`
- `git diff --check`

## Known follow-up
- Broader runtime contract tests are blocked locally by existing incomplete Homeboy runtime constants fixture: `run_outcome_envelope` is missing.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigation, helper extraction, runtime cleanup, test updates, and verification orchestration.