### PR TITLE
Add WordPress fuzz campaign orchestrator

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -392,9 +392,10 @@ homeboy fuzz plan my-wordpress-component \
 ```
 
 The WordPress extension boundary is the data contract: fuzz manifests, surface
-discovery, WordPress fuzz plans, runtime capabilities, and the Codebox-owned
-`wp-codebox/fuzz-suite/v1` payload. The extension does not assemble
-`homeboy fuzz ...` shell commands for workflow callers.
+discovery, WordPress fuzz plans, runtime capabilities, the Codebox-owned
+`wp-codebox/fuzz-suite/v1` payload, and the product-agnostic campaign
+orchestrator API. The extension does not assemble `homeboy fuzz ...` shell
+commands for workflow callers.
 
 ### Surface discovery and fuzz schemas
 
@@ -433,6 +434,46 @@ test.
   ]
 }
 ```
+
+### WordPress fuzz campaign orchestrator
+
+`runWordPressFuzzCampaign()` is the reusable production WordPress fuzz campaign
+primitive for callers that need one API instead of hand-rolling discovery,
+planning, WP Codebox execution, result aggregation, artifact validation, and
+summary persistence.
+
+The orchestrator accepts either a normalized discovery artifact or live discovery
+configuration. It compiles the discovery through `compileWordPressFuzzCampaign()`,
+executes the generated `wp-codebox/fuzz-suite/v1` request, aggregates coverage
+and gaps, validates required artifacts, and optionally writes a JSON summary.
+Product-specific selection, fixtures, assertions, and runtime inputs remain
+caller-owned.
+
+```js
+const {
+  runWordPressFuzzCampaign,
+} = require('homeboy-extension-wordpress/wordpress-fuzz-campaign');
+
+const summary = await runWordPressFuzzCampaign({
+  id: 'production-fuzz-campaign',
+  destructive: true,
+  discovery,
+  target: { type: 'wordpress-plugin', slug: 'sample-plugin' },
+  summaryPath: 'artifacts/fuzz/campaign-summary.json',
+}, {
+  runFuzzSuite: wpCodeboxRunner,
+});
+```
+
+When destructive mode is requested, the campaign is treated as production-grade
+and the run summary fails validation unless the result exports all required
+guardrail artifacts: sandbox isolation proof, mutation isolation, delete
+boundary, external side-effect guardrail, runtime access, coverage, and hotspots.
+
+The returned summary uses `homeboy/wordpress-fuzz-campaign-run/v1` and includes
+the compiled campaign, normalized WP Codebox result, aggregate coverage/gap
+report, and `homeboy/wordpress-fuzz-campaign-artifact-validation/v1` validation
+block.
 
 ### Live runtime surface discovery
 

--- a/wordpress/lib/wordpress-fuzz-campaign.js
+++ b/wordpress/lib/wordpress-fuzz-campaign.js
@@ -1,6 +1,12 @@
 'use strict';
 
 /**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
  * Internal dependencies
  */
 const {
@@ -17,8 +23,12 @@ const {
 	buildWordPressPerformanceObservation,
 } = require('./wordpress-performance-observation-aggregate');
 const {
+	runWordPressLiveSurfaceDiscoveryWorkload,
+} = require('./wordpress-live-surface-discovery');
+const {
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	WP_CODEBOX_WORDPRESS_HOTSPOTS_SCHEMA,
+	runWpCodeboxFuzzSuite,
 	wordpressFuzzPostprocessArtifactDeclarations,
 	wordpressFuzzPostprocessBinding,
 	wordpressFuzzPostprocessExpectedArtifacts,
@@ -30,8 +40,102 @@ const {
 } = require('./wordpress-fuzz-runtime-workload-operations');
 
 const WORDPRESS_FUZZ_CAMPAIGN_SCHEMA = 'homeboy/wordpress-fuzz-campaign/v1';
+const WORDPRESS_FUZZ_CAMPAIGN_RUN_SCHEMA = 'homeboy/wordpress-fuzz-campaign-run/v1';
+const WORDPRESS_FUZZ_CAMPAIGN_ARTIFACT_VALIDATION_SCHEMA = 'homeboy/wordpress-fuzz-campaign-artifact-validation/v1';
 const HOMEBOY_FUZZ_WORKLOAD_SCHEMA = 'homeboy/fuzz-workload/v1';
 const WORDPRESS_FUZZ_PLAN_RESULT_GAP_REPORT_SCHEMA = 'homeboy/wordpress-fuzz-plan-result-gap-report/v1';
+const DESTRUCTIVE_CAMPAIGN_REQUIRED_ARTIFACTS = [
+	{ semantic_key: 'fuzz.disposable.sandbox_isolation_proof', label: 'sandbox isolation proof' },
+	{ semantic_key: 'fuzz.mutation.isolation', label: 'mutation isolation artifact' },
+	{ semantic_key: 'fuzz.delete.boundary', label: 'delete boundary artifact' },
+	{ semantic_key: 'fuzz.external_http.guardrail', label: 'external side-effect guardrail' },
+	{ semantic_key: 'fuzz.runtime.access', label: 'runtime access artifact' },
+	{ semantic_key: 'fuzz.coverage', alternatives: ['fuzz.coverage.summary'], label: 'coverage artifact' },
+	{ semantic_key: 'fuzz.hotspot.summary', alternatives: ['fuzz.hotspot.codebox'], label: 'hotspots artifact' },
+];
+
+async function runWordPressFuzzCampaign(input = {}, options = {}) {
+	const discovery = await resolveCampaignDiscovery(input, options);
+	const destructive = isDestructiveCampaign(input, options);
+	const campaign = compileWordPressFuzzCampaign({
+		...input,
+		discovery,
+		production: input.production || input.production_campaign || destructive || undefined,
+	}, options);
+	const result = await runWpCodeboxFuzzSuite({
+		...(objectOrUndefined(options.execution) || objectOrUndefined(options.execute) || {}),
+		...(objectOrUndefined(input.execution) || objectOrUndefined(input.execute) || {}),
+		taskId: campaign.wp_codebox.task_request.task_id || campaign.wp_codebox.task_request.id || campaign.id,
+		input: campaign.wp_codebox.input,
+		request: campaign.wp_codebox.task_request,
+		artifactDeclarations: campaign.wp_codebox.task_request.artifact_declarations,
+		expectedArtifacts: campaign.wp_codebox.task_request.expected_artifacts,
+		runtimeId: input.runtime_id || input.runtimeId || options.runtime_id || options.runtimeId || 'wp-codebox',
+		runFuzzSuite: input.runFuzzSuite || options.runFuzzSuite || input.run_fuzz_suite || options.run_fuzz_suite,
+	});
+	const aggregate = aggregateWordPressFuzzCampaignResult({
+		campaign,
+		result,
+		coverage: result.coverage || result.coverage_summary || result.artifacts,
+		performance: result.performance || result.performance_observation || result.performanceObservation,
+	});
+	const artifactValidation = validateWordPressFuzzCampaignArtifacts({
+		campaign,
+		result,
+		destructive,
+		requiredArtifacts: options.requiredArtifacts || options.required_artifacts || input.requiredArtifacts || input.required_artifacts,
+	});
+	const status = resultStatus(result, artifactValidation);
+	const summary = stripUndefined({
+		schema: WORDPRESS_FUZZ_CAMPAIGN_RUN_SCHEMA,
+		status,
+		succeeded: status === 'succeeded',
+		campaign,
+		result,
+		aggregate,
+		artifact_validation: artifactValidation,
+		metadata: {
+			destructive_campaign: destructive || undefined,
+		},
+	});
+	writeCampaignSummary(summary, input.summary_path || input.summaryPath || options.summary_path || options.summaryPath);
+	return summary;
+}
+
+async function resolveCampaignDiscovery(input = {}, options = {}) {
+	const supplied = input.discovery || input.surfaceDiscovery || input.surface_discovery || options.discovery || options.surfaceDiscovery || options.surface_discovery;
+	if (supplied) {
+		return supplied;
+	}
+	const liveDiscoveryOptions = objectOrUndefined(input.live_discovery || input.liveDiscovery || input.discovery_config || input.discoveryConfig || options.live_discovery || options.liveDiscovery || options.discovery_config || options.discoveryConfig);
+	if (liveDiscoveryOptions) {
+		return (await runWordPressLiveSurfaceDiscoveryWorkload(liveDiscoveryOptions)).artifact;
+	}
+	return input;
+}
+
+function validateWordPressFuzzCampaignArtifacts(input = {}) {
+	const destructive = Boolean(input.destructive);
+	const requiredArtifacts = normalizeRequiredCampaignArtifacts(
+		input.requiredArtifacts || input.required_artifacts || (destructive ? DESTRUCTIVE_CAMPAIGN_REQUIRED_ARTIFACTS : [])
+	);
+	const artifacts = campaignResultArtifacts(input.result);
+	const missing = requiredArtifacts.filter((requirement) => !hasSuccessfulCampaignArtifact(artifacts, requirement));
+	return {
+		schema: WORDPRESS_FUZZ_CAMPAIGN_ARTIFACT_VALIDATION_SCHEMA,
+		status: missing.length === 0 ? 'passed' : 'failed',
+		destructive_campaign: destructive,
+		required_artifacts: requiredArtifacts,
+		observed_artifacts: artifacts.map((artifact) => stripUndefined({
+			name: artifact.name,
+			role: artifact.role,
+			semantic_key: artifact.semantic_key || artifact.semanticKey || artifact.metadata?.semantic_key || artifact.metadata?.semanticKey,
+			schema: artifact.schema || artifact.metadata?.schema,
+			status: artifact.status || artifact.metadata?.status,
+		})),
+		missing_artifacts: missing,
+	};
+}
 
 function compileWordPressFuzzCampaign(input = {}, options = {}) {
 	const production = Boolean(input.production || options.production || input.production_campaign || options.production_campaign);
@@ -349,6 +453,72 @@ function normalizeStatus(value) {
 	return String(value || '').trim().toLowerCase().replace(/_/g, '-');
 }
 
+function normalizeRequiredCampaignArtifacts(requirements = []) {
+	return arrayOf(requirements).map((requirement) => {
+		const entry = typeof requirement === 'string' ? { semantic_key: requirement } : objectOrUndefined(requirement);
+		return entry ? stripUndefined({
+			semantic_key: entry.semantic_key || entry.semanticKey || entry.key,
+			alternatives: arrayOf(entry.alternatives || entry.alternative_semantic_keys || entry.alternativeSemanticKeys),
+			label: entry.label || entry.name,
+		}) : undefined;
+	}).filter((requirement) => requirement?.semantic_key);
+}
+
+function campaignResultArtifacts(result = {}) {
+	return [
+		...arrayOf(result.artifacts),
+		...arrayOf(result.wp_codebox_result?.artifacts),
+		...arrayOf(result.result?.artifacts),
+		...arrayOf(result.derived_artifacts?.artifacts),
+		...arrayOf(result.wp_codebox_result?.derived_artifacts?.artifacts),
+	].filter(objectOrUndefined);
+}
+
+function hasSuccessfulCampaignArtifact(artifacts = [], requirement = {}) {
+	const keys = new Set([requirement.semantic_key, ...arrayOf(requirement.alternatives)].filter(Boolean));
+	return artifacts.some((artifact) => {
+		const status = normalizeStatus(artifact.status || artifact.metadata?.status);
+		const semanticKey = artifact.semantic_key || artifact.semanticKey || artifact.metadata?.semantic_key || artifact.metadata?.semanticKey;
+		return keys.has(semanticKey) && !['failed', 'errored', 'error', 'missing'].includes(status);
+	});
+}
+
+function isDestructiveCampaign(input = {}, options = {}) {
+	const value = input.destructive || input.destructive_mode || input.destructiveMode || options.destructive || options.destructive_mode || options.destructiveMode;
+	if (value !== undefined) {
+		return Boolean(value);
+	}
+	const mutationMode = String(input.mutation_mode || input.mutationMode || options.mutation_mode || options.mutationMode || '').toLowerCase();
+	return ['aggressive', 'destructive', 'production-destructive', 'production_destructive'].includes(mutationMode);
+}
+
+function resultStatus(result = {}, artifactValidation = {}) {
+	if (artifactValidation.status === 'failed') {
+		return 'failed';
+	}
+	const status = normalizeStatus(result.status);
+	if (!status || ['succeeded', 'success', 'passed', 'ok'].includes(status)) {
+		return 'succeeded';
+	}
+	return status;
+}
+
+function writeCampaignSummary(summary, summaryPath) {
+	if (!summaryPath) {
+		return;
+	}
+	const resolvedPath = path.resolve(String(summaryPath));
+	fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+	fs.writeFileSync(resolvedPath, `${JSON.stringify(summary, null, 2)}\n`);
+}
+
+function stripUndefined(value) {
+	if (!objectOrUndefined(value)) {
+		return value;
+	}
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
 function arrayOf(value) {
 	return Array.isArray(value) ? value.filter(Boolean) : [];
 }
@@ -359,10 +529,15 @@ function objectOrUndefined(value) {
 
 module.exports = {
 	HOMEBOY_FUZZ_WORKLOAD_SCHEMA,
+	DESTRUCTIVE_CAMPAIGN_REQUIRED_ARTIFACTS,
+	WORDPRESS_FUZZ_CAMPAIGN_ARTIFACT_VALIDATION_SCHEMA,
+	WORDPRESS_FUZZ_CAMPAIGN_RUN_SCHEMA,
 	WORDPRESS_FUZZ_CAMPAIGN_SCHEMA,
 	WORDPRESS_FUZZ_PLAN_RESULT_GAP_REPORT_SCHEMA,
 	aggregateWordPressFuzzCampaignResult,
 	buildWordPressFuzzCampaignWorkload,
 	compileWordPressFuzzCampaign,
 	detectWordPressFuzzPlanResultGaps,
+	runWordPressFuzzCampaign,
+	validateWordPressFuzzCampaignArtifacts,
 };

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -133,6 +133,7 @@
     "test:wordpress-fuzz-plan-from-surfaces": "node tests/wordpress-fuzz-plan-from-surfaces-smoke.js",
     "test:core-fuzz-plan-boundary": "node tests/core-fuzz-plan-boundary-smoke.js",
     "test:wordpress-fuzz-campaign": "node tests/wordpress-fuzz-campaign-smoke.js",
+    "test:wordpress-fuzz-campaign-orchestrator": "node tests/wordpress-fuzz-campaign-orchestrator-smoke.js",
     "test:wordpress-dependency-materialization-recipes": "node tests/wordpress-dependency-materialization-recipes-smoke.js",
     "test:wp-codebox-browser-metrics": "node tests/wp-codebox-browser-metrics-smoke.js",
     "test:wp-codebox-visual-compare": "node tests/wp-codebox-visual-compare-smoke.js",

--- a/wordpress/tests/wordpress-fuzz-campaign-orchestrator-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-campaign-orchestrator-smoke.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	WORDPRESS_FUZZ_CAMPAIGN_ARTIFACT_VALIDATION_SCHEMA,
+	WORDPRESS_FUZZ_CAMPAIGN_RUN_SCHEMA,
+	runWordPressFuzzCampaign,
+	validateWordPressFuzzCampaignArtifacts,
+} = require('../lib/wordpress-fuzz-campaign');
+
+function artifact(semanticKey, name = semanticKey, schema) {
+	return { name, semantic_key: semanticKey, schema, status: 'passed' };
+}
+
+(async () => {
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-fuzz-campaign-'));
+	const summaryPath = path.join(tmpDir, 'campaign-summary.json');
+	const seen = {};
+	const summary = await runWordPressFuzzCampaign({
+		id: 'production-destructive-campaign',
+		destructive: true,
+		summaryPath,
+		target: { type: 'wordpress-plugin', slug: 'sample-plugin' },
+		discovery: {
+			id: 'live-wordpress-surfaces',
+			surfaces: [
+				{ id: 'rest:items-delete', type: 'rest_route', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'DELETE' },
+			],
+		},
+		rest_mutation_opt_ins: {
+			entries: [{ id: 'delete-item', route: '/example/v1/items/(?P<id>[\\d]+)', method: 'DELETE' }],
+		},
+	}, {
+		plan: {
+			fixture_bindings: { 'rest:items-delete': { route_params: { id: 42 } } },
+			runtimeCapabilities: { capabilities: ['rest', 'checkpoint', 'rest-rollback', 'restore'] },
+			runtimeReadiness: { schema: 'wp-codebox/fuzz-runner-readiness/v1', status: 'ready', operationKinds: ['mutation'], mutationIsolation: true, deleteBoundary: true },
+		},
+		runFuzzSuite: async (request) => {
+			seen.request = request;
+			return {
+				schema: 'wp-codebox/fuzz-suite-result/v1',
+				request_id: request.task_id,
+				status: 'succeeded',
+				wordpress_fuzz_result: {
+					cases: [{ id: request.input.cases[0].id, surface_id: 'rest:items-delete', status: 'passed' }],
+				},
+				hotspot_summary: {
+					schema: 'wp-codebox/wordpress-hotspots/v1',
+					hotspots: [{ id: 'rest:items-delete', metric: 'duration_ms', value: 1 }],
+				},
+				artifacts: [
+					artifact('fuzz.result.normalized', 'wp-codebox-fuzz-suite-result'),
+					artifact('fuzz.result.envelope', 'result-envelope'),
+					artifact('fuzz.case.log', 'case-log'),
+					artifact('fuzz.replay.data', 'replay-data'),
+					artifact('fuzz.coverage.summary', 'coverage-summary'),
+					artifact('fuzz.disposable.sandbox_isolation_proof', 'sandbox-isolation-proof'),
+					artifact('fuzz.mutation.isolation', 'mutation-isolation-artifact'),
+					artifact('fuzz.delete.boundary', 'delete-boundary-artifact'),
+					artifact('fuzz.external_http.guardrail', 'external-http-guardrail'),
+					artifact('fuzz.runtime.access', 'runtime-access'),
+					artifact('fuzz.coverage', 'wordpress-fuzz-coverage'),
+					artifact('fuzz.hotspot.summary', 'homeboy-hotspot-summary'),
+					artifact('fuzz.coverage.gap_report', 'wordpress-fuzz-gap-report'),
+					artifact('fuzz.hotspot.codebox', 'wordpress-hotspots', 'wp-codebox/wordpress-hotspots/v1'),
+				],
+			};
+		},
+	});
+
+	assert.equal(summary.schema, WORDPRESS_FUZZ_CAMPAIGN_RUN_SCHEMA);
+	assert.equal(summary.status, 'succeeded');
+	assert.equal(summary.succeeded, true);
+	assert.equal(summary.campaign.wp_codebox.input.schema, 'wp-codebox/fuzz-suite/v1');
+	assert.equal(summary.campaign.wp_codebox.input.metadata.production_campaign, true);
+	assert.equal(summary.artifact_validation.schema, WORDPRESS_FUZZ_CAMPAIGN_ARTIFACT_VALIDATION_SCHEMA);
+	assert.equal(summary.artifact_validation.status, 'passed');
+	assert.equal(summary.artifact_validation.required_artifacts.length, 7);
+	assert.equal(summary.artifact_validation.missing_artifacts.length, 0);
+	assert.equal(seen.request.input.schema, 'wp-codebox/fuzz-suite/v1');
+	assert.equal(seen.request.expected_artifacts.includes('wordpress-hotspots'), true);
+	assert.equal(seen.request.artifact_declarations.find((entry) => entry.semantic_key === 'fuzz.hotspot.codebox').required, true);
+	assert.equal(JSON.parse(fs.readFileSync(summaryPath, 'utf8')).schema, WORDPRESS_FUZZ_CAMPAIGN_RUN_SCHEMA);
+	assert(!JSON.stringify(summary).includes('woocommerce'), 'campaign orchestrator must stay product-agnostic');
+
+	const missing = validateWordPressFuzzCampaignArtifacts({
+		destructive: true,
+		result: { artifacts: [artifact('fuzz.coverage')] },
+	});
+	assert.equal(missing.status, 'failed');
+	assert(missing.missing_artifacts.some((entry) => entry.semantic_key === 'fuzz.delete.boundary'));
+
+	console.log('wordpress fuzz campaign orchestrator smoke passed');
+})().catch((error) => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/wordpress/tests/wordpress-public-export-boundary.test.js
+++ b/wordpress/tests/wordpress-public-export-boundary.test.js
@@ -39,6 +39,8 @@ assert.equal(typeof wordpress.normalizeWordPressRuntimeSurfaceDiscovery, 'functi
 assert.equal(typeof wordpress.buildWordPressRuntimeSurfaceCoverageManifest, 'function');
 assert.equal(typeof wordpress.buildWordPressFuzzPlanFromSurfaces, 'function');
 assert.equal(typeof wordpress.compileWordPressFuzzCampaign, 'function');
+assert.equal(typeof wordpress.runWordPressFuzzCampaign, 'function');
+assert.equal(typeof wordpress.validateWordPressFuzzCampaignArtifacts, 'function');
 assert.equal(typeof wordpress.detectWordPressFuzzPlanResultGaps, 'function');
 assert.equal(typeof wordpress.buildWordPressFuzzRunnerResult, 'function');
 assert.equal(typeof wordpress.buildWordPressFuzzRuntimeTaskRequest, 'function');


### PR DESCRIPTION
## Summary
- Adds a reusable product-agnostic WordPress fuzz campaign orchestrator API.
- Composes campaign compile, WP Codebox fuzz execution, result aggregation, artifact validation, and optional summary persistence.
- Requires destructive campaign artifacts for sandbox proof, mutation isolation, delete boundary, external side-effect guardrail, runtime access, coverage, and hotspots.

## Stack
- Stacked on #2147 so the managed WP Codebox contract-source fix lands first.

## Verification
- `npm run test:wordpress-fuzz-campaign-orchestrator`
- `npm run test:wordpress-fuzz-campaign`
- `npm run test:wordpress-fuzz-plan-from-surfaces`
- `npm run test:wordpress-fuzz-runtime-task`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-destructive-codebox-readiness-gate`
- `npm run test:wordpress-public-export-boundary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the production WordPress fuzz campaign orchestrator and smoke coverage with Chris directing the upstream/downstream contract split.