### PR TITLE
feat: declare WP Codebox recipe preflight

### DIFF
--- a/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
+++ b/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
@@ -29,6 +29,12 @@ assert.doesNotMatch(descriptorSource, /run-agent-task', '--help/);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'wp-codebox.json'), 'utf8'));
 assert.equal(manifest.component_path_defaults, undefined);
+const providerPreflight = manifest.agent_task_executors[0].config_preflights.find((preflight) => preflight.id === 'recipe-command-compatibility');
+assert.equal(providerPreflight.label, 'WP Codebox recipe command compatibility');
+assert.deepEqual(providerPreflight.required_values.keys, ['command']);
+assert.equal(providerPreflight.supported_values.scoped_keys.includes('supported_recipe_commands'), true);
+assert.deepEqual(providerPreflight.reference_key_contains, ['recipe']);
+assert.equal(providerPreflight.binary_probe.path_env.includes('HOMEBOY_WP_CODEBOX_BIN'), true);
 
 const executorSource = fs.readFileSync(path.join(runtimeRoot, 'lib', 'codebox-agent-task-executor.js'), 'utf8');
 assert.doesNotMatch(executorSource, /function defaultRuntimeRequirements/);

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -622,6 +622,50 @@
           "evidence_refs"
         ]
       },
+      "config_preflights": [
+        {
+          "id": "recipe-command-compatibility",
+          "label": "WP Codebox recipe command compatibility",
+          "required_values": {
+            "keys": ["command"]
+          },
+          "supported_values": {
+            "scoped_keys": [
+              "commands",
+              "supported_commands",
+              "recipe_commands",
+              "supported_recipe_commands"
+            ],
+            "scope_key_contains": ["codebox", "recipe"],
+            "scope_value_contains": ["codebox", "recipe"],
+            "enum_keys": ["command"]
+          },
+          "reference_key_contains": ["recipe"],
+          "binary_probe": {
+            "path_keys": [
+              "codebox_binary_path",
+              "wp_codebox_binary_path",
+              "wp_codebox_binary",
+              "binary_path",
+              "executable_path",
+              "binary"
+            ],
+            "path_env": ["HOMEBOY_WP_CODEBOX_BIN", "WP_CODEBOX_BIN"],
+            "json_commands": [["commands", "--json"], ["schema", "--json"]],
+            "version_command": ["--version"],
+            "fingerprint_command": ["fingerprint"],
+            "version_keys": ["codebox_version", "wp_codebox_version", "version"],
+            "fingerprint_keys": [
+              "codebox_fingerprint",
+              "wp_codebox_fingerprint",
+              "fingerprint",
+              "commit",
+              "revision"
+            ]
+          },
+          "remediation": "Refresh or upgrade the selected WP Codebox runner so its recipe schema advertises every generated workflow command before dispatching."
+        }
+      ],
       "role_aliases": {
         "artifact_roles": {
           "artifact_bundle": ["codebox-artifact-bundle", "artifact-bundle", "codebox-artifact-directory", "codebox-session-artifacts"],


### PR DESCRIPTION
## Summary
- Declare the WP Codebox recipe command compatibility preflight in the WP Codebox agent runtime provider manifest.
- Keep the existing stale-runner protection after Homeboy core moves the preflight engine behind a generic provider config preflight seam.
- Add a boundary assertion proving the WP Codebox provider manifest carries the rule.

## Design
Homeboy core now owns only a generic `config_preflights` executor-provider contract. HBX supplies the WP Codebox-specific rule:
- collect generated recipe `command` values from executor config and recipe JSON refs,
- collect supported commands from runner-scoped config fields and schema enums,
- optionally probe the selected WP Codebox binary with `commands --json`, `schema --json`, `--version`, and `fingerprint`,
- emit the existing operator remediation when a generated recipe uses unsupported commands.

## Companion PR
- Homeboy core seam: https://github.com/Extra-Chill/homeboy/pull/7464

## Test evidence
- `node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js` passed.
- `npm --prefix agent-runtimes/wp-codebox run test:wp-codebox-adapter-contract` passed.
- `npm --prefix agent-runtimes/wp-codebox run test:wp-codebox-runtime-contract-source` passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated via Claude (opencode)
- **Used for:** Implemented the refactor, tests, and PRs from a scoped investigation brief; human reviews every line.
