### PR TITLE
Fix WP Codebox runtime freshness resolution

### DIFF
--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js
@@ -56,10 +56,10 @@ function wpCodeboxBin(options = {}) {
   return firstValue(
     ...(options.preferPackagedRuntime ? packagedRuntimeCandidates : explicitBinCandidates),
     options.bin,
+    ...(options.preferPackagedRuntime ? explicitBinCandidates : packagedRuntimeCandidates),
     ...descriptor.env.map((key) => env[key]),
     ...descriptor.settings.map((key) => settings[key]),
     env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN,
-    ...(options.preferPackagedRuntime ? explicitBinCandidates : packagedRuntimeCandidates),
     options.executable === undefined ? descriptor.executable : options.executable,
   );
 }

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -51,8 +51,9 @@ assert.deepEqual(cliDescriptor.commands, {
 	run_agent_task: 'run-agent-task',
 	recipe_run: 'recipe-run',
 });
-assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_BIN: '/usr/local/bin/wp-codebox' } }), '/usr/local/bin/wp-codebox');
-assert.equal(wpCodeboxBin({ settings: { wp_codebox_bin: '/settings/wp-codebox' } }), '/settings/wp-codebox');
+const emptyManagedInstallDir = path.join(tmpdir(), 'homeboy-wp-codebox-empty-managed');
+assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_INSTALL_DIR: emptyManagedInstallDir, HOMEBOY_WP_CODEBOX_BIN: '/usr/local/bin/wp-codebox' } }), '/usr/local/bin/wp-codebox');
+assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_INSTALL_DIR: emptyManagedInstallDir }, settings: { wp_codebox_bin: '/settings/wp-codebox' } }), '/settings/wp-codebox');
 assert.deepEqual(wpCodeboxCommand('/tmp/wp-codebox.mjs'), { command: process.execPath, args: ['/tmp/wp-codebox.mjs'] });
 
 const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'homeboy-wp-codebox-bin-'));
@@ -93,6 +94,21 @@ try {
 	assert.equal(
 		wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_INSTALL_DIR: path.join(fixtureRoot, 'managed') }, executable: '' }),
 		managedCli
+	);
+	assert.equal(
+		wpCodeboxBin({
+			env: {
+				HOMEBOY_WP_CODEBOX_INSTALL_DIR: path.join(fixtureRoot, 'managed'),
+				HOMEBOY_WP_CODEBOX_BIN: '/stale/env/wp-codebox',
+			},
+			settings: { wp_codebox_bin: '/stale/settings/wp-codebox' },
+			executable: '',
+		}),
+		managedCli
+	);
+	assert.equal(
+		wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_INSTALL_DIR: path.join(fixtureRoot, 'managed') }, runtime_bin: '/fresh/runtime/wp-codebox', executable: '' }),
+		'/fresh/runtime/wp-codebox'
 	);
 } finally {
 	rmSync(fixtureRoot, { recursive: true, force: true });

--- a/wordpress/scripts/doctor/wp-codebox-doctor.sh
+++ b/wordpress/scripts/doctor/wp-codebox-doctor.sh
@@ -23,40 +23,8 @@ Environment:
 USAGE
 }
 
-settings_wp_codebox_bin() {
-    [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] || return 0
-    [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ] || return 0
-
-    if command -v jq >/dev/null 2>&1; then
-        printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_bin // empty' 2>/dev/null || true
-        return 0
-    fi
-
-    if command -v node >/dev/null 2>&1; then
-        node -e '
-const input = process.env.HOMEBOY_SETTINGS_JSON || "{}";
-try {
-  const value = JSON.parse(input).wp_codebox_bin;
-  if (typeof value === "string") process.stdout.write(value);
-} catch {}
-' 2>/dev/null || true
-    fi
-}
-
-resolve_wp_codebox_bin() {
-    local bin="${HOMEBOY_WP_CODEBOX_BIN:-}"
-    if [ -z "$bin" ]; then
-        bin="$(settings_wp_codebox_bin)"
-    fi
-    bin="${bin:-wp-codebox}"
-
-    if [[ "$bin" = */* ]]; then
-        printf '%s\n' "$bin"
-        return 0
-    fi
-
-    command -v "$bin" 2>/dev/null || printf '%s\n' "$bin"
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/wp-codebox-paths.sh"
 
 MODE="doctor"
 if [ "$#" -gt 0 ]; then
@@ -72,5 +40,6 @@ if [ "$#" -gt 0 ]; then
     esac
 fi
 
-WP_CODEBOX_BIN="$(resolve_wp_codebox_bin)"
-exec "$WP_CODEBOX_BIN" "$MODE" "$@"
+WP_CODEBOX_BIN="$(homeboy_wp_codebox_resolve_bin "${HOMEBOY_SETTINGS_JSON:-}")"
+homeboy_wp_codebox_set_command "$WP_CODEBOX_BIN"
+exec "${HOMEBOY_WP_CODEBOX_COMMAND[@]}" "$MODE" "$@"

--- a/wordpress/scripts/lib/wp-codebox-paths.sh
+++ b/wordpress/scripts/lib/wp-codebox-paths.sh
@@ -53,6 +53,17 @@ homeboy_wp_codebox_resolve_bin() {
     local candidates=()
 
     if [ -n "$settings_json" ] && [ "$settings_json" != "{}" ]; then
+        bin=$(printf '%s' "$settings_json" | jq -r '.runtime_bin // empty' 2>/dev/null || true)
+    fi
+    if [ -n "$bin" ]; then
+        candidates+=("$bin")
+    fi
+
+    while IFS= read -r candidate; do
+        [ -n "$candidate" ] && candidates+=("$candidate")
+    done < <(homeboy_wp_codebox_managed_cli_candidates)
+
+    if [ -n "$settings_json" ] && [ "$settings_json" != "{}" ]; then
         bin=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_bin // empty' 2>/dev/null || true)
     fi
     if [ -n "$bin" ]; then
@@ -126,6 +137,12 @@ homeboy_wp_codebox_global_cli_candidates() {
             "${root}/@automattic/wp-codebox-cli/dist/index.js" \
             "${root}/wp-codebox-workspace/node_modules/@automattic/wp-codebox-cli/dist/index.js"
     done
+}
+
+homeboy_wp_codebox_managed_cli_candidates() {
+    local install_dir="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+
+    printf '%s\n' "${install_dir}/source/packages/cli/dist/index.js"
 }
 
 homeboy_wp_codebox_bin_is_runnable() {

--- a/wordpress/scripts/test/wp-codebox-doctor-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-doctor-smoke.sh
@@ -16,6 +16,9 @@ cat > "$FAKE_BIN" <<'SH'
 set -euo pipefail
 printf '%s\n' "$*" >> "$WP_CODEBOX_CALLS"
 case "$1" in
+    commands)
+        printf 'doctor\ncleanup\n'
+        ;;
     doctor)
         printf 'WP Codebox doctor: warning\n'
         ;;
@@ -31,6 +34,7 @@ SH
 chmod +x "$FAKE_BIN"
 
 output=$(WP_CODEBOX_CALLS="$CALLS" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMPDIR}/empty-install" \
     HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
     bash "$DOCTOR" doctor --fix --stale-after-seconds 1 --archive-root "$ARCHIVE_ROOT" --json 2>&1)
 
@@ -41,6 +45,7 @@ if [[ "$output" != *"WP Codebox doctor: warning"* ]]; then
 fi
 
 cleanup_output=$(WP_CODEBOX_CALLS="$CALLS" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMPDIR}/empty-install" \
     HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
     bash "$DOCTOR" cleanup --stale-after-seconds 0 --archive-root "$ARCHIVE_ROOT" 2>&1)
 
@@ -67,17 +72,86 @@ cat > "$SETTINGS_BIN" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$WP_CODEBOX_CALLS"
-printf 'settings wp-codebox %s\n' "$1"
+case "$1" in
+    commands)
+        printf 'doctor\ncleanup\n'
+        ;;
+    *)
+        printf 'settings wp-codebox %s\n' "$1"
+        ;;
+esac
 SH
 chmod +x "$SETTINGS_BIN"
 
 settings_output=$(WP_CODEBOX_CALLS="$CALLS" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMPDIR}/empty-install" \
     HOMEBOY_SETTINGS_JSON="{\"wp_codebox_bin\":\"$SETTINGS_BIN\"}" \
     bash "$DOCTOR" --json 2>&1)
 
 if [[ "$settings_output" != *"settings wp-codebox doctor"* ]]; then
     echo "Expected settings wp_codebox_bin to be used" >&2
     echo "$settings_output" >&2
+    exit 1
+fi
+
+MANAGED_HOME="${TMPDIR}/managed-home"
+MANAGED_BIN="${MANAGED_HOME}/.cache/homeboy/wp-codebox/source/packages/cli/dist/index.js"
+STALE_BIN="${TMPDIR}/stale-wp-codebox"
+RUNTIME_BIN="${TMPDIR}/runtime-wp-codebox"
+mkdir -p "$(dirname "$MANAGED_BIN")"
+
+cat > "$MANAGED_BIN" <<'NODE'
+#!/usr/bin/env node
+const fs = require('node:fs');
+fs.appendFileSync(process.env.WP_CODEBOX_CALLS, `${process.argv.slice(2).join(' ')}\n`);
+switch (process.argv[2]) {
+  case 'commands': process.exit(0);
+  case 'doctor': console.log('managed wp-codebox doctor'); break;
+  default: process.exit(64);
+}
+NODE
+chmod +x "$MANAGED_BIN"
+
+cat > "$STALE_BIN" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'stale wp-codebox should not run\n' >&2
+exit 65
+SH
+chmod +x "$STALE_BIN"
+
+managed_output=$(WP_CODEBOX_CALLS="$CALLS" \
+    HOME="$MANAGED_HOME" \
+    HOMEBOY_WP_CODEBOX_BIN="$STALE_BIN" \
+    HOMEBOY_SETTINGS_JSON="{\"wp_codebox_bin\":\"$STALE_BIN\"}" \
+    bash "$DOCTOR" --json 2>&1)
+
+if [[ "$managed_output" != *"managed wp-codebox doctor"* ]]; then
+    echo "Expected managed WP Codebox cache to outrank stale legacy env/settings" >&2
+    echo "$managed_output" >&2
+    exit 1
+fi
+
+cat > "$RUNTIME_BIN" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$WP_CODEBOX_CALLS"
+case "$1" in
+    commands) exit 0 ;;
+    doctor) printf 'runtime wp-codebox doctor\n' ;;
+    *) exit 64 ;;
+esac
+SH
+chmod +x "$RUNTIME_BIN"
+
+runtime_output=$(WP_CODEBOX_CALLS="$CALLS" \
+    HOME="$MANAGED_HOME" \
+    HOMEBOY_SETTINGS_JSON="{\"runtime_bin\":\"$RUNTIME_BIN\"}" \
+    bash "$DOCTOR" --json 2>&1)
+
+if [[ "$runtime_output" != *"runtime wp-codebox doctor"* ]]; then
+    echo "Expected generic runtime_bin to outrank managed WP Codebox cache" >&2
+    echo "$runtime_output" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- prefer explicit generic runtime_bin first, then the managed WP Codebox source cache, before legacy HOMEBOY_WP_CODEBOX_BIN/wp_codebox_bin aliases
- make the WP Codebox doctor wrapper use the shared resolver instead of duplicating stale precedence rules
- add smoke coverage for managed cache freshness beating stale legacy settings and runtime_bin beating managed cache

## Validation
- node tests/wp-codebox-adapter-contract-smoke.mjs
- bash wordpress/scripts/test/wp-codebox-doctor-smoke.sh
- bash wordpress/scripts/build/setup-wp-codebox-smoke.sh

## Operator commands meanwhile
- Install this PR’s WordPress extension on a runner for parity testing: `homeboy extension refresh https://github.com/Extra-Chill/homeboy-extensions.git --id wordpress --ref fix/runtime-freshness-automation-20260703 --runner <runner-id>`
- Refresh runner WP Codebox cache from the extension checkout: `wordpress/scripts/build/update-wp-codebox-cache.sh --runner <runner-id> --ref main`
- Force source setup on a runner without manually pinning HOMEBOY_WP_CODEBOX_BIN: `homeboy extension setup --runner <runner-id> --runner-env HOMEBOY_WP_CODEBOX_INSTALL_MODE=source --runner-env HOMEBOY_WP_CODEBOX_REF=main wordpress`
- If a runner has stale global env, remove `HOMEBOY_WP_CODEBOX_BIN`; use generic `runtime_bin` only when intentionally selecting a specific binary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated recent runtime freshness failures, implemented resolver precedence changes, added smoke coverage, and prepared this PR.