### PR TITLE
Purge WP Codebox Data Machine plumbing

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1481,7 +1481,6 @@ function runtimeComponentPaths(config, options = {}) {
     agents_api: contractPaths.agents_api || firstValue(process.env.WP_CODEBOX_AGENTS_API_PATH, process.env.HOMEBOY_WP_CODEBOX_AGENTS_API_PATH),
     agent_runtime: contractPaths.agent_runtime || explicit.agent_runtime || config.agent_runtime || options.agentRuntime,
     agent_runtime_tools: config.agent_runtime_tools || options.agentRuntimeTools,
-    data_machine_code: contractPaths.data_machine_code || firstValue(process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH, process.env.HOMEBOY_WP_CODEBOX_DATA_MACHINE_CODE_PATH),
     ...explicit,
     runtime: explicit.runtime || runtimeComponents.runtime,
   };
@@ -1499,8 +1498,6 @@ function runtimeComponentPaths(config, options = {}) {
     })));
   }
 
-  resolved.agent_runtime = resolved.agent_runtime || firstValue(process.env.WP_CODEBOX_DATA_MACHINE_PATH, process.env.HOMEBOY_WP_CODEBOX_DATA_MACHINE_PATH);
-
   return Object.fromEntries(Object.entries(resolved).filter(([, value]) => value !== undefined && value !== ''));
 }
 
@@ -1509,12 +1506,6 @@ function runtimeEnvWithComponentPaths(runtimeEnv = {}, components = {}) {
 
   if (components.agents_api) {
     env.WP_CODEBOX_AGENTS_API_PATH = components.agents_api;
-  }
-  if (components.agent_runtime) {
-    env.WP_CODEBOX_DATA_MACHINE_PATH = components.agent_runtime;
-  }
-  if (components.data_machine_code) {
-    env.WP_CODEBOX_DATA_MACHINE_CODE_PATH = components.data_machine_code;
   }
 
   return env;
@@ -1567,17 +1558,7 @@ function runtimeComponentPathsFromContracts(contracts, options = {}) {
 
 function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const settings = firstObject(options.settings, parseJsonObject(process.env.HOMEBOY_SETTINGS_JSON)) || {};
-  const discovery = runtimeComponentDiscovery(options);
   const workspaceRoot = resolveWorkspaceRoot(request, config, inputs, settings, options);
-  const workspaceBase = workspaceRoot ? path.dirname(workspaceRoot) : process.cwd();
-  const agentRuntimePath = firstExistingPath(
-    options.agentRuntime,
-    ...componentDiscoveryCandidates('agent_runtime', discovery, settings, workspaceBase),
-  );
-  const agentRuntimeToolsPath = firstExistingPath(
-    options.agentRuntimeTools,
-    ...componentDiscoveryCandidates('agent_runtime_tools', discovery, settings, workspaceBase),
-  );
   const providerPluginPath = firstExistingPath(
     settings.wp_codebox_provider_plugin_path,
     process.env.HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH,
@@ -1587,10 +1568,6 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const providerConfig = providerConfigFor(provider, settings, providerDefaults);
   const model = config.model || options.model || defaultModelForProvider(provider, settings, providerConfig);
   return {
-    agentRuntime: agentRuntimePath,
-    agentRuntimeTools: agentRuntimeToolsPath,
-    legacyRuntime: agentRuntimePath,
-    legacyRuntimeTools: agentRuntimeToolsPath,
     providerPluginPaths: defaultProviderPluginPaths(provider, config, options, settings, providerConfig, providerPluginPath),
     provider,
     model,

--- a/rust/scripts/refactor/imports.py
+++ b/rust/scripts/refactor/imports.py
@@ -240,7 +240,7 @@ def resolve_imports(moved_items: list[dict], source_content: str, source_path: s
     # Never scan raw text with startswith("use ") here — test fixtures and raw
     # strings can contain foreign-language `use` lines (e.g. PHP namespace imports)
     # that are not Rust imports. Those bogus lines caused PR #1024 to inject
-    # `use DataMachine\Core\Pipeline;` into Rust files.
+    # `use ExamplePlugin\Core\Pipeline;` into Rust files.
     source_uses = extract_top_level_use_statements(source_lines)
 
     # Collect all real top-level definitions from the source file via the Rust

--- a/rust/scripts/refactor/test_imports.py
+++ b/rust/scripts/refactor/test_imports.py
@@ -343,10 +343,10 @@ mod tests {
     #[test]
     fn load_and_use_php_grammar() {
         let sample = r#"<?php
-namespace DataMachine\Abilities;
+namespace ExamplePlugin\Abilities;
 
 use WP_UnitTestCase;
-use DataMachine\Core\Pipeline;
+use ExamplePlugin\Core\Pipeline;
 
 class PipelineAbilities extends BaseAbilities {}
 "#;
@@ -372,7 +372,7 @@ class PipelineAbilities extends BaseAbilities {}
         import_text = "\n".join(imports)
         self.assertEqual(import_text, "")
         self.assertNotIn("WP_UnitTestCase", import_text)
-        self.assertNotIn("DataMachine\\Core\\Pipeline", import_text)
+        self.assertNotIn("ExamplePlugin\\Core\\Pipeline", import_text)
 
     def test_ignores_comment_mentions_of_source_definitions(self):
         """Names mentioned in comments/docs must not trigger same-module imports."""

--- a/wordpress/docs/commands/wp.md
+++ b/wordpress/docs/commands/wp.md
@@ -24,19 +24,19 @@ Arguments are passed directly to WP-CLI. The shell processes quotes **before** h
 ### Do NOT quote multi-word commands
 
 ```sh
-# WRONG - shell passes single arg: "datamachine-events health-check --scope=upcoming"
-homeboy wp extra-chill events "datamachine-events health-check --scope=upcoming"
+# WRONG - shell passes single arg: "sample-plugin health-check --scope=upcoming"
+homeboy wp example-site staging "sample-plugin health-check --scope=upcoming"
 
 # CORRECT - shell passes separate args to homeboy
-homeboy wp extra-chill events datamachine-events health-check --scope=upcoming
+homeboy wp example-site staging sample-plugin health-check --scope=upcoming
 ```
 
 ### DO quote values with spaces
 
 ```sh
 # CORRECT - quotes protect the value, not the command structure
-homeboy wp extra-chill post create --post_title="My New Post"
-homeboy wp extra-chill user create bob@example.com --display_name="Bob Smith"
+homeboy wp example-site post create --post_title="My New Post"
+homeboy wp example-site user create bob@example.com --display_name="Bob Smith"
 ```
 
 ### Subtarget example
@@ -44,11 +44,11 @@ homeboy wp extra-chill user create bob@example.com --display_name="Bob Smith"
 For projects with subtargets, specify the subtarget after the project ID:
 
 ```sh
-# Run WP-CLI on the 'events' subtarget
-homeboy wp extra-chill events core version
+# Run WP-CLI on the 'staging' subtarget
+homeboy wp example-site staging core version
 
 # Run a plugin command on a subtarget
-homeboy wp extra-chill events datamachine-events health-check --scope=upcoming
+homeboy wp example-site staging sample-plugin health-check --scope=upcoming
 ```
 
 ## JSON output

--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -67,7 +67,7 @@ apply_filters = 'filter'
 # ===========================================================================
 
 [patterns.namespace]
-# Matches: namespace DataMachine\Abilities;
+# Matches: namespace ExampleVendor\Plugin;
 # Allows optional leading whitespace — PHP accepts indented top-level
 # namespace declarations (e.g. after a docblock), and `context = top_level`
 # already guarantees brace depth 0.

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -254,10 +254,8 @@ def namespace_to_path(namespace, psr4_mappings=None):
     """Convert a PHP namespace to a directory path using PSR-4 mappings.
 
     With PSR-4 mappings from composer.json:
-        DataMachineSocials\\Abilities\\Traits -> inc/Abilities/Traits
-        (if composer.json has "DataMachineSocials\\": "inc/")
-
-    Falls back to heuristic for DataMachine -> inc/ when no mappings found.
+        ExamplePlugin\\Abilities\\Traits -> inc/Abilities/Traits
+        (if composer.json has "ExamplePlugin\\": "inc/")
     """
     if psr4_mappings:
         # Sort by specificity — longest namespace prefix first
@@ -275,17 +273,13 @@ def namespace_to_path(namespace, psr4_mappings=None):
                 remainder = namespace[len(ns_prefix) + 1:]
                 return dir_path + '/' + remainder.replace('\\', '/')
 
-    # Fallback: hardcoded DataMachine -> inc/ for backwards compatibility
-    parts = namespace.split('\\')
-    if parts and parts[0] == 'DataMachine':
-        parts[0] = 'inc'
-    return '/'.join(parts)
+    return namespace.replace('\\', '/')
 
 
-def path_to_namespace(file_path, psr4_mappings=None, root_mapping='inc:DataMachine'):
+def path_to_namespace(file_path, psr4_mappings=None, root_mapping='inc:ExamplePlugin'):
     """Convert a file path to a PHP namespace using PSR-4 mappings.
 
-    inc/Abilities/Traits/HasPermissionCheck.php -> DataMachine\\Abilities\\Traits
+    inc/Abilities/Traits/HasPermissionCheck.php -> ExamplePlugin\\Abilities\\Traits
     """
     # Strip the file extension
     path = re.sub(r'\.php$', '', file_path)
@@ -416,7 +410,7 @@ def generate_trait_file(function_name, method_source, namespace_base, trait_name
     Args:
         function_name: Name of the duplicated function
         method_source: The full method source code (with doc comment)
-        namespace_base: Base namespace for the trait (e.g., DataMachine\\Abilities)
+        namespace_base: Base namespace for the trait (e.g., ExamplePlugin\\Abilities)
         trait_name: Name of the trait
         dependency_imports: List of use statements the method depends on
     """
@@ -472,9 +466,9 @@ def generate_trait_file(function_name, method_source, namespace_base, trait_name
 def common_namespace_prefix(namespaces):
     """Find the longest common namespace prefix from a list of namespaces.
 
-    ['DataMachine\\Abilities\\Flow', 'DataMachine\\Abilities\\Job',
-     'DataMachine\\Abilities\\Taxonomy']
-    → 'DataMachine\\Abilities'
+    ['ExamplePlugin\\Abilities\\Flow', 'ExamplePlugin\\Abilities\\Job',
+     'ExamplePlugin\\Abilities\\Taxonomy']
+    → 'ExamplePlugin\\Abilities'
     """
     if not namespaces:
         return ''

--- a/wordpress/scripts/release/publish.sh
+++ b/wordpress/scripts/release/publish.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 #
 # Reads the release payload from HOMEBOY_SETTINGS_JSON which homeboy passes
 # when invoking extension actions. The payload shape is:
-#   { "release": { "tag": "vX.Y.Z", "component_id": "data-machine", ... },
+#   { "release": { "tag": "vX.Y.Z", "component_id": "sample-plugin", ... },
 #     "config":  { ... } }
 #
 # Reads the release-latest branch name from the component's homeboy.json at
@@ -184,7 +184,7 @@ resolve_github_token
 # Assert the artifact's internal version matches the release tag before
 # uploading. This is the last chokepoint before a ZIP becomes the GitHub
 # Release asset that deploys consume — a stale artifact here means silent
-# production rollback (data-machine-socials v0.14.0 shipped a v0.8.1 zip
+# production rollback (sample-plugin v0.14.0 shipped a v0.8.1 zip
 # for 6 days). Strip the leading "v" and any monorepo "<component>-v"
 # prefix from the tag to get the bare semver.
 EXPECTED_VERSION="${TAG##*v}"

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -941,8 +941,8 @@ const explicitRuntimePackageComponentTaskInput = codeboxTaskRequestFromAgentTask
       provider: 'codex',
       component_contracts: [
         { slug: 'agents-api', path: '/components/agents-api' },
-        { slug: 'data-machine', path: '/components/data-machine' },
-        { slug: 'data-machine-code', path: '/components/data-machine-code' },
+        { slug: 'sample-plugin', path: '/components/sample-plugin' },
+        { slug: 'sample-plugin-tools', path: '/components/sample-plugin-tools' },
       ],
     },
   },
@@ -957,22 +957,23 @@ const explicitRuntimePackageComponentTaskInput = codeboxTaskRequestFromAgentTask
   componentPathDefaults: {
     contract_slug_map: {
       'agents-api': 'agents_api',
-      'data-machine': 'agent_runtime',
-      'data-machine-code': 'data_machine_code',
+      'sample-plugin': 'agent_runtime',
+      'sample-plugin-tools': 'agent_runtime_tools',
     },
     path_aliases: {
       agent_runtime: ['contract:agent_runtime'],
+      agent_runtime_tools: ['contract:agent_runtime_tools'],
     },
   },
 });
 assert.equal(explicitRuntimePackageComponentTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
-assert.deepEqual(explicitRuntimePackageComponentTaskInput.component_contracts.map((contract) => contract.slug), ['agents-api', 'data-machine', 'data-machine-code']);
+assert.deepEqual(explicitRuntimePackageComponentTaskInput.component_contracts.map((contract) => contract.slug), ['agents-api', 'sample-plugin', 'sample-plugin-tools']);
 assert.equal(explicitRuntimePackageComponentTaskInput.runtime_component_paths.agents_api, '/components/agents-api');
-assert.equal(explicitRuntimePackageComponentTaskInput.runtime_component_paths.agent_runtime, '/components/data-machine');
-assert.equal(explicitRuntimePackageComponentTaskInput.runtime_component_paths.data_machine_code, '/components/data-machine-code');
+assert.equal(explicitRuntimePackageComponentTaskInput.runtime_component_paths.agent_runtime, '/components/sample-plugin');
+assert.equal(explicitRuntimePackageComponentTaskInput.runtime_component_paths.agent_runtime_tools, '/components/sample-plugin-tools');
 assert.equal(explicitRuntimePackageComponentTaskInput.runtime_env.WP_CODEBOX_AGENTS_API_PATH, '/components/agents-api');
-assert.equal(explicitRuntimePackageComponentTaskInput.runtime_env.WP_CODEBOX_DATA_MACHINE_PATH, '/components/data-machine');
-assert.equal(explicitRuntimePackageComponentTaskInput.runtime_env.WP_CODEBOX_DATA_MACHINE_CODE_PATH, '/components/data-machine-code');
+assert.equal(explicitRuntimePackageComponentTaskInput.runtime_env.WP_CODEBOX_DATA_MACHINE_PATH, undefined);
+assert.equal(explicitRuntimePackageComponentTaskInput.runtime_env.WP_CODEBOX_DATA_MACHINE_CODE_PATH, undefined);
 
 const previousStaleDataMachinePath = process.env.WP_CODEBOX_DATA_MACHINE_PATH;
 process.env.WP_CODEBOX_DATA_MACHINE_PATH = '/components/stale-data-machine';
@@ -984,11 +985,11 @@ const explicitRuntimeComponentOverridesEnvTaskInput = codeboxTaskRequestFromAgen
     config: {
       provider: 'codex',
       runtime_component_paths: {
-        agent_runtime: '/components/explicit-data-machine',
+        agent_runtime: '/components/explicit-sample-plugin',
       },
     },
   },
-  instructions: 'Run a runtime-package task with an explicit Data Machine component path.',
+  instructions: 'Run a runtime-package task with an explicit sample component path.',
   inputs: {
     ability_request: {
       name: 'runtime-package/run',
@@ -997,8 +998,8 @@ const explicitRuntimeComponentOverridesEnvTaskInput = codeboxTaskRequestFromAgen
   },
 });
 restoreEnv('WP_CODEBOX_DATA_MACHINE_PATH', previousStaleDataMachinePath);
-assert.equal(explicitRuntimeComponentOverridesEnvTaskInput.runtime_component_paths.agent_runtime, '/components/explicit-data-machine');
-assert.equal(explicitRuntimeComponentOverridesEnvTaskInput.runtime_env.WP_CODEBOX_DATA_MACHINE_PATH, '/components/explicit-data-machine');
+assert.equal(explicitRuntimeComponentOverridesEnvTaskInput.runtime_component_paths.agent_runtime, '/components/explicit-sample-plugin');
+assert.equal(explicitRuntimeComponentOverridesEnvTaskInput.runtime_env.WP_CODEBOX_DATA_MACHINE_PATH, undefined);
 
 const runtimePackageWithoutSubstrateTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -1038,8 +1039,8 @@ restoreEnv('WP_CODEBOX_DATA_MACHINE_PATH', previousDataMachinePath);
 restoreEnv('WP_CODEBOX_DATA_MACHINE_CODE_PATH', previousDataMachineCodePath);
 assert.deepEqual(runtimePackageEnvSubstrateTaskInput.component_contracts, []);
 assert.equal(runtimePackageEnvSubstrateTaskInput.runtime_component_paths.agents_api, workspaceRoot);
-assert.equal(runtimePackageEnvSubstrateTaskInput.runtime_component_paths.agent_runtime, workspaceRoot);
-assert.equal(runtimePackageEnvSubstrateTaskInput.runtime_component_paths.data_machine_code, workspaceRoot);
+assert.equal(runtimePackageEnvSubstrateTaskInput.runtime_component_paths.agent_runtime, undefined);
+assert.equal(runtimePackageEnvSubstrateTaskInput.runtime_component_paths.data_machine_code, undefined);
 
 const explicitRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1051,9 +1051,9 @@ try {
   const runtimeToolsPath = path.join(defaultsRoot, 'example-runtime-tools');
   const staleStandaloneAgentsApiPath = path.join(defaultsRoot, 'agents-api');
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
-  const dataMachinePath = path.join(defaultsRoot, 'data-machine');
+  const samplePluginPath = path.join(defaultsRoot, 'sample-plugin');
   const phpAiClientPath = path.join(defaultsRoot, 'php-ai-client');
-  for (const directory of [workspaceRoot, bundledAgentsApiPath, runtimeToolsPath, staleStandaloneAgentsApiPath, providerPath, dataMachinePath, phpAiClientPath]) {
+  for (const directory of [workspaceRoot, bundledAgentsApiPath, runtimeToolsPath, staleStandaloneAgentsApiPath, providerPath, samplePluginPath, phpAiClientPath]) {
     fs.mkdirSync(directory, { recursive: true });
   }
 
@@ -1119,11 +1119,11 @@ try {
     inputs: {
       target: { root: workspaceRoot },
     },
-  }, {
-    agentRuntime: runtimePath,
-    settings: {
-      wp_codebox_chat_handler_plugin_paths: [dataMachinePath],
-    },
+    }, {
+      agentRuntime: runtimePath,
+      settings: {
+        wp_codebox_chat_handler_plugin_paths: [samplePluginPath],
+      },
   });
   assert.deepEqual((chatHandlerRequest.runtime_requirements.component_contracts || []).map((contract) => contract.slug), []);
   assert.deepEqual(chatHandlerRequest.component_contracts.map((contract) => contract.slug), []);
@@ -3051,7 +3051,6 @@ try {
     GENERIC_PROVIDER_CONFIG: '/runtime/provider/config.json',
     XDG_DATA_HOME: '/runtime/provider/data',
     WP_CODEBOX_AGENTS_API_PATH: '/components/agents-api',
-    WP_CODEBOX_DATA_MACHINE_PATH: '/components/example-runtime',
   };
   const fullRunnerRuntimeStateMounts = [{
     source: '/host/provider/state.json',

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-refactor-source-wp-codebox-'));
+const fixtureCodeboxCoreModule = path.join(__dirname, '..', '..', 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 
 function pathInside(parent, candidate) {
   const relative = path.relative(fs.realpathSync(parent), path.resolve(candidate));
@@ -66,10 +67,11 @@ const os = require('node:os');
 const path = require('node:path');
 const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
 const inputPath = inputArg ? inputArg.slice('--input-file='.length) : '';
-if (process.argv[2] !== 'agent-task-run' || !inputPath) {
+if (!['agent-task-run', 'run-agent-task'].includes(process.argv[2]) || !inputPath) {
   process.exit(2);
 }
-const task = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+const runRequest = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+const task = runRequest.task_input || runRequest;
 const artifactsRoot = task.artifacts_path || '';
 const sessionId = task.sandbox_session_id;
 if (process.env.FIXTURE_HANG_GROUP === task.group_key) {
@@ -201,6 +203,7 @@ process.stdout.write(JSON.stringify({
     input: JSON.stringify(writeCommand),
     env: {
       ...process.env,
+      HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCodeboxCoreModule,
       OPENCODE_API_KEY: 'redacted-test-key',
     },
   });
@@ -243,6 +246,7 @@ process.stdout.write(JSON.stringify({
     }),
     env: {
       ...process.env,
+      HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCodeboxCoreModule,
       FIXTURE_INVALID_PATCH: '1',
       OPENCODE_API_KEY: 'redacted-test-key',
     },
@@ -269,6 +273,7 @@ process.stdout.write(JSON.stringify({
     }),
     env: {
       ...process.env,
+      HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCodeboxCoreModule,
       FIXTURE_HANG_GROUP: 'docs-reference',
       OPENCODE_API_KEY: 'redacted-test-key',
     },
@@ -299,6 +304,7 @@ process.stdout.write(JSON.stringify({
     }),
     env: {
       ...process.env,
+      HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCodeboxCoreModule,
       OPENCODE_API_KEY: '',
     },
   });

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -919,7 +919,7 @@
       "examples": [
         "homeboy wp my-site plugin list",
         "homeboy wp my-site option get blogname",
-        "homeboy wp extra-chill:events datamachine pipelines list"
+        "homeboy wp example-site:staging sample-plugin health-check"
       ]
     }
   },


### PR DESCRIPTION
## Summary
Purge the legacy Data Machine dependency plumbing from the WP Codebox executor and adjacent task-runner/refactor surfaces on top of the #2171 WP Codebox contract adapter consolidation.

Closes #2172

## Deletion Map
- Removed `data_machine_bundle` / `dataMachineBundle` bundle aliases from the WP Codebox executor and task runner.
- Removed `DATAMACHINE_HOST_TOOL_POLICY_JSON` runtime env injection; #2171's consolidated runtime policy handling remains.
- Removed Data Machine/Data Machine Code runtime component env fallback and env injection from the consolidated WP Codebox executor.
- Removed Data Machine/Data Machine Code runtime component default discovery from WP Codebox executor defaults.
- Kept #2171's canonical adapter/runtime-package consolidation intact, including `agent-runtimes/wp-codebox/lib/wp-codebox-contract-adapter.js` and the single `wpCodebox` namespace export shape.
- Genericized Data Machine-specific docs/examples in `wordpress/docs/commands/wp.md`, `wordpress/grammar.toml`, `wordpress/wordpress.json`, release/refactor comments, and Rust refactor fixtures.
- Updated WP Codebox executor/task-runner smokes to use generic sample runtime fixtures where explicit generic runtime paths are still supported.

## Residual Reference Inventory
Post-rebase non-`CHANGELOG.md` files matching `datamachine|data_machine|data-machine|DataMachine|DATA_MACHINE`:

```text
nodejs/scripts/bench/nodejs-browser-performance-profiler-smoke.sh
tests/runtime-agent-ci-contract-smoke.mjs
tests/wordpress-release-artifact-version-smoke.sh
tests/wp-codebox-adapter-contract-smoke.mjs
tests/wp-codebox-callback-data-smoke.mjs
wordpress/docs/CHANGELOG.md
wordpress/scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh
wordpress/scripts/lint/php-fixers/wp-filesystem-fixer.php
wordpress/scripts/release/verify-artifact-version.sh
wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh
wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh
wordpress/scripts/test/parsers/classify-error.php
wordpress/scripts/test/parsers/testdox.php
wordpress/scripts/test/test-runner-file-routing-smoke.sh
wordpress/scripts/test/wp-codebox-bootstrap-failure-smoke.sh
wordpress/tests/audit-detector-config-smoke.sh
wordpress/tests/audit-wp-codebox-fanout-smoke.js
wordpress/tests/codebox-agent-task-executor-boundary.test.js
wordpress/tests/codebox-agent-task-executor-smoke.js
wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-i18n-text-domain.php
wordpress/tests/fixtures/bench-db-activation-dep/bench-db-activation-dep.php
wordpress/tests/page-profiler-smoke.js
wordpress/tests/refactor-source-wp-codebox-smoke.js
wordpress/tests/wordpress-runtime-task-planner-smoke.js
wordpress/tests/wp-cli-runtime-dispatch-fingerprint-smoke.sh
wordpress/tests/wp-codebox-task-runner-smoke.js
```

These remaining references are retained because they are unrelated parser/test fixtures, historical incident comments, runtime-agent boundary guards, or explicit negative assertions.

## Verification
Passed:
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/refactor-source-wp-codebox-smoke.js`
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `bash tests/runtime-helpers-smoke.sh`
- `python3 -m rust.scripts.refactor.test_imports`
- `git diff --check`

Not present post-rebase:
- `wordpress/tests/datamachine-agent-ci-plan-smoke.js` / datamachine-agent-ci plan smoke was removed by #2171.

Known pre-existing/newly runnable failure:
- `node tests/wp-codebox-callback-data-smoke.mjs` now exists after #2171 and fails on the known callback fixture mismatch: the fake WP Codebox reads `input.runtime_env.HOMEBOY_CALLBACK_DATA_PATH`, while the consolidated stable runner passes a run request wrapper with `task_input.runtime_env`. This purge did not paper over that mismatch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Purged legacy Data Machine plumbing from the WP Codebox executor; Chris reviews and owns the change.
