### PR TITLE
Allow npm deps hydration without lockfile

### DIFF
--- a/nodejs/scripts/deps/deps-runner.sh
+++ b/nodejs/scripts/deps/deps-runner.sh
@@ -21,11 +21,6 @@ for lockfile in pnpm-lock.yaml yarn.lock package-lock.json; do
 done
 
 lockfile_error_code() {
-    if [ "${#LOCKFILES[@]}" -eq 0 ]; then
-        printf '%s\n' "nodejs.lockfile_missing"
-        return
-    fi
-
     if [ "${#LOCKFILES[@]}" -gt 1 ]; then
         printf '%s\n' "nodejs.lockfile_ambiguous"
         return
@@ -34,9 +29,6 @@ lockfile_error_code() {
 
 lockfile_error_message() {
     case "$(lockfile_error_code)" in
-        nodejs.lockfile_missing)
-            printf '%s\n' "Node.js dependency hydration requires a lockfile. Add package-lock.json, pnpm-lock.yaml, or yarn.lock."
-            ;;
         nodejs.lockfile_ambiguous)
             printf 'Multiple Node.js lockfiles found: %s. Keep exactly one lockfile so Homeboy can choose a deterministic package manager.\n' "${LOCKFILES[*]}"
             ;;
@@ -56,7 +48,11 @@ dependency_command() {
             printf '%s\n' "yarn install --frozen-lockfile"
             ;;
         npm|*)
-            printf '%s\n' "npm ci"
+            if [ -f "${HOMEBOY_PROJECT_DEPENDENCY_ROOT}/package-lock.json" ]; then
+                printf '%s\n' "npm ci"
+            else
+                printf '%s\n' "npm install --no-audit --no-fund"
+            fi
             ;;
     esac
 }

--- a/tests/nodejs-deps-provider-smoke.sh
+++ b/tests/nodejs-deps-provider-smoke.sh
@@ -69,28 +69,25 @@ rm "$PROJECT_DIR/package-lock.json"
 status_json="$($ROOT_DIR/nodejs/scripts/deps/deps-runner.sh status)"
 STATUS_JSON="$status_json" node <<'NODE'
 const status = JSON.parse(process.env.STATUS_JSON);
-if (!status.errors.some((error) => error.code === 'nodejs.lockfile_missing')) {
-  throw new Error(`expected missing lockfile error, got ${JSON.stringify(status.errors)}`);
+if (status.errors.length !== 0) {
+  throw new Error(`expected package-only npm workspace to hydrate with fallback install, got ${JSON.stringify(status.errors)}`);
 }
 NODE
 
-set +e
 command_json="$($ROOT_DIR/nodejs/scripts/deps/deps-runner.sh install-command)"
-command_status=$?
-set -e
-if [ "$command_status" -eq 0 ]; then
-    echo "expected install-command to fail without a lockfile" >&2
-    exit 1
-fi
 COMMAND_JSON="$command_json" node <<'NODE'
 const plan = JSON.parse(process.env.COMMAND_JSON);
-if (!Array.isArray(plan.command) || plan.command.length !== 0) {
-  throw new Error(`expected empty command for unsupported install plan, got ${JSON.stringify(plan.command)}`);
-}
-if (!plan.errors.some((error) => error.code === 'nodejs.lockfile_missing')) {
-  throw new Error(`expected missing lockfile error, got ${JSON.stringify(plan.errors)}`);
+if (JSON.stringify(plan.command) !== JSON.stringify(['npm', 'install', '--no-audit', '--no-fund'])) {
+  throw new Error(`expected npm install fallback plan, got ${JSON.stringify(plan.command)}`);
 }
 NODE
+
+: >"$HOMEBOY_FAKE_NPM_LOG"
+"$ROOT_DIR/nodejs/scripts/deps/deps-runner.sh" install >/dev/null
+if [ "$(cat "$HOMEBOY_FAKE_NPM_LOG")" != "install --no-audit --no-fund" ]; then
+    echo "expected package-only install to run npm install fallback" >&2
+    exit 1
+fi
 
 cat >"$PROJECT_DIR/package-lock.json" <<'JSON'
 {


### PR DESCRIPTION
## Summary

- Allow the `nodejs` deps provider to hydrate npm package-only workspaces with `npm install --no-audit --no-fund` when `package.json` exists without `package-lock.json`.
- Keep locked npm workspaces on `npm ci`.
- Keep ambiguous multiple-lockfile workspaces as hard errors.

## Context

SSI Lab fixture matrix path staging reached the remote runner, but the remote rig check failed before the matrix workload because `tools/fixture-matrix.test.mjs` imported `pngjs` before dependencies were installed. Static Site Importer declares the `nodejs` extension and has `package.json` dependencies without a lockfile, so the nodejs deps provider returned no install plan.

This aligns the deps provider with the existing project helper fallback behavior for npm package-only workspaces, while preserving deterministic locked installs when a lockfile is present.

## Verification

- `tests/nodejs-deps-provider-smoke.sh`

Lab evidence from investigation:

- Runner/resource state: `homeboy runs resources --actionable` reported `actionable_count: 0` and `cleanup_eligible_count: 0`.
- SSI Lab retry reached remote path staging and failed remotely, not locally, with missing `pngjs` during rig check.
- No `--local` fallback was used for the SSI proof attempts.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5 via OpenCode
- **Used for:** Investigated Homeboy Lab/SSI lock and deps state, identified the nodejs deps-provider gap, implemented the targeted fix, and ran verification.
