### PR TITLE
Remove dead compatibility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,17 +176,8 @@ an injected `runtime_manifest` when the caller does not want to rely on the
 checked-in runtime registry. It emits durable JSON loop results, ordered events,
 and the existing outcome/results files consumed by workflow adapters.
 
-The public `runtime-agent-ci` binaries are the package `bin` entries. Legacy
-agent-loop, artifact-fanout, agent-task-to-review, and WordPress compatibility
-wrapper commands were removed after active callsites migrated to the canonical
-loop, fanout, and review publication primitives. Use
-`homeboy-runtime-agent-ci/generic-orchestration`,
-`homeboy-runtime-agent-ci/provider-adapters`,
-`homeboy-runtime-agent-ci/generic-fanout-reconcile-workflow`,
-`homeboy-runtime-agent-ci/fanout-reconcile-runner`,
-`runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs`, and the
-`.github/scripts/runtime-agent-full-run/*` workflow helpers directly. The
-package exposes only explicit subpath exports for those public surfaces.
+The public `runtime-agent-ci` binaries are the package `bin` entries. The
+package exposes only explicit subpath exports for public surfaces.
 
 WP Codebox is expected to consume a `wp-codebox/runtime-profile/v1` payload with
 generic runtime dependencies such as `components`, `plugins`, `mu_plugins`,

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -110,19 +110,6 @@ records. Keep new executor-neutral extraction behavior in
 `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js`; keep Codebox request/session/artifact
 details inside the Codebox audit fanout lane.
 
-## Static Site Fanout Adapter
-
-The static-site fanout adapter emits generic `homeboy/agent-task-request/v1`
-requests by default. It does not select WP Codebox or any other executor backend
-unless the caller passes an explicit `backend`/`runtime_backend` value or agent
-task backend override.
-
-WP Codebox task-input compatibility is an opt-in compatibility path for callers
-that still consume `wp-codebox/task-input/v1`. Select it with
-`compatibility_provider: "wp-codebox"` or the legacy
-`request_kind: "wp-codebox"` flag. New callers should prefer the generic
-agent-task request schema and make runtime selection outside the adapter.
-
 ## Product Adapter Boundaries
 
 Generic WordPress helpers keep default profiling and helper manifests scoped to

--- a/managed-preview/tests/public-preview-backend-smoke.mjs
+++ b/managed-preview/tests/public-preview-backend-smoke.mjs
@@ -23,13 +23,13 @@ const planned = run([
   '--broker-url',
   'https://preview-broker.example/api/managed-previews',
   '--target-id',
-  'wpcom-ai-landing',
+  'example-landing',
   '--target-url',
-  'https://wordpress.com/ai/',
+  'https://www.example.com/landing',
   '--route',
-  'landing=https://wordpress.com/ai/',
+  'landing=https://www.example.com/landing',
   '--route',
-  'builder_handoff=https://wordpress.com/setup/ai-site-builder',
+  'builder_handoff=https://www.example.com/setup/builder',
   '--dry-run',
 ]);
 
@@ -40,21 +40,21 @@ assert.equal(plannedJson.status, 'planned');
 assert.equal(plannedJson.provider, 'external-broker');
 assert.equal(plannedJson.registration.status, 'planned');
 assert.equal(plannedJson.registration.broker_url, 'https://preview-broker.example/api/managed-previews');
-assert.equal(plannedJson.target.id, 'wpcom-ai-landing');
-assert.equal(plannedJson.target.url, 'https://wordpress.com/ai/');
-assert.equal(plannedJson.target.routes.landing, 'https://wordpress.com/ai/');
-assert.equal(plannedJson.target.routes.builder_handoff, 'https://wordpress.com/setup/ai-site-builder');
+assert.equal(plannedJson.target.id, 'example-landing');
+assert.equal(plannedJson.target.url, 'https://www.example.com/landing');
+assert.equal(plannedJson.target.routes.landing, 'https://www.example.com/landing');
+assert.equal(plannedJson.target.routes.builder_handoff, 'https://www.example.com/setup/builder');
 
 const blocked = run([
   scriptPath,
   '--local-url',
-  'http://calypso.localhost:3000',
+  'http://example.localhost:3000',
   '--public-url',
   'https://preview-broker.example/runs/run-123',
   '--expected-effective-origin',
-  'http://calypso.localhost:3000',
+  'http://example.localhost:3000',
   '--expected-config-hostname',
-  'calypso.localhost',
+  'example.localhost',
   '--require-host-preservation',
   '--dry-run',
 ]);
@@ -68,23 +68,23 @@ assert.match(blockedJson.reason, /requires HOMEBOY_PREVIEW_BROKER_URL|--broker-u
 const preserved = run([
   scriptPath,
   '--local-url',
-  'http://calypso.localhost:3000',
+  'http://example.localhost:3000',
   '--public-url',
   'https://preview-broker.example/runs/run-123',
   '--broker-url',
   'https://preview-broker.example/api/managed-previews',
   '--target-id',
-  'calypso-start',
+  'example-start',
   '--target-url',
-  'http://calypso.localhost:3000/start',
+  'http://example.localhost:3000/start',
   '--route',
-  'start=http://calypso.localhost:3000/start',
+  'start=http://example.localhost:3000/start',
   '--route',
-  'builder_handoff=http://calypso.localhost:3000/setup/ai-site-builder',
+  'builder_handoff=http://example.localhost:3000/setup/builder',
   '--expected-effective-origin',
-  'http://calypso.localhost:3000',
+  'http://example.localhost:3000',
   '--expected-config-hostname',
-  'calypso.localhost',
+  'example.localhost',
   '--require-host-preservation',
   '--dry-run',
 ]);
@@ -93,9 +93,9 @@ assert.equal(preserved.status, 0, preserved.stderr);
 const preservedJson = JSON.parse(preserved.stdout);
 assert.equal(preservedJson.host_preservation.supported, true);
 assert.equal(preservedJson.host_preservation.mode, 'broker-must-prove-host-preservation');
-assert.equal(preservedJson.registration.request.target.id, 'calypso-start');
-assert.equal(preservedJson.registration.request.target.routes.start, 'http://calypso.localhost:3000/start');
-assert.equal(preservedJson.registration.request.target.routes.builder_handoff, 'http://calypso.localhost:3000/setup/ai-site-builder');
+assert.equal(preservedJson.registration.request.target.id, 'example-start');
+assert.equal(preservedJson.registration.request.target.routes.start, 'http://example.localhost:3000/start');
+assert.equal(preservedJson.registration.request.target.routes.builder_handoff, 'http://example.localhost:3000/setup/builder');
 
 const brokerLifecycle = await listenBrokerLifecycle();
 try {

--- a/nodejs/scripts/test/nodejs-targeted-script-smoke.sh
+++ b/nodejs/scripts/test/nodejs-targeted-script-smoke.sh
@@ -7,13 +7,13 @@ EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-targeted.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-run_gutenberg_fallback_smoke() {
-    local project_dir="${TMPDIR}/gutenberg"
+run_declared_targeted_script_smoke() {
+    local project_dir="${TMPDIR}/declared"
     mkdir -p "$project_dir/packages/core-data/src/test"
 
     cat > "${project_dir}/package.json" <<'JSON'
 {
-  "name": "gutenberg",
+  "name": "declared-targeted-script",
   "scripts": {
     "test": "node aggregate-test-should-not-run.mjs",
     "test:unit": "node unit-test-recorder.mjs"
@@ -45,12 +45,13 @@ JS
 
     HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
     HOMEBOY_COMPONENT_PATH="$project_dir" \
-    HOMEBOY_COMPONENT_ID="gutenberg-targeted-smoke" \
-    bash "${SCRIPT_DIR}/test-runner.sh" packages/core-data/src/test/resolvers.js --runInBand > "${TMPDIR}/gutenberg.out"
+    HOMEBOY_COMPONENT_ID="declared-targeted-smoke" \
+    HOMEBOY_SETTINGS_JSON='{"test_script":"test:unit"}' \
+    bash "${SCRIPT_DIR}/test-runner.sh" packages/core-data/src/test/resolvers.js --runInBand > "${TMPDIR}/declared.out"
 
-    if ! grep -q 'Command:   npm run test:unit --' "${TMPDIR}/gutenberg.out"; then
-        echo "Expected Gutenberg targeted args to use test:unit" >&2
-        cat "${TMPDIR}/gutenberg.out" >&2
+    if ! grep -q 'Command:   npm run test:unit --' "${TMPDIR}/declared.out"; then
+        echo "Expected declared targeted args to use test:unit" >&2
+        cat "${TMPDIR}/declared.out" >&2
         exit 1
     fi
 
@@ -117,7 +118,7 @@ JS
     fi
 }
 
-run_gutenberg_fallback_smoke
+run_declared_targeted_script_smoke
 run_configured_script_smoke
 
 echo "nodejs targeted-script smoke passed"

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -57,16 +57,6 @@ elif [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     done <<< "$HOMEBOY_CHANGED_TEST_FILES"
 fi
 
-homeboy_node_package_value() {
-    local expression="$1"
-    PACKAGE_JSON_PATH="${PROJECT_PATH}/package.json" \
-    node -e "
-        const pkg = require(process.env.PACKAGE_JSON_PATH);
-        const value = (${expression});
-        if (typeof value === 'string' && value) console.log(value);
-    " 2>/dev/null || true
-}
-
 homeboy_node_script_command() {
     local script_name="$1"
     printf '%s --' "$(homeboy_project_run_script_command "$script_name")"
@@ -84,13 +74,6 @@ homeboy_node_targeted_test_script() {
             exit 1
         fi
         printf '%s' "$configured_script"
-        return 0
-    fi
-
-    local package_name
-    package_name="$(homeboy_node_package_value "pkg.name || ''")"
-    if [ "$package_name" = "gutenberg" ] && homeboy_has_npm_script "test:unit"; then
-        printf '%s' "test:unit"
         return 0
     fi
 

--- a/tests/architectural-boundary-contract.mjs
+++ b/tests/architectural-boundary-contract.mjs
@@ -33,7 +33,5 @@ for (const exportName of stableWpCodeboxConsumerExports) {
 
 const wordpressPackage = await import(path.join(repoRoot, 'wordpress/index.js'));
 assert.equal(typeof wordpressPackage.default.auditFanoutRuntimeProviderInterface, 'function');
-assert.equal(wordpressPackage.default.createAuditWpCodeboxFanoutPlan, undefined);
-assert.equal(wordpressPackage.default.wpCodebox?.createAuditWpCodeboxFanoutPlan, undefined);
 
 console.log('architectural boundary contract passed');

--- a/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
+++ b/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
@@ -20,16 +20,22 @@ const baseEnv = {
   PROVIDER_PLUGIN: '{}',
   PROVIDER: 'openai',
 };
+const fixtureProviderId = 'openai';
+const fixtureProviderPluginRepo = 'WordPress/ai-provider-for-openai';
+const fixtureProviderPluginTarget = '.ci/ai-provider-for-openai';
+const fixtureProviderCanonicalSecretEnv = 'OPENAI_API_KEY';
+const fixtureProviderSecretKey = 'connectors_ai_openai_api_key';
+const fixtureProviderSecretEnv = 'PROVIDER_SECRET_1';
 
 assert.deepEqual(dependencyEntries(baseEnv), []);
 assert.deepEqual(resolvePlan(dependencyEntries(baseEnv), true), []);
-assert.deepEqual(normalizeProviderPlugin('{}', 'openai', true).provider_secret_env, {});
+assert.deepEqual(normalizeProviderPlugin('{}', fixtureProviderId, true).provider_secret_env, {});
 const explicitProviderPlugin = {
-  repo: 'WordPress/ai-provider-for-openai',
+  repo: fixtureProviderPluginRepo,
   ref: 'trunk',
   path: '.',
   provider_secret_env: {
-    connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
+    [fixtureProviderSecretKey]: fixtureProviderSecretEnv,
   },
 };
 const providerPluginPlan = resolvePlan(dependencyEntries({
@@ -37,13 +43,13 @@ const providerPluginPlan = resolvePlan(dependencyEntries({
   PROVIDER_PLUGIN: JSON.stringify(explicitProviderPlugin),
 }), true, { workspace: repoRoot });
 assert.deepEqual(providerPluginPlan, [{
-  repo: 'WordPress/ai-provider-for-openai',
+  repo: fixtureProviderPluginRepo,
   ref: 'trunk',
-  target: '.ci/ai-provider-for-openai',
-  targetPath: path.join(repoRoot, '.ci', 'ai-provider-for-openai'),
+  target: fixtureProviderPluginTarget,
+  targetPath: path.join(repoRoot, fixtureProviderPluginTarget),
 }]);
-assert.deepEqual(normalizeProviderPlugin(JSON.stringify(explicitProviderPlugin), 'openai', true).provider_secret_env, {
-  connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
+assert.deepEqual(normalizeProviderPlugin(JSON.stringify(explicitProviderPlugin), fixtureProviderId, true).provider_secret_env, {
+  [fixtureProviderSecretKey]: fixtureProviderSecretEnv,
 });
 
 for (const unsafeTarget of ['.', '/tmp/foo', '../repo']) {
@@ -66,10 +72,10 @@ const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutra
 const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutral-runner-'));
 const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutral-bin-'));
 const runtime = resolveRuntimeProvider('wp-codebox', { workspace });
-assert.deepEqual(providerBenchEnvFromManifest(runtime, 'openai', {
-  OPENAI_API_KEY: 'manifest-secret-value',
-}), new Set(['OPENAI_API_KEY']));
-assert.deepEqual(providerBenchEnvFromManifest(runtime, 'openai', {}), new Set(['OPENAI_API_KEY']));
+assert.deepEqual(providerBenchEnvFromManifest(runtime, fixtureProviderId, {
+  [fixtureProviderCanonicalSecretEnv]: 'manifest-secret-value',
+}), new Set([fixtureProviderCanonicalSecretEnv]));
+assert.deepEqual(providerBenchEnvFromManifest(runtime, fixtureProviderId, {}), new Set([fixtureProviderCanonicalSecretEnv]));
 
 const config = buildConfig({
   GITHUB_WORKSPACE: workspace,
@@ -84,22 +90,22 @@ const config = buildConfig({
       id: 'local-shell-profile',
     },
   }),
-  PROVIDER: 'openai',
+  PROVIDER: fixtureProviderId,
   PROVIDER_PLUGIN: JSON.stringify(explicitProviderPlugin),
-  PROVIDER_SECRET_1: 'secret-value',
-  OPENAI_API_KEY: 'manifest-secret-value',
+  [fixtureProviderSecretEnv]: 'secret-value',
+  [fixtureProviderCanonicalSecretEnv]: 'manifest-secret-value',
 });
 
 assert.deepEqual(config.provider_secret_env_mapping, {
-  connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
+  [fixtureProviderSecretKey]: fixtureProviderSecretEnv,
 });
 assert.deepEqual(config.secret_env, [
   'GITHUB_TOKEN',
   'HOMEBOY_GITHUB_APP_TOKEN',
-  'PROVIDER_SECRET_1',
+  fixtureProviderSecretEnv,
 ]);
-assert.equal('PROVIDER_SECRET_1' in config.bench_env, false);
-assert.equal('OPENAI_API_KEY' in config.bench_env, false);
+assert.equal(fixtureProviderSecretEnv in config.bench_env, false);
+assert.equal(fixtureProviderCanonicalSecretEnv in config.bench_env, false);
 assert.equal('GITHUB_TOKEN' in config.bench_env, false);
 assert.equal('HOMEBOY_GITHUB_APP_TOKEN' in config.bench_env, false);
 assert.equal(JSON.stringify(config).includes('secret-value'), false);
@@ -118,12 +124,12 @@ const neutralConfig = buildConfig({
       id: 'local-shell-profile',
     },
   }),
-  PROVIDER: 'openai',
+  PROVIDER: fixtureProviderId,
   PROVIDER_PLUGIN: '{}',
 });
 
 assert.deepEqual(neutralConfig.provider_secret_env_mapping, {});
-assert.equal('OPENAI_API_KEY' in neutralConfig.bench_env, false);
+assert.equal(fixtureProviderCanonicalSecretEnv in neutralConfig.bench_env, false);
 assert.deepEqual(neutralConfig.secret_env, ['GITHUB_TOKEN', 'HOMEBOY_GITHUB_APP_TOKEN']);
 
 // Secret env fallbacks: the provider's canonical key is sourced from the mapped
@@ -132,12 +138,12 @@ assert.deepEqual(
   buildSecretEnvFallbacks({
     githubTokenEnv: 'HOMEBOY_GITHUB_APP_TOKEN',
     githubRepositoryTokenEnv: 'GITHUB_TOKEN',
-    providerCanonicalSecretEnvNames: ['OPENAI_API_KEY'],
-    providerCredentialSourceEnvNames: ['PROVIDER_SECRET_1'],
+    providerCanonicalSecretEnvNames: [fixtureProviderCanonicalSecretEnv],
+    providerCredentialSourceEnvNames: [fixtureProviderSecretEnv],
   }),
   {
     HOMEBOY_GITHUB_APP_TOKEN: ['GITHUB_TOKEN'],
-    OPENAI_API_KEY: ['PROVIDER_SECRET_1'],
+    [fixtureProviderCanonicalSecretEnv]: [fixtureProviderSecretEnv],
   }
 );
 
@@ -146,7 +152,7 @@ assert.deepEqual(
   buildSecretEnvFallbacks({
     githubTokenEnv: 'HOMEBOY_GITHUB_APP_TOKEN',
     githubRepositoryTokenEnv: 'GITHUB_TOKEN',
-    providerCanonicalSecretEnvNames: ['OPENAI_API_KEY'],
+    providerCanonicalSecretEnvNames: [fixtureProviderCanonicalSecretEnv],
     providerCredentialSourceEnvNames: [],
   }),
   { HOMEBOY_GITHUB_APP_TOKEN: ['GITHUB_TOKEN'] }
@@ -157,8 +163,8 @@ assert.deepEqual(
   buildSecretEnvFallbacks({
     githubTokenEnv: 'HOMEBOY_GITHUB_APP_TOKEN',
     githubRepositoryTokenEnv: 'GITHUB_TOKEN',
-    providerCanonicalSecretEnvNames: ['OPENAI_API_KEY'],
-    providerCredentialSourceEnvNames: ['OPENAI_API_KEY'],
+    providerCanonicalSecretEnvNames: [fixtureProviderCanonicalSecretEnv],
+    providerCredentialSourceEnvNames: [fixtureProviderCanonicalSecretEnv],
   }),
   { HOMEBOY_GITHUB_APP_TOKEN: ['GITHUB_TOKEN'] }
 );

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -11,7 +11,6 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const workspace = path.join(rootDir, 'fixture-workspace');
 const {
 	DEFAULT_RUNTIME_ID,
-	normalizeRuntimeId,
 	resolveRuntimeProvider,
 	runtimeRegistry,
 } = require('../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
@@ -60,13 +59,6 @@ assert.deepEqual(runtime.executor.runtime_execution_contracts.bundle, {
 	ability_field: 'runtime_bundle_ability',
 	required_capabilities: ['agent_bundle_execution'],
 });
-
-assert.equal(normalizeRuntimeId('codebox'), 'codebox');
-assert.throws(
-	() => resolveRuntimeProvider('codebox', { repoRoot: rootDir, workspace }),
-	/Unsupported agent_runtime: codebox/,
-	'legacy codebox runtime id is not accepted'
-);
 
 const envRuntime = resolveRuntimeProvider('wp-codebox', {
 	repoRoot: rootDir,

--- a/tests/wp-codebox-artifact-contract-smoke.mjs
+++ b/tests/wp-codebox-artifact-contract-smoke.mjs
@@ -20,7 +20,6 @@ const {
   normalizeTypedArtifactEntry,
   normalizeTypedArtifacts,
   typedArtifactsFromCodeboxResult,
-  typedArtifactFileRefs,
 } = require(path.join(repoRoot, 'agent-runtimes/wp-codebox/lib/codebox-artifact-contract'));
 const {
   AGENT_TASK_REQUEST_SCHEMA,
@@ -35,8 +34,6 @@ assert.equal(artifactRoleFromCodeboxArtifact({ kind: 'codebox-patch' }, { artifa
 assert.equal(artifactRoleFromCodeboxArtifact({ path: '/tmp/files/changed-files.json' }), 'artifact');
 assert.equal(artifactRoleFromCodeboxArtifact({ path: '/tmp/files/changed-files.json' }, { allowArtifactRoleFallbackCompatibility: true }), 'changed_files');
 assert.equal(allowArtifactRoleFallbackCompatibility({}), false);
-
-assert.deepEqual(typedArtifactFileRefs({ fileRefs: [{ path: 'artifact.json' }] }), [{ path: 'artifact.json' }]);
 
 assert.deepEqual(normalizeTypedArtifactEntry('packet', {
   kind: 'json',
@@ -102,34 +99,6 @@ const projectedResult = {
 assert.equal(artifactResultEnvelopeFromCodeboxResult(projectedResult), null);
 assert.deepEqual(Object.keys(typedArtifactsFromCodeboxResult(projectedResult)), []);
 assert.equal(artifactResultEnvelopeFromCodeboxResult({ artifactResult: artifactResultEnvelope }), null);
-assert.deepEqual(typedArtifactsFromCodeboxResult({
-  artifact_result: artifactResultEnvelope,
-  metadata: {
-    agent_runtime: {
-      result: {
-        outputs: {
-          typed_artifacts: {
-            legacy: { type: 'json', payload: { old: true } },
-          },
-        },
-      },
-    },
-  },
-}).review.artifact_schema, 'example/review/v1');
-assert.equal(Object.hasOwn(typedArtifactsFromCodeboxResult({
-  artifact_result: artifactResultEnvelope,
-  metadata: {
-    agent_runtime: {
-      result: {
-        outputs: {
-          typed_artifacts: {
-            legacy: { type: 'json', payload: { old: true } },
-          },
-        },
-      },
-    },
-  },
-}), 'legacy'), false);
 
 const runtimeAccessResult = {
   artifact_result: normalizeArtifactResultEnvelope({
@@ -233,19 +202,6 @@ assert.ok(missingConceptPacketOutcome.diagnostics.some((diagnostic) => (
   diagnostic.class === 'codebox.required_typed_artifacts_missing'
     && diagnostic.message.includes('concept_packet')
 )));
-assert.deepEqual(typedArtifactsFromCodeboxResult({
-  metadata: {
-    agent_runtime: {
-      result: {
-        outputs: {
-          typed_artifacts: {
-            legacy: { type: 'json', payload: { old: true } },
-          },
-        },
-      },
-    },
-  },
-}), {});
 assert.deepEqual(normalizeCaseArtifactIndex({
   case_refs: [{
     componentId: 'component-one',

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -149,10 +149,6 @@ const {
 assert.equal(REQUIRED_RUNTIME_CONTRACT_PATHS.includes('schemas.runtimeBoundary.profile'), true);
 assert.equal(REQUIRED_RUNTIME_CONTRACT_PATHS.includes('commands.wordpressRuntime.runFuzzSuite'), true);
 assert.equal(REQUIRED_RUNTIME_CONTRACT_PATHS.includes('readiness.wordpressRuntime.schema'), true);
-// The canonical wp-codebox runtime contract dropped the legacy run-response alias
-// (Automattic/wp-codebox#1637). The loader must not require a manifest path the
-// canonical contract no longer publishes, or every real run fails validation.
-assert.equal(REQUIRED_RUNTIME_CONTRACT_PATHS.includes('schemas.agentTask.legacyRunResponse'), false);
 for (const requiredPath of REQUIRED_RUNTIME_CONTRACT_PATHS) {
   assert.equal(
     typeof requiredPath.split('.').reduce((value, key) => (value == null ? value : value[key]), canonicalManifest),
@@ -185,18 +181,6 @@ assert.deepEqual(wpCodeboxProviderRuntimeInvocationContract(), {
 });
 
 validateCanonicalRuntimeContractManifest(canonicalManifest);
-
-const runtimeContractSource = fs.readFileSync(
-  path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-runtime-contract-source.js'),
-  'utf8'
-);
-assert.deepEqual(
-  [...runtimeContractSource.matchAll(/const\s+(FALLBACK_[A-Z0-9_]+)/g)].map((match) => match[1]),
-  [],
-  'Do not carry hardcoded WP Codebox fallback contract constants; consume the public Codebox runtime contract manifest instead.'
-);
-assert.doesNotMatch(runtimeContractSource, /homeboy-extensions-fallback/);
-assert.doesNotMatch(runtimeContractSource, /\.cache\/homeboy\/wp-codebox|setupCacheCoreModuleCandidates|HOMEBOY_WP_CODEBOX_INSTALL_DIR/);
 
 assert.throws(
   () => validateCanonicalRuntimeContractManifest({


### PR DESCRIPTION
## Summary
- Deleted absence assertions for legacy runtime id rejection, dropped WP Codebox contract fallback constants, removed audit fanout export absence checks, and legacy typed-artifact exclusion checks.
- Deleted stale removed-wrapper history docs and the undocumented/static-site fanout compatibility docs with no matching code path.
- Removed the Gutenberg-specific `test:unit` fallback from the generic Node.js runner; targeted script selection now comes from declared config only.
- Replaced WPCOM/Calypso public-preview fixtures with neutral example routes and parameterized provider-specific test fixture values in the provider-neutral smoke.

## LOC
- 168 LOC deleted.
- 66 LOC added.
- Net -102 LOC.

## Verification
- `node --check tests/runtime-provider-resolver-smoke.mjs tests/wp-codebox-runtime-contract-source-smoke.mjs tests/architectural-boundary-contract.mjs tests/wp-codebox-artifact-contract-smoke.mjs managed-preview/tests/public-preview-backend-smoke.mjs tests/runtime-agent-full-run-provider-neutral-smoke.mjs` - passed.
- `bash -n nodejs/scripts/test/test-runner.sh nodejs/scripts/test/nodejs-targeted-script-smoke.sh` - passed.
- `node tests/runtime-provider-resolver-smoke.mjs && node tests/wp-codebox-runtime-contract-source-smoke.mjs && node tests/architectural-boundary-contract.mjs && node tests/wp-codebox-artifact-contract-smoke.mjs && node tests/runtime-agent-full-run-provider-neutral-smoke.mjs && node managed-preview/tests/public-preview-backend-smoke.mjs` - passed.
- `HOMEBOY_RUNTIME_RUNNER_PRELUDE=/Users/chubes/Developer/homeboy/src/core/extension/runtime/runner-prelude.sh HOMEBOY_RUNTIME_COMMAND_CAPTURE=/Users/chubes/Developer/homeboy/src/core/extension/runtime/command-capture.sh bash nodejs/scripts/test/nodejs-targeted-script-smoke.sh` - passed.
- `(cd agent-runtimes/wp-codebox && npm run test:wp-codebox-runtime-contract-source && npm run test:wp-codebox-adapter-contract)` - passed.
- `(cd wordpress && npm run test:architectural-boundary-contract)` - passed.
- `git diff --check` - passed.
- Broad `for test in tests/*.mjs; do node "$test"; done` sweep was run within the 15-minute timebox. Touched tests passed; unrelated pre-existing failures remain in `tests/generic-agent-loop-runner-smoke.mjs`, `tests/runtime-agent-full-run-secret-bridge-smoke.mjs`, `tests/wp-codebox-bundled-agents-api-smoke.mjs`, `tests/wp-codebox-callback-data-smoke.mjs`, and `tests/wp-codebox-runtime-contract-built-module-canary.mjs`.

## Left in place
- `wp_codebox_provider_plugin_paths` / `HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH` remain because they are live implementation paths in `agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js` and `agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js`, and are covered by `wordpress/tests/codebox-agent-task-executor-smoke.js` and `wordpress/tests/refactor-source-wp-codebox-smoke.js`.
- Typed artifact runtime/output handling remains because canonical `outputs.typed_artifacts` is a live shipped path across the WP Codebox adapter and tests; only legacy/absence assertions were deleted.

Part of #2156. Closes #2161. Related: #1969.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (claude-fable-5) orchestrator with GPT 5.5 coding subagent
- **Used for:** Investigation identified the targets; the subagent executed the deletions, layering fixes, and verification.