### PR TITLE
Fix opencode agent task execution

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -645,6 +645,31 @@ function resolveCommandSpec(config = {}, options = {}) {
 	return { command: configuredCommand.trim(), args: configuredArgs };
 }
 
+function opencodeRunArgs(request = {}, config = {}, commandSpec = {}) {
+	const model = config.model || request.executor?.model || request.model;
+	const format = config.format || 'json';
+	return [
+		...arrayValue(commandSpec.args),
+		'run',
+		...(format ? ['--format', format] : []),
+		...(model ? ['--model', model] : []),
+		...(config.agent ? ['--agent', config.agent] : []),
+		...(config.variant ? ['--variant', config.variant] : []),
+		...(config.title ? ['--title', config.title] : []),
+		request.instructions,
+	];
+}
+
+function resolveOpenCodeCwd(request = {}, config = {}) {
+	return config.cwd
+		|| config.workspace_root
+		|| config.workspaceRoot
+		|| request.workspace_path
+		|| request.workspace?.path
+		|| request.workspace?.root
+		|| process.cwd();
+}
+
 async function executeOpenCodeAgentTask(request = {}, options = {}) {
 	const validationError = validateOpenCodeRequest(request);
 	if (validationError) {
@@ -663,18 +688,9 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 		});
 	}
 
-	const cwd = config.cwd || config.workspace_root || config.workspaceRoot || request.workspace_path || request.workspace?.path || request.workspace?.root || process.cwd();
-	const model = config.model || request.executor.model || request.model;
-	const args = [
-		...commandSpec.args,
-		'run',
-		...(model ? ['--model', model] : []),
-		...(config.agent ? ['--agent', config.agent] : []),
-		...(config.variant ? ['--variant', config.variant] : []),
-		...(config.title ? ['--title', config.title] : []),
-		request.instructions,
-	];
-	const spawnExtra = { env: opencodeSpawnEnv(request, options) };
+	const cwd = resolveOpenCodeCwd(request, config);
+	const args = opencodeRunArgs(request, config, commandSpec);
+	const spawnExtra = { env: { ...opencodeSpawnEnv(request, options), PWD: cwd } };
 	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
 	const runtimeLogPaths = openCodeRuntimeLogPaths(request, config);
 	const spawnResult = await spawnOpenCodeStreaming(commandSpec.command, args, {
@@ -956,16 +972,10 @@ const { outcome, validationFailure } = createCliAgentTaskExecutor({
 	resolveCommandSpec,
 	successOutcome: opencodeSuccessOutcome,
 	failureOutcome: opencodeFailureOutcome,
-	buildArgs: (request, config, commandSpec) => [
-		...commandSpec.args,
-		'run',
-		...(config.model ? ['--model', config.model] : []),
-		...(config.agent ? ['--agent', config.agent] : []),
-		...(config.variant ? ['--variant', config.variant] : []),
-		...(config.title ? ['--title', config.title] : []),
-		request.instructions,
-	],
-	buildSpawn: (request, config, options) => ({ env: opencodeSpawnEnv(request, options) }),
+	buildArgs: opencodeRunArgs,
+	buildSpawn: (request, config, options) => ({
+		env: { ...opencodeSpawnEnv(request, options), PWD: resolveOpenCodeCwd(request, config) },
+	}),
 	messages: {
 		invalidRequest: { code: 'agent_task.invalid_opencode_request', summary: 'OpenCode request validation failed.' },
 		invalidCommand: { code: 'agent_task.invalid_opencode_command', summary: 'OpenCode command configuration is invalid.' },

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -152,7 +152,8 @@ process.exit(0);
 	fs.writeFileSync(modelCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
 assert.equal(process.cwd(), ${JSON.stringify(realModelWorkspace)});
-assert.deepEqual(process.argv.slice(2, 5), ['run', '--model', 'opencode-go/kimi-k2.7-code']);
+assert.equal(process.env.PWD, ${JSON.stringify(modelWorkspace)});
+assert.deepEqual(process.argv.slice(2, 7), ['run', '--format', 'json', '--model', 'opencode-go/kimi-k2.7-code']);
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
 assert.equal(config.$schema, 'https://opencode.ai/config.json');
 assert.equal(config.model, 'opencode-go/kimi-k2.7-code');


### PR DESCRIPTION
## Summary
- Run OpenCode in JSON event mode for agent-task executions so the provider process exits cleanly after the terminal event stream.
- Set the spawned OpenCode child env PWD to the same path used for cwd; OpenCode hangs silently when cwd and inherited PWD disagree.
- Cover the argv and PWD contract in the opencode executor boundary test.

## Verification
- npm run test:opencode-agent-task-executor
- npm run check:runtime-manifest
- node --check agent-runtimes/opencode/lib/opencode-agent-task-executor.js && node --check agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
- Refreshed local runtime with: homeboy runtime refresh opencode --source /Users/chubes/Developer/homeboy-extensions@fix-opencode-executor-json-run
- Proved real cook completion: homeboy agent-task cook --to-worktree homeboy@proof-opencode-cook-homeboy-executes --repo homeboy --backend opencode --cwd /Users/chubes/Developer/homeboy@proof-opencode-cook-homeboy-executes --prompt "Read README.md and output one sentence describing what Homeboy is. Make no file changes." --timeout-ms 300000 --verify true --no-finalize
- Successful run: agent-task-ce523c93-2a53-487b-aa04-f7a0aee35254; aggregate status succeeded with provider artifacts patch, agent_result, transcript, opencode-runtime-stdout, executor input, and executor result.

## Root cause
Homeboy passed a child cwd pointing at the target worktree while preserving the parent PWD from the orchestrator shell. OpenCode 1.17.13 hangs with no stdout/stderr in that state before emitting provider events. Its default formatted run mode can also leave a process alive after printing an answer, so the executor now uses the JSON run format.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Diagnosed the opencode executor hang, implemented the runtime fix, and ran verification.