### PR TITLE
Consolidate shared shell helper coverage

### DIFF
--- a/nodejs/scripts/lint/lint-fix-results-smoke.sh
+++ b/nodejs/scripts/lint/lint-fix-results-smoke.sh
@@ -7,11 +7,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
     echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
     exit 1
 fi
 
@@ -42,6 +52,8 @@ HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_EXTENSION_PATH="${ROOT_DIR}/nodejs" \
 HOMEBOY_COMPONENT_ID="node-fix-results-smoke" \
 HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
 HOMEBOY_FIX_ONLY=1 \
 HOMEBOY_FIX_RESULTS_FILE="$RESULTS_FILE" \
 HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \

--- a/nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh
+++ b/nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh
@@ -5,12 +5,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_DIR}/../.." && pwd)/homeboy}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 RUNNER="$SCRIPT_DIR/lint-runner.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
     echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
     exit 1
 fi
 
@@ -35,6 +45,8 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$PROJECT_PATH" \
 HOMEBOY_COMPONENT_ID="node-lint-sidecar-smoke" \
 HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
 HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \
     bash "$RUNNER" >"$OUTPUT_FILE" 2>&1
 status=$?

--- a/nodejs/scripts/lint/typecheck-ci-command-smoke.sh
+++ b/nodejs/scripts/lint/typecheck-ci-command-smoke.sh
@@ -5,11 +5,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
     echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
     exit 1
 fi
 
@@ -28,6 +38,8 @@ JSON
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_PATH="$PROJECT" \
 HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
 HOMEBOY_NODE_LINT_COMMAND="__homeboy_typecheck" \
     bash "${EXTENSION_PATH}/scripts/lint/lint-runner.sh" > "${TMPDIR}/typecheck.out"
 

--- a/nodejs/scripts/test/nodejs-changed-scope-smoke.sh
+++ b/nodejs/scripts/test/nodejs-changed-scope-smoke.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_DIR}/../.." && pwd)/homeboy}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
+
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
+    exit 1
+fi
 
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-scope.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -39,6 +51,8 @@ touch "${PROJECT_DIR}/tests/mcp-config.test.ts" "${PROJECT_DIR}/tests/mcp.test.t
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_COMPONENT_ID="node-scope-smoke" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
 HOMEBOY_CHANGED_TEST_FILES=$'tests/mcp-config.test.ts\ntests/mcp.test.ts' \
 bash "${SCRIPT_DIR}/test-runner.sh" > "${TMPDIR}/runner.out"
 

--- a/nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh
+++ b/nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh
@@ -5,12 +5,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_DIR}/../.." && pwd)/homeboy}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-nx-vitest.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
     echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
     exit 1
 fi
 
@@ -69,6 +79,8 @@ HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_COMPONENT_ID="node-nx-vitest-smoke" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${TMPDIR}/write-results.sh" \
 HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
 HOMEBOY_TEST_RESULTS_FILE="${TMPDIR}/test-results.json" \
 HOMEBOY_TEST_FAILURES_FILE="${TMPDIR}/test-failures.json" \
 bash "${SCRIPT_DIR}/test-runner.sh" > "${TMPDIR}/runner.out" 2>&1

--- a/nodejs/scripts/test/nodejs-targeted-script-smoke.sh
+++ b/nodejs/scripts/test/nodejs-targeted-script-smoke.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_DIR}/../.." && pwd)/homeboy}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
+
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
+    exit 1
+fi
 
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-targeted.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -46,6 +58,8 @@ JS
     HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
     HOMEBOY_COMPONENT_PATH="$project_dir" \
     HOMEBOY_COMPONENT_ID="declared-targeted-smoke" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_SETTINGS_JSON='{"test_script":"test:unit"}' \
     bash "${SCRIPT_DIR}/test-runner.sh" packages/core-data/src/test/resolvers.js --runInBand > "${TMPDIR}/declared.out"
 
@@ -102,6 +116,8 @@ JS
     HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
     HOMEBOY_COMPONENT_PATH="$project_dir" \
     HOMEBOY_COMPONENT_ID="configured-targeted-smoke" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_SETTINGS_JSON='{"test_script":"test:unit"}' \
     bash "${SCRIPT_DIR}/test-runner.sh" tests/example.test.js > "${TMPDIR}/configured.out"
 

--- a/nodejs/scripts/trace/nodejs-trace-runner-smoke.sh
+++ b/nodejs/scripts/trace/nodejs-trace-runner-smoke.sh
@@ -5,11 +5,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_DIR}/../.." && pwd)/homeboy}"
 BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
 MANIFEST="${EXTENSION_DIR}/nodejs.json"
 RUNNER="${SCRIPT_DIR}/trace-runner.sh"
 HELPER_FIXTURE="${SCRIPT_DIR}/fixtures/helper.trace.mjs"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-trace.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$BASH_PREFLIGHT_HELPER" ]; then
+    echo "Missing bash preflight helper: $BASH_PREFLIGHT_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
+    exit 1
+fi
 
 assert_json() {
     local file="$1"
@@ -40,6 +50,7 @@ run_trace() {
     HOMEBOY_TRACE_EXTRA_WORKLOADS="$extra_workloads" \
     HOMEBOY_RUN_DIR="$(dirname "$results_file")" \
     HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
         bash "$RUNNER"
 }
 
@@ -79,6 +90,7 @@ HOMEBOY_TRACE_LIST_ONLY="1" \
 HOMEBOY_TRACE_RESULTS_FILE="$LIST_RESULTS" \
 HOMEBOY_TRACE_EXTRA_WORKLOADS="$EXTRA_TRACE_FILE" \
 HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
     bash "$RUNNER" >/dev/null
 assert_json "$LIST_RESULTS" '
 if (data.status !== "pass") throw new Error("list envelope did not pass");

--- a/rust/scripts/bench/rust-bench-smoke.sh
+++ b/rust/scripts/bench/rust-bench-smoke.sh
@@ -24,6 +24,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
 BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
 FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-noop"
 CRITERION_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-criterion"
 
@@ -39,6 +40,16 @@ fi
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "ERROR: jq required for smoke assertions" >&2
+    exit 1
+fi
+
+if [ ! -f "$BASH_PREFLIGHT_HELPER" ]; then
+    echo "ERROR: missing bash preflight helper: $BASH_PREFLIGHT_HELPER" >&2
+    exit 1
+fi
+
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "ERROR: missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
     exit 1
 fi
 
@@ -68,6 +79,7 @@ HOMEBOY_COMPONENT_ID="bench-noop-fixture" \
 HOMEBOY_BENCH_ITERATIONS="$ITERATIONS" \
 HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
 HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
     bash "${SCRIPT_DIR}/bench-runner.sh"
 
 echo
@@ -149,6 +161,7 @@ HOMEBOY_BENCH_ITERATIONS="$ITERATIONS" \
 HOMEBOY_BENCH_LIST_ONLY=1 \
 HOMEBOY_BENCH_RESULTS_FILE="$LIST_TMPFILE" \
 HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
     bash "${SCRIPT_DIR}/bench-runner.sh"
 
 assert "list iterations" "$(jq -r '.iterations' "$LIST_TMPFILE")" "0"
@@ -186,6 +199,7 @@ HOMEBOY_RUST_BENCH_CARGO_TIMINGS=1 \
 HOMEBOY_BENCH_RESULTS_ARTIFACT_DIR="$ARTIFACT_TMPDIR" \
 HOMEBOY_BENCH_RESULTS_FILE="$CARGO_TIMING_TMPFILE" \
 HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
     bash "${SCRIPT_DIR}/bench-runner.sh"
 
 CARGO_TIMING_STATUS="$(jq -r '.metadata.rust_runner.cargo_timing_status // "missing"' "$CARGO_TIMING_TMPFILE")"
@@ -237,6 +251,7 @@ HOMEBOY_RUST_BENCH_PROFILES=1 \
 HOMEBOY_BENCH_SCENARIOS="rust-clean-build,rust-warm-build,rust-changed-file-check" \
 HOMEBOY_BENCH_RESULTS_FILE="$PROFILES_TMPFILE" \
 HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
     bash "${SCRIPT_DIR}/bench-runner.sh"
 
 for _profile in rust-clean-build rust-warm-build rust-changed-file-check; do
@@ -261,6 +276,7 @@ if [ -d "$CRITERION_FIXTURE_DIR" ]; then
     HOMEBOY_RUST_BENCH_CRITERION=1 \
     HOMEBOY_BENCH_RESULTS_FILE="$CRITERION_TMPFILE" \
     HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
         bash "${SCRIPT_DIR}/bench-runner.sh"
 
     CRITERION_COUNT="$(jq -r '[.scenarios[] | select(.source == "criterion")] | length' "$CRITERION_TMPFILE")"

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -2,8 +2,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
+
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
+    exit 1
+fi
 
 PROJECT_DIR="$WORKDIR/project"
 HELPER_DIR="$WORKDIR/helpers"
@@ -94,6 +107,8 @@ OUTPUT=$(
     HOMEBOY_TEST_SCOPE_KIND='rust_integration' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed integration tests: integration_scope' \
     HOMEBOY_TEST_RUNNER_ARGS=$'--test\nintegration_scope' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -116,6 +131,8 @@ OUTPUT=$(
     HOMEBOY_TEST_SCOPE_KIND='rust_filter' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed files: core::daemon::daemon_test' \
     HOMEBOY_TEST_RUNNER_ARGS=$'--\ncore::daemon::daemon_test' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -137,6 +154,8 @@ OUTPUT=$(
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_TEST_SCOPE_KIND='full' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Changed files include multiple inline test modules; running full cargo test.' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -158,6 +177,8 @@ OUTPUT=$(
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_TEST_SCOPE_KIND='full' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Changed files include nested tests without a direct Cargo target; running full cargo test.' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -227,6 +248,8 @@ OUTPUT=$(
     HOMEBOY_TEST_SCOPE_KIND='args' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed Cargo package: targeted-pkg.' \
     HOMEBOY_TEST_RUNNER_ARGS=$'-p\ntargeted-pkg' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -248,6 +271,8 @@ OUTPUT=$(
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_TEST_SCOPE_KIND='full' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Changed path is cross-cutting for Cargo: Cargo.toml' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"

--- a/rust/scripts/rust-nextest-runner-smoke.sh
+++ b/rust/scripts/rust-nextest-runner-smoke.sh
@@ -2,8 +2,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
+
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
+    exit 1
+fi
 
 PROJECT_DIR="$WORKDIR/project"
 HELPER_DIR="$WORKDIR/helpers"
@@ -78,6 +91,8 @@ OUTPUT=$(
     HOMEBOY_TEST_SCOPE_KIND='rust_integration' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed integration tests: integration_scope' \
     HOMEBOY_TEST_RUNNER_ARGS=$'--test\nintegration_scope' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     HOMEBOY_RUNTIME_SIDECAR_WRITER="$HELPER_DIR/sidecar-writer.sh" \
@@ -143,6 +158,8 @@ OUTPUT=$(
     HOMEBOY_RUST_NEXTEST_FALLBACK=0 \
     HOMEBOY_TEST_SCOPE_KIND='rust_integration' \
     HOMEBOY_TEST_RUNNER_ARGS=$'--test\nintegration_scope' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh" 2>&1 || true

--- a/rust/scripts/rust-runner-steps-direct-smoke.sh
+++ b/rust/scripts/rust-runner-steps-direct-smoke.sh
@@ -2,8 +2,20 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 PROJECT_DIR="$(mktemp -d)"
 trap 'rm -rf "$PROJECT_DIR"' EXIT
+
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
+    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
+    exit 1
+fi
 
 cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
 [package]
@@ -15,6 +27,8 @@ EOF
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$ROOT_DIR/rust" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_STEP="none" \
     env -u HOMEBOY_RUNTIME_RUNNER_STEPS \
     bash "$ROOT_DIR/rust/scripts/lint-runner.sh"
@@ -33,6 +47,8 @@ fi
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$ROOT_DIR/rust" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
     HOMEBOY_STEP="none" \
     env -u HOMEBOY_RUNTIME_RUNNER_STEPS \
     bash "$ROOT_DIR/rust/scripts/test-runner.sh"

--- a/swift/tests/lint-runner-smoke.sh
+++ b/swift/tests/lint-runner-smoke.sh
@@ -3,8 +3,15 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWIFT_DIR="$ROOT_DIR/swift"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
+    exit 1
+fi
 
 FIXTURE="$TMP_DIR/minimal-swift"
 mkdir -p "$FIXTURE"
@@ -14,7 +21,7 @@ struct AppModel {
 }
 SWIFT
 
-HOMEBOY_COMPONENT_PATH="$FIXTURE" bash "$SWIFT_DIR/scripts/lint-runner.sh" > "$TMP_DIR/lint.out"
+HOMEBOY_COMPONENT_PATH="$FIXTURE" HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" bash "$SWIFT_DIR/scripts/lint-runner.sh" > "$TMP_DIR/lint.out"
 
 if ! command -v swiftlint >/dev/null 2>&1 && ! command -v swiftformat >/dev/null 2>&1; then
     if ! grep -Fq "Swift lint skipped" "$TMP_DIR/lint.out"; then

--- a/swift/tests/script-runner-smoke.sh
+++ b/swift/tests/script-runner-smoke.sh
@@ -3,8 +3,15 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWIFT_DIR="$ROOT_DIR/swift"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
 
 assert_contains() {
     local file="$1"
@@ -29,17 +36,17 @@ guard fixturesPath.hasSuffix("tests") else {
 print("contract ok")
 SWIFT
 
-HOMEBOY_COMPONENT_PATH="$FIXTURE" bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/pass.out"
+HOMEBOY_COMPONENT_PATH="$FIXTURE" HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/pass.out"
 assert_contains "$TMP_DIR/pass.out" "Running: ContractTests.swift"
 assert_contains "$TMP_DIR/pass.out" "contract ok"
 assert_contains "$TMP_DIR/pass.out" "Results: 1/1 tests passed"
 
-HOMEBOY_COMPONENT_PATH="$FIXTURE" HOMEBOY_SETTINGS_JSON='{"test_type":"script"}' bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/settings.out"
+HOMEBOY_COMPONENT_PATH="$FIXTURE" HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" HOMEBOY_SETTINGS_JSON='{"test_type":"script"}' bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/settings.out"
 assert_contains "$TMP_DIR/settings.out" "Results: 1/1 tests passed"
 
 NO_TESTS="$TMP_DIR/no-tests"
 mkdir -p "$NO_TESTS"
-if HOMEBOY_COMPONENT_PATH="$NO_TESTS" bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/missing.out" 2>&1; then
+if HOMEBOY_COMPONENT_PATH="$NO_TESTS" HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/missing.out" 2>&1; then
     echo "Expected missing tests directory to fail" >&2
     exit 1
 fi

--- a/swift/tests/validate-runner-smoke.sh
+++ b/swift/tests/validate-runner-smoke.sh
@@ -3,8 +3,15 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWIFT_DIR="$ROOT_DIR/swift"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
+    exit 1
+fi
 
 assert_contains() {
     local file="$1"
@@ -24,11 +31,11 @@ struct AppModel {
 }
 SWIFT
 
-HOMEBOY_COMPONENT_PATH="$MINIMAL" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/minimal.out"
+HOMEBOY_COMPONENT_PATH="$MINIMAL" HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/minimal.out"
 assert_contains "$TMP_DIR/minimal.out" "Swift validation passed"
 
 XCODEGEN="$TMP_DIR/xcodegen"
-mkdir -p "$XCODEGEN/Homeboy" "$XCODEGEN/Homeboy.xcodeproj"
+mkdir -p "$XCODEGEN/Homeboy"
 cat > "$XCODEGEN/project.yml" <<'YAML'
 name: Homeboy
 targets:
@@ -43,7 +50,7 @@ struct AppModel {
 }
 SWIFT
 
-HOMEBOY_COMPONENT_PATH="$XCODEGEN" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/xcodegen.out"
+HOMEBOY_COMPONENT_PATH="$XCODEGEN" HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/xcodegen.out"
 assert_contains "$TMP_DIR/xcodegen.out" "Swift validation passed"
 if ! command -v xcodegen >/dev/null 2>&1; then
     assert_contains "$TMP_DIR/xcodegen.out" "project.yml found, but xcodegen is not installed"
@@ -57,7 +64,7 @@ struct Broken {
 }
 SWIFT
 
-if HOMEBOY_COMPONENT_PATH="$BAD" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/bad.out" 2>&1; then
+if HOMEBOY_COMPONENT_PATH="$BAD" HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/bad.out" 2>&1; then
     echo "Expected invalid Swift syntax to fail" >&2
     exit 1
 fi

--- a/tests/nodejs-wordpress-helper-discovery-smoke.sh
+++ b/tests/nodejs-wordpress-helper-discovery-smoke.sh
@@ -5,9 +5,23 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
 BENCH_HELPER="${HOMEBOY_RUNTIME_BENCH_HELPER_JS:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bench-helper.mjs}"
 BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
+WORDPRESS_HELPER_MANIFEST="${ROOT_DIR}/wordpress/lib/helper-manifest.js"
 
 if [ ! -f "$BENCH_HELPER" ]; then
     echo "Missing required file: $BENCH_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$BASH_PREFLIGHT_HELPER" ]; then
+    echo "Missing required file: $BASH_PREFLIGHT_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing required file: $RESOLVE_CONTEXT_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$WORDPRESS_HELPER_MANIFEST" ]; then
+    echo "Missing required file: $WORDPRESS_HELPER_MANIFEST" >&2
     exit 1
 fi
 
@@ -68,6 +82,11 @@ HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_FILE" \
 HOMEBOY_BENCH_ITERATIONS=1 \
 HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
 HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_WORDPRESS_HELPER_MANIFEST="$WORDPRESS_HELPER_MANIFEST" \
+HOMEBOY_WORDPRESS_REQUEST_PROFILER_HELPER="${ROOT_DIR}/wordpress/lib/request-profiler.js" \
+HOMEBOY_WORDPRESS_TIMING_CORRELATOR_HELPER="${ROOT_DIR}/wordpress/lib/timing-correlator.js" \
+HOMEBOY_WORDPRESS_BOOTSTRAP_TIMELINE_HELPER="${ROOT_DIR}/wordpress/lib/wordpress-bootstrap-timeline.js" \
     bash "$ROOT_DIR/nodejs/scripts/bench/bench-runner.sh" >/dev/null
 
 node --input-type=module - "$RESULTS_FILE" <<'NODE'
@@ -76,7 +95,7 @@ import { readFileSync } from 'node:fs';
 const results = JSON.parse(readFileSync(process.argv[2], 'utf8'));
 const scenario = results.scenarios?.[0];
 if (!scenario) throw new Error('missing scenario');
-if (scenario.metrics?.helper_count !== 12) {
+if (scenario.metrics?.helper_count !== 13) {
     throw new Error(`helper count metric regressed: ${JSON.stringify(scenario.metrics)}`);
 }
 if (!scenario.metadata?.wordpress_helper_manifest?.endsWith('/wordpress/lib/helper-manifest.js')) {

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -47,6 +47,15 @@ assert_not_contains() {
     fi
 }
 
+assert_sources() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to source shared helper via: $expected" >&2
+        exit 1
+    fi
+}
+
 assert_file "$FAILURE_TRAP_HELPER"
 assert_file "$WRITE_TEST_RESULTS_HELPER"
 assert_file "$SIDECAR_WRITER_HELPER"
@@ -331,35 +340,66 @@ fi
 assert_contains "$TMP_DIR/node-build.out" 'BUILD FAILED: No build defined'
 assert_contains "$TMP_DIR/node-build.out" 'Error details:'
 
-if grep -R "print_failure_summary()" \
-    "$ROOT_DIR/nodejs/scripts" \
-    "$ROOT_DIR/rust/scripts" \
-    "$ROOT_DIR/wordpress/scripts/test" \
-    "$ROOT_DIR/wordpress/scripts/bench" >/dev/null; then
-    echo "Runner scripts should not define local print_failure_summary functions" >&2
-    exit 1
-fi
+for runner in \
+    nodejs/scripts/build/build-runner.sh \
+    nodejs/scripts/lint/lint-runner.sh \
+    nodejs/scripts/test/test-runner.sh \
+    rust/scripts/lint-runner.sh \
+    rust/scripts/test-runner.sh \
+    swift/scripts/test-runner.sh \
+    wordpress/scripts/lint/lint-runner.sh \
+    wordpress/scripts/test/test-runner.sh; do
+    assert_sources "$ROOT_DIR/$runner" 'HOMEBOY_RUNTIME_RUNNER_PRELUDE'
+done
 
-if grep -R --exclude='*smoke.sh' "homeboy_write_test_results()" \
-    "$ROOT_DIR/nodejs/scripts" \
-    "$ROOT_DIR/rust/scripts" \
-    "$ROOT_DIR/wordpress/scripts/test" >/dev/null; then
-    echo "Extension scripts should not define local homeboy_write_test_results functions" >&2
-    exit 1
-fi
+for runner in \
+    nodejs/scripts/bench/bench-runner.sh \
+    nodejs/scripts/trace/trace-runner.sh \
+    rust/scripts/bench/bench-runner.sh \
+    wordpress/scripts/bench/bench-runner.sh; do
+    assert_sources "$ROOT_DIR/$runner" 'HOMEBOY_RUNTIME_BASH_PREFLIGHT'
+done
 
-if grep "BASH_VERSINFO" \
-    "$ROOT_DIR/nodejs/scripts/bench/bench-runner.sh" \
-    "$ROOT_DIR/nodejs/scripts/build/build-runner.sh" \
-    "$ROOT_DIR/nodejs/scripts/lint/lint-runner.sh" \
-    "$ROOT_DIR/nodejs/scripts/test/test-runner.sh" \
-    "$ROOT_DIR/nodejs/scripts/trace/trace-runner.sh" \
-    "$ROOT_DIR/rust/scripts/bench/bench-runner.sh" \
-    "$ROOT_DIR/wordpress/scripts/bench/bench-runner.sh" \
-    "$ROOT_DIR/wordpress/scripts/lint/lint-runner.sh" \
-    "$ROOT_DIR/wordpress/scripts/test/test-runner.sh" >/dev/null; then
-    echo "Runner scripts should use HOMEBOY_RUNTIME_BASH_PREFLIGHT instead of local BASH_VERSINFO checks" >&2
-    exit 1
-fi
+for runner in \
+    nodejs/scripts/bench/bench-runner.sh \
+    nodejs/scripts/format.sh \
+    nodejs/scripts/trace/trace-runner.sh \
+    nodejs/scripts/validate.sh \
+    rust/scripts/bench/bench-runner.sh \
+    rust/scripts/format.sh \
+    rust/scripts/validate.sh \
+    swift/scripts/lint-runner.sh \
+    swift/scripts/validate.sh \
+    wordpress/scripts/bench/bench-runner-wp-codebox.sh \
+    wordpress/scripts/build/build.sh \
+    wordpress/scripts/lint/eslint-runner.sh \
+    wordpress/scripts/lint/lint-runner-core-dev.sh \
+    wordpress/scripts/test/test-runner-host-smoke-wp.sh \
+    wordpress/scripts/test/test-runner-wp-codebox.sh; do
+    assert_sources "$ROOT_DIR/$runner" 'HOMEBOY_RUNTIME_RESOLVE_CONTEXT'
+done
+
+for runner in \
+    nodejs/scripts/build/build-runner.sh \
+    nodejs/scripts/test/test-runner.sh \
+    rust/scripts/lint-runner.sh \
+    rust/scripts/test-runner.sh; do
+    assert_sources "$ROOT_DIR/$runner" 'HOMEBOY_RUNTIME_COMMAND_CAPTURE'
+done
+
+for runner in \
+    nodejs/scripts/test/test-runner.sh \
+    rust/scripts/bench/bench-runner.sh \
+    rust/scripts/test-runner.sh \
+    wordpress/scripts/test/test-runner.sh; do
+    assert_sources "$ROOT_DIR/$runner" 'scripts/lib/settings.sh'
+done
+
+for runner in \
+    nodejs/scripts/lint/lint-runner.sh \
+    rust/scripts/lint-runner.sh \
+    wordpress/scripts/lint/lint-runner.sh; do
+    assert_sources "$ROOT_DIR/$runner" 'scripts/lib/fix-results.sh'
+done
 
 echo "runtime helper smoke passed"

--- a/tests/wordpress-build-staging-syntax-smoke.sh
+++ b/tests/wordpress-build-staging-syntax-smoke.sh
@@ -2,9 +2,16 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
 BUILD_SCRIPT="$ROOT_DIR/wordpress/scripts/build/build.sh"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
+    exit 1
+fi
 
 PROJECT_DIR="$TMP_DIR/staging-smoke-plugin"
 OUTPUT_FILE="$TMP_DIR/build.out"
@@ -31,7 +38,7 @@ EOF
 
 (
     cd "$PROJECT_DIR"
-    bash "$BUILD_SCRIPT" >"$OUTPUT_FILE"
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" bash "$BUILD_SCRIPT" >"$OUTPUT_FILE"
 )
 
 ZIP_FILE="$PROJECT_DIR/build/staging-smoke-plugin.zip"
@@ -78,7 +85,7 @@ EOF
 
 if (
     cd "$BAD_PROJECT_DIR"
-    bash "$BUILD_SCRIPT" >"$BAD_OUTPUT_FILE" 2>&1
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" bash "$BUILD_SCRIPT" >"$BAD_OUTPUT_FILE" 2>&1
 ); then
     echo "Build unexpectedly passed with invalid staged PHP" >&2
     cat "$BAD_OUTPUT_FILE" >&2

--- a/tests/wordpress-eslint-scope-smoke.sh
+++ b/tests/wordpress-eslint-scope-smoke.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
 RUNNER="$ROOT_DIR/wordpress/scripts/lint/eslint-runner.sh"
 
 assert_contains() {
@@ -28,6 +30,11 @@ assert_not_contains() {
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
+    exit 1
+fi
 
 COMPONENT_DIR="$TMP_DIR/example-plugin"
 FAKE_EXTENSION="$TMP_DIR/fake-wordpress-extension"
@@ -64,9 +71,9 @@ cat > "$COMPONENT_DIR/docs/example.md" <<'MD'
 # Example docs
 MD
 
-cat > "$FAKE_EXTENSION/.eslintrc.json" <<'JSON'
-{}
-JSON
+cat > "$FAKE_EXTENSION/eslint.config.mjs" <<'JS'
+export default [];
+JS
 
 cat > "$SIDECAR_WRITER" <<'SH'
 homeboy_sidecar_merge_json_array() {
@@ -99,6 +106,7 @@ chmod +x "$FAKE_EXTENSION/node_modules/.bin/eslint"
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
 ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_FILE='docs/example.md' \
@@ -113,6 +121,7 @@ fi
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
 ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_GLOB='{example-plugin.php,inc/runtime.php}' \
@@ -128,6 +137,7 @@ fi
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
 ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_GLOB='{example-plugin.php,assets/admin.js,inc/runtime.php,assets/view.ts}' \
@@ -144,6 +154,7 @@ rm -f "$ESLINT_ARGS_FILE"
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
 ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_FILE='assets/admin.js' \
@@ -151,9 +162,8 @@ HOMEBOY_LINT_FILE='assets/admin.js' \
 
 assert_contains "$TMP_DIR/js-success.out" "Linting single file: assets/admin.js"
 assert_contains "$TMP_DIR/js-success.out" "ESLint linting passed"
-assert_contains "$ESLINT_ARGS_FILE" "--no-eslintrc"
-assert_contains "$ESLINT_ARGS_FILE" "--resolve-plugins-relative-to"
-assert_contains "$ESLINT_ARGS_FILE" "$FAKE_EXTENSION"
+assert_contains "$ESLINT_ARGS_FILE" "--config"
+assert_contains "$ESLINT_ARGS_FILE" "$FAKE_EXTENSION/eslint.config.mjs"
 assert_contains "$ESLINT_ARGS_FILE" "assets/admin.js"
 
 cat > "$COMPONENT_DIR/assets/bad.js" <<'JS'
@@ -164,6 +174,7 @@ set +e
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
 ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \

--- a/tests/wordpress-lint-context-smoke.sh
+++ b/tests/wordpress-lint-context-smoke.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
 RUNNER="$ROOT_DIR/wordpress/scripts/lint/lint-runner.sh"
 PHPSTAN_RUNNER="$ROOT_DIR/wordpress/scripts/lint/phpstan-runner.sh"
 PHPSTAN_CONFIG="$ROOT_DIR/wordpress/phpstan.neon.dist"
@@ -18,6 +21,15 @@ assert_contains() {
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
+    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
+    exit 1
+fi
+
 COMPONENT_DIR="$TMP_DIR/example-plugin"
 FAKE_EXTENSION="$TMP_DIR/fake-wordpress-extension"
 mkdir -p "$COMPONENT_DIR/tools" "$COMPONENT_DIR/tests" "$COMPONENT_DIR/vendor_prefixed/example" "$FAKE_EXTENSION/vendor/bin" "$FAKE_EXTENSION/HomeboyWordPress"
@@ -30,7 +42,16 @@ cat > "$COMPONENT_DIR/example-plugin.php" <<'PHP'
  */
 PHP
 
-touch "$FAKE_EXTENSION/vendor/bin/phpcs" "$FAKE_EXTENSION/vendor/bin/phpcbf" "$FAKE_EXTENSION/phpcs.xml.dist"
+cat > "$FAKE_EXTENSION/vendor/bin/phpcs" <<'BASH'
+#!/usr/bin/env bash
+exit 0
+BASH
+cat > "$FAKE_EXTENSION/vendor/bin/phpcbf" <<'BASH'
+#!/usr/bin/env bash
+exit 0
+BASH
+chmod +x "$FAKE_EXTENSION/vendor/bin/phpcs" "$FAKE_EXTENSION/vendor/bin/phpcbf"
+touch "$FAKE_EXTENSION/phpcs.xml.dist"
 
 cat > "$COMPONENT_DIR/scoper.inc.php" <<'PHP'
 <?php
@@ -63,12 +84,13 @@ PHP
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
 HOMEBOY_STEP="none" \
     bash "$RUNNER" > "$TMP_DIR/lint.out" 2>&1
 
 assert_contains "$TMP_DIR/lint.out" "Linting passed"
 
-assert_contains "$RUNNER" 'homeboy_resolve_context --component-alias PLUGIN_PATH'
+assert_contains "$RUNNER" 'homeboy_runner_init --bash 4 --steps --sidecar-writer --component-alias PLUGIN_PATH'
 assert_contains "$RUNNER" "*/vendor_prefixed/*"
 assert_contains "$RUNNER" "*/tools/*"
 assert_contains "$RUNNER" "*/scoper.inc.php"
@@ -82,19 +104,38 @@ assert_contains "$PHPSTAN_CONFIG" "customRulesetUsed: false"
 
 for non_runtime_file in \
     scoper.inc.php \
-    tools/build-autoloader.php \
     tests/smoke-example.php \
     tests/ExampleUnitTest.php \
     vendor_prefixed/example/generated.php; do
+    set +e
     HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
     HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
     HOMEBOY_COMPONENT_ID="example-plugin" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
     HOMEBOY_LINT_FILE="$non_runtime_file" \
         bash "$RUNNER" > "$TMP_DIR/non-runtime.out" 2>&1
+    non_runtime_status=$?
+    set -e
+
+    if [ "$non_runtime_status" -ne 0 ]; then
+        echo "Expected non-runtime lint scope to pass for $non_runtime_file" >&2
+        sed 's/^/  /' "$TMP_DIR/non-runtime.out" >&2
+        exit 1
+    fi
 
     assert_contains "$TMP_DIR/non-runtime.out" "Skipping production WordPress lint profile for non-runtime file scope"
     assert_contains "$TMP_DIR/non-runtime.out" "Linting passed"
 done
+
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_LINT_FILE="tools/build-autoloader.php" \
+    bash "$RUNNER" > "$TMP_DIR/tooling.out" 2>&1
+assert_contains "$TMP_DIR/tooling.out" "WordPress lint role: tooling"
+assert_contains "$TMP_DIR/tooling.out" "PHPCS linting passed"
+assert_contains "$TMP_DIR/tooling.out" "Linting passed"
 
 mkdir -p "$COMPONENT_DIR/includes" "$COMPONENT_DIR/vendor_prefixed/Example/Vendor"
 
@@ -182,6 +223,7 @@ EXPECTED_VENDOR_PREFIXED_AUTOLOAD="$COMPONENT_DIR/vendor_prefixed/autoload.php" 
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 HOMEBOY_LINT_FILE="includes/class-example-adapter.php" \
     bash "$PHPSTAN_RUNNER" > "$TMP_DIR/phpstan-scoped.out" 2>&1
 
@@ -240,6 +282,7 @@ EXPECTED_RUNTIME_CLASS="$COMPONENT_DIR/includes/class-example-adapter.php" \
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
     bash "$PHPSTAN_RUNNER" > "$TMP_DIR/phpstan-full.out" 2>&1
 
 assert_contains "$TMP_DIR/phpstan-full.out" "PHPStan full fake passed"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -11,6 +11,7 @@ EXTRA_WORKLOAD_DIR="${TMP_ROOT}/rig-workloads"
 EXTRA_WORKLOAD="${EXTRA_WORKLOAD_DIR}/rig-workload.php"
 UNSELECTED_EXTRA_WORKLOAD="${EXTRA_WORKLOAD_DIR}/unselected-crash.php"
 mkdir -p "${SOURCE_ROOT}/static-sites/demo" "${SOURCE_ROOT}/.github/homeboy" "${SOURCE_ROOT}/tests/bench" "${SOURCE_ROOT}/scenarios" "$EXTRA_WORKLOAD_DIR"
+printf '<?php\n/**\n * Plugin Name: WP Site Generator Fixture\n */\n' > "${SOURCE_ROOT}/wp-site-generator.php"
 printf '<!doctype html><title>Demo</title>\n' > "${SOURCE_ROOT}/static-sites/demo/index.html"
 printf '<?php return array();\n' > "${SOURCE_ROOT}/.github/homeboy/ssi-import-diagnostics.php"
 printf '<?php return function (): array { return array(); };\n' > "${SOURCE_ROOT}/tests/bench/website-generation.php"
@@ -84,7 +85,7 @@ WP_CODEBOX_CORE_MODULE="${TMP_ROOT}/wp-codebox-core.mjs"
 cat > "$WP_CODEBOX_CORE_MODULE" <<'STUB'
 export function buildWordPressBenchRecipe(options) {
   const defines = options.wpConfigDefines || {};
-  const extraPlugins = options.extra_plugins || options.extraPlugins || [];
+  const extraPlugins = options.extra_plugins || [];
   const blueprint = options.blueprint && typeof options.blueprint === 'object' && !Array.isArray(options.blueprint)
     ? {...options.blueprint, steps: [...(Array.isArray(options.blueprint.steps) ? options.blueprint.steps : [])]}
     : {steps: []};
@@ -94,7 +95,7 @@ export function buildWordPressBenchRecipe(options) {
   return {
     schema: 'wp-codebox/workspace-recipe/v1',
     runtime: {wp: options.wordpressVersion, blueprint},
-    inputs: {extraPlugins, mounts: options.mounts || []},
+    inputs: {extra_plugins: extraPlugins, mounts: options.mounts || []},
     workflow: {steps: [{
       command: 'wordpress.bench',
       args: [
@@ -194,7 +195,7 @@ HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
 bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 
 if ! jq -e --arg sourceRoot "$SOURCE_ROOT" '
-    .recipe.inputs.extraPlugins == []
+    .recipe.inputs.extra_plugins == []
     and (.recipe.inputs.mounts[] | select(.source == $sourceRoot and .target == "/wordpress/wp-content/plugins/wp-site-generator" and .mode == "readonly"))
     and (.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/rig-workload.php")) | .target == "/wordpress/wp-content/plugins/wp-site-generator/.homeboy/bench-rig/rig-workload.php")
     and (.recipe.runtime.blueprint.steps[] | select(.step == "installPlugin" and .options.targetFolderName == "static-site-importer"))
@@ -340,7 +341,7 @@ HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
 bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 
 if ! jq -e --arg sourceRoot "$PLUGIN_ROOT" '
-    .recipe.inputs.extraPlugins == [{source: $sourceRoot, slug: "wp-site-generator", pluginFile: "wp-site-generator/plugin-main.php", activate: false}]
+    .recipe.inputs.extra_plugins == [{source: $sourceRoot, slug: "wp-site-generator", pluginFile: "wp-site-generator/plugin-main.php", activate: false}]
     and ([.recipe.inputs.mounts[] | select(.source == $sourceRoot and .target == "/wordpress/wp-content/plugins/wp-site-generator")] | length == 0)
 ' "$PLUGIN_CAPTURE_FILE" >/dev/null; then
     echo "ERROR: generated WP Codebox recipe did not include expected plugin bench inputs" >&2
@@ -370,7 +371,7 @@ HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
 bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 
 jq -e '
-    .recipe.inputs.extraPlugins[0].pluginFile == "wp-site-generator/plugin-main.php"
+    .recipe.inputs.extra_plugins[0].pluginFile == "wp-site-generator/plugin-main.php"
     and (.recipe.inputs.mounts[] | select((.source | endswith("/rig-workloads/rig-workload.php")) and .target == "/wordpress/wp-content/plugins/wp-site-generator/.homeboy/bench-rig/rig-workload.php"))
     and ([.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("\"source\":\"rig\"") and contains("\"overridesDiscovered\":true") and contains(".homeboy/bench-rig/rig-workload.php"))] | length) == 1
     and ([.recipe.workflow.steps[0].args[] | select(startswith("scenario-ids-json=") and contains("rig-workload"))] | length) == 1
@@ -403,7 +404,7 @@ HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
 bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 
 jq -e --arg pluginRoot "$PLUGIN_ROOT" --arg dependencyRoot "${DEPENDENCY_ROOT}/packages/wordpress-plugin" '
-    .recipe.inputs.extraPlugins == [
+    .recipe.inputs.extra_plugins == [
         {source: $pluginRoot, slug: "wp-site-generator", pluginFile: "wp-site-generator/plugin-main.php", activate: false},
         {source: $dependencyRoot, slug: "declared-wp-codebox", pluginFile: "declared-wp-codebox/wp-codebox.php", activate: false}
     ]


### PR DESCRIPTION
Closes #2165

## Summary
- Replaces the old duplicate-function policing in tests/runtime-helpers-smoke.sh with explicit checks that runners source the canonical shared helpers.
- Keeps core-owned helpers (runner-prelude, command-capture, resolve-context, bash-preflight) sourced through HOMEBOY_RUNTIME_* paths injected by Homeboy core.
- Keeps extension-owned helpers (settings.sh and fix-results.sh) single-sourced from top-level scripts/lib, relying on Homeboy's established monorepo install behavior that materializes scripts/ as a sibling of installed extensions.
- Updates direct smoke-test invocations to pass the same runtime helper env vars that Homeboy injects during real capability dispatch.

## Installed-layout sourcing mechanism
Homeboy core already materializes monorepo-level scripts/ into ~/.config/homeboy/extensions/scripts/ for cloned and linked monorepo installs, so extension-owned fallbacks like ../../../scripts/lib/settings.sh resolve in both the source checkout and installed layout. Core-owned runtime helpers are materialized by Homeboy and exported as HOMEBOY_RUNTIME_RUNNER_PRELUDE, HOMEBOY_RUNTIME_COMMAND_CAPTURE, HOMEBOY_RUNTIME_RESOLVE_CONTEXT, and related env vars before extension execution.

## Reconciled helper-copy diffs
- Current fresh main already had the per-extension helper copies removed; the only remaining repo copies for this issue's helper names are scripts/lib/settings.sh and scripts/lib/fix-results.sh.
- runner-prelude.sh, command-capture.sh, and resolve-context.sh are not kept in this repo; runners source the Homeboy core runtime copies through HOMEBOY_RUNTIME_*.
- Smoke fixtures were updated where they were invoking runners directly without the core-injected env contract.

## Verification
- PASS: bash tests/runtime-helpers-smoke.sh
- PASS: bash nodejs/scripts/build/build-runner-shell-smoke.sh
- PASS: targeted direct runner smokes for Node lint/test/trace, Rust changed-scope/nextest/runner-steps, Swift lint/test/validate, WordPress ESLint/lint/build context, and nodejs-wordpress helper discovery.
- PARTIAL: attempted the full discovered shell smoke sweep; it progresses past the helper-related failures but still hits an existing live WP Codebox runtime policy failure in wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh: Command is not allowed by runtime policy: wordpress.run-php.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude, fable-5)
- **Used for:** implementation, tests, and PR drafting; reviewed by Chris before merge