### PR TITLE
Publish dependency adapter manifests

### DIFF
--- a/dependency-adapters/README.md
+++ b/dependency-adapters/README.md
@@ -14,6 +14,8 @@ policy.
 | File | Purpose |
 | --- | --- |
 | `schema.json` | Stable manifest shape for extension-owned dependency adapters. |
+| `index.json` | Stable manifest index for core or runners to discover installed adapter manifests. |
+| `index.mjs` | Node helper that loads the manifest index and manifest bodies from this directory. |
 | `examples/nodejs.json` | Node.js package manager selection and dependency outputs. |
 | `examples/composer.json` | Composer dependency materialization for PHP projects. |
 | `examples/wordpress.json` | WordPress helper composition over Composer, Node.js, and WP-CLI surfaces. |
@@ -26,8 +28,17 @@ Adapters may describe:
 | --- | --- |
 | `ecosystem` | Generic ecosystem identity, such as `nodejs`, `php`, or `wordpress`. |
 | `project_signals` | Files that identify a project root or optional capability. |
+| `lockfile_priority` | Ordered lockfiles for deterministic package-manager selection. |
 | `package_managers` | Selection signals, install intent, script runner commands, and dependency outputs. |
+| `package_identity` | Manifest paths for reading package name, version, and declared dependency maps. |
 | `helpers` | Extension-owned helper capabilities that prepare dependencies without requiring core to know their implementation. |
+
+## Discovery
+
+Core consumers should discover manifests through `index.json` from the installed
+extension directory. JavaScript consumers can import `index.mjs` and call
+`dependencyAdapterManifestPaths()` or `loadDependencyAdapterManifests()` when a
+filesystem-backed helper is more convenient than raw JSON loading.
 
 Adapters should not describe:
 

--- a/dependency-adapters/examples/composer.json
+++ b/dependency-adapters/examples/composer.json
@@ -9,6 +9,7 @@
     "root_match": "any",
     "optional_files": ["composer.lock"]
   },
+  "lockfile_priority": ["composer.lock"],
   "capabilities": {
     "discover_project_root": true,
     "select_package_manager": false,
@@ -31,10 +32,32 @@
         "command": "composer install",
         "fallback_command": "composer update"
       },
+      "commands": {
+        "status": {
+          "command": "composer validate --no-check-publish",
+          "success_exit_codes": [0]
+        },
+        "install": {
+          "command": "composer install",
+          "success_exit_codes": [0],
+          "requires_lockfile": false
+        },
+        "update": {
+          "command": "composer update",
+          "success_exit_codes": [0],
+          "produces_lockfile": true
+        }
+      },
       "scripts": {
         "manifest": "composer.json",
         "run_command": "composer run-script",
         "exec_command": "composer exec"
+      },
+      "package_identity": {
+        "manifest": "composer.json",
+        "name": "name",
+        "version": "version",
+        "dependencies": ["require", "require-dev"]
       },
       "outputs": [
         { "kind": "directory", "path": "vendor", "required": true },

--- a/dependency-adapters/examples/nodejs.json
+++ b/dependency-adapters/examples/nodejs.json
@@ -8,6 +8,7 @@
     "root_files": ["package.json"],
     "optional_files": ["pnpm-workspace.yaml", "pnpm-lock.yaml", "yarn.lock", "package-lock.json"]
   },
+  "lockfile_priority": ["pnpm-lock.yaml", "yarn.lock", "package-lock.json"],
   "capabilities": {
     "discover_project_root": true,
     "select_package_manager": true,
@@ -28,10 +29,33 @@
         "intent": "frozen-lockfile",
         "command": "pnpm install --frozen-lockfile"
       },
+      "commands": {
+        "status": {
+          "command": "pnpm install --frozen-lockfile --offline",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "install": {
+          "command": "pnpm install --frozen-lockfile",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "update": {
+          "command": "pnpm install --lockfile-only",
+          "success_exit_codes": [0],
+          "produces_lockfile": true
+        }
+      },
       "scripts": {
         "manifest": "package.json",
         "run_command": "pnpm run",
         "exec_command": "pnpm exec"
+      },
+      "package_identity": {
+        "manifest": "package.json",
+        "name": "name",
+        "version": "version",
+        "dependencies": ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]
       },
       "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
     },
@@ -46,10 +70,33 @@
         "intent": "frozen-lockfile",
         "command": "yarn install --frozen-lockfile"
       },
+      "commands": {
+        "status": {
+          "command": "yarn install --frozen-lockfile --offline",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "install": {
+          "command": "yarn install --frozen-lockfile",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "update": {
+          "command": "yarn install --mode=update-lockfile",
+          "success_exit_codes": [0],
+          "produces_lockfile": true
+        }
+      },
       "scripts": {
         "manifest": "package.json",
         "run_command": "yarn",
         "exec_command": "yarn"
+      },
+      "package_identity": {
+        "manifest": "package.json",
+        "name": "name",
+        "version": "version",
+        "dependencies": ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]
       },
       "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
     },
@@ -66,10 +113,33 @@
         "command": "npm ci",
         "fallback_command": "npm install"
       },
+      "commands": {
+        "status": {
+          "command": "npm ci --dry-run",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "install": {
+          "command": "npm ci",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "update": {
+          "command": "npm install --package-lock-only",
+          "success_exit_codes": [0],
+          "produces_lockfile": true
+        }
+      },
       "scripts": {
         "manifest": "package.json",
         "run_command": "npm run",
         "exec_command": "npx"
+      },
+      "package_identity": {
+        "manifest": "package.json",
+        "name": "name",
+        "version": "version",
+        "dependencies": ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]
       },
       "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
     }

--- a/dependency-adapters/index.json
+++ b/dependency-adapters/index.json
@@ -1,0 +1,20 @@
+{
+  "schema": "homeboy-extension/dependency-adapter-index/v1",
+  "manifests": [
+    {
+      "id": "composer-package-manager",
+      "ecosystem": "php",
+      "path": "examples/composer.json"
+    },
+    {
+      "id": "nodejs-package-managers",
+      "ecosystem": "nodejs",
+      "path": "examples/nodejs.json"
+    },
+    {
+      "id": "wordpress-dependency-helpers",
+      "ecosystem": "wordpress",
+      "path": "examples/wordpress.json"
+    }
+  ]
+}

--- a/dependency-adapters/index.mjs
+++ b/dependency-adapters/index.mjs
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const adapterRoot = path.dirname(fileURLToPath(import.meta.url));
+const indexPath = path.join(adapterRoot, 'index.json');
+
+export function dependencyAdapterManifestIndex() {
+	return JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+}
+
+export function dependencyAdapterManifestPaths() {
+	return dependencyAdapterManifestIndex().manifests.map((manifest) => path.join(adapterRoot, manifest.path));
+}
+
+export function loadDependencyAdapterManifests() {
+	return dependencyAdapterManifestPaths().map((manifestPath) => JSON.parse(fs.readFileSync(manifestPath, 'utf8')));
+}

--- a/dependency-adapters/schema.json
+++ b/dependency-adapters/schema.json
@@ -56,6 +56,10 @@
         "prepare_runtime_helpers": { "type": "boolean" }
       }
     },
+    "lockfile_priority": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "package_managers": {
       "type": "array",
       "items": { "$ref": "#/$defs/package_manager" }
@@ -105,6 +109,15 @@
             "fallback_command": { "type": "string" }
           }
         },
+        "commands": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "status": { "$ref": "#/$defs/command" },
+            "install": { "$ref": "#/$defs/command" },
+            "update": { "$ref": "#/$defs/command" }
+          }
+        },
         "scripts": {
           "type": "object",
           "additionalProperties": false,
@@ -114,10 +127,39 @@
             "exec_command": { "type": "string" }
           }
         },
+        "package_identity": { "$ref": "#/$defs/package_identity" },
         "outputs": {
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/output" }
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": { "type": "string" },
+        "success_exit_codes": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "produces_lockfile": { "type": "boolean" },
+        "requires_lockfile": { "type": "boolean" }
+      }
+    },
+    "package_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifest", "name", "version"],
+      "properties": {
+        "manifest": { "type": "string" },
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "dependencies": {
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     },

--- a/tests/dependency-adapter-manifests-smoke.mjs
+++ b/tests/dependency-adapter-manifests-smoke.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const manifestRoot = path.join(repoRoot, 'dependency-adapters');
 const schema = JSON.parse(fs.readFileSync(path.join(manifestRoot, 'schema.json'), 'utf8'));
+const index = JSON.parse(fs.readFileSync(path.join(manifestRoot, 'index.json'), 'utf8'));
 const exampleDir = path.join(manifestRoot, 'examples');
 const exampleFiles = fs.readdirSync(exampleDir).filter((file) => file.endsWith('.json')).sort();
 
@@ -14,14 +15,24 @@ assert.ok(schema.required.includes('ecosystem'));
 assert.ok(schema.required.includes('project_signals'));
 assert.ok(schema.required.includes('capabilities'));
 assert.deepEqual(exampleFiles, ['composer.json', 'nodejs.json', 'wordpress.json']);
+assert.equal(index.schema, 'homeboy-extension/dependency-adapter-index/v1');
+assert.deepEqual(
+	index.manifests.map((manifest) => manifest.path).sort(),
+	exampleFiles.map((file) => `examples/${file}`).sort(),
+	'index lists every shipped adapter manifest'
+);
 
 const ids = new Set();
 const productSpecificTerms = ['woocommerce', 'jetpack', 'studio-native'];
 
 for (const file of exampleFiles) {
 	const manifest = JSON.parse(fs.readFileSync(path.join(exampleDir, file), 'utf8'));
+	const indexEntry = index.manifests.find((entry) => entry.path === `examples/${file}`);
 	const serialized = JSON.stringify(manifest).toLowerCase();
 
+	assert.ok(indexEntry, `${file} has an index entry`);
+	assert.equal(indexEntry.id, manifest.id, `${file} index id matches manifest id`);
+	assert.equal(indexEntry.ecosystem, manifest.ecosystem, `${file} index ecosystem matches manifest ecosystem`);
 	assert.equal(manifest.schema, schema.properties.schema.const, `${file} uses the adapter schema`);
 	assert.equal(typeof manifest.id, 'string', `${file} has an id`);
 	assert.equal(typeof manifest.version, 'number', `${file} has a version`);
@@ -40,6 +51,13 @@ for (const file of exampleFiles) {
 		assert.equal(typeof manager.id, 'string', `${file} package manager has id`);
 		assert.equal(typeof manager.selection.priority, 'number', `${manager.id} has priority`);
 		assert.equal(typeof manager.install.intent, 'string', `${manager.id} has install intent`);
+		assert.equal(typeof manager.commands?.status?.command, 'string', `${manager.id} declares a status command`);
+		assert.equal(typeof manager.commands?.install?.command, 'string', `${manager.id} declares an install command`);
+		assert.equal(typeof manager.commands?.update?.command, 'string', `${manager.id} declares an update command`);
+		assert.equal(typeof manager.package_identity?.manifest, 'string', `${manager.id} declares package identity manifest`);
+		assert.equal(typeof manager.package_identity?.name, 'string', `${manager.id} declares package name path`);
+		assert.equal(typeof manager.package_identity?.version, 'string', `${manager.id} declares package version path`);
+		assert.ok(Array.isArray(manager.package_identity.dependencies), `${manager.id} declares dependency paths`);
 		assert.ok(Array.isArray(manager.outputs), `${manager.id} declares outputs`);
 		assert.ok(manager.outputs.length > 0, `${manager.id} has at least one output`);
 	}
@@ -52,10 +70,26 @@ for (const file of exampleFiles) {
 }
 
 const nodeManifest = JSON.parse(fs.readFileSync(path.join(exampleDir, 'nodejs.json'), 'utf8'));
+assert.deepEqual(nodeManifest.lockfile_priority, ['pnpm-lock.yaml', 'yarn.lock', 'package-lock.json']);
 assert.deepEqual(
 	nodeManifest.package_managers.map((manager) => manager.id),
 	['pnpm', 'yarn', 'npm'],
 	'Node.js adapter documents the current deterministic package-manager priority'
+);
+
+const composerManifest = JSON.parse(fs.readFileSync(path.join(exampleDir, 'composer.json'), 'utf8'));
+assert.deepEqual(composerManifest.lockfile_priority, ['composer.lock']);
+
+const adapterModule = await import(path.join(manifestRoot, 'index.mjs'));
+assert.deepEqual(
+	adapterModule.dependencyAdapterManifestPaths().map((manifestPath) => path.relative(manifestRoot, manifestPath)).sort(),
+	exampleFiles.map((file) => path.join('examples', file)).sort(),
+	'index helper returns every adapter manifest path'
+);
+assert.deepEqual(
+	adapterModule.loadDependencyAdapterManifests().map((manifest) => manifest.id).sort(),
+	index.manifests.map((manifest) => manifest.id).sort(),
+	'index helper loads every adapter manifest'
 );
 
 console.log('dependency adapter manifest smoke passed');


### PR DESCRIPTION
## Summary
- Add dependency adapter manifest index and Node helper exports.
- Extend Composer and Node adapter manifests with lockfile priority, status/install/update commands, and package identity hints.
- Strengthen schema and smoke tests for manifest/index coherence.

## Verification
- `node tests/dependency-adapter-manifests-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Manifest contract updates, helper implementation, tests, and verification orchestration.