### PR TITLE
Converge shell runners on shared harness

### DIFF
--- a/go/scripts/lint-runner.sh
+++ b/go/scripts/lint-runner.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
-# shellcheck source=/dev/null
-if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
-    source "$SIDECAR_WRITER_HELPER"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
 fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../scripts/lib" && pwd)}"
+# shellcheck source=/dev/null
+source "${SHARED_LIB_DIR}/runner-harness.sh"
+# shellcheck source=/dev/null
+source "${SHARED_LIB_DIR}/lint-findings-adapter.sh"
+homeboy_runner_harness_init --sidecar-writer
 
 write_lint_findings() {
     local gofmt_file="$1"
@@ -16,13 +21,8 @@ write_lint_findings() {
         return 0
     fi
 
-    if ! type homeboy_merge_lint_findings >/dev/null 2>&1; then
-        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
-        return 1
-    fi
-
     local findings_file
-    findings_file="$(mktemp)"
+    homeboy_runner_harness_temp findings_file "homeboy-go-lint-findings.XXXXXX"
 
     python3 - "$PROJECT_PATH" "$gofmt_file" "$govet_file" "$findings_file" <<'PY'
 import hashlib
@@ -103,13 +103,11 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(findings, handle, indent=2)
     handle.write("\n")
 PY
-    homeboy_merge_lint_findings "$findings_file"
-    rm -f "$findings_file"
+    homeboy_lint_findings_merge_file "$findings_file"
 }
 
-GOFMT_FILE="$(mktemp)"
-GOVET_FILE="$(mktemp)"
-trap 'rm -f "$GOFMT_FILE" "$GOVET_FILE"' EXIT
+homeboy_runner_harness_temp GOFMT_FILE "homeboy-go-gofmt.XXXXXX"
+homeboy_runner_harness_temp GOVET_FILE "homeboy-go-vet.XXXXXX"
 
 find "$PROJECT_PATH" -name '*.go' -not -path '*/vendor/*' -not -path '*/.git/*' -print0 | while IFS= read -r -d '' file; do
     gofmt -l "$file"

--- a/go/scripts/test-runner.sh
+++ b/go/scripts/test-runner.sh
@@ -1,26 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../scripts/lib" && pwd)}"
 # shellcheck source=/dev/null
-source "$RUNNER_PRELUDE"
-homeboy_runner_init --sidecar-writer
-OUTPUT_FILE="$(mktemp)"
-trap 'rm -f "$OUTPUT_FILE"' EXIT
+source "${SHARED_LIB_DIR}/runner-harness.sh"
+# shellcheck source=/dev/null
+source "${SHARED_LIB_DIR}/test-failures-adapter.sh"
+homeboy_runner_harness_init --sidecar-writer
+homeboy_runner_harness_temp OUTPUT_FILE "homeboy-go-test.XXXXXX"
 
 set +e
 (cd "$PROJECT_PATH" && go test -json ./...) 2>&1 | tee "$OUTPUT_FILE"
 TEST_EXIT=${PIPESTATUS[0]}
 set -e
 
-if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
-    if ! type homeboy_merge_test_failures >/dev/null 2>&1; then
-        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
-        exit 1
-    fi
-    TEST_FAILURES_TMP="$(mktemp)"
+if homeboy_test_failures_enabled; then
+    homeboy_runner_harness_temp TEST_FAILURES_TMP "homeboy-go-test-failures.XXXXXX"
     python3 - "$PROJECT_PATH" "$OUTPUT_FILE" "$TEST_FAILURES_TMP" <<'PY'
 import hashlib
 import json
@@ -91,8 +91,7 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(failures, handle, indent=2)
     handle.write("\n")
 PY
-    homeboy_merge_test_failures "$TEST_FAILURES_TMP"
-    rm -f "$TEST_FAILURES_TMP"
+    homeboy_test_failures_merge_file "$TEST_FAILURES_TMP"
 fi
 
 exit "$TEST_EXIT"

--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -22,11 +22,17 @@ set -euo pipefail
 # empty unless we recognize the format."
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
-FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${SCRIPT_DIR}/../../../scripts/lib/fix-results.sh}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../../scripts/lib" && pwd)}"
+FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${SHARED_LIB_DIR}/fix-results.sh}"
 # shellcheck source=/dev/null
-source "$RUNNER_PRELUDE"
-homeboy_runner_init --bash 4 --sidecar-writer --failure-trap
+source "${SHARED_LIB_DIR}/runner-harness.sh"
+# shellcheck source=/dev/null
+source "${SHARED_LIB_DIR}/lint-findings-adapter.sh"
+homeboy_runner_harness_init --bash 4 --sidecar-writer --failure-trap
 # shellcheck source=../../../scripts/lib/fix-results.sh
 source "$FIX_RESULTS_HELPER"
 # shellcheck source=../lib/node-helpers.sh
@@ -37,10 +43,7 @@ homeboy_detect_package_manager
 FIX_MODE="${HOMEBOY_FIX_ONLY:-0}"
 FINDINGS_FILE="${HOMEBOY_LINT_FINDINGS_FILE:-${PROJECT_PATH}/.node-lint-findings.json}"
 export HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE"
-if ! type homeboy_sidecar_merge >/dev/null 2>&1; then
-    echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
-    exit 1
-fi
+homeboy_lint_findings_require_writer
 
 # Detect if eslint is available locally (vendored in node_modules) — that's
 # our preferred runner because we can ask for JSON output.
@@ -68,7 +71,7 @@ if [ -n "${HOMEBOY_NODE_LINT_COMMAND:-}" ]; then
         else
             FAILED_STEP="No typecheck script defined"
             FAILURE_OUTPUT="CI job requested typecheck, but package.json does not define scripts.typecheck. Set HOMEBOY_NODE_LINT_COMMAND to a project-specific command or add scripts.typecheck."
-            homeboy_sidecar_write lint.findings
+            homeboy_lint_findings_write_empty
             exit 1
         fi
     else
@@ -92,7 +95,7 @@ elif [ $HAS_ESLINT_CONFIG -eq 1 ]; then
         # clear message rather than silently npx-installing it.
         FAILED_STEP="eslint config found but eslint not installed"
         FAILURE_OUTPUT="Run: npm i -D eslint (or your package manager equivalent) in ${PROJECT_PATH}"
-        homeboy_sidecar_write lint.findings
+        homeboy_lint_findings_write_empty
         exit 1
     fi
 else
@@ -101,7 +104,7 @@ else
     echo "⚠ No lint surface detected (no scripts.lint, no eslint config)."
     echo "  Skipping lint — emitting empty findings."
     echo ""
-    homeboy_sidecar_write lint.findings
+    homeboy_lint_findings_write_empty
     exit 0
 fi
 
@@ -118,10 +121,10 @@ echo ""
 
 cd "$PROJECT_PATH"
 
-OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-node-lint.XXXXXX")
+homeboy_runner_harness_temp OUTPUT_FILE "homeboy-node-lint.XXXXXX"
 FIX_BEFORE=""
 if [ "$FIX_MODE" = "1" ]; then
-    FIX_BEFORE=$(mktemp "${TMPDIR:-/tmp}/homeboy-node-lint-before.XXXXXX")
+    homeboy_runner_harness_temp FIX_BEFORE "homeboy-node-lint-before.XXXXXX"
     homeboy_fix_results_capture "$FIX_BEFORE" "$PROJECT_PATH"
 fi
 set +e
@@ -139,7 +142,6 @@ set -e
 
 if [ "$FIX_MODE" = "1" ] && [ -n "$FIX_BEFORE" ]; then
     homeboy_fix_results_append_changed "nodejs_lint" "rewrite" "$FIX_BEFORE" "" "$PROJECT_PATH"
-    rm -f "$FIX_BEFORE"
     homeboy_fix_results_write
 fi
 
@@ -152,7 +154,7 @@ if [ $USE_ESLINT_JSON -eq 1 ] && [ -s "$OUTPUT_FILE" ]; then
     # only if HOMEBOY_LINT_INCLUDE_WARNINGS=1 (matches Rust extension's
     # ratchet-friendly default).
     INCLUDE_WARNINGS="${HOMEBOY_LINT_INCLUDE_WARNINGS:-0}"
-    FINDINGS_TMP="$(mktemp)"
+    homeboy_runner_harness_temp FINDINGS_TMP "homeboy-node-lint-findings.XXXXXX"
     node - "$OUTPUT_FILE" "$FINDINGS_TMP" "$INCLUDE_WARNINGS" "$PROJECT_PATH" <<'NODEJS'
 const crypto = require('node:crypto');
 const fs = require('node:fs');
@@ -234,14 +236,11 @@ for (const file of report) {
 
 fs.writeFileSync(outputFile, JSON.stringify(findings, null, 2));
 NODEJS
-    homeboy_sidecar_merge lint.findings "$FINDINGS_TMP"
-    rm -f "$FINDINGS_TMP"
+    homeboy_lint_findings_merge_file "$FINDINGS_TMP"
 else
     # Unknown runner output — emit empty findings, rely on exit code.
-    homeboy_sidecar_write lint.findings
+    homeboy_lint_findings_write_empty
 fi
-
-rm -f "$OUTPUT_FILE"
 
 if [ "$FIX_MODE" = "1" ]; then
     # In fix mode the engine runs validation separately. Just report exit.

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -28,16 +28,20 @@ set -euo pipefail
 #   HOMEBOY_DEBUG                — verbose
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
-COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:?HOMEBOY_RUNTIME_COMMAND_CAPTURE is required}"
-SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../../../scripts/lib/settings.sh}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../../scripts/lib" && pwd)}"
+SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SHARED_LIB_DIR}/settings.sh}"
 # shellcheck source=/dev/null
-source "$RUNNER_PRELUDE"
-homeboy_runner_init --bash 4 --sidecar-writer --failure-trap
+source "${SHARED_LIB_DIR}/runner-harness.sh"
+# shellcheck source=/dev/null
+source "${SHARED_LIB_DIR}/test-failures-adapter.sh"
+homeboy_runner_harness_init --bash 4 --sidecar-writer --failure-trap
 # shellcheck source=/dev/null
 source "$SETTINGS_HELPER"
-# shellcheck source=/dev/null
-source "$COMMAND_CAPTURE_HELPER"
+homeboy_runner_harness_source_command_capture
 # shellcheck source=../lib/node-helpers.sh
 source "${SCRIPT_DIR}/../lib/node-helpers.sh"
 homeboy_require_package_json
@@ -153,39 +157,8 @@ extract_vitest_failure_line() {
 write_node_failure_json() {
     [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] || return 0
     [ -n "$FAILED_TEST_NAME" ] || return 0
-    if ! type homeboy_sidecar_emit >/dev/null 2>&1; then
-        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
-        return 1
-    fi
-
-    FAILURE_JSON="$(HOMEBOY_NODE_TEST_OUTPUT="$OUTPUT" node - "$FAILED_TEST_NAME" "$FAILED_TEST_FILE" "$FAILED_ERROR_TYPE" "$FAILED_MESSAGE" <<'JS'
-const crypto = require('node:crypto');
-
-const [testName, testFile, errorType, message] = process.argv.slice(2);
-const stdout = process.env.HOMEBOY_NODE_TEST_OUTPUT || '';
-const fingerprintInput = [testName, testFile, errorType, message].join('\0');
-const fingerprint = crypto.createHash('sha256').update(fingerprintInput).digest('hex');
-const stdoutExcerpt = stdout.split(/\r?\n/).slice(-40).join('\n');
-
-console.log(JSON.stringify({
-  test_name: testName,
-  test_file: testFile,
-  error_type: errorType,
-  test_id: testName,
-  suite: '',
-  file: testFile,
-  line: 0,
-  message,
-  failure_type: errorType,
-  fingerprint,
-  stdout_excerpt: stdoutExcerpt,
-  stderr_excerpt: '',
-  source_file: testFile,
-  source_line: 0
-}));
-JS
-)"
-    homeboy_sidecar_emit test.failure "$FAILURE_JSON"
+    FAILURE_JSON="$(homeboy_test_failure_record_json nodejs "$FAILED_TEST_NAME" "" "$FAILED_TEST_FILE" 0 "$FAILED_MESSAGE" "$FAILED_ERROR_TYPE" "$(printf '%s' "$OUTPUT" | tail -40)" "")"
+    homeboy_test_failure_emit_record_json "$FAILURE_JSON"
 }
 
 # Vitest summary lines look like:

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -23,14 +23,19 @@ set -euo pipefail
 #   HOMEBOY_FIX_RESULTS_FILE — JSON sidecar receiving applied fix records
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:?HOMEBOY_RUNTIME_COMMAND_CAPTURE is required}"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
-FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${SCRIPT_DIR}/../../scripts/lib/fix-results.sh}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../scripts/lib" && pwd)}"
+FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${SHARED_LIB_DIR}/fix-results.sh}"
 # shellcheck source=/dev/null
-source "$RUNNER_PRELUDE"
-homeboy_runner_init --steps --failure-trap --sidecar-writer
+source "${SHARED_LIB_DIR}/runner-harness.sh"
 # shellcheck source=/dev/null
-source "${COMMAND_CAPTURE_HELPER}"
+source "${SHARED_LIB_DIR}/lint-findings-adapter.sh"
+homeboy_runner_harness_init --steps --failure-trap --sidecar-writer
+# shellcheck source=/dev/null
+homeboy_runner_harness_source_command_capture
 # shellcheck source=../../scripts/lib/fix-results.sh
 source "$FIX_RESULTS_HELPER"
 
@@ -78,13 +83,8 @@ write_lint_findings_from_output() {
         return 0
     fi
 
-    if ! type homeboy_sidecar_merge >/dev/null 2>&1; then
-        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
-        return 1
-    fi
-
     local findings_file
-    findings_file="$(mktemp)"
+    homeboy_runner_harness_temp findings_file "homeboy-rust-lint-findings.XXXXXX"
 
     python3 - "$PROJECT_PATH" "$tool" "$output_file" "$findings_file" <<'PY'
 import hashlib
@@ -179,8 +179,7 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(findings, handle, indent=2)
     handle.write("\n")
 PY
-    homeboy_sidecar_merge lint.findings "$findings_file"
-    rm -f "$findings_file"
+    homeboy_lint_findings_merge_file "$findings_file"
 }
 
 trap write_fix_results_sidecar EXIT

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -17,14 +17,19 @@ set -euo pipefail
 # Passthrough args after -- are forwarded to cargo test.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:?HOMEBOY_RUNTIME_COMMAND_CAPTURE is required}"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
-SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../../scripts/lib/settings.sh}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../scripts/lib" && pwd)}"
+SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SHARED_LIB_DIR}/settings.sh}"
 # shellcheck source=/dev/null
-source "$RUNNER_PRELUDE"
-homeboy_runner_init --steps --failure-trap --sidecar-writer
+source "${SHARED_LIB_DIR}/runner-harness.sh"
 # shellcheck source=/dev/null
-source "${COMMAND_CAPTURE_HELPER}"
+source "${SHARED_LIB_DIR}/test-failures-adapter.sh"
+homeboy_runner_harness_init --steps --failure-trap --sidecar-writer
+# shellcheck source=/dev/null
+homeboy_runner_harness_source_command_capture
 # shellcheck source=../../scripts/lib/settings.sh
 source "${SETTINGS_HELPER}"
 
@@ -388,12 +393,8 @@ else
         echo "$SUMMARY"
     fi
 
-    if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
-        if ! type homeboy_sidecar_merge >/dev/null 2>&1; then
-            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
-            exit 1
-        fi
-        TEST_FAILURES_TMP="$(mktemp)"
+    if homeboy_test_failures_enabled; then
+        homeboy_runner_harness_temp TEST_FAILURES_TMP "homeboy-rust-test-failures.XXXXXX"
         python3 - "$PROJECT_PATH" "$TEST_TMPFILE" "$TEST_FAILURES_TMP" <<'PY'
 import hashlib
 import json
@@ -451,8 +452,7 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(failures, handle, indent=2)
     handle.write("\n")
 PY
-        homeboy_sidecar_merge test.failures "$TEST_FAILURES_TMP"
-        rm -f "$TEST_FAILURES_TMP"
+        homeboy_test_failures_merge_file "$TEST_FAILURES_TMP"
     fi
 
     FAILED_STEP="$COMMAND_LABEL"

--- a/scripts/lib/lint-findings-adapter.sh
+++ b/scripts/lib/lint-findings-adapter.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Shared lint-findings sidecar adapter helpers.
+
+homeboy_lint_findings_enabled() {
+    [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]
+}
+
+homeboy_lint_findings_merge_file() {
+    local findings_file="$1"
+    [ -f "$findings_file" ] || return 0
+
+    if type homeboy_sidecar_merge >/dev/null 2>&1; then
+        homeboy_sidecar_merge lint.findings "$findings_file"
+        return $?
+    fi
+
+    if type homeboy_merge_lint_findings >/dev/null 2>&1; then
+        homeboy_merge_lint_findings "$findings_file"
+        return $?
+    fi
+
+    if type homeboy_sidecar_merge_json_array >/dev/null 2>&1; then
+        homeboy_sidecar_merge_json_array "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$findings_file"
+        return $?
+    fi
+
+    echo "Warning: sidecar writer unavailable (HOMEBOY_RUNTIME_SIDECAR_WRITER unset); skipping lint findings sidecar" >&2
+    return 0
+}
+
+homeboy_lint_findings_require_writer() {
+    if type homeboy_sidecar_merge >/dev/null 2>&1 || type homeboy_merge_lint_findings >/dev/null 2>&1 || type homeboy_sidecar_merge_json_array >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
+    return 1
+}
+
+homeboy_lint_findings_write_empty() {
+    if type homeboy_sidecar_write >/dev/null 2>&1; then
+        homeboy_sidecar_write lint.findings
+        return $?
+    fi
+
+    if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
+        printf '[]\n' > "$HOMEBOY_LINT_FINDINGS_FILE"
+    fi
+}

--- a/scripts/lib/runner-harness.sh
+++ b/scripts/lib/runner-harness.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Shared shell-runner harness helpers for extension wrappers.
+
+homeboy_runner_harness_init() {
+    local prelude="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-}"
+    if [ -z "$prelude" ]; then
+        local repo_root
+        repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+        prelude="${repo_root}/../homeboy/src/core/extension/runtime/runner-prelude.sh"
+    fi
+    if [ ! -f "$prelude" ]; then
+        echo "Error: HOMEBOY_RUNTIME_RUNNER_PRELUDE is required" >&2
+        return 1
+    fi
+    # shellcheck source=/dev/null
+    source "$prelude"
+    homeboy_runner_init "$@"
+}
+
+homeboy_runner_harness_source_command_capture() {
+    local helper="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-}"
+    if [ -z "$helper" ]; then
+        local repo_root
+        repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+        helper="${repo_root}/../homeboy/src/core/extension/runtime/command-capture.sh"
+    fi
+    if [ ! -f "$helper" ]; then
+        echo "Error: HOMEBOY_RUNTIME_COMMAND_CAPTURE is required" >&2
+        return 1
+    fi
+    # shellcheck source=/dev/null
+    source "$helper"
+}
+
+homeboy_runner_harness_source_if_file() {
+    local helper="$1"
+    if [ -n "$helper" ] && [ -f "$helper" ]; then
+        # shellcheck source=/dev/null
+        source "$helper"
+    fi
+}
+
+homeboy_runner_harness_mktemp() {
+    local template="${1:-homeboy-runner.XXXXXX}"
+    local tmpdir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"
+
+    if [ -d "$tmpdir" ] && [ -w "$tmpdir" ]; then
+        mktemp "${tmpdir%/}/${template}" 2>/dev/null && return 0
+    fi
+
+    mktemp 2>/dev/null
+}
+
+homeboy_runner_harness_register_cleanup() {
+    local path="$1"
+    [ -n "$path" ] || return 0
+    HOMEBOY_RUNNER_HARNESS_CLEANUP="${HOMEBOY_RUNNER_HARNESS_CLEANUP:-}${HOMEBOY_RUNNER_HARNESS_CLEANUP:+$'\n'}$path"
+    if [ "${HOMEBOY_RUNNER_HARNESS_TRAP_SET:-0}" != "1" ]; then
+        trap 'homeboy_runner_harness_cleanup' EXIT
+        HOMEBOY_RUNNER_HARNESS_TRAP_SET=1
+    fi
+}
+
+homeboy_runner_harness_temp() {
+    local __var_name="$1"
+    local template="${2:-homeboy-runner.XXXXXX}"
+    local __tmp
+    __tmp="$(homeboy_runner_harness_mktemp "$template")"
+    printf -v "$__var_name" '%s' "$__tmp"
+    homeboy_runner_harness_register_cleanup "$__tmp"
+}
+
+homeboy_runner_harness_cleanup() {
+    local path
+    while IFS= read -r path; do
+        [ -n "$path" ] && rm -f "$path"
+    done <<EOF
+${HOMEBOY_RUNNER_HARNESS_CLEANUP:-}
+EOF
+}
+
+homeboy_runner_harness_note_failure() {
+    local label="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -ne 0 ]; then
+        FAILED_STEP="${label} (exit ${exit_code})"
+    fi
+}

--- a/scripts/lib/test-failures-adapter.sh
+++ b/scripts/lib/test-failures-adapter.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared test-failure sidecar adapter helpers.
+
+homeboy_test_failures_enabled() {
+    [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]
+}
+
+homeboy_test_failures_require_writer() {
+    if type homeboy_merge_test_failures >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
+    return 1
+}
+
+homeboy_test_failures_merge_file() {
+    local failures_file="$1"
+    homeboy_test_failures_enabled || return 0
+    [ -f "$failures_file" ] || return 0
+    homeboy_test_failures_require_writer || return 1
+    homeboy_merge_test_failures "$failures_file"
+}
+
+homeboy_test_failure_record_json() {
+    local namespace="$1"
+    local test_id="$2"
+    local suite="$3"
+    local file="$4"
+    local line="$5"
+    local message="$6"
+    local failure_type="$7"
+    local stdout_excerpt="${8:-}"
+    local stderr_excerpt="${9:-}"
+
+    node - "$namespace" "$test_id" "$suite" "$file" "$line" "$message" "$failure_type" "$stdout_excerpt" "$stderr_excerpt" <<'NODE'
+const crypto = require('node:crypto');
+const [namespace, testId, suite, file, line, message, failureType, stdoutExcerpt, stderrExcerpt] = process.argv.slice(2);
+const fingerprintInput = [namespace, testId, suite, file, line, message, failureType].join('\0');
+const sourceLine = line === '' ? null : Number(line || 0);
+const record = {
+  test_id: testId,
+  test_name: testId,
+  suite: suite || null,
+  file: file || null,
+  test_file: file || null,
+  line: sourceLine,
+  message,
+  failure_type: failureType || 'test_failure',
+  error_type: failureType || 'test_failure',
+  fingerprint: crypto.createHash('sha256').update(fingerprintInput).digest('hex'),
+  stdout_excerpt: stdoutExcerpt || '',
+  stderr_excerpt: stderrExcerpt || '',
+  source_file: file || null,
+  source_line: sourceLine,
+};
+console.log(JSON.stringify(record));
+NODE
+}
+
+homeboy_test_failure_emit_record_json() {
+    local failure_json="$1"
+    homeboy_test_failures_enabled || return 0
+    if ! type homeboy_sidecar_emit >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
+        return 1
+    fi
+    homeboy_sidecar_emit test.failure "$failure_json"
+}

--- a/swift/scripts/lint-runner.sh
+++ b/swift/scripts/lint-runner.sh
@@ -2,15 +2,25 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:?HOMEBOY_RUNTIME_RESOLVE_CONTEXT is required}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../scripts/lib" && pwd)}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
-source "$RESOLVE_CONTEXT_HELPER"
-homeboy_resolve_context
+source "${SHARED_LIB_DIR}/runner-harness.sh"
 # shellcheck source=/dev/null
-if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
-    source "$SIDECAR_WRITER_HELPER"
+source "${SHARED_LIB_DIR}/lint-findings-adapter.sh"
+if [ -n "$RESOLVE_CONTEXT_HELPER" ]; then
+    # shellcheck source=/dev/null
+    source "$RESOLVE_CONTEXT_HELPER"
+    homeboy_resolve_context
+else
+    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
 fi
+homeboy_runner_harness_source_if_file "$SIDECAR_WRITER_HELPER"
 
 echo "Running Swift lint for: $(basename "$COMPONENT_PATH")"
 
@@ -21,13 +31,8 @@ write_swiftlint_findings() {
         return 0
     fi
 
-    if ! type homeboy_merge_lint_findings >/dev/null 2>&1; then
-        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
-        return 1
-    fi
-
     local findings_file
-    findings_file="$(mktemp)"
+    homeboy_runner_harness_temp findings_file "homeboy-swift-lint-findings.XXXXXX"
 
     python3 - "$COMPONENT_PATH" "$input_file" "$findings_file" <<'PY'
 import hashlib
@@ -88,13 +93,11 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(findings, handle, indent=2)
     handle.write("\n")
 PY
-    homeboy_merge_lint_findings "$findings_file"
-    rm -f "$findings_file"
+    homeboy_lint_findings_merge_file "$findings_file"
 }
 
 if command -v swiftlint >/dev/null 2>&1; then
-    SWIFTLINT_JSON="$(mktemp)"
-    trap 'rm -f "$SWIFTLINT_JSON"' EXIT
+    homeboy_runner_harness_temp SWIFTLINT_JSON "homeboy-swiftlint.XXXXXX"
     set +e
     swiftlint lint --path "$COMPONENT_PATH" --reporter json > "$SWIFTLINT_JSON"
     SWIFTLINT_EXIT=$?

--- a/swift/scripts/test-runner.sh
+++ b/swift/scripts/test-runner.sh
@@ -2,10 +2,16 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../scripts/lib" && pwd)}"
 # shellcheck source=/dev/null
-source "$RUNNER_PRELUDE"
-homeboy_runner_init --component-alias COMPONENT_PATH --sidecar-writer
+source "${SHARED_LIB_DIR}/runner-harness.sh"
+# shellcheck source=/dev/null
+source "${SHARED_LIB_DIR}/test-failures-adapter.sh"
+homeboy_runner_harness_init --component-alias COMPONENT_PATH --sidecar-writer
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -48,8 +54,7 @@ if [ "$TEST_TYPE" = "xcodebuild" ]; then
     WORKSPACE=$(find "$COMPONENT_PATH" -maxdepth 1 -name "*.xcworkspace" | head -1)
     PROJECT=$(find "$COMPONENT_PATH" -maxdepth 1 -name "*.xcodeproj" | head -1)
 
-    XCODE_OUTPUT="$(mktemp)"
-    trap 'rm -f "$XCODE_OUTPUT"' EXIT
+    homeboy_runner_harness_temp XCODE_OUTPUT "homeboy-swift-xcode.XXXXXX"
     if [ -n "$WORKSPACE" ]; then
         set +e
         xcodebuild test -workspace "$WORKSPACE" -scheme "$(basename "$WORKSPACE" .xcworkspace)" -destination 'platform=macOS' "$@" 2>&1 | tee "$XCODE_OUTPUT"
@@ -65,12 +70,8 @@ if [ "$TEST_TYPE" = "xcodebuild" ]; then
         exit 1
     fi
 
-    if [ "$XCODE_EXIT" -ne 0 ] && [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
-        if ! type homeboy_merge_test_failures >/dev/null 2>&1; then
-            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
-            exit 1
-        fi
-        TEST_FAILURES_TMP="$(mktemp)"
+    if [ "$XCODE_EXIT" -ne 0 ] && homeboy_test_failures_enabled; then
+        homeboy_runner_harness_temp TEST_FAILURES_TMP "homeboy-swift-xcode-failures.XXXXXX"
         python3 - "$COMPONENT_PATH" "$XCODE_OUTPUT" "$TEST_FAILURES_TMP" <<'PY'
 import hashlib
 import json
@@ -121,17 +122,15 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(failures, handle, indent=2)
     handle.write("\n")
 PY
-        homeboy_merge_test_failures "$TEST_FAILURES_TMP"
-        rm -f "$TEST_FAILURES_TMP"
+        homeboy_test_failures_merge_file "$TEST_FAILURES_TMP"
     fi
     exit "$XCODE_EXIT"
 else
     # Script mode - run .swift files directly
     TESTS_RUN=0
     TESTS_FAILED=0
-    FAILURES_FILE="$(mktemp)"
+    homeboy_runner_harness_temp FAILURES_FILE "homeboy-swift-script-failures.XXXXXX"
     : > "$FAILURES_FILE"
-    trap 'rm -f "$FAILURES_FILE"' EXIT
 
     for test_file in "$TEST_DIR"/*.swift; do
         if [ -f "$test_file" ]; then
@@ -139,7 +138,7 @@ else
             TEST_NAME=$(basename "$test_file")
             echo "Running: $TEST_NAME"
 
-            TEST_OUTPUT="$(mktemp)"
+            homeboy_runner_harness_temp TEST_OUTPUT "homeboy-swift-script-output.XXXXXX"
             if swift "$test_file" "$TEST_DIR" > "$TEST_OUTPUT" 2>&1; then
                 cat "$TEST_OUTPUT"
                 echo "  PASS"
@@ -162,12 +161,8 @@ else
     echo "Results: $((TESTS_RUN - TESTS_FAILED))/$TESTS_RUN tests passed"
 
     if [ $TESTS_FAILED -gt 0 ]; then
-        if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
-            if ! type homeboy_merge_test_failures >/dev/null 2>&1; then
-                echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
-                exit 1
-            fi
-            TEST_FAILURES_TMP="$(mktemp)"
+        if homeboy_test_failures_enabled; then
+            homeboy_runner_harness_temp TEST_FAILURES_TMP "homeboy-swift-script-failures-json.XXXXXX"
             python3 - "$FAILURES_FILE" "$TEST_FAILURES_TMP" <<'PY'
 import hashlib
 import json
@@ -202,8 +197,7 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(failures, handle, indent=2)
     handle.write("\n")
 PY
-            homeboy_merge_test_failures "$TEST_FAILURES_TMP"
-            rm -f "$TEST_FAILURES_TMP"
+            homeboy_test_failures_merge_file "$TEST_FAILURES_TMP"
         fi
         while IFS=$'\t' read -r _ output_path; do
             [ -n "$output_path" ] && rm -f "$output_path"

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -59,6 +59,24 @@ assert_sources() {
     fi
 }
 
+assert_sources_prelude() {
+    local file="$1"
+    if ! grep -Fq 'HOMEBOY_RUNTIME_RUNNER_PRELUDE' "$file" \
+        && ! grep -Fq '/runner-harness.sh' "$file"; then
+        echo "Expected $file to load the runner prelude directly (HOMEBOY_RUNTIME_RUNNER_PRELUDE) or via the shared runner-harness.sh" >&2
+        exit 1
+    fi
+}
+
+assert_sources_command_capture() {
+    local file="$1"
+    if ! grep -Fq 'HOMEBOY_RUNTIME_COMMAND_CAPTURE' "$file" \
+        && ! grep -Fq 'homeboy_runner_harness_source_command_capture' "$file"; then
+        echo "Expected $file to load command capture directly (HOMEBOY_RUNTIME_COMMAND_CAPTURE) or via the shared harness" >&2
+        exit 1
+    fi
+}
+
 assert_file "$FAILURE_TRAP_HELPER"
 assert_file "$WRITE_TEST_RESULTS_HELPER"
 assert_file "$SIDECAR_WRITER_HELPER"
@@ -380,7 +398,7 @@ for runner in \
     swift/scripts/test-runner.sh \
     wordpress/scripts/lint/lint-runner.sh \
     wordpress/scripts/test/test-runner.sh; do
-    assert_sources "$ROOT_DIR/$runner" 'HOMEBOY_RUNTIME_RUNNER_PRELUDE'
+    assert_sources_prelude "$ROOT_DIR/$runner"
 done
 
 for runner in \
@@ -415,7 +433,7 @@ for runner in \
     nodejs/scripts/test/test-runner.sh \
     rust/scripts/lint-runner.sh \
     rust/scripts/test-runner.sh; do
-    assert_sources "$ROOT_DIR/$runner" 'HOMEBOY_RUNTIME_COMMAND_CAPTURE'
+    assert_sources_command_capture "$ROOT_DIR/$runner"
 done
 
 for runner in \
@@ -423,14 +441,14 @@ for runner in \
     rust/scripts/bench/bench-runner.sh \
     rust/scripts/test-runner.sh \
     wordpress/scripts/test/test-runner.sh; do
-    assert_sources "$ROOT_DIR/$runner" 'scripts/lib/settings.sh'
+    assert_sources "$ROOT_DIR/$runner" '/settings.sh'
 done
 
 for runner in \
     nodejs/scripts/lint/lint-runner.sh \
     rust/scripts/lint-runner.sh \
     wordpress/scripts/lint/lint-runner.sh; do
-    assert_sources "$ROOT_DIR/$runner" 'scripts/lib/fix-results.sh'
+    assert_sources "$ROOT_DIR/$runner" '/fix-results.sh'
 done
 
 echo "runtime helper smoke passed"

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -16,6 +16,9 @@ PROJECT_SCRIPTS_HELPER="${ROOT_DIR}/scripts/lib/project-scripts.sh"
 FIX_RESULTS_HELPER="${ROOT_DIR}/scripts/lib/fix-results.sh"
 BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
 SETTINGS_HELPER="${ROOT_DIR}/scripts/lib/settings.sh"
+RUNNER_HARNESS_HELPER="${ROOT_DIR}/scripts/lib/runner-harness.sh"
+TEST_FAILURES_ADAPTER_HELPER="${ROOT_DIR}/scripts/lib/test-failures-adapter.sh"
+LINT_FINDINGS_ADAPTER_HELPER="${ROOT_DIR}/scripts/lib/lint-findings-adapter.sh"
 
 assert_file() {
     local path="$1"
@@ -73,6 +76,12 @@ assert_file "$FIX_RESULTS_HELPER"
 bash -c 'source "$1"; type homeboy_fix_results_capture >/dev/null; type homeboy_fix_results_append_changed >/dev/null; type homeboy_fix_results_write >/dev/null' _ "$FIX_RESULTS_HELPER"
 assert_file "$SETTINGS_HELPER"
 bash -c 'source "$1"; type homeboy_setting >/dev/null; type homeboy_setting_bool >/dev/null; type homeboy_setting_array >/dev/null' _ "$SETTINGS_HELPER"
+assert_file "$RUNNER_HARNESS_HELPER"
+bash -c 'source "$1"; type homeboy_runner_harness_init >/dev/null; type homeboy_runner_harness_temp >/dev/null; type homeboy_runner_harness_source_command_capture >/dev/null' _ "$RUNNER_HARNESS_HELPER"
+assert_file "$TEST_FAILURES_ADAPTER_HELPER"
+bash -c 'source "$1"; type homeboy_test_failures_merge_file >/dev/null; type homeboy_test_failure_record_json >/dev/null; type homeboy_test_failure_emit_record_json >/dev/null' _ "$TEST_FAILURES_ADAPTER_HELPER"
+assert_file "$LINT_FINDINGS_ADAPTER_HELPER"
+bash -c 'source "$1"; type homeboy_lint_findings_merge_file >/dev/null; type homeboy_lint_findings_write_empty >/dev/null; type homeboy_lint_findings_require_writer >/dev/null' _ "$LINT_FINDINGS_ADAPTER_HELPER"
 bash -c 'source "$1"; type homeboy_run_step >/dev/null; type homeboy_run_step_capture >/dev/null; type homeboy_cleanup_step_capture >/dev/null' _ "$COMMAND_CAPTURE_CORE_HELPER"
 
 # Single-source guarantee: extension-owned shared libs (settings, fix-results,
@@ -140,6 +149,12 @@ assert_resolves nodejs/scripts/lint    ../../../scripts/lib/fix-results.sh      
 assert_resolves rust/scripts           ../../scripts/lib/fix-results.sh         "$FIX_RESULTS_HELPER"
 assert_resolves wordpress/scripts/lint ../../../scripts/lib/fix-results.sh      "$FIX_RESULTS_HELPER"
 assert_resolves nodejs/scripts/lib     ../../../scripts/lib/project-scripts.sh  "$PROJECT_SCRIPTS_HELPER"
+assert_resolves go/scripts             ../../scripts/lib/runner-harness.sh      "$RUNNER_HARNESS_HELPER"
+assert_resolves rust/scripts           ../../scripts/lib/runner-harness.sh      "$RUNNER_HARNESS_HELPER"
+assert_resolves swift/scripts          ../../scripts/lib/runner-harness.sh      "$RUNNER_HARNESS_HELPER"
+assert_resolves nodejs/scripts/test    ../../../scripts/lib/runner-harness.sh   "$RUNNER_HARNESS_HELPER"
+assert_resolves nodejs/scripts/lint    ../../../scripts/lib/lint-findings-adapter.sh "$LINT_FINDINGS_ADAPTER_HELPER"
+assert_resolves wordpress/scripts/lint ../../../scripts/lib/lint-findings-adapter.sh "$LINT_FINDINGS_ADAPTER_HELPER"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -212,6 +227,22 @@ assert_contains "$SIDECAR_TMP_DIR/lint.json" '"id":"lint"'
 assert_contains "$SIDECAR_TMP_DIR/test.json" '"test_id":"test"'
 assert_contains "$SIDECAR_TMP_DIR/fix.json" '"file":"fixed.php"'
 assert_contains "$SIDECAR_TMP_DIR/annotations/phpcs.json" '"file":"plugin.php"'
+
+HARNESS_TEMP=""
+source "$RUNNER_HARNESS_HELPER"
+homeboy_runner_harness_temp HARNESS_TEMP "homeboy-harness-smoke.XXXXXX"
+if [ ! -f "$HARNESS_TEMP" ]; then
+    echo "Expected harness temp helper to create a file" >&2
+    exit 1
+fi
+homeboy_runner_harness_cleanup
+if [ -e "$HARNESS_TEMP" ]; then
+    echo "Expected harness cleanup to remove temp file" >&2
+    exit 1
+fi
+
+FAILURE_RECORD="$(source "$TEST_FAILURES_ADAPTER_HELPER"; homeboy_test_failure_record_json smoke 'suite::test' suite tests/smoke.test 12 'failed hard' assertion 'stdout tail' '')"
+printf '%s' "$FAILURE_RECORD" | node -e 'const fs=require("node:fs"); const record=JSON.parse(fs.readFileSync(0,"utf8")); if (record.test_id!=="suite::test" || record.file!=="tests/smoke.test" || record.line!==12 || !/^[a-f0-9]{64}$/.test(record.fingerprint)) process.exit(1);'
 
 WORDPRESS_OUTPUT="$TMP_DIR/phpunit.txt"
 WORDPRESS_RESULTS="$TMP_DIR/wordpress-results.json"

--- a/tests/wordpress-lint-context-smoke.sh
+++ b/tests/wordpress-lint-context-smoke.sh
@@ -90,7 +90,7 @@ HOMEBOY_STEP="none" \
 
 assert_contains "$TMP_DIR/lint.out" "Linting passed"
 
-assert_contains "$RUNNER" 'homeboy_runner_init --bash 4 --steps --sidecar-writer --component-alias PLUGIN_PATH'
+assert_contains "$RUNNER" 'homeboy_runner_harness_init --bash 4 --steps --sidecar-writer --component-alias PLUGIN_PATH'
 assert_contains "$RUNNER" "*/vendor_prefixed/*"
 assert_contains "$RUNNER" "*/tools/*"
 assert_contains "$RUNNER" "*/scoper.inc.php"

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -21,19 +21,30 @@ fi
 
 # Resolve execution context (shared helper)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:?HOMEBOY_RUNTIME_RESOLVE_CONTEXT is required}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../../scripts/lib" && pwd)}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-}"
 # Homeboy core provides the sidecar writer via HOMEBOY_RUNTIME_SIDECAR_WRITER.
 # When it is genuinely unavailable, the findings/annotation sidecar writes
 # below degrade to no-ops — they are observability output, not lint results, so
 # they must never fail the lint gate (homeboy-extensions#1402).
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
-source "${RESOLVE_CONTEXT_HELPER}"
-homeboy_resolve_context --component-alias PLUGIN_PATH
+source "${SHARED_LIB_DIR}/runner-harness.sh"
 # shellcheck source=/dev/null
-if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
-    source "$SIDECAR_WRITER_HELPER"
+source "${SHARED_LIB_DIR}/lint-findings-adapter.sh"
+if [ -n "$RESOLVE_CONTEXT_HELPER" ]; then
+    # shellcheck source=/dev/null
+    source "${RESOLVE_CONTEXT_HELPER}"
+    homeboy_resolve_context --component-alias PLUGIN_PATH
+else
+    PLUGIN_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
 fi
+homeboy_runner_harness_source_if_file "$SIDECAR_WRITER_HELPER"
 
 write_eslint_findings_sidecar() {
     local target="$1"
@@ -42,16 +53,11 @@ write_eslint_findings_sidecar() {
     [ -z "$target" ] && return 0
     [ ! -s "$source" ] && return 0
 
-    if ! type homeboy_sidecar_merge_json_array >/dev/null 2>&1; then
-        # The findings sidecar is Homeboy observability output, not a result.
-        # Skip writing it when the writer is unavailable rather than failing the
-        # lint step (homeboy-extensions#1402).
-        echo "Warning: sidecar writer unavailable; skipping ESLint lint findings sidecar" >&2
-        return 0
-    fi
-
     rm -f "$target"
-    homeboy_sidecar_merge_json_array "$target" "$source"
+    local previous_target="${HOMEBOY_LINT_FINDINGS_FILE:-}"
+    HOMEBOY_LINT_FINDINGS_FILE="$target"
+    homeboy_lint_findings_merge_file "$source"
+    HOMEBOY_LINT_FINDINGS_FILE="$previous_target"
 }
 
 # Check if component has JavaScript files
@@ -207,7 +213,7 @@ set -e
 # and PHPStan findings. Direct ESLint runs may write HOMEBOY_LINT_FINDINGS_FILE.
 ESLINT_FINDINGS_FILE="${_HOMEBOY_ESLINT_FINDINGS_FILE:-${HOMEBOY_LINT_FINDINGS_FILE:-}}"
 if [ -n "$ESLINT_FINDINGS_FILE" ] && [ -n "$json_output" ] && command -v node &> /dev/null; then
-    ESLINT_FINDINGS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-eslint-findings.XXXXXX")
+    homeboy_runner_harness_temp ESLINT_FINDINGS_TMPFILE "homeboy-eslint-findings.XXXXXX"
     node -e '
         const fs = require("fs");
         const path = require("path");
@@ -261,7 +267,6 @@ if [ -n "$ESLINT_FINDINGS_FILE" ] && [ -n "$json_output" ] && command -v node &>
     ' "$json_output" "$PLUGIN_PATH" "$ESLINT_FINDINGS_TMPFILE" 2>/dev/null || true
     # Best-effort observability; never fail the gate on a sidecar write.
     write_eslint_findings_sidecar "$ESLINT_FINDINGS_FILE" "$ESLINT_FINDINGS_TMPFILE" || true
-    rm -f "$ESLINT_FINDINGS_TMPFILE"
 fi
 
 # Parse JSON and print summary header (only if issues exist)

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -11,12 +11,18 @@ set -euo pipefail
 # flows go through `homeboy refactor --from lint --write` (#1145).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../../scripts/lib" && pwd)}"
 # shellcheck source=/dev/null
-source "$RUNNER_PRELUDE"
-homeboy_runner_init --bash 4 --steps --sidecar-writer --component-alias PLUGIN_PATH
+source "${SHARED_LIB_DIR}/runner-harness.sh"
+# shellcheck source=/dev/null
+source "${SHARED_LIB_DIR}/lint-findings-adapter.sh"
+homeboy_runner_harness_init --bash 4 --steps --sidecar-writer --component-alias PLUGIN_PATH
 
-FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${SCRIPT_DIR}/../../../scripts/lib/fix-results.sh}"
+FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${SHARED_LIB_DIR}/fix-results.sh}"
 # shellcheck source=../../../scripts/lib/fix-results.sh
 source "$FIX_RESULTS_HELPER"
 
@@ -89,42 +95,13 @@ fi
 
 homeboy_mktemp() {
     local template="$1"
-    local tmpdir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"
-
-    if [ -d "$tmpdir" ] && [ -w "$tmpdir" ]; then
-        mktemp "${tmpdir%/}/${template}" 2>/dev/null && return 0
-    fi
-
-    mktemp 2>/dev/null
+    homeboy_runner_harness_mktemp "$template"
 }
 
 merge_findings_into_sidecar() {
     local extra_file="$1"
     [ ! -f "$extra_file" ] && return 0
-
-    if type homeboy_sidecar_merge >/dev/null 2>&1; then
-        homeboy_sidecar_merge lint.findings "$extra_file"
-        return $?
-    fi
-
-    if type homeboy_merge_lint_findings >/dev/null 2>&1; then
-        homeboy_merge_lint_findings "$extra_file"
-        return $?
-    fi
-
-    if type homeboy_sidecar_merge_json_array >/dev/null 2>&1; then
-        homeboy_sidecar_merge_json_array "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$extra_file"
-        return $?
-    fi
-
-    # The findings sidecar is Homeboy observability output, not a lint result.
-    # If the sidecar writer is unavailable (e.g. a standalone run that did not
-    # export HOMEBOY_RUNTIME_SIDECAR_WRITER), skip writing it rather than
-    # failing the lint step — a missing writer must never masquerade as a lint
-    # finding (homeboy-extensions#1402). The real pass/fail signal comes from
-    # phpcs/eslint/phpstan exit codes below.
-    echo "Warning: sidecar writer unavailable (HOMEBOY_RUNTIME_SIDECAR_WRITER unset); skipping lint findings sidecar" >&2
-    return 0
+    homeboy_lint_findings_merge_file "$extra_file"
 }
 
 write_lint_producers_sidecar() {


### PR DESCRIPTION
## Summary
- Add shared shell runner harness, test-failure adapter, and lint-findings adapter under `scripts/lib`.
- Converge Go, Rust, Swift, Node.js, and WordPress test/lint runner plumbing onto the shared helpers while keeping language-specific parsing local.
- Add harness-level smoke coverage in `tests/runtime-helpers-smoke.sh` for shared temp cleanup, failure record shape, sidecar adapter functions, and shared-lib path resolution.

## Harness design
- `scripts/lib/runner-harness.sh` owns prelude loading, local core fallback for smoke tests, command-capture sourcing, temp file allocation, trap cleanup, and standard failure note helpers.
- `scripts/lib/test-failures-adapter.sh` owns sidecar writer checks, failure file merges, and the common single-record failure envelope used by Node timeout emission.
- `scripts/lib/lint-findings-adapter.sh` owns lint findings sidecar merge/write behavior with the existing non-fatal standalone fallback semantics.
- Shared lib resolution checks `HOMEBOY_SHARED_LIB_DIR`, then the installed sibling layout at `${HOMEBOY_EXTENSION_PATH}/../scripts/lib`, then the source-tree relative fallback. This covers copied and symlinked installs related to #1356.

## Runner LOC before/after
| Area | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Go test+lint runners | 229 | 226 | -3 |
| Rust test+lint runners | 969 | 968 | -1 |
| Swift test+lint runners | 324 | 321 | -3 |
| Node.js test+lint runners | 544 | 516 | -28 |
| WordPress lint runners | 1507 | 1489 | -18 |
| Runner total | 3573 | 3520 | -53 |
| Shared libs | 0 | 206 | +206 |
| Harness smoke coverage | 0 | 31 | +31 |

Overall PR delta: +392/-208, net +184. Runner files alone are -53 LOC; shared code is now single-sourced under `scripts/lib`.

## Deleted-test list
- None deleted in this slice. Harness-only assertions were consolidated into `tests/runtime-helpers-smoke.sh`; existing parser/runner smokes were kept because they still verify language-local parser behavior and CLI contracts.

## Verification
- `bash -n scripts/lib/runner-harness.sh scripts/lib/test-failures-adapter.sh scripts/lib/lint-findings-adapter.sh go/scripts/test-runner.sh go/scripts/lint-runner.sh rust/scripts/test-runner.sh rust/scripts/lint-runner.sh swift/scripts/test-runner.sh swift/scripts/lint-runner.sh nodejs/scripts/test/test-runner.sh nodejs/scripts/lint/lint-runner.sh wordpress/scripts/lint/lint-runner.sh wordpress/scripts/lint/eslint-runner.sh tests/runtime-helpers-smoke.sh` passed.
- `git diff --check` passed.
- `bash tests/runtime-helpers-smoke.sh` passed.
- Node.js: `bash nodejs/scripts/test/nodejs-changed-scope-smoke.sh`, `bash nodejs/scripts/test/nodejs-targeted-script-smoke.sh`, `bash nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh`, `bash nodejs/scripts/lint/typecheck-ci-command-smoke.sh`, `bash nodejs/scripts/lint/lint-fix-results-smoke.sh`, `bash nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh` passed.
- Rust: `bash rust/scripts/rust-runner-steps-direct-smoke.sh`, `bash rust/scripts/rust-nextest-runner-smoke.sh`, `bash rust/scripts/lint-fix-results-smoke.sh`, `bash rust/scripts/rust-changed-scope-smoke.sh`, `bash rust/scripts/parse-test-results-smoke.sh` passed.
- Swift: `bash swift/tests/lint-runner-smoke.sh`, `bash swift/tests/script-runner-smoke.sh`, `bash swift/tests/swift-extension-smoke.sh`, `bash swift/tests/fingerprint-smoke.sh` passed.
- WordPress lint: `bash wordpress/scripts/lint/wordpress-lint-role-smoke.sh`, `bash wordpress/scripts/lint/vendor-prefixed-exclusion-smoke.sh`, `bash wordpress/scripts/lint/eslint-no-files-smoke.sh`, `bash wordpress/scripts/lint/eslint-glob-filter-smoke.sh`, `bash wordpress/scripts/lint/lint-producers-smoke.sh`, `bash wordpress/scripts/lint/fix-results-smoke.sh`, `bash wordpress/scripts/lint/sidecar-writer-missing-exit-smoke.sh`, `bash wordpress/scripts/lint/phpcbf-readonly-smoke.sh`, `bash wordpress/scripts/lint/autofixable-exit-smoke.sh` passed.
- Direct fixture runner checks passed for worktree Go test/lint, Rust test/lint, Node.js test/lint, and Swift test/lint scripts.
- `homeboy` binary was available. A real `homeboy test --extension go --path <fixture>` attempt failed with `extension.not_found`; `homeboy extension list` shows Go is not installed and installed Node/Rust/Swift/WordPress entries point at local extension registry copies or stale linked revisions rather than this worktree. I did not mutate local extension registration to avoid making the verification depend on local machine state.
- `bash swift/tests/validate-runner-smoke.sh` failed in untouched `swift/scripts/validate.sh` due missing `HOMEBOY_RUNTIME_RESOLVE_CONTEXT`; `git diff --quiet origin/main -- swift/scripts/validate.sh` confirmed this file is unchanged by this PR.

Closes #1972. Part of #2156. Related: #1969, #1356.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (claude-fable-5) orchestrator with GPT 5.5 coding subagent
- **Used for:** Investigation mapped the per-language runner duplication; the subagent built the shared harness and converged the runners.
