### PR TITLE
Prefer requested WP Codebox source setup

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -16,7 +16,12 @@ OVERRIDE_GITHUB_ENV_FILE="${TMPDIR}/override-github-env"
 ARTIFACT_ROOT="${TMPDIR}/artifact-root"
 ARTIFACT_PATH="${TMPDIR}/wp-codebox-cli-linux-x64.tar.gz"
 
-mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist"
+mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}/scripts/build" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist"
+
+cat > "${EXTENSION_DIR}/scripts/build/persist-wp-codebox-overrides.mjs" <<'NODE'
+#!/usr/bin/env node
+process.exit(0);
+NODE
 
 cat > "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox" <<'SH'
 #!/usr/bin/env bash
@@ -286,6 +291,43 @@ if grep -q "${STALE_ROOT}" "${OVERRIDE_GITHUB_ENV_FILE}"; then
     exit 1
 fi
 
+SOURCE_PRECEDENCE_HOME="${TMPDIR}/source-precedence-home"
+SOURCE_PRECEDENCE_INSTALL_DIR="${TMPDIR}/source-precedence-install"
+SOURCE_PRECEDENCE_GITHUB_ENV_FILE="${TMPDIR}/source-precedence-github-env"
+SOURCE_PRECEDENCE_STALE_BIN="${SOURCE_PRECEDENCE_HOME}/.local/bin/wp-codebox"
+
+mkdir -p "${SOURCE_PRECEDENCE_HOME}/.local/bin"
+cat > "${SOURCE_PRECEDENCE_STALE_BIN}" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'stale configured wp-codebox'
+SH
+chmod +x "${SOURCE_PRECEDENCE_STALE_BIN}"
+
+(
+    cd "${EXTENSION_DIR}"
+    HOME="${SOURCE_PRECEDENCE_HOME}" \
+    PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GITHUB_ENV="${SOURCE_PRECEDENCE_GITHUB_ENV_FILE}" \
+    HOMEBOY_WP_CODEBOX_BIN="${SOURCE_PRECEDENCE_STALE_BIN}" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${SOURCE_PRECEDENCE_INSTALL_DIR}" \
+    HOMEBOY_WP_CODEBOX_SOURCE="https://example.test/wp-codebox.git" \
+    HOMEBOY_WP_CODEBOX_REF="main" \
+    bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/source-precedence-setup.out"
+)
+
+source_precedence_wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${SOURCE_PRECEDENCE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
+
+if [ "${source_precedence_wp_codebox_bin}" != "${SOURCE_PRECEDENCE_INSTALL_DIR}/source/packages/cli/dist/index.js" ]; then
+    echo "Expected HOMEBOY_WP_CODEBOX_SOURCE to replace stale configured CLI, got: ${source_precedence_wp_codebox_bin}" >&2
+    cat "${TMPDIR}/source-precedence-setup.out" >&2
+    exit 1
+fi
+
+if [ "$(PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" "${source_precedence_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
+    echo "Expected source-precedence setup to execute built WP Codebox CLI" >&2
+    exit 1
+fi
+
 (
     cd "${EXTENSION_DIR}"
     HOME="${HOME_DIR}" \
@@ -311,8 +353,8 @@ if [ "${missing_release_wp_codebox_bin}" != "${TMPDIR}/missing-release-install/s
     exit 1
 fi
 
-if ! grep -q 'WP Codebox release artifact not published' "${TMPDIR}/missing-release-setup.err"; then
-    echo "Expected missing release artifact message" >&2
+if grep -q 'WP Codebox release artifact not published' "${TMPDIR}/missing-release-setup.err"; then
+    echo "Explicit source/ref setup should not probe release artifacts before source install" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -107,7 +107,13 @@ install_wp_codebox() {
         return 0
     fi
 
-    if [ -n "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && [ -x "${HOMEBOY_WP_CODEBOX_BIN}" ]; then
+    local source_install_requested=0
+    if [ -n "${HOMEBOY_WP_CODEBOX_SOURCE:-}" ] || [ -n "${HOMEBOY_WP_CODEBOX_REF:-}" ] || [ "${HOMEBOY_WP_CODEBOX_INSTALL_MODE:-}" = "source" ]; then
+        source_install_requested=1
+        export HOMEBOY_WP_CODEBOX_INSTALL_MODE="source"
+    fi
+
+    if [ "${source_install_requested}" -eq 0 ] && [ -n "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && [ -x "${HOMEBOY_WP_CODEBOX_BIN}" ]; then
         echo "WP Codebox already configured: ${HOMEBOY_WP_CODEBOX_BIN}"
         if resolve_core_module_from_known_locations; then
             return 0
@@ -115,7 +121,7 @@ install_wp_codebox() {
         echo "WP Codebox CLI is configured without a runtime core module; (re)installing source module" >&2
     fi
 
-    if command -v wp-codebox >/dev/null 2>&1; then
+    if [ "${source_install_requested}" -eq 0 ] && command -v wp-codebox >/dev/null 2>&1; then
         local detected_bin
         detected_bin="$(command -v wp-codebox)"
         echo "WP Codebox already available: ${detected_bin}"


### PR DESCRIPTION
## Summary
- Make WordPress extension setup honor explicit `HOMEBOY_WP_CODEBOX_SOURCE`, `HOMEBOY_WP_CODEBOX_REF`, or source install mode before accepting a stale configured `HOMEBOY_WP_CODEBOX_BIN`.
- Add setup smoke coverage for source/ref overriding stale configured binaries.
- Update the missing-release smoke expectation because explicit source/ref now skips release probing.

## Verification
- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash -n wordpress/scripts/build/setup.sh wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `git diff --check`

## Runtime evidence
- This unblocks lab setup from selecting stale `~/.local/bin/wp-codebox` after rebuilding WP Codebox from source. With the managed source CLI selected, WPCOM disposable PHPUnit canaries passed through Homeboy lab.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed setup precedence from lab runner evidence, implemented the setup fix, and updated regression smoke coverage.