### PR TITLE
Remove OpenCode executor re-export shim

### DIFF
--- a/wordpress/lib/opencode-agent-task-executor.js
+++ b/wordpress/lib/opencode-agent-task-executor.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('../../agent-runtimes/opencode/lib/opencode-agent-task-executor');


### PR DESCRIPTION
## Summary
- delete the unused WordPress-side OpenCode executor re-export shim
- keep the executor owned by the OpenCode runtime package

Refs Extra-Chill/homeboy-extensions#1982
Refs Extra-Chill/homeboy-extensions#1969

## Testing
- npm run test:opencode-agent-task-executor-boundary in agent-runtimes/opencode
- npm run test:architectural-boundary-contract in wordpress
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode plus local implementation subagent
- **Used for:** Investigation, patch drafting, and targeted verification.