### PR TITLE
Consume path materialization projections

### DIFF
--- a/runtime-agent-ci/lib/path-materialization-plan.cjs
+++ b/runtime-agent-ci/lib/path-materialization-plan.cjs
@@ -25,45 +25,109 @@ function normalizePathMaterializationPlan(plan, options = {}) {
   }
 
   const workspace = requiredString(options.workspace, 'workspace');
-  const paths = plainObject(plan.paths) ? plan.paths : {};
+  const projection = pathMaterializationProjection(plan);
+  const projectedPathRemaps = normalizePathRemaps(projection.path_remaps, workspace, 'path_materialization_plan.projection.path_remaps');
+  const canonicalPathRemaps = projectedPathRemaps.length > 0
+    ? []
+    : normalizeCanonicalEntryPathRemaps(plan.entries || [], workspace);
+  const pathRemaps = projectedPathRemaps.length > 0 ? projectedPathRemaps : canonicalPathRemaps;
+  const primaryWorkspaceRemotePath = firstString(
+    projection.runner_workspace_guest_checkout,
+    primaryWorkspaceRemotePathFromRemaps(pathRemaps),
+    primaryWorkspaceRemotePathFromEntries(plan.entries || [])
+  );
 
   return stripUndefined({
     schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
     runner_workspace_guest_checkout: optionalGuestPath(
-      paths.runner_workspace_guest_checkout,
-      'path_materialization_plan.paths.runner_workspace_guest_checkout'
+      primaryWorkspaceRemotePath,
+      'path_materialization_plan.projection.runner_workspace_guest_checkout'
     ),
     transcript_host_dir: optionalHostPath(
-      paths.transcript_host_dir,
+      projection.transcript_host_dir,
       workspace,
-      'path_materialization_plan.paths.transcript_host_dir'
+      'path_materialization_plan.projection.transcript_host_dir'
     ),
     transcript_dir: optionalGuestPath(
-      paths.transcript_dir,
-      'path_materialization_plan.paths.transcript_dir'
+      projection.transcript_dir,
+      'path_materialization_plan.projection.transcript_dir'
     ),
-    runtime_mounts: normalizeMounts(plan.runtime_mounts || [], workspace),
+    path_remaps: pathRemaps,
+    runtime_mounts: runtimeMountsFromPathRemaps(pathRemaps),
   });
 }
 
-function normalizeMounts(mounts, workspace) {
-  if (!Array.isArray(mounts)) {
-    throw new Error('path_materialization_plan.runtime_mounts must be an array');
+function pathMaterializationProjection(plan) {
+  if (plainObject(plan.projection)) {
+    return plan.projection;
   }
-  return mounts.map((mount, index) => {
-    if (!plainObject(mount)) {
-      throw new Error(`path_materialization_plan.runtime_mounts[${index}] must be an object`);
+  return plan;
+}
+
+function normalizeCanonicalEntryPathRemaps(entries, workspace) {
+  if (!Array.isArray(entries)) {
+    throw new Error('path_materialization_plan.entries must be an array');
+  }
+  return entries.flatMap((entry, index) => {
+    if (!plainObject(entry)) {
+      throw new Error(`path_materialization_plan.entries[${index}] must be an object`);
     }
-    const source = requiredHostPath(mount.source, workspace, `path_materialization_plan.runtime_mounts[${index}].source`, { allowWorkspaceRoot: true });
-    const target = requiredGuestPath(mount.target, `path_materialization_plan.runtime_mounts[${index}].target`);
-    return stripUndefined({
-      type: mount.type || 'directory',
-      source,
-      target,
-      mode: mount.mode || 'readwrite',
-      metadata: plainObject(mount.metadata) ? mount.metadata : undefined,
-    });
+    if (!entry.local_path && !entry.remote_path) {
+      return [];
+    }
+    if (!entry.local_path || !entry.remote_path) {
+      return [];
+    }
+    return [normalizePathRemap(entry, workspace, `path_materialization_plan.entries[${index}]`)];
   });
+}
+
+function normalizePathRemaps(pathRemaps, workspace, name) {
+  if (pathRemaps === undefined) {
+    return [];
+  }
+  if (!Array.isArray(pathRemaps)) {
+    throw new Error(`${name} must be an array`);
+  }
+  return pathRemaps.map((remap, index) => normalizePathRemap(remap, workspace, `${name}[${index}]`));
+}
+
+function normalizePathRemap(remap, workspace, name) {
+  if (!plainObject(remap)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return stripUndefined({
+    role: typeof remap.role === 'string' && remap.role.length > 0 ? remap.role : undefined,
+    owner: typeof remap.owner === 'string' && remap.owner.length > 0 ? remap.owner : undefined,
+    local_path: requiredHostPath(remap.local_path, workspace, `${name}.local_path`, { allowWorkspaceRoot: true }),
+    remote_path: requiredGuestPath(remap.remote_path, `${name}.remote_path`),
+  });
+}
+
+function runtimeMountsFromPathRemaps(pathRemaps) {
+  return pathRemaps.map((remap) => stripUndefined({
+    type: 'directory',
+    source: remap.local_path,
+    target: remap.remote_path,
+    mode: 'readwrite',
+    metadata: stripUndefined({
+      role: remap.role,
+      owner: remap.owner,
+    }),
+  }));
+}
+
+function primaryWorkspaceRemotePathFromRemaps(pathRemaps) {
+  const primary = pathRemaps.find((remap) => remap.role === 'primary_workspace') || pathRemaps[0];
+  return primary ? primary.remote_path : '';
+}
+
+function primaryWorkspaceRemotePathFromEntries(entries) {
+  if (!Array.isArray(entries)) {
+    return '';
+  }
+  const primary = entries.find((entry) => plainObject(entry) && entry.role === 'primary_workspace' && typeof entry.remote_path === 'string');
+  return primary ? primary.remote_path : '';
 }
 
 function requiredHostPath(value, workspace, name, options = {}) {
@@ -147,5 +211,6 @@ function stripUndefined(value) {
 module.exports = {
   PATH_MATERIALIZATION_PLAN_SCHEMA,
   normalizePathMaterializationPlan,
+  normalizePathRemaps,
   parsePathMaterializationPlan,
 };

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -54,44 +54,69 @@ const pathPlanWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-path-pl
 try {
   const pathPlan = normalizePathMaterializationPlan({
     schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
-    paths: {
+    projection: {
       runner_workspace_guest_checkout: '/runtime/workspace/example',
       transcript_host_dir: 'artifacts/transcript',
       transcript_dir: '/runtime/workspace/example/artifacts/transcript',
+      path_remaps: [{ role: 'primary_workspace', owner: 'runner', local_path: '.', remote_path: '/runtime/workspace/example' }],
     },
-    runtime_mounts: [{ source: '.', target: '/runtime/workspace/example', metadata: { kind: 'runner-workspace' } }],
   }, { workspace: pathPlanWorkspace });
   assert.equal(pathPlan.runner_workspace_guest_checkout, '/runtime/workspace/example');
   assert.equal(pathPlan.transcript_host_dir, path.join(pathPlanWorkspace, 'artifacts/transcript'));
   assert.equal(pathPlan.transcript_dir, '/runtime/workspace/example/artifacts/transcript');
+  assert.deepEqual(pathPlan.path_remaps, [{
+    role: 'primary_workspace',
+    owner: 'runner',
+    local_path: pathPlanWorkspace,
+    remote_path: '/runtime/workspace/example',
+  }]);
   assert.deepEqual(pathPlan.runtime_mounts, [{
     type: 'directory',
     source: pathPlanWorkspace,
     target: '/runtime/workspace/example',
     mode: 'readwrite',
-    metadata: { kind: 'runner-workspace' },
+    metadata: { role: 'primary_workspace', owner: 'runner' },
+  }]);
+
+  const canonicalFallbackPathPlan = normalizePathMaterializationPlan({
+    schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
+    entries: [{
+      role: 'primary_workspace',
+      owner: 'runner_exec.source_snapshot',
+      local_path: '.',
+      remote_path: '/runtime/workspace/example',
+      materialization_mode: 'snapshot',
+      validation_status: 'materialized',
+    }],
+  }, { workspace: pathPlanWorkspace });
+  assert.equal(canonicalFallbackPathPlan.runner_workspace_guest_checkout, '/runtime/workspace/example');
+  assert.deepEqual(canonicalFallbackPathPlan.path_remaps, [{
+    role: 'primary_workspace',
+    owner: 'runner_exec.source_snapshot',
+    local_path: pathPlanWorkspace,
+    remote_path: '/runtime/workspace/example',
   }]);
 
   assert.throws(
     () => normalizePathMaterializationPlan({
       schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
-      paths: { transcript_host_dir: '../outside' },
+      projection: { transcript_host_dir: '../outside' },
     }, { workspace: pathPlanWorkspace }),
     /transcript_host_dir.*parent-directory|transcript_host_dir.*under GITHUB_WORKSPACE/
   );
   assert.throws(
     () => normalizePathMaterializationPlan({
       schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
-      paths: { transcript_dir: 'relative/transcript' },
+      projection: { transcript_dir: 'relative/transcript' },
     }, { workspace: pathPlanWorkspace }),
     /transcript_dir must be an absolute POSIX path/
   );
   assert.throws(
     () => normalizePathMaterializationPlan({
       schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
-      runtime_mounts: [{ source: '.', target: '/runtime/../escape' }],
+      projection: { path_remaps: [{ local_path: '.', remote_path: '/runtime/../escape' }] },
     }, { workspace: pathPlanWorkspace }),
-    /runtime_mounts\[0\]\.target.*normalized absolute POSIX path/
+    /path_remaps\[0\]\.remote_path.*normalized absolute POSIX path/
   );
 } finally {
   fs.rmSync(pathPlanWorkspace, { recursive: true, force: true });
@@ -143,12 +168,12 @@ try {
     RUNNER_WORKSPACE_CONFIG: '{"enabled":true}',
     PATH_MATERIALIZATION_PLAN: JSON.stringify({
       schema: PATH_MATERIALIZATION_PLAN_SCHEMA,
-      paths: {
+      projection: {
         runner_workspace_guest_checkout: '/runtime/workspace/example',
         transcript_host_dir: 'runtime-artifacts/path-plan-fixture',
         transcript_dir: '/runtime/workspace/example/runtime-artifacts/path-plan-fixture',
+        path_remaps: [{ role: 'primary_workspace', owner: 'runner', local_path: '.', remote_path: '/runtime/workspace/example' }],
       },
-      runtime_mounts: [{ source: '.', target: '/runtime/workspace/example', mode: 'readwrite' }],
     }),
   });
 
@@ -160,6 +185,7 @@ try {
     source: materializedTmpRoot,
     target: '/runtime/workspace/example',
     mode: 'readwrite',
+    metadata: { role: 'primary_workspace', owner: 'runner' },
   }]);
   assert.equal(config.path_materialization_plan.schema, PATH_MATERIALIZATION_PLAN_SCHEMA);
 } finally {


### PR DESCRIPTION
## Summary
- Consume normalized path materialization projection `path_remaps` in runtime-agent-ci.
- Retain canonical `entries` fallback for currently shipped Homeboy versions.
- Remove legacy `paths`/`runtime_mounts` plan parsing from the consumer.

## Tests
- `node runtime-agent-ci/tests/build-runner-config.test.js`
- `node runtime-agent-ci/tests/homeboy-contract-surface-probe.test.js`
- `npm test` from `runtime-agent-ci/`

## Related
- Relates to Homeboy #7646.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified runtime-agent path materialization projection consumption.
