### PR TITLE
Fix WordPress release package cwd

### DIFF
--- a/tests/wordpress-release-package-cwd-smoke.sh
+++ b/tests/wordpress-release-package-cwd-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXTENSION_DIR="${ROOT_DIR}/wordpress"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+RESOLVE_CONTEXT_CORE_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-release-package-cwd.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+component_dir="${TMP_DIR}/component"
+mkdir -p "${component_dir}/includes"
+component_dir="$(cd "${component_dir}" && pwd)"
+
+cat > "${component_dir}/cwd-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: CWD Plugin
+ * Version: 1.2.3
+ */
+PHP
+
+printf '%s\n' '<?php' > "${component_dir}/includes/bootstrap.php"
+
+cat > "${component_dir}/package.json" <<'JSON'
+{
+  "scripts": {
+    "build": "pwd > npm-build-cwd.txt"
+  }
+}
+JSON
+
+payload="$(jq -cn \
+  --arg path "${component_dir}" \
+  '{release:{version:"1.2.3",tag:"cwd-plugin-v1.2.3",component_id:"cwd-plugin",local_path:$path}}')"
+
+(
+  cd "${TMP_DIR}"
+  HOMEBOY_COMPONENT_ID="cwd-plugin" \
+  HOMEBOY_RUNTIME_RESOLVE_CONTEXT="${RESOLVE_CONTEXT_CORE_HELPER}" \
+  HOMEBOY_SKIP_TESTS=1 \
+  HOMEBOY_SETTINGS_JSON="${payload}" \
+    bash "${EXTENSION_DIR}/scripts/release/package.sh" > "${TMP_DIR}/package.json.out" 2> "${TMP_DIR}/package.stderr"
+)
+
+if [[ ! -f "${component_dir}/build/cwd-plugin.zip" ]]; then
+  echo "Expected package script to build artifact in release.local_path" >&2
+  sed 's/^/  /' "${TMP_DIR}/package.stderr" >&2
+  exit 1
+fi
+
+if [[ "$(cat "${component_dir}/npm-build-cwd.txt")" != "${component_dir}" ]]; then
+  echo "Expected npm build to run from release.local_path" >&2
+  echo "  got: $(cat "${component_dir}/npm-build-cwd.txt")" >&2
+  echo "  want: ${component_dir}" >&2
+  exit 1
+fi
+
+if ! jq -e '.[0].path == "build/cwd-plugin.zip" and .[0].type == "wordpress-zip"' "${TMP_DIR}/package.json.out" >/dev/null; then
+  echo "Expected release artifact JSON on stdout" >&2
+  sed 's/^/  /' "${TMP_DIR}/package.json.out" >&2
+  exit 1
+fi
+
+echo "WordPress release package cwd smoke passed."

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -48,6 +48,7 @@
       "bash tests/audit-dead-guard-fallback-smoke.sh",
       "bash tests/eslint-eqeqeq-null-smoke.sh",
       "bash tests/release-scripts-smoke.sh",
+      "bash ../tests/wordpress-release-package-cwd-smoke.sh",
       "node tests/admin-page-scenarios-smoke.js",
       "node tests/admin-page-fuzz-surfaces-smoke.js",
       "node tests/wordpress-bootstrap-timeline-smoke.js",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -160,6 +160,7 @@
     "test:wp-codebox-bench-prepare-steps": "node tests/wp-codebox-bench-prepare-steps-smoke.js",
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",
+    "test:release-package-cwd": "bash ../tests/wordpress-release-package-cwd-smoke.sh",
     "test:agent-task-core-contract-drift": "node tests/agent-task-core-contract-drift.test.js",
     "fixture:agent-task-core-contract": "node ../agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs",
     "fixture:agent-task-core-contract:check": "node ../agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs --check",

--- a/wordpress/scripts/release/package.sh
+++ b/wordpress/scripts/release/package.sh
@@ -36,6 +36,15 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+RELEASE_LOCAL_PATH="$(printf '%s' "${HOMEBOY_SETTINGS_JSON:-}" | jq -r 'try (.release.local_path // empty) catch empty' 2>/dev/null || true)"
+if [[ -n "${RELEASE_LOCAL_PATH}" ]]; then
+  if [[ ! -d "${RELEASE_LOCAL_PATH}" ]]; then
+    echo "Error: release.local_path is not a directory: ${RELEASE_LOCAL_PATH}" >&2
+    exit 1
+  fi
+  cd "${RELEASE_LOCAL_PATH}"
+fi
+
 COMPONENT_SETTINGS_JSON="{}"
 if [[ -f homeboy.json ]]; then
   COMPONENT_SETTINGS_JSON="$(jq -c '.extensions.wordpress.settings // {} | if type == "object" then . else {} end' homeboy.json 2>/dev/null || printf '{}')"


### PR DESCRIPTION
## Summary
- Make the WordPress release package action enter `release.local_path` from the Homeboy release payload before reading component settings or running the build.
- Add a regression smoke that invokes the package action from the preflight parent directory and verifies npm runs in the component checkout.
- Wire the smoke into the WordPress extension test metadata.

## Verification
- `bash ../tests/wordpress-release-package-cwd-smoke.sh`
- `bash ../tests/wordpress-release-artifact-version-smoke.sh`
- `npm run test:build-package-artifacts`
- `npm run test:release-package-cwd`
- `bash -n scripts/release/package.sh ../tests/wordpress-release-package-cwd-smoke.sh`

## Notes
- `homeboy review --changed-only --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-package-cwd/wordpress wordpress test` could not run locally because the installed Homeboy registry reports no extension provider configured for component `wordpress`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Investigated the release packaging cwd failure, implemented the WordPress extension fix, added regression coverage, and ran targeted verification.
