### PR TITLE
Fix WP Codebox callback smoke envelope

### DIFF
--- a/tests/wp-codebox-callback-data-smoke.mjs
+++ b/tests/wp-codebox-callback-data-smoke.mjs
@@ -32,8 +32,9 @@ fs.writeFileSync(fakeBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
 const input = JSON.parse(fs.readFileSync(inputArg.slice('--input-file='.length), 'utf8'));
-const callbackPath = input.runtime_env.HOMEBOY_CALLBACK_DATA_PATH;
-const helper = input.extra_plugins.find((plugin) => plugin.metadata?.source === 'homeboy-runtime-callback-data');
+const taskInput = input.task_input;
+const callbackPath = taskInput.runtime_env.HOMEBOY_CALLBACK_DATA_PATH;
+const helper = taskInput.extra_plugins.find((plugin) => plugin.metadata?.source === 'homeboy-runtime-callback-data');
 if (!callbackPath || !helper || !fs.existsSync(callbackPath)) {
   throw new Error('callback data helper was not injected');
 }


### PR DESCRIPTION
## Root cause
The stable Homeboy WP Codebox runner is correct to invoke the canonical `wp-codebox/run-agent-task/v1` contract: it wraps the prepared task input under `task_input`. The stale side was `tests/wp-codebox-callback-data-smoke.mjs`'s fake WP Codebox binary, which read `input.runtime_env` as if the input file were a bare task input. WP Codebox `origin/main` confirms the consumer normalizes runtime-task input from `input['input']`, then `input['task_input']`, then the whole input in `packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php`, so callback runtime env belongs at `task_input.runtime_env` for the stable run-agent-task envelope.

Related #1969

## Verification
- `node tests/wp-codebox-callback-data-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `bash tests/runtime-helpers-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Root-caused and fixed the callback runtime_env contract mismatch; Chris reviews and owns the change.