### PR TITLE
Use runtime contract fixtures in direct tests

### DIFF
--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 /**
  * External dependencies
  */

--- a/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
+++ b/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('./helpers/runtime-contract-constants-fixture.cjs');
+
 const assert = require('node:assert/strict');
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');

--- a/runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs
+++ b/runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+const path = require('node:path');
+
+process.env.HOMEBOY_RUNTIME_CONTRACT_CONSTANTS_FIXTURE ||= path.join(
+  __dirname,
+  '..',
+  'fixtures',
+  'homeboy-runtime-contract-constants.generated.json'
+);

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('./helpers/runtime-contract-constants-fixture.cjs');
+
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');

--- a/wordpress/tests/generic-agent-runtime-contract.test.js
+++ b/wordpress/tests/generic-agent-runtime-contract.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');


### PR DESCRIPTION
## Summary
- Add a shared test helper that points direct Node tests at the generated Homeboy runtime contract constants fixture before runtime-contract modules load.
- Wire previously blocked runtime adapter tests to use the fixture while keeping production runtime behavior strict.

## Verification
- `node runtime-agent-ci/tests/build-runner-config.test.js`
- `node wordpress/tests/generic-agent-runtime-contract.test.js`
- `node runtime-agent-ci/tests/runtime-provider-boundary.test.js`
- `node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js`
- `node agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js`
- `node runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js`

## Follow-up
- Live installed Homeboy still needs to publish `run_outcome_envelope`; this PR unblocks direct tests by using the generated fixture.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Test fixture repair, runtime test verification, and follow-up identification.