### PR TITLE
Declare core seam data for Homeboy extensions

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -228,6 +228,18 @@
         ],
         "display": "node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs"
       },
+      "cli": {
+        "reserved_selector_hints": ["opencode", "codex", "claude-code"],
+        "profiles": [
+          {
+            "name": "opencode-codex-gpt55",
+            "backend": "opencode",
+            "model": "gpt-5.5",
+            "ai_disclosure": "OpenCode (GPT-5.5)"
+          }
+        ],
+        "default_ai_disclosure": "OpenCode (GPT-5.5)"
+      },
       "request_schema": "homeboy/agent-task-request/v1",
       "outcome_schema": "homeboy/agent-task-outcome/v1",
       "request_required_fields": [

--- a/homeboy-extension-root.json
+++ b/homeboy-extension-root.json
@@ -1,0 +1,9 @@
+{
+  "shared_assets": [
+    "scripts/lib",
+    "dependency-adapters",
+    "agent-runtimes",
+    "runtime-agent-ci",
+    "agent-task-contracts"
+  ]
+}

--- a/wordpress/scripts/env-provider.sh
+++ b/wordpress/scripts/env-provider.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER_SOURCE="${SCRIPT_DIR}/runtime/bench-helper.php"
+
+python3 - "$HELPER_SOURCE" <<'PY'
+import json
+import sys
+
+helper_source = sys.argv[1]
+print(json.dumps({
+    "HOMEBOY_REDACTION_SENSITIVE_HEADERS": "x-wp-nonce",
+    "HOMEBOY_RUNTIME_HELPERS_JSON": json.dumps([
+        {
+            "filename": "bench-helper.php",
+            "source": helper_source,
+            "env_var": "HOMEBOY_RUNTIME_BENCH_HELPER_PHP",
+            "legacy_fallback": True,
+        }
+    ], separators=(",", ":")),
+}, separators=(",", ":")))
+PY

--- a/wordpress/scripts/runtime/bench-helper.php
+++ b/wordpress/scripts/runtime/bench-helper.php
@@ -1,0 +1,168 @@
+<?php
+/** Shared BenchResults helpers for PHP extension runners. */
+
+/** R-7 percentile, the runner contract used by Homeboy BenchResults producers. */
+function homeboy_bench_percentile(array $sorted_values, float $p): float {
+    $n = count($sorted_values);
+    if ($n === 0) {
+        return 0.0;
+    }
+    if ($n === 1) {
+        return (float) $sorted_values[0];
+    }
+
+    $rank = $p * ($n - 1);
+    $lo = (int) floor($rank);
+    $hi = (int) ceil($rank);
+    if ($lo === $hi) {
+        return (float) $sorted_values[$lo];
+    }
+
+    $frac = $rank - $lo;
+    return (float) ($sorted_values[$lo] * (1 - $frac) + $sorted_values[$hi] * $frac);
+}
+
+/** scenario slug helper: turn a workload basename into a stable BenchScenario id. */
+function homeboy_bench_scenario_id(string $basename): string {
+    $name = preg_replace('/\.[^.]+$/', '', $basename);
+    $name = preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $name);
+    $name = strtolower($name);
+    $name = preg_replace('/[^a-z0-9]+/', '-', $name);
+    return trim($name, '-');
+}
+
+function homeboy_bench_selected_scenarios(?string $selected = null): array {
+    $selected = $selected ?? (getenv('HOMEBOY_BENCH_SCENARIOS') ?: '');
+    return array_values(array_filter(array_map('trim', explode(',', $selected)), static fn($scenario) => $scenario !== ''));
+}
+
+function homeboy_bench_scenario_selected(string $scenario, ?array $selected = null): bool {
+    $selected = $selected ?? homeboy_bench_selected_scenarios();
+    return count($selected) === 0 || in_array($scenario, $selected, true);
+}
+
+function homeboy_bench_artifact_ref(string $path, ?string $kind = null, ?string $label = null): array {
+    if ($path === '') {
+        throw new InvalidArgumentException('homeboy_bench_artifact_ref requires a path');
+    }
+
+    $ref = ['path' => $path];
+    if ($kind !== null && $kind !== '') {
+        $ref['kind'] = $kind;
+    }
+    if ($label !== null && $label !== '') {
+        $ref['label'] = $label;
+    }
+    return $ref;
+}
+
+function homeboy_bench_results_envelope(string $component_id, int $iterations, array $scenarios): array {
+    return [
+        'component_id' => $component_id,
+        'iterations' => $iterations,
+        'scenarios' => $scenarios,
+    ];
+}
+
+function homeboy_bench_scenario_inventory_entry(array $scenario): array {
+    if (empty($scenario['id'])) {
+        throw new InvalidArgumentException('homeboy_bench_scenario_inventory_entry requires an id');
+    }
+
+    $entry = [
+        'id' => $scenario['id'],
+        'iterations' => 0,
+        'tags' => $scenario['tags'] ?? [],
+        'metrics' => $scenario['metrics'] ?? [],
+    ];
+
+    if (array_key_exists('default_iterations', $scenario)) {
+        $entry['default_iterations'] = (int) $scenario['default_iterations'];
+    }
+
+    foreach (['file', 'source', 'metadata', 'provenance', 'artifacts'] as $key) {
+        if (isset($scenario[$key]) && $scenario[$key] !== [] && $scenario[$key] !== '') {
+            $entry[$key] = $scenario[$key];
+        }
+    }
+
+    return $entry;
+}
+
+function homeboy_bench_scenario_inventory_envelope(string $component_id, int $default_iterations, array $scenarios): array {
+    return homeboy_bench_results_envelope(
+        $component_id,
+        0,
+        array_map(
+            static function (array $scenario) use ($default_iterations): array {
+                if (!array_key_exists('default_iterations', $scenario)) {
+                    $scenario['default_iterations'] = $default_iterations;
+                }
+                return homeboy_bench_scenario_inventory_entry($scenario);
+            },
+            $scenarios
+        )
+    );
+}
+
+function homeboy_write_bench_results(string $results_path, string $component_id, int $iterations, array $scenarios): void {
+    $json = json_encode(homeboy_bench_results_envelope($component_id, $iterations, $scenarios), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($json === false) {
+        throw new RuntimeException('json_encode failed: ' . json_last_error_msg());
+    }
+    $results_dir = dirname($results_path);
+    if (!is_dir($results_dir) && !mkdir($results_dir, 0777, true) && !is_dir($results_dir)) {
+        throw new RuntimeException("failed to create $results_dir");
+    }
+    if (file_put_contents($results_path, $json) === false) {
+        throw new RuntimeException("failed to write $results_path");
+    }
+}
+
+function homeboy_write_empty_bench_results(string $results_path, string $component_id, int $iterations = 0): void {
+    homeboy_write_bench_results($results_path, $component_id, $iterations, []);
+}
+
+function homeboy_write_bench_scenario_inventory(string $results_path, string $component_id, int $default_iterations, array $scenarios): void {
+    $json = json_encode(homeboy_bench_scenario_inventory_envelope($component_id, $default_iterations, $scenarios), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($json === false) {
+        throw new RuntimeException('json_encode failed: ' . json_last_error_msg());
+    }
+    $results_dir = dirname($results_path);
+    if (!is_dir($results_dir) && !mkdir($results_dir, 0777, true) && !is_dir($results_dir)) {
+        throw new RuntimeException("failed to create $results_dir");
+    }
+    if (file_put_contents($results_path, $json) === false) {
+        throw new RuntimeException("failed to write $results_path");
+    }
+}
+
+function homeboy_bench_responsiveness_ping(array $event = []): void {
+    static $started_at = null;
+    if ($started_at === null) {
+        $started_at = microtime(true);
+    }
+    $file = getenv('HOMEBOY_BENCH_RESPONSIVENESS_FILE') ?: '';
+    if ($file === '') {
+        return;
+    }
+
+    $ping = array_merge(
+        [
+            'at' => gmdate('Y-m-d\TH:i:s\Z'),
+            't_ms' => (int) round((microtime(true) - $started_at) * 1000),
+        ],
+        $event
+    );
+    $dir = dirname($file);
+    if (!is_dir($dir) && !mkdir($dir, 0777, true) && !is_dir($dir)) {
+        throw new RuntimeException("failed to create $dir");
+    }
+    $json = json_encode($ping, JSON_UNESCAPED_SLASHES);
+    if ($json === false) {
+        throw new RuntimeException('json_encode failed: ' . json_last_error_msg());
+    }
+    if (file_put_contents($file, $json . "\n", FILE_APPEND | LOCK_EX) === false) {
+        throw new RuntimeException("failed to append $file");
+    }
+}


### PR DESCRIPTION
## Summary

Follow-ups from Extra-Chill/homeboy#7563. This PR moves the extension-side declarations into homeboy-extensions so Homeboy core can keep removing transitional product/runtime hardcodes.

## Seam declarations

| Core seam | Extension declaration | Core contract fields consumed |
| --- | --- | --- |
| Monorepo shared assets | Root `homeboy-extension-root.json` | `shared_assets` with `scripts/lib`, `dependency-adapters`, `agent-runtimes`, `runtime-agent-ci`, `agent-task-contracts` |
| Agent task CLI selector hints | `agent-runtimes/wp-codebox/wp-codebox.json` provider `cli` metadata | `cli.reserved_selector_hints` = `opencode`, `codex`, `claude-code` |
| Agent task provider profile | `agent-runtimes/wp-codebox/wp-codebox.json` provider `cli` metadata | `cli.profiles[].name`, `backend`, `model`, `ai_disclosure`; declares `opencode-codex-gpt55` as `backend=opencode`, `model=gpt-5.5` |
| AI assistance disclosure default | `agent-runtimes/wp-codebox/wp-codebox.json` provider `cli` metadata | `cli.default_ai_disclosure` = `OpenCode (GPT-5.5)` |
| Declared PHP bench runtime helper | WordPress extension env provider plus `wordpress/scripts/runtime/bench-helper.php` | `HOMEBOY_RUNTIME_HELPERS_JSON` entries with `filename`, `source`, `env_var`, `legacy_fallback`; declares `HOMEBOY_RUNTIME_BENCH_HELPER_PHP` |
| WordPress nonce redaction header | WordPress extension env provider | `HOMEBOY_REDACTION_SENSITIVE_HEADERS` appends `x-wp-nonce` |

## Gaps found

- No blocking core seam gaps found for the requested items.
- Core currently exposes redaction/runtime-helper seams as environment variables, not as rich manifest fields, so the WordPress extension declares them through `env_provider` output.
- This repo currently has an `agent-runtimes/opencode` package but no `agent-runtimes/opencode/*.json` runtime manifest under core discovery. I did not invent an unconsumed manifest; the profile is declared on the active WP Codebox provider manifest.
- While validating installed providers, Homeboy reported an unrelated existing diagnostic for `/Users/chubes/.config/homeboy/agent-runtimes/opencode/opencode.json`: `missing field env`.
- `tests/bootstrap-standard-extensions-smoke.sh` is not usable on this machine as written because its dry-run path still invokes `/opt/homeboy/bin/homeboy`; left unchanged as unrelated.

## Verification

- `node -e "for (const f of ['homeboy-extension-root.json','agent-runtimes/wp-codebox/wp-codebox.json','wordpress/wordpress.json']) JSON.parse(require('fs').readFileSync(f,'utf8'));"`
- `wordpress/scripts/env-provider.sh`
- `bash tests/runtime-helpers-smoke.sh`
- `homeboy extension install /Users/chubes/Developer/homeboy-extensions@feat-declare-core-seams-7563 --id wordpress --replace`
- Restored local registry with `homeboy extension install /Users/chubes/Developer/homeboy-extensions --id wordpress --replace`
- `homeboy runtime helper path HOMEBOY_RUNTIME_BENCH_HELPER_PHP --plain` with `HOMEBOY_RUNTIME_HELPERS_JSON` from the WordPress env provider
- `cmp -s ~/.config/homeboy/runtime/bench-helper.php wordpress/scripts/runtime/bench-helper.php && php -l wordpress/scripts/runtime/bench-helper.php`
- Node assertions for `cli.reserved_selector_hints`, `cli.profiles`, `cli.default_ai_disclosure`, and root `shared_assets`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Declared the extension-side data for core's new generic seams; Chris reviews and owns the change.
