### PR TITLE
Harden nodejs deps lockfile errors

### DIFF
--- a/nodejs/scripts/deps/deps-runner.sh
+++ b/nodejs/scripts/deps/deps-runner.sh
@@ -13,7 +13,41 @@ PACKAGE_FILTER="${2:-}"
 homeboy_require_package_json "$PROJECT_PATH" >/dev/null
 homeboy_detect_package_manager "$PROJECT_PATH" >/dev/null
 
+LOCKFILES=()
+for lockfile in pnpm-lock.yaml yarn.lock package-lock.json; do
+    if [ -f "${HOMEBOY_PROJECT_DEPENDENCY_ROOT}/${lockfile}" ]; then
+        LOCKFILES+=("$lockfile")
+    fi
+done
+
+lockfile_error_code() {
+    if [ "${#LOCKFILES[@]}" -eq 0 ]; then
+        printf '%s\n' "nodejs.lockfile_missing"
+        return
+    fi
+
+    if [ "${#LOCKFILES[@]}" -gt 1 ]; then
+        printf '%s\n' "nodejs.lockfile_ambiguous"
+        return
+    fi
+}
+
+lockfile_error_message() {
+    case "$(lockfile_error_code)" in
+        nodejs.lockfile_missing)
+            printf '%s\n' "Node.js dependency hydration requires a lockfile. Add package-lock.json, pnpm-lock.yaml, or yarn.lock."
+            ;;
+        nodejs.lockfile_ambiguous)
+            printf 'Multiple Node.js lockfiles found: %s. Keep exactly one lockfile so Homeboy can choose a deterministic package manager.\n' "${LOCKFILES[*]}"
+            ;;
+    esac
+}
+
 dependency_command() {
+    if [ -n "$(lockfile_error_code)" ]; then
+        return 64
+    fi
+
     case "$HOMEBOY_PROJECT_PACKAGE_MANAGER" in
         pnpm)
             printf '%s\n' "pnpm install --frozen-lockfile"
@@ -22,11 +56,7 @@ dependency_command() {
             printf '%s\n' "yarn install --frozen-lockfile"
             ;;
         npm|*)
-            if [ -f "${HOMEBOY_PROJECT_DEPENDENCY_ROOT}/package-lock.json" ]; then
-                printf '%s\n' "npm ci"
-            else
-                printf '%s\n' "npm install"
-            fi
+            printf '%s\n' "npm ci"
             ;;
     esac
 }
@@ -35,6 +65,9 @@ emit_status() {
     HOMEBOY_NODE_DEPS_PACKAGE_MANAGER="$HOMEBOY_PROJECT_PACKAGE_MANAGER" \
     HOMEBOY_NODE_DEPS_PACKAGE_JSON="${HOMEBOY_PROJECT_ROOT}/package.json" \
     HOMEBOY_NODE_DEPS_PACKAGE_FILTER="$PACKAGE_FILTER" \
+    HOMEBOY_NODE_DEPS_LOCKFILES="${LOCKFILES[*]}" \
+    HOMEBOY_NODE_DEPS_ERROR_CODE="$(lockfile_error_code)" \
+    HOMEBOY_NODE_DEPS_ERROR_MESSAGE="$(lockfile_error_message)" \
         node <<'NODE'
 const fs = require('fs');
 const pkg = JSON.parse(fs.readFileSync(process.env.HOMEBOY_NODE_DEPS_PACKAGE_JSON, 'utf8'));
@@ -51,12 +84,34 @@ for (const section of sections) {
 process.stdout.write(JSON.stringify({
   package_manager: process.env.HOMEBOY_NODE_DEPS_PACKAGE_MANAGER || 'npm',
   dependency_identities: pkg.name ? [String(pkg.name)] : [],
+  lockfiles: (process.env.HOMEBOY_NODE_DEPS_LOCKFILES || '').split(/\s+/).filter(Boolean),
   packages,
+  errors: process.env.HOMEBOY_NODE_DEPS_ERROR_CODE ? [{
+    code: process.env.HOMEBOY_NODE_DEPS_ERROR_CODE,
+    message: process.env.HOMEBOY_NODE_DEPS_ERROR_MESSAGE || process.env.HOMEBOY_NODE_DEPS_ERROR_CODE,
+  }] : [],
 }) + '\n');
 NODE
 }
 
 emit_install_command() {
+    local error_code
+    error_code="$(lockfile_error_code)"
+    if [ -n "$error_code" ]; then
+        HOMEBOY_NODE_DEPS_ERROR_CODE="$error_code" \
+        HOMEBOY_NODE_DEPS_ERROR_MESSAGE="$(lockfile_error_message)" \
+            node <<'NODE'
+process.stdout.write(JSON.stringify({
+  command: [],
+  errors: [{
+    code: process.env.HOMEBOY_NODE_DEPS_ERROR_CODE,
+    message: process.env.HOMEBOY_NODE_DEPS_ERROR_MESSAGE || process.env.HOMEBOY_NODE_DEPS_ERROR_CODE,
+  }],
+}) + '\n');
+NODE
+        exit 64
+    fi
+
     HOMEBOY_NODE_DEPS_COMMAND="$(dependency_command)" node <<'NODE'
 const command = (process.env.HOMEBOY_NODE_DEPS_COMMAND || '').split(/\s+/).filter(Boolean);
 process.stdout.write(JSON.stringify({ command }) + '\n');
@@ -64,6 +119,13 @@ NODE
 }
 
 run_install() {
+    local error_code
+    error_code="$(lockfile_error_code)"
+    if [ -n "$error_code" ]; then
+        echo "$(lockfile_error_message)" >&2
+        exit 64
+    fi
+
     local command
     command="$(dependency_command)"
     echo "Installing Node.js dependencies with ${HOMEBOY_PROJECT_PACKAGE_MANAGER}: ${command}" >&2

--- a/tests/nodejs-deps-provider-smoke.sh
+++ b/tests/nodejs-deps-provider-smoke.sh
@@ -65,4 +65,47 @@ if [ "$(cat "$HOMEBOY_FAKE_NPM_LOG")" != "ci" ]; then
     exit 1
 fi
 
+rm "$PROJECT_DIR/package-lock.json"
+status_json="$($ROOT_DIR/nodejs/scripts/deps/deps-runner.sh status)"
+STATUS_JSON="$status_json" node <<'NODE'
+const status = JSON.parse(process.env.STATUS_JSON);
+if (!status.errors.some((error) => error.code === 'nodejs.lockfile_missing')) {
+  throw new Error(`expected missing lockfile error, got ${JSON.stringify(status.errors)}`);
+}
+NODE
+
+set +e
+command_json="$($ROOT_DIR/nodejs/scripts/deps/deps-runner.sh install-command)"
+command_status=$?
+set -e
+if [ "$command_status" -eq 0 ]; then
+    echo "expected install-command to fail without a lockfile" >&2
+    exit 1
+fi
+COMMAND_JSON="$command_json" node <<'NODE'
+const plan = JSON.parse(process.env.COMMAND_JSON);
+if (!Array.isArray(plan.command) || plan.command.length !== 0) {
+  throw new Error(`expected empty command for unsupported install plan, got ${JSON.stringify(plan.command)}`);
+}
+if (!plan.errors.some((error) => error.code === 'nodejs.lockfile_missing')) {
+  throw new Error(`expected missing lockfile error, got ${JSON.stringify(plan.errors)}`);
+}
+NODE
+
+cat >"$PROJECT_DIR/package-lock.json" <<'JSON'
+{
+  "name": "fixture-node-project",
+  "lockfileVersion": 3,
+  "packages": {}
+}
+JSON
+touch "$PROJECT_DIR/yarn.lock"
+status_json="$($ROOT_DIR/nodejs/scripts/deps/deps-runner.sh status)"
+STATUS_JSON="$status_json" node <<'NODE'
+const status = JSON.parse(process.env.STATUS_JSON);
+if (!status.errors.some((error) => error.code === 'nodejs.lockfile_ambiguous')) {
+  throw new Error(`expected ambiguous lockfile error, got ${JSON.stringify(status.errors)}`);
+}
+NODE
+
 echo "nodejs deps provider smoke passed"


### PR DESCRIPTION
## Summary
- Report structured nodejs deps status errors when no lockfile is present.
- Report structured ambiguity errors when multiple Node.js lockfiles are present.
- Keep locked npm projects on the runner-safe `npm ci` install plan.

## Tests
- `bash tests/nodejs-deps-provider-smoke.sh`
- `node tests/extension-shape-lint.mjs`
- `node tests/dependency-adapter-manifests-smoke.mjs`
- `/Users/chubes/Developer/homeboy@controller-origin-main-7628/target/release/homeboy deps status --path /Users/chubes/Developer/static-site-importer@chore-rig-path-inputs-offload`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via opencode
- **Used for:** Fixed the nodejs deps provider contract follow-up for structured lockfile errors and verified the SSI deps status path.