### PR TITLE
Fix WordPress release package source cwd

### DIFF
--- a/tests/wordpress-release-package-cwd-smoke.sh
+++ b/tests/wordpress-release-package-cwd-smoke.sh
@@ -63,3 +63,71 @@ if ! jq -e '.[0].path == "build/cwd-plugin.zip" and .[0].type == "wordpress-zip"
 fi
 
 echo "WordPress release package cwd smoke passed."
+
+nested_repo="${TMP_DIR}/nested-repo"
+nested_component_dir="${nested_repo}/plugins/host/nested-plugin"
+temp_package_dir="${TMP_DIR}/temp-package/nested-plugin"
+mkdir -p "${nested_component_dir}/includes" "${temp_package_dir}"
+nested_component_dir="$(cd "${nested_component_dir}" && pwd)"
+temp_package_dir="$(cd "${temp_package_dir}" && pwd)"
+
+printf '%s\n' 'repo-root-marker' > "${nested_repo}/repo-root.txt"
+cat > "${nested_component_dir}/nested-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Nested Plugin
+ * Version: 2.0.0
+ */
+PHP
+
+printf '%s\n' '<?php' > "${nested_component_dir}/includes/bootstrap.php"
+cat > "${nested_component_dir}/package.json" <<'JSON'
+{
+  "scripts": {
+    "build": "cd ../../.. && test -f repo-root.txt && pwd > plugins/host/nested-plugin/repo-root-cwd.txt"
+  }
+}
+JSON
+
+cp "${nested_component_dir}/nested-plugin.php" "${temp_package_dir}/nested-plugin.php"
+
+nested_payload="$(jq -cn \
+  --arg tempPath "${temp_package_dir}" \
+  '{release:{version:"2.0.0",tag:"nested-plugin-v2.0.0",component_id:"nested-plugin",local_path:$tempPath}}')"
+
+(
+  cd "${TMP_DIR}"
+  HOMEBOY_COMPONENT_ID="nested-plugin" \
+  HOMEBOY_COMPONENT_PATH="${nested_component_dir}" \
+  HOMEBOY_RUNTIME_RESOLVE_CONTEXT="${RESOLVE_CONTEXT_CORE_HELPER}" \
+  HOMEBOY_SKIP_TESTS=1 \
+  HOMEBOY_SETTINGS_JSON="${nested_payload}" \
+    bash "${EXTENSION_DIR}/scripts/release/package.sh" > "${TMP_DIR}/nested-package.json.out" 2> "${TMP_DIR}/nested-package.stderr"
+)
+
+if [[ ! -f "${nested_component_dir}/build/nested-plugin.zip" ]]; then
+  echo "Expected nested package script to build artifact in HOMEBOY_COMPONENT_PATH" >&2
+  sed 's/^/  /' "${TMP_DIR}/nested-package.stderr" >&2
+  exit 1
+fi
+
+if [[ -f "${temp_package_dir}/build/nested-plugin.zip" ]]; then
+  echo "Expected temp package directory not to receive the release artifact" >&2
+  exit 1
+fi
+
+expected_repo_root="$(cd "${nested_repo}" && pwd)"
+if [[ "$(cat "${nested_component_dir}/repo-root-cwd.txt")" != "${expected_repo_root}" ]]; then
+  echo "Expected nested npm build to climb from real component path to repo root" >&2
+  echo "  got: $(cat "${nested_component_dir}/repo-root-cwd.txt")" >&2
+  echo "  want: ${expected_repo_root}" >&2
+  exit 1
+fi
+
+if ! jq -e '.[0].path == "build/nested-plugin.zip" and .[0].type == "wordpress-zip"' "${TMP_DIR}/nested-package.json.out" >/dev/null; then
+  echo "Expected nested release artifact JSON on stdout" >&2
+  sed 's/^/  /' "${TMP_DIR}/nested-package.json.out" >&2
+  exit 1
+fi
+
+echo "WordPress release package nested component cwd smoke passed."

--- a/wordpress/scripts/release/package.sh
+++ b/wordpress/scripts/release/package.sh
@@ -21,6 +21,11 @@ set -euo pipefail
 #   HOMEBOY_SETTINGS_JSON  - JSON payload from homeboy with release.version,
 #                            release.tag, release.component_id, and any dynamic
 #                            settings. Invalid or missing JSON is treated as {}.
+#   HOMEBOY_COMPONENT_PATH - original component checkout path. Preferred over
+#                            release.local_path because release package preflight
+#                            may run from a temporary package context.
+#   HOMEBOY_WORDPRESS_PACKAGE_SOURCE_PATH
+#                          - explicit source checkout override for package builds.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -37,13 +42,15 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 RELEASE_LOCAL_PATH="$(printf '%s' "${HOMEBOY_SETTINGS_JSON:-}" | jq -r 'try (.release.local_path // empty) catch empty' 2>/dev/null || true)"
-if [[ -n "${RELEASE_LOCAL_PATH}" ]]; then
-  if [[ ! -d "${RELEASE_LOCAL_PATH}" ]]; then
-    echo "Error: release.local_path is not a directory: ${RELEASE_LOCAL_PATH}" >&2
+PACKAGE_SOURCE_PATH="${HOMEBOY_WORDPRESS_PACKAGE_SOURCE_PATH:-${HOMEBOY_COMPONENT_PATH:-${RELEASE_LOCAL_PATH}}}"
+if [[ -n "${PACKAGE_SOURCE_PATH}" ]]; then
+  if [[ ! -d "${PACKAGE_SOURCE_PATH}" ]]; then
+    echo "Error: WordPress package source path is not a directory: ${PACKAGE_SOURCE_PATH}" >&2
     exit 1
   fi
-  cd "${RELEASE_LOCAL_PATH}"
+  cd "${PACKAGE_SOURCE_PATH}"
 fi
+export HOMEBOY_COMPONENT_PATH="$(pwd)"
 
 COMPONENT_SETTINGS_JSON="{}"
 if [[ -f homeboy.json ]]; then


### PR DESCRIPTION
## Summary
- Prefer the real WordPress component source path for release packaging when Homeboy provides HOMEBOY_COMPONENT_PATH.
- Keep release.local_path as the fallback for standalone/package-only contexts.
- Add a regression for nested WordPress components whose package build climbs to the repository root while preflight is invoked from a temp package context.

## Verification
- `bash -n wordpress/scripts/release/package.sh tests/wordpress-release-package-cwd-smoke.sh wordpress/tests/release-scripts-smoke.sh && bash tests/wordpress-release-package-cwd-smoke.sh`
- `bash tests/release-scripts-smoke.sh` from `wordpress/`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the release packaging cwd contract, implemented the WordPress extension fix, added regression coverage, and ran focused verification.