### PR TITLE
Harden runtime artifact contracts

### DIFF
--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -667,6 +667,7 @@ jobs:
             ${{ runner.temp }}/runtime-agent-run/events.json
             ${{ runner.temp }}/runtime-agent-run/run-outcome-envelope.json
             ${{ runner.temp }}/runtime-agent-run/runner-execution-record.json
+            ${{ runner.temp }}/runtime-agent-run/homeboy-artifact-manifest.json
             ${{ runner.temp }}/runtime-agent-run/loop-result.json
             ${{ runner.temp }}/runtime-agent-run/loop-policy.json
             ${{ runner.temp }}/runtime-agent-run/*-runtime-stderr.txt

--- a/runtime-agent-ci/lib/artifact-paths.cjs
+++ b/runtime-agent-ci/lib/artifact-paths.cjs
@@ -13,36 +13,24 @@ function runtimeAgentArtifactPaths(options = {}) {
   const provided = options.artifact_paths && typeof options.artifact_paths === 'object' && !Array.isArray(options.artifact_paths) ? options.artifact_paths : {};
   const runDir = firstString(
     provided.run_dir,
-    provided.runDir,
-    options.runDir,
     options.run_dir,
-    options.artifactsDir,
-    options.artifacts_dir,
-    options.artifactsPath,
-    options.artifacts_path,
-    options.plan?.artifacts_path,
-    options.plan?.artifacts,
     options.env?.HOMEBOY_RUNTIME_AGENT_RUN_DIR,
-    options.env?.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR,
-    options.env?.HOMEBOY_RUNTIME_AGENT_ARTIFACTS,
     process.env.HOMEBOY_RUNTIME_AGENT_RUN_DIR,
-    process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR,
-    process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS
   );
   return stripUndefined({
     schema: ARTIFACT_PATHS_SCHEMA,
     run_dir: runDir,
-    events: firstString(provided.events, options.eventsFile, options.events_file, options.env?.HOMEBOY_RUNTIME_AGENT_EVENTS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_EVENTS_FILE, runArtifactPath(runDir, 'events')),
-    status: firstString(provided.status, options.statusFile, options.status_file, options.env?.HOMEBOY_RUNTIME_AGENT_STATUS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_STATUS_FILE, runArtifactPath(runDir, 'status')),
-    results: firstString(provided.results, options.resultsFile, options.results_file, options.env?.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE, runArtifactPath(runDir, 'results')),
-    outcome: firstString(provided.outcome, options.outcomeFile, options.outcome_file, options.env?.HOMEBOY_AGENT_TASK_OUTCOME_FILE, process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE, runArtifactPath(runDir, 'outcome')),
-    run_outcome_envelope: firstString(provided.run_outcome_envelope, provided.runOutcomeEnvelope, options.runOutcomeEnvelopeFile, options.run_outcome_envelope_file, options.env?.HOMEBOY_RUNTIME_AGENT_RUN_OUTCOME_ENVELOPE_FILE, process.env.HOMEBOY_RUNTIME_AGENT_RUN_OUTCOME_ENVELOPE_FILE, runArtifactPath(runDir, 'run_outcome_envelope')),
-    runner_execution_record: firstString(provided.runner_execution_record, provided.runnerExecutionRecord, options.runnerExecutionRecordFile, options.runner_execution_record_file, options.env?.HOMEBOY_RUNTIME_AGENT_RUNNER_EXECUTION_RECORD_FILE, process.env.HOMEBOY_RUNTIME_AGENT_RUNNER_EXECUTION_RECORD_FILE, runArtifactPath(runDir, 'runner_execution_record')),
-    stderr: firstString(provided.stderr, options.stderrFile, options.stderr_file, options.env?.HOMEBOY_RUNTIME_AGENT_STDERR_FILE, process.env.HOMEBOY_RUNTIME_AGENT_STDERR_FILE),
-    fanout_run: firstString(provided.fanout_run, provided.fanoutRun, options.fanoutRunFile, options.fanout_run_file, options.runsOutputPath, options.runs_output_path, options.env?.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, process.env.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, runArtifactPath(runDir, 'fanout_run')),
-    loop_result: firstString(provided.loop_result, provided.loopResult, options.loopResultFile, options.loop_result_file, options.resultFile, options.result_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, runArtifactPath(runDir, 'loop_result')),
-    loop_policy: firstString(provided.loop_policy, provided.loopPolicy, options.loopPolicyFile, options.loop_policy_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, runArtifactPath(runDir, 'loop_policy')),
-    artifact_manifest: firstString(provided.artifact_manifest, provided.artifactManifest, options.artifactManifestFile, options.artifact_manifest_file, options.env?.HOMEBOY_RUNTIME_AGENT_ARTIFACT_MANIFEST_FILE, process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACT_MANIFEST_FILE, runDir ? path.join(runDir, ARTIFACT_MANIFEST_FILE) : ''),
+    events: firstString(provided.events, options.events_file, options.env?.HOMEBOY_RUNTIME_AGENT_EVENTS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_EVENTS_FILE, runArtifactPath(runDir, 'events')),
+    status: firstString(provided.status, options.status_file, options.env?.HOMEBOY_RUNTIME_AGENT_STATUS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_STATUS_FILE, runArtifactPath(runDir, 'status')),
+    results: firstString(provided.results, options.results_file, options.env?.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE, process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE, runArtifactPath(runDir, 'results')),
+    outcome: firstString(provided.outcome, options.outcome_file, options.env?.HOMEBOY_AGENT_TASK_OUTCOME_FILE, process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE, runArtifactPath(runDir, 'outcome')),
+    run_outcome_envelope: firstString(provided.run_outcome_envelope, options.run_outcome_envelope_file, options.env?.HOMEBOY_RUNTIME_AGENT_RUN_OUTCOME_ENVELOPE_FILE, process.env.HOMEBOY_RUNTIME_AGENT_RUN_OUTCOME_ENVELOPE_FILE, runArtifactPath(runDir, 'run_outcome_envelope')),
+    runner_execution_record: firstString(provided.runner_execution_record, options.runner_execution_record_file, options.env?.HOMEBOY_RUNTIME_AGENT_RUNNER_EXECUTION_RECORD_FILE, process.env.HOMEBOY_RUNTIME_AGENT_RUNNER_EXECUTION_RECORD_FILE, runArtifactPath(runDir, 'runner_execution_record')),
+    stderr: firstString(provided.stderr, options.stderr_file, options.env?.HOMEBOY_RUNTIME_AGENT_STDERR_FILE, process.env.HOMEBOY_RUNTIME_AGENT_STDERR_FILE),
+    fanout_run: firstString(provided.fanout_run, options.fanout_run_file, options.env?.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, process.env.HOMEBOY_RUNTIME_AGENT_FANOUT_RUN_FILE, runArtifactPath(runDir, 'fanout_run')),
+    loop_result: firstString(provided.loop_result, options.loop_result_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_RESULT_FILE, runArtifactPath(runDir, 'loop_result')),
+    loop_policy: firstString(provided.loop_policy, options.loop_policy_file, options.env?.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, process.env.HOMEBOY_RUNTIME_AGENT_LOOP_POLICY_FILE, runArtifactPath(runDir, 'loop_policy')),
+    artifact_manifest: firstString(provided.artifact_manifest, options.artifact_manifest_file, options.env?.HOMEBOY_RUNTIME_AGENT_ARTIFACT_MANIFEST_FILE, process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACT_MANIFEST_FILE, runDir ? path.join(runDir, ARTIFACT_MANIFEST_FILE) : ''),
   });
 }
 
@@ -60,7 +48,7 @@ function artifactManifestForFiles(artifactPaths = {}, files = []) {
   return {
     schema: ARTIFACT_MANIFEST_SCHEMA,
     artifacts: normalizeManifestFiles(files)
-      .map((file) => manifestEntryForFile(root, file))
+      .map((file) => manifestEntryForFile(root, file, artifactPaths))
       .filter(Boolean),
   };
 }
@@ -71,24 +59,38 @@ function normalizeManifestFiles(files) {
     .filter((file) => file && typeof file === 'object' && typeof file.path === 'string' && file.path.trim() !== '');
 }
 
-function manifestEntryForFile(root, file) {
+function manifestEntryForFile(root, file, artifactPaths = {}) {
   const relative = relativeArtifactPath(root, file.path);
   if (!relative) {
     return null;
   }
+  const semanticKey = firstString(file.semantic_key, file.semanticKey, canonicalSemanticKeyForPath(artifactPaths, file.path));
   return stripUndefined({
     id: firstString(file.id, file.name, file.role, path.basename(relative)),
     path: relative,
     kind: firstString(file.kind, file.type, 'file'),
     role: firstString(file.role),
     label: firstString(file.label, file.name),
-    semantic_key: firstString(file.semantic_key, file.semanticKey),
+    semantic_key: semanticKey,
     content_type: firstString(file.content_type, file.contentType),
     public_url: firstString(file.public_url, file.publicUrl),
     size_bytes: Number.isFinite(file.size_bytes) ? file.size_bytes : Number.isFinite(file.bytes) ? file.bytes : undefined,
     sha256: firstString(file.sha256),
     metadata: file.metadata && typeof file.metadata === 'object' && !Array.isArray(file.metadata) ? file.metadata : {},
   });
+}
+
+function canonicalSemanticKeyForPath(artifactPaths, filePath) {
+  const absolute = path.resolve(filePath);
+  for (const [key, value] of Object.entries(artifactPaths || {})) {
+    if (key === 'schema' || key === 'run_dir' || typeof value !== 'string' || value.trim() === '') {
+      continue;
+    }
+    if (path.resolve(value) === absolute) {
+      return key;
+    }
+  }
+  return '';
 }
 
 function relativeArtifactPath(root, filePath) {

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -480,7 +480,7 @@ function persistRuntimeInvocationStderr(content, options = {}) {
     return null;
   }
   const taskId = options.request?.task_id || options.plan?.workload_id || options.plan?.task_id || 'runtime-agent-task';
-  const filePath = runtimeAgentArtifactPaths({ ...options, stderrFile: options.stderrFile || options.stderr_file }).stderr || path.join(artifactDir, `${safeFileSegment(taskId)}-runtime-stderr.txt`);
+  const filePath = runtimeAgentArtifactPaths(options).stderr || path.join(artifactDir, `${safeFileSegment(taskId)}-runtime-stderr.txt`);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content);
   return {

--- a/runtime-agent-ci/lib/runtime-contracts.cjs
+++ b/runtime-agent-ci/lib/runtime-contracts.cjs
@@ -10,6 +10,7 @@ const REQUIRED_RUNTIME_CONTRACT_FIELDS = Object.freeze({
   artifact_paths: Object.freeze(['schema_id']),
   runner_artifact_manifest_ref: Object.freeze(['schema_id']),
   runner_execution_record: Object.freeze(['schema_id']),
+  path_materialization_plan: Object.freeze(['schema_id']),
   run_outcome_envelope: Object.freeze(['schema_id']),
 });
 

--- a/runtime-agent-ci/tests/artifact-paths.test.js
+++ b/runtime-agent-ci/tests/artifact-paths.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+require('./helpers/runtime-contract-constants-fixture.cjs');
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  ARTIFACT_MANIFEST_FILE,
+  artifactManifestForFiles,
+  runtimeAgentArtifactPaths,
+} = require('../lib/artifact-paths.cjs');
+
+const canonicalRunDir = path.join('/tmp', 'homeboy-runtime-agent-run');
+assert.equal(
+  runtimeAgentArtifactPaths({ artifact_paths: { run_dir: canonicalRunDir } }).artifact_manifest,
+  path.join(canonicalRunDir, ARTIFACT_MANIFEST_FILE)
+);
+
+const legacyOnly = runtimeAgentArtifactPaths({
+  runDir: '/tmp/legacy-run-dir',
+  artifactManifestFile: '/tmp/legacy-manifest.json',
+});
+assert.equal(legacyOnly.run_dir, undefined);
+assert.equal(legacyOnly.artifact_manifest, undefined);
+
+const canonicalOptions = runtimeAgentArtifactPaths({
+  run_dir: canonicalRunDir,
+  artifact_manifest_file: '/tmp/canonical-manifest.json',
+});
+assert.equal(canonicalOptions.run_dir, canonicalRunDir);
+assert.equal(canonicalOptions.artifact_manifest, '/tmp/canonical-manifest.json');
+
+const projectedPaths = runtimeAgentArtifactPaths({ artifact_paths: { run_dir: canonicalRunDir } });
+const projectedManifest = artifactManifestForFiles(projectedPaths, [
+  { path: projectedPaths.outcome },
+  { path: projectedPaths.results, semantic_key: 'explicit-results' },
+]);
+assert.deepEqual(projectedManifest.artifacts.map((artifact) => artifact.semantic_key), ['outcome', 'explicit-results']);
+
+process.stdout.write('Runtime agent artifact path contract checks passed\n');

--- a/runtime-agent-ci/tests/fixtures/homeboy-runtime-contract-constants.generated.json
+++ b/runtime-agent-ci/tests/fixtures/homeboy-runtime-contract-constants.generated.json
@@ -21,6 +21,9 @@
       "runner_execution_record": {
         "schema_id": "homeboy/runner-execution-record/v1"
       },
+      "path_materialization_plan": {
+        "schema_id": "homeboy/path-materialization-plan/v1"
+      },
       "secret_env_plan": {
         "schema_id": "homeboy/secret-env-plan/v1"
       }

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -324,7 +324,8 @@ process.stdout.write(JSON.stringify({
           },
         },
       },
-      plan: { ...plan, workload_id: 'manifest-noisy', artifacts_path: noisyArtifactsDir },
+      plan: { ...plan, workload_id: 'manifest-noisy' },
+      artifact_paths: { run_dir: noisyArtifactsDir },
       validationPolicy: { success_completion_outcomes: ['done'] },
       stderrMaxBytes: 256,
     });
@@ -369,6 +370,7 @@ process.stdout.write(JSON.stringify({
   assert.equal(sharedEnvelope.outcome.task_id, 'shared-artifact-paths');
   assert.equal(sharedEnvelope.results.scenarios[0].id, 'shared-artifact-paths');
   assert.equal(sharedEnvelope.artifact_manifest.manifest_schema, ARTIFACT_MANIFEST_SCHEMA);
+  assert.equal(sharedEnvelope.artifact_manifest.path, path.join(sharedArtifactDir, ARTIFACT_MANIFEST_FILE));
   const sharedManifest = JSON.parse(fs.readFileSync(path.join(sharedArtifactDir, ARTIFACT_MANIFEST_FILE), 'utf8'));
   assert.equal(sharedManifest.schema, ARTIFACT_MANIFEST_SCHEMA);
   assert.deepEqual(sharedManifest.artifacts.map((artifact) => artifact.path).sort(), [
@@ -377,6 +379,12 @@ process.stdout.write(JSON.stringify({
     'run-outcome-envelope.json',
     'shared-artifact-paths-runtime-stderr.txt',
     'status.json',
+  ]);
+  assert.deepEqual(sharedManifest.artifacts.map((artifact) => artifact.semantic_key).filter(Boolean).sort(), [
+    'outcome',
+    'results',
+    'run_outcome_envelope',
+    'status',
   ]);
   assert.equal(sharedManifest.artifacts.every((artifact) => !path.isAbsolute(artifact.path)), true);
 

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -384,9 +384,11 @@ try {
   const loopResultFile = path.join(tmpRoot, 'loop-result.json');
   writeHeadlessDeterministicLoopArtifacts({
     result: twoRevolution,
-    loopPolicyFile,
-    statusFile,
-    loopResultFile,
+    artifact_paths: {
+      loop_policy: loopPolicyFile,
+      status: statusFile,
+      loop_result: loopResultFile,
+    },
   });
   const loopPolicyArtifact = JSON.parse(fs.readFileSync(loopPolicyFile, 'utf8'));
   const statusArtifact = JSON.parse(fs.readFileSync(statusFile, 'utf8'));

--- a/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
+++ b/runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
@@ -85,6 +85,33 @@ const singleContractShape = probeHomeboyContractSurface({
 assert.equal(singleContractShape.status, 'passed');
 assert.deepEqual(singleContractShape.argv, ['contract', 'constants', 'artifact-manifest']);
 
+const missingPathMaterializationPlan = probeHomeboyContractSurface({
+  homeboyCommand: 'homeboy',
+  spawnSync: () => ({
+    status: 0,
+    stdout: JSON.stringify({
+      success: true,
+      data: {
+        constants: {
+          artifact_manifest: CORE_PUBLISHED_CONTRACT_CONSTANTS.artifact_manifest,
+          secret_env_plan: CORE_PUBLISHED_CONTRACT_CONSTANTS.secret_env_plan,
+          run_location_index: CORE_PUBLISHED_CONTRACT_CONSTANTS.run_location_index,
+          artifact_paths: CORE_PUBLISHED_CONTRACT_CONSTANTS.artifact_paths,
+          runner_artifact_manifest_ref: CORE_PUBLISHED_CONTRACT_CONSTANTS.runner_artifact_manifest_ref,
+          runner_execution_record: CORE_PUBLISHED_CONTRACT_CONSTANTS.runner_execution_record,
+          run_outcome_envelope: CORE_PUBLISHED_CONTRACT_CONSTANTS.run_outcome_envelope,
+        },
+        contract_id: 'all',
+        schema: 'homeboy/contract-constants/v1',
+      },
+    }),
+    stderr: '',
+  }),
+});
+
+assert.equal(missingPathMaterializationPlan.status, 'failed');
+assert.match(missingPathMaterializationPlan.message, /path_materialization_plan\.schema_id is missing/);
+
 const drift = probeHomeboyContractSurface({
   homeboyCommand: 'homeboy',
   spawnSync: () => ({


### PR DESCRIPTION
## Summary
- Consume canonical runtime artifact path keys without falling back to stale legacy aliases when canonical snake_case entries are present.
- Upload the generated homeboy artifact manifest in the reusable runtime workflow.
- Add path_materialization_plan.schema_id to runtime contract surface expectations and fixture coverage.
- Derive artifact manifest semantic keys from canonical artifact paths while preserving explicit semantic keys.

## Tests
- node runtime-agent-ci/tests/artifact-paths.test.js
- node runtime-agent-ci/tests/generic-agent-loop-runner.test.js
- node runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
- node runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js
- npm test from runtime-agent-ci/

## Notes
- This PR does not depend on the unmerged Homeboy core path-materialization projection.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified the runtime-agent artifact contract cleanup.