### PR TITLE
Use release source path for WordPress packages

### DIFF
--- a/tests/wordpress-release-package-cwd-smoke.sh
+++ b/tests/wordpress-release-package-cwd-smoke.sh
@@ -93,12 +93,13 @@ cp "${nested_component_dir}/nested-plugin.php" "${temp_package_dir}/nested-plugi
 
 nested_payload="$(jq -cn \
   --arg tempPath "${temp_package_dir}" \
-  '{release:{version:"2.0.0",tag:"nested-plugin-v2.0.0",component_id:"nested-plugin",local_path:$tempPath}}')"
+  --arg sourcePath "${nested_component_dir}" \
+  '{release:{version:"2.0.0",tag:"nested-plugin-v2.0.0",component_id:"nested-plugin",local_path:$tempPath,source_path:$sourcePath}}')"
 
 (
   cd "${TMP_DIR}"
   HOMEBOY_COMPONENT_ID="nested-plugin" \
-  HOMEBOY_COMPONENT_PATH="${nested_component_dir}" \
+  HOMEBOY_COMPONENT_PATH="${temp_package_dir}" \
   HOMEBOY_RUNTIME_RESOLVE_CONTEXT="${RESOLVE_CONTEXT_CORE_HELPER}" \
   HOMEBOY_SKIP_TESTS=1 \
   HOMEBOY_SETTINGS_JSON="${nested_payload}" \

--- a/wordpress/scripts/release/package.sh
+++ b/wordpress/scripts/release/package.sh
@@ -26,6 +26,8 @@ set -euo pipefail
 #                            may run from a temporary package context.
 #   HOMEBOY_WORDPRESS_PACKAGE_SOURCE_PATH
 #                          - explicit source checkout override for package builds.
+#   HOMEBOY_RELEASE_SOURCE_PATH
+#                          - generic release source checkout path from Homeboy.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -42,7 +44,8 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 RELEASE_LOCAL_PATH="$(printf '%s' "${HOMEBOY_SETTINGS_JSON:-}" | jq -r 'try (.release.local_path // empty) catch empty' 2>/dev/null || true)"
-PACKAGE_SOURCE_PATH="${HOMEBOY_WORDPRESS_PACKAGE_SOURCE_PATH:-${HOMEBOY_COMPONENT_PATH:-${RELEASE_LOCAL_PATH}}}"
+RELEASE_SOURCE_PATH="$(printf '%s' "${HOMEBOY_SETTINGS_JSON:-}" | jq -r 'try (.release.source_path // empty) catch empty' 2>/dev/null || true)"
+PACKAGE_SOURCE_PATH="${HOMEBOY_WORDPRESS_PACKAGE_SOURCE_PATH:-${HOMEBOY_RELEASE_SOURCE_PATH:-${RELEASE_SOURCE_PATH:-${HOMEBOY_COMPONENT_PATH:-${RELEASE_LOCAL_PATH}}}}}"
 if [[ -n "${PACKAGE_SOURCE_PATH}" ]]; then
   if [[ ! -d "${PACKAGE_SOURCE_PATH}" ]]; then
     echo "Error: WordPress package source path is not a directory: ${PACKAGE_SOURCE_PATH}" >&2


### PR DESCRIPTION
## Summary
- Prefer release.source_path / HOMEBOY_RELEASE_SOURCE_PATH for WordPress package builds before falling back to legacy env/local_path sources.
- Keep release.local_path as the package/staging path.
- Tighten the nested WordPress package smoke to match wp-build: HOMEBOY_COMPONENT_PATH points at the temp package path while release.source_path points at the real nested source component.

## Dependency
- Depends on Extra-Chill/homeboy#7629 for the generic release.source_path payload and HOMEBOY_RELEASE_SOURCE_PATH env contract.

## Verification
- bash ../tests/wordpress-release-package-cwd-smoke.sh

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updated the WordPress release package script to consume the upstream source-path contract and added nested package regression coverage.