### PR TITLE
Classify OpenCode policy denials

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -36,6 +36,7 @@ const OPENCODE_FATAL_LOG_PATTERNS = [
 		classification: 'provider_quota',
 	},
 ];
+const OPENCODE_PERMISSION_DENIED_PATTERN = /user rejected permission|permission policy rejected|policy denied|permission request denied/i;
 
 const OPENCODE_CAPABILITIES = [
 	'cli_runtime',
@@ -321,7 +322,7 @@ function findArtifact(artifacts, declaration) {
 }
 
 function opencodeSuccessOutcome(context) {
-	return {
+	return withPolicyDeniedOutcome(context, {
 		status: 'succeeded',
 		summary: 'OpenCode completed successfully.',
 		diagnostics: [{ classification: 'provider', message: 'OpenCode CLI exited with status 0.' }],
@@ -330,11 +331,11 @@ function opencodeSuccessOutcome(context) {
 			opencode_session: sessionMetadata(context),
 		},
 		...collectOpenCodeArtifacts(context),
-	};
+	});
 }
 
 function opencodeFailureOutcome(context) {
-	return {
+	return withPolicyDeniedOutcome(context, {
 		status: 'failed',
 		failure_classification: 'execution_failed',
 		failure_code: 'agent_task.opencode_failed',
@@ -346,7 +347,128 @@ function opencodeFailureOutcome(context) {
 			opencode_session: sessionMetadata(context),
 		},
 		...collectOpenCodeArtifacts(context),
+	});
+}
+
+function withPolicyDeniedOutcome(context = {}, terminal = {}) {
+	const denial = detectOpenCodePolicyDenial(context);
+	if (!denial) {
+		return terminal;
+	}
+	return {
+		...terminal,
+		status: 'failed',
+		failure_classification: 'policy_denied',
+		failure_code: 'agent_task.opencode_policy_denied',
+		summary: 'OpenCode stopped after a permission policy denial.',
+		diagnostics: [
+			...(Array.isArray(terminal.diagnostics) ? terminal.diagnostics : []),
+			{
+				class: 'opencode.policy_denied',
+				classification: 'policy_denied',
+				message: deniedToolCallSummary(denial),
+				data: { denied_tool_call: denial },
+			},
+		],
+		metadata: {
+			...(terminal.metadata || {}),
+			denied_tool_call: denial,
+		},
 	};
+}
+
+function deniedToolCallSummary(denial = {}) {
+	const details = [denial.tool, denial.command].filter(Boolean).join(': ');
+	return details ? `OpenCode permission policy denied tool call ${details}.` : 'OpenCode permission policy denied a tool call.';
+}
+
+function detectOpenCodePolicyDenial(context = {}) {
+	const spawnResult = context.spawnResult || {};
+	const text = redactKnownSecrets([
+		spawnResult.stdout,
+		spawnResult.stderr,
+	].filter(Boolean).join('\n'), context.spawnExtra?.env);
+	if (!OPENCODE_PERMISSION_DENIED_PATTERN.test(text)) {
+		return null;
+	}
+	return sanitizeDeniedToolCall(extractDeniedToolCall(text));
+}
+
+function extractDeniedToolCall(text = '') {
+	const parsed = parseJsonObjectsFromText(text);
+	for (const value of parsed) {
+		const found = findDeniedToolCall(value);
+		if (found) {
+			return found;
+		}
+	}
+	return {
+		tool: firstRegexCapture(text, /"(?:tool|name)"\s*:\s*"([^"]+)"/),
+		command: firstRegexCapture(text, /"command"\s*:\s*"([^"]+)"/),
+		timestamp: firstRegexCapture(text, /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/),
+	};
+}
+
+function parseJsonObjectsFromText(text = '') {
+	return String(text).split(/\r?\n/).map((line) => {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
+			return null;
+		}
+		try {
+			return JSON.parse(trimmed);
+		} catch {
+			return null;
+		}
+	}).filter(Boolean);
+}
+
+function findDeniedToolCall(value, inherited = {}) {
+	if (!value || typeof value !== 'object') {
+		return null;
+	}
+	const current = {
+		tool: stringValue(value.tool || value.name || inherited.tool),
+		command: stringValue(value.command || value.input?.command || inherited.command),
+		timestamp: stringValue(value.timestamp || value.time?.created || value.created || value.created_at || value.time || inherited.timestamp),
+	};
+	const message = stringValue(value.error || value.message || value.text || value.output || value.state?.error || value.result?.error);
+	if (OPENCODE_PERMISSION_DENIED_PATTERN.test(message)) {
+		return current;
+	}
+	for (const child of Object.values(value)) {
+		if (Array.isArray(child)) {
+			for (const item of child) {
+				const found = findDeniedToolCall(item, current);
+				if (found) {
+					return found;
+				}
+			}
+		} else if (child && typeof child === 'object') {
+			const found = findDeniedToolCall(child, current);
+			if (found) {
+				return found;
+			}
+		}
+	}
+	return null;
+}
+
+function sanitizeDeniedToolCall(value = {}) {
+	return Object.fromEntries(Object.entries({
+		tool: stringValue(value.tool),
+		command: stringValue(value.command),
+		timestamp: stringValue(value.timestamp),
+	}).filter(([, entry]) => entry));
+}
+
+function firstRegexCapture(text, pattern) {
+	const match = String(text || '').match(pattern);
+	return match ? match[1] : '';
+}
+
+function stringValue(value) {
+	return typeof value === 'string' ? value : '';
 }
 
 function collectOpenCodeArtifacts(context = {}) {
@@ -387,10 +509,16 @@ function collectOpenCodeArtifacts(context = {}) {
 	const stderr = redactKnownSecrets(String(spawnResult.stderr || ''), context.spawnExtra?.env);
 	const transcript = [stdout, stderr].filter(Boolean).join('\n');
 	const patch = gitDiff(context.cwd);
+	const policyDenial = detectOpenCodePolicyDenial(context);
 	const resultEnvelope = JSON.stringify({
 		schema: 'homeboy/opencode-agent-result/v1',
 		task_id: request.task_id,
-		status: 'succeeded',
+		status: policyDenial ? 'failed' : 'succeeded',
+		...(policyDenial ? {
+			failure_classification: 'policy_denied',
+			failure_code: 'agent_task.opencode_policy_denied',
+			denied_tool_call: policyDenial,
+		} : {}),
 		exit_code: spawnResult.status,
 		command: context.commandSpec?.command,
 		args: Array.isArray(context.commandSpec?.args) ? context.commandSpec.args : [],

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -295,6 +295,71 @@ process.exit(0);
 	const quietAgentResult = JSON.parse(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
 	assert.deepEqual(quietAgentResult.artifacts, { patch: false, transcript: false });
 
+	const deniedWorkspace = path.join(root, 'denied-workspace');
+	const deniedArtifactDir = path.join(root, 'denied-artifacts');
+	fs.mkdirSync(deniedWorkspace, { recursive: true });
+	spawnSync('git', ['init'], { cwd: deniedWorkspace, encoding: 'utf8' });
+	fs.writeFileSync(path.join(deniedWorkspace, 'README.md'), 'unchanged\n');
+	spawnSync('git', ['add', 'README.md'], { cwd: deniedWorkspace, encoding: 'utf8' });
+	spawnSync('git', ['commit', '-m', 'initial'], {
+		cwd: deniedWorkspace,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Homeboy Test',
+			GIT_AUTHOR_EMAIL: 'homeboy@example.test',
+			GIT_COMMITTER_NAME: 'Homeboy Test',
+			GIT_COMMITTER_EMAIL: 'homeboy@example.test',
+		},
+	});
+	const deniedCliPath = path.join(root, 'mock-opencode-policy-denied.cjs');
+	fs.writeFileSync(deniedCliPath, `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: 'message',
+  timestamp: '2026-07-03T15:12:00.000Z',
+  parts: [{
+    type: 'tool',
+    tool: 'bash',
+    input: { command: 'cd /tmp && git clone https://example.invalid/private.git' },
+    state: { error: 'The user rejected permission to use this specific tool call.' }
+  }]
+}) + '\\n');
+process.exit(0);
+`);
+	const deniedResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-policy-denied',
+		workspace_path: deniedWorkspace,
+		artifacts_path: deniedArtifactDir,
+		expected_artifacts: ['patch', 'transcript', 'agent_result'],
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				command_args: [deniedCliPath],
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(deniedResult.status, 'failed');
+	assert.equal(deniedResult.failure_classification, 'policy_denied');
+	assert.equal(deniedResult.failure_code, 'agent_task.opencode_policy_denied');
+	assert.equal(deniedResult.failure_category, 'task.policy_denied');
+	assert.equal(deniedResult.retryable, false);
+	assert.equal(deniedResult.metadata.missing_declared_artifacts, undefined);
+	assert.deepEqual(deniedResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stdout', 'patch', 'transcript']);
+	assert.deepEqual(deniedResult.metadata.denied_tool_call, {
+		tool: 'bash',
+		command: 'cd /tmp && git clone https://example.invalid/private.git',
+		timestamp: '2026-07-03T15:12:00.000Z',
+	});
+	assert.equal(deniedResult.diagnostics.some((diagnostic) => diagnostic.class === 'opencode.policy_denied'), true);
+	assert.match(fs.readFileSync(deniedResult.artifacts.find((artifact) => artifact.name === 'transcript').path, 'utf8'), /rejected permission/);
+	assert.equal(fs.readFileSync(deniedResult.artifacts.find((artifact) => artifact.name === 'patch').path, 'utf8'), '');
+	const deniedAgentResult = JSON.parse(fs.readFileSync(deniedResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
+	assert.equal(deniedAgentResult.status, 'failed');
+	assert.equal(deniedAgentResult.failure_classification, 'policy_denied');
+	assert.deepEqual(deniedAgentResult.denied_tool_call, deniedResult.metadata.denied_tool_call);
+
 	const inheritedPipeCliPath = path.join(root, 'mock-opencode-inherited-pipe.cjs');
 	fs.writeFileSync(inheritedPipeCliPath, `#!/usr/bin/env node
 const { spawn } = require('node:child_process');


### PR DESCRIPTION
## Summary
- Detect OpenCode permission-policy denials from redacted runtime streams.
- Return policy_denied outcome metadata instead of generic missing-artifact failures.
- Preserve sanitized denied tool-call diagnostics and keep result/transcript artifacts available.

Fixes #2136.

## Testing
- HOMEBOY_RUNTIME_CONTRACT_CONSTANTS_FIXTURE=/Users/chubes/Developer/homeboy-extensions@fix-2136-policy-denied-outcome/runtime-agent-ci/tests/fixtures/homeboy-runtime-contract-constants.generated.json npm run test:opencode-agent-task-executor-boundary
- node --check lib/opencode-agent-task-executor.js && node --check tests/opencode-agent-task-executor-boundary.test.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Local coding subagent implemented the fix and regression coverage; I reviewed, committed, pushed, and opened the PR.