### PR TITLE
Fail explicit PHPUnit no-test scopes

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -57,14 +57,35 @@ settings_json="${HOMEBOY_SETTINGS_JSON:-}"
 [ -n "$settings_json" ] || settings_json="{}"
 
 PHPUNIT_NO_TESTS="skipped"
+PHPUNIT_NO_TESTS_CONFIGURED=0
 WP_CODEBOX_PHPUNIT_TEST_ROOT=""
+WP_CODEBOX_PHPUNIT_CONFIG=""
 if [ "$settings_json" != "{}" ]; then
     extracted=$(printf '%s' "$settings_json" | jq -r '.phpunit_no_tests // empty' 2>/dev/null || true)
-    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PHPUNIT_NO_TESTS="$extracted"
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        PHPUNIT_NO_TESTS="$extracted"
+        PHPUNIT_NO_TESTS_CONFIGURED=1
+    fi
 
     extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_phpunit_test_root // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_PHPUNIT_TEST_ROOT="$extracted"
+
+    extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_phpunit_config // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_PHPUNIT_CONFIG="$extracted"
 fi
+
+phpunit_no_tests_is_failure_policy() {
+    [ "$PHPUNIT_NO_TESTS" = "failed" ] || [ "$PHPUNIT_NO_TESTS" = "fail" ]
+}
+
+phpunit_no_tests_allows_skip() {
+    [ "$PHPUNIT_NO_TESTS_CONFIGURED" -eq 1 ] || return 1
+    [ "$PHPUNIT_NO_TESTS" = "skipped" ] || [ "$PHPUNIT_NO_TESTS" = "skip" ]
+}
+
+phpunit_has_explicit_scope_request() {
+    [ -n "$WP_CODEBOX_PHPUNIT_TEST_ROOT" ] || [ -n "$WP_CODEBOX_PHPUNIT_CONFIG" ]
+}
 
 WP_CODEBOX_SOURCE_ROOT=""
 WP_CODEBOX_SOURCE_SUBPATH=""
@@ -361,7 +382,7 @@ if ! guard_component_path; then
 fi
 
 TEST_DIR="${PLUGIN_PATH}/tests"
-if [ ! -d "$TEST_DIR" ] && [ -z "$WP_CODEBOX_PHPUNIT_TEST_ROOT" ]; then
+if [ ! -d "$TEST_DIR" ] && ! phpunit_has_explicit_scope_request; then
     if component_has_composer_test_script; then
         run_composer_test_script
         exit $?
@@ -372,7 +393,7 @@ if [ ! -d "$TEST_DIR" ] && [ -z "$WP_CODEBOX_PHPUNIT_TEST_ROOT" ]; then
         exit $?
     fi
 
-    if [ "$PHPUNIT_NO_TESTS" = "failed" ] || [ "$PHPUNIT_NO_TESTS" = "fail" ]; then
+    if phpunit_no_tests_is_failure_policy; then
         echo ""
         echo "NO PHPUNIT TEST DIRECTORY DISCOVERED"
         echo "  Expected: ${TEST_DIR}"
@@ -768,7 +789,6 @@ PHPUNIT_ENV_JSON="{}"
 WP_CODEBOX_FILE_MOUNTS_JSON="[]"
 WP_CODEBOX_PHPUNIT_MOUNTS_JSON="[]"
 WP_CODEBOX_PHPUNIT_TEST_ROOT=""
-WP_CODEBOX_PHPUNIT_CONFIG=""
 WP_CODEBOX_PHPUNIT_CWD=""
 WP_CODEBOX_PHPUNIT_PRELOAD_FILES_JSON="[]"
 WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON="null"
@@ -797,7 +817,10 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_PHPUNIT_PRELOAD_FILES_JSON="$extracted"
 
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.phpunit_no_tests // empty' 2>/dev/null || true)
-    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PHPUNIT_NO_TESTS="$extracted"
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        PHPUNIT_NO_TESTS="$extracted"
+        PHPUNIT_NO_TESTS_CONFIGURED=1
+    fi
 
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wordpress_runtime_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
@@ -1425,11 +1448,13 @@ if echo "$PHPUNIT_OUTPUT" | grep -q "^NO_TEST_FILES"; then
         exit $?
     fi
 
-    if [ "$PHPUNIT_NO_TESTS" = "failed" ] || [ "$PHPUNIT_NO_TESTS" = "fail" ] || [ -f "${PLUGIN_PATH}/phpunit.xml" ] || [ -f "${PLUGIN_PATH}/phpunit.xml.dist" ]; then
+    if phpunit_no_tests_is_failure_policy || [ -f "${PLUGIN_PATH}/phpunit.xml" ] || [ -f "${PLUGIN_PATH}/phpunit.xml.dist" ] || { phpunit_has_explicit_scope_request && ! phpunit_no_tests_allows_skip; }; then
         dump_diagnostics "NO PHPUNIT TEST FILES DISCOVERED"
         echo ""
-        if [ "$PHPUNIT_NO_TESTS" = "failed" ] || [ "$PHPUNIT_NO_TESTS" = "fail" ]; then
+        if phpunit_no_tests_is_failure_policy; then
             echo "PHPUnit no-test discovery is configured as failure, and no files matched the WordPress runner discovery contract."
+        elif phpunit_has_explicit_scope_request; then
+            echo "Explicit PHPUnit test scope/config was requested, but no files matched the WordPress runner discovery contract."
         else
             echo "PHPUnit config exists, but no files matched the WordPress runner discovery contract."
         fi

--- a/wordpress/scripts/test/wp-codebox-phpunit-profile-validation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-phpunit-profile-validation-smoke.sh
@@ -80,6 +80,7 @@ settings_json=$(jq -nc \
     }')
 
 run_runner() {
+    local settings_for_run="${HOMEBOY_SETTINGS_JSON_OVERRIDE:-$settings_json}"
     HOMEBOY_COMPONENT_ID="sample-plugin" \
     HOMEBOY_COMPONENT_PATH="$PLUGIN_DIR" \
     HOMEBOY_PROJECT_PATH="$PLUGIN_DIR" \
@@ -88,7 +89,7 @@ run_runner() {
     HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
     HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
     HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="$FAKE_BUILDER" \
-    HOMEBOY_SETTINGS_JSON="$settings_json" \
+    HOMEBOY_SETTINGS_JSON="$settings_for_run" \
     WP_CODEBOX_RAN_FILE="$WP_CODEBOX_RAN_FILE" \
     bash "$RUNNER"
 }
@@ -105,6 +106,28 @@ fi
 if [ ! -f "$WP_CODEBOX_RAN_FILE" ]; then
     echo "Expected WP Codebox to run after valid profile recipe generation" >&2
     echo "$valid_output" >&2
+    exit 1
+fi
+
+rm -f "$WP_CODEBOX_RAN_FILE"
+settings_without_no_test_policy=$(printf '%s' "$settings_json" | jq -c 'del(.phpunit_no_tests)')
+set +e
+default_policy_output=$(HOMEBOY_SETTINGS_JSON_OVERRIDE="$settings_without_no_test_policy" run_runner 2>&1)
+default_policy_status=$?
+set -e
+if [ "$default_policy_status" -eq 0 ]; then
+    echo "Expected explicit PHPUnit profile with zero discovered tests to fail by default" >&2
+    echo "$default_policy_output" >&2
+    exit 1
+fi
+if [ ! -f "$WP_CODEBOX_RAN_FILE" ]; then
+    echo "Expected WP Codebox to run before default no-test policy failure" >&2
+    echo "$default_policy_output" >&2
+    exit 1
+fi
+if [[ "$default_policy_output" != *"Explicit PHPUnit test scope/config was requested"* ]]; then
+    echo "Expected explicit PHPUnit no-test diagnostic" >&2
+    echo "$default_policy_output" >&2
     exit 1
 fi
 

--- a/wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh
+++ b/wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh
@@ -12,6 +12,7 @@ PLUGIN_DIR="${MONOREPO_DIR}/plugins/sample-plugin"
 FAKE_BIN="${TMPDIR}/wp-codebox"
 RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
 CAPTURED_RECIPE="${TMPDIR}/recipe.json"
+RUNNER_OUTPUT="${TMPDIR}/runner-output.txt"
 CORE_MODULE="${ROOT_DIR}/tests/fixtures/wp-codebox-core-recipe-builder.mjs"
 
 mkdir -p "${PLUGIN_DIR}/tests"
@@ -34,6 +35,11 @@ PHP
 cat > "$FAKE_BIN" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [ "${1:-}" = "commands" ]; then
+    printf '%s\n' 'recipe-run'
+    exit 0
+fi
 
 recipe=""
 while [ "$#" -gt 0 ]; do
@@ -67,6 +73,7 @@ homeboy_resolve_context() {
 SH
 chmod +x "$RESOLVE_CONTEXT_HELPER"
 
+set +e
 HOMEBOY_COMPONENT_ID="sample-plugin" \
 HOMEBOY_COMPONENT_PATH="$PLUGIN_DIR" \
 HOMEBOY_PROJECT_PATH="$PLUGIN_DIR" \
@@ -79,7 +86,13 @@ HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT="$MONOREPO_DIR" \
 HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH="plugins/sample-plugin" \
 CAPTURED_RECIPE="$CAPTURED_RECIPE" \
 HOMEBOY_SETTINGS_JSON="{\"phpunit_no_tests\":\"skip\"}" \
-bash "$RUNNER" >/dev/null
+bash "$RUNNER" >"$RUNNER_OUTPUT" 2>&1
+runner_status=$?
+set -e
+if [ "$runner_status" -ne 0 ]; then
+    cat "$RUNNER_OUTPUT" >&2
+    exit "$runner_status"
+fi
 
 node - "$CAPTURED_RECIPE" "$MONOREPO_DIR" <<'NODE'
 const assert = require('node:assert/strict');


### PR DESCRIPTION
## Summary
- fail WP Codebox PHPUnit runs when an explicit `wp_codebox_phpunit_test_root` or `wp_codebox_phpunit_config` request discovers zero test files
- keep legacy unconfigured no-test discovery skippable, and allow explicit no-test success only with `phpunit_no_tests: skip|skipped`
- add smoke coverage for the default failure contract and harden the source-root fake CLI preflight

## Validation
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/wp-codebox-phpunit-profile-validation-smoke.sh wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh wordpress/scripts/test/wp-codebox-missing-tests-fail-policy-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-phpunit-profile-validation-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-missing-tests-fail-policy-smoke.sh`
- `bash wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh`
- `npm --prefix wordpress run test:wp-codebox-phpunit-recipe-builder`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Investigated the generic WP Codebox PHPUnit no-test contract, implemented the runner change, added smoke coverage, and ran focused validation.
