### PR TITLE
Add runtime workload profile input

### DIFF
--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -19,6 +19,10 @@ name: Runtime Agent Full Run (reusable)
         description: Runtime provider ref.
         type: string
         default: main
+      runtime_workload_profile_json:
+        description: JSON object carrying compact defaults for non-secret runtime/workload knobs. Explicit workflow inputs take precedence.
+        type: string
+        default: '{}'
       profile:
         description: Runtime profile id selected from runtime_profiles.
         type: string
@@ -481,6 +485,7 @@ jobs:
           SECRET_ENV_MAP: ${{ inputs.secret_env_map }}
           SECRET_ENV_PLAN: ${{ inputs.secret_env_plan }}
           RUNTIME: ${{ inputs.runtime }}
+          RUNTIME_WORKLOAD_PROFILE_JSON: ${{ inputs.runtime_workload_profile_json }}
           AGENT_RUNTIME_REF: ${{ inputs.runtime_ref }}
           RUNTIME_REF: ${{ inputs.runtime_ref }}
           PROFILE: ${{ inputs.profile }}

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -45,14 +45,15 @@ function writeFullRunConfig(env = process.env) {
 }
 
 function buildConfig(env) {
+  const workloadProfile = parseRuntimeWorkloadProfile(env.RUNTIME_WORKLOAD_PROFILE_JSON || '{}');
   const workspace = required(env.GITHUB_WORKSPACE, 'GITHUB_WORKSPACE');
   const runnerTemp = required(env.RUNNER_TEMP, 'RUNNER_TEMP');
-  const workloadId = required(env.WORKLOAD_ID, 'WORKLOAD_ID');
+  const workloadId = required(env.WORKLOAD_ID || workloadProfile.workload_id, 'WORKLOAD_ID');
   const targetRepo = required(env.TARGET_REPO, 'TARGET_REPO');
   const componentId = env.COMPONENT_ID || path.basename(workspace);
   const componentPath = env.COMPONENT_PATH || workspace;
-  const runtimeId = runtimeIdFromOptions({ runtime: env.RUNTIME }, env);
-  const runtimeProfile = required(env.PROFILE, 'PROFILE');
+  const runtimeId = runtimeIdFromOptions({ runtime: env.RUNTIME || workloadProfile.runtime }, env);
+  const runtimeProfile = required(env.PROFILE || workloadProfile.profile, 'PROFILE');
   const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
   const runtime = resolveRuntimeProvider(runtimeId, { workspace, env });
   const runtimeBin = runtime.paths.runtime_bin;
@@ -94,8 +95,8 @@ function buildConfig(env) {
 
   const runtimeTask = runtimeTaskFromEnv(env);
   const runtimeExecution = parseJsonInput('runtime_execution', env.RUNTIME_EXECUTION || '{}', 'object', {});
-  const workload = runtimeWorkloadFromEnv(env, workloadId);
-  const toolProfile = parseJsonInput('tool_profile', env.TOOL_PROFILE || '{}', 'object', {});
+  const workload = runtimeWorkloadFromEnv(env, workloadId, workloadProfile.workload);
+  const toolProfile = parseProfileDefaultObject('tool_profile', env.TOOL_PROFILE, workloadProfile.tool_profile);
   const runtimeOutputProjections = parseJsonInput('runtime_output_projections', env.RUNTIME_OUTPUT_PROJECTIONS || '{}', 'object', {});
   const evidenceProjections = parseJsonInput('evidence_projections', env.EVIDENCE_PROJECTIONS || '[]', 'array', []);
   const runtimeComponents = parseJsonInput('runtime_components', env.RUNTIME_COMPONENTS || '{}', 'object', {});
@@ -105,7 +106,7 @@ function buildConfig(env) {
   const runtimeEnv = parseJsonInput('runtime_env', env.RUNTIME_ENV || '{}', 'object', {});
   const runtimeConfig = parseJsonInput('runtime_config', env.RUNTIME_CONFIG || '{}', 'object', {});
   const pathMaterializationPlan = parsePathMaterializationPlan(env.PATH_MATERIALIZATION_PLAN || '', { workspace });
-  const loopPolicy = loopPolicyFromEnv(env);
+  const loopPolicy = loopPolicyFromEnv(env, workloadProfile.loop_policy);
   const providerPluginPaths = validationDependencies.providerPluginHostPath ? [validationDependencies.providerPluginHostPath] : [];
   const renderedRuntimeInputs = renderRuntimeWorkflowInputs({
     runtimeProviderConfig: runtime,
@@ -267,17 +268,50 @@ function buildConfig(env) {
   };
 }
 
-function loopPolicyFromEnv(env) {
-  const policy = parseJsonInput('loop_policy', env.LOOP_POLICY || '{}', 'object', {});
-  const maxRevolutions = positiveNumber(env.MAX_REVOLUTIONS);
-  const durationMs = positiveNumber(env.DURATION_MS);
-  const deadlineAt = String(env.DEADLINE_AT || '').trim();
+function loopPolicyFromEnv(env, profilePolicy = {}) {
+  const policy = parseProfileDefaultObject('loop_policy', env.LOOP_POLICY, profilePolicy);
+  const maxRevolutions = positiveNumber(env.MAX_REVOLUTIONS || profilePolicy.max_revolutions);
+  const durationMs = positiveNumber(env.DURATION_MS || profilePolicy.duration_ms);
+  const deadlineAt = String(env.DEADLINE_AT || profilePolicy.deadline_at || '').trim();
   return {
     ...policy,
     ...(maxRevolutions > 0 ? { max_revolutions: maxRevolutions } : {}),
     ...(durationMs > 0 ? { duration_ms: durationMs } : {}),
     ...(deadlineAt !== '' ? { deadline_at: deadlineAt } : {}),
   };
+}
+
+function parseRuntimeWorkloadProfile(value) {
+  try {
+    const profile = parseJsonInput('runtime_workload_profile_json', value || '{}', 'object', {});
+    return {
+      runtime: stringDefault(profile.runtime),
+      profile: stringDefault(profile.profile),
+      workload_id: stringDefault(profile.workload_id),
+      workload: objectDefault(profile.workload),
+      tool_profile: objectDefault(profile.tool_profile),
+      loop_policy: objectDefault(profile.loop_policy),
+    };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid runtime_workload_profile_json: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+function parseProfileDefaultObject(name, explicitValue, profileValue) {
+  const profileObject = objectDefault(profileValue);
+  const explicitObject = parseJsonInput(name, explicitValue || '{}', 'object', {});
+  return { ...profileObject, ...explicitObject };
+}
+
+function stringDefault(value) {
+  return typeof value === 'string' ? value : '';
+}
+
+function objectDefault(value) {
+  return plainObject(value) ? value : {};
 }
 
 function positiveNumber(value) {
@@ -328,8 +362,8 @@ function uniqueStrings(values) {
   return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0))).sort();
 }
 
-function runtimeWorkloadFromEnv(env, fallbackId) {
-  const workload = parseJsonInput('workload', env.WORKLOAD || '{}', 'object', {});
+function runtimeWorkloadFromEnv(env, fallbackId, profileWorkload = {}) {
+  const workload = parseProfileDefaultObject('workload', env.WORKLOAD, profileWorkload);
   return Object.keys(workload).length > 0 ? workload : { id: fallbackId };
 }
 
@@ -515,4 +549,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys, writeFullRunConfig };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, parseRuntimeWorkloadProfile, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys, writeFullRunConfig };

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -13,6 +13,7 @@ const {
   buildSecretEnvPlan,
   loopPolicyFromEnv,
   normalizePathMaterializationPlan,
+  parseRuntimeWorkloadProfile,
   PATH_MATERIALIZATION_PLAN_SCHEMA,
   SECRET_ENV_PLAN_SCHEMA,
 } = require('../provider-adapters');
@@ -49,6 +50,26 @@ assert.deepEqual(loopPolicyFromEnv({
   duration_ms: 5000,
   deadline_at: '2030-01-01T00:00:00.000Z',
 });
+
+assert.deepEqual(parseRuntimeWorkloadProfile(JSON.stringify({
+  runtime: 'local-shell',
+  profile: 'profile-default',
+  workload: { id: 'profile-workload', label: 'Profile workload' },
+  tool_profile: { workspace_tools: { inspect: { command: 'git status --short' } } },
+  loop_policy: { mode: 'duration', max_revolutions: 2 },
+})), {
+  runtime: 'local-shell',
+  profile: 'profile-default',
+  workload_id: '',
+  workload: { id: 'profile-workload', label: 'Profile workload' },
+  tool_profile: { workspace_tools: { inspect: { command: 'git status --short' } } },
+  loop_policy: { mode: 'duration', max_revolutions: 2 },
+});
+
+assert.throws(
+  () => parseRuntimeWorkloadProfile('{bad-json'),
+  /Invalid runtime_workload_profile_json:/
+);
 
 const pathPlanWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-path-plan-'));
 try {
@@ -127,6 +148,71 @@ try {
   assert.deepEqual(config.secret_env_plan.secret_env_names, config.secret_env);
 } finally {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
+}
+
+const profileTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-build-runner-profile-'));
+try {
+  const config = buildConfig({
+    ...process.env,
+    GITHUB_WORKSPACE: profileTmpRoot,
+    RUNNER_TEMP: profileTmpRoot,
+    WORKLOAD_ID: '',
+    TARGET_REPO: 'Extra-Chill/example',
+    PROFILE: '',
+    RUNTIME_PROFILES: '{}',
+    RUNTIME: '',
+    LOOP_POLICY: '{}',
+    TOOL_PROFILE: '{}',
+    WORKLOAD: '{}',
+    RUNTIME_WORKLOAD_PROFILE_JSON: JSON.stringify({
+      runtime: 'local-shell',
+      profile: 'profile-default',
+      workload_id: 'profile-workload',
+      workload: { label: 'Profile workload' },
+      tool_profile: { workspace_tools: { inspect: { command: 'git status --short' } } },
+      loop_policy: { mode: 'duration', max_revolutions: 2 },
+    }),
+  });
+
+  assert.equal(config.runtime_id, 'local-shell');
+  assert.equal(config.runtime_profile, 'profile-default');
+  assert.equal(config.workload_id, 'profile-workload');
+  assert.equal(config.workload_label, 'Profile workload');
+  assert.deepEqual(config.loop_policy, { mode: 'duration', max_revolutions: 2 });
+} finally {
+  fs.rmSync(profileTmpRoot, { recursive: true, force: true });
+}
+
+const explicitProfileTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-build-runner-profile-explicit-'));
+try {
+  const config = buildConfig({
+    ...process.env,
+    GITHUB_WORKSPACE: explicitProfileTmpRoot,
+    RUNNER_TEMP: explicitProfileTmpRoot,
+    WORKLOAD_ID: 'explicit-workload',
+    TARGET_REPO: 'Extra-Chill/example',
+    PROFILE: 'explicit-profile',
+    RUNTIME_PROFILES: '{}',
+    RUNTIME: 'local-shell',
+    WORKLOAD: '{"label":"Explicit workload"}',
+    LOOP_POLICY: '{"mode":"revolution"}',
+    MAX_REVOLUTIONS: '5',
+    RUNTIME_WORKLOAD_PROFILE_JSON: JSON.stringify({
+      runtime: 'other-runtime',
+      profile: 'profile-default',
+      workload_id: 'profile-workload',
+      workload: { label: 'Profile workload' },
+      loop_policy: { mode: 'duration', max_revolutions: 2 },
+    }),
+  });
+
+  assert.equal(config.runtime_id, 'local-shell');
+  assert.equal(config.runtime_profile, 'explicit-profile');
+  assert.equal(config.workload_id, 'explicit-workload');
+  assert.equal(config.workload_label, 'Explicit workload');
+  assert.deepEqual(config.loop_policy, { mode: 'revolution', max_revolutions: 5 });
+} finally {
+  fs.rmSync(explicitProfileTmpRoot, { recursive: true, force: true });
 }
 
 const materializedTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-build-runner-config-path-plan-'));


### PR DESCRIPTION
## Summary
- Add optional runtime_workload_profile_json workflow input and pass it as one environment variable to the full-run config builder.
- Parse the JSON as compact defaults for runtime, profile, workload/workload_id, tool_profile, and loop_policy.
- Preserve existing explicit input/env precedence and clear invalid JSON failures.

## Tests
- node runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js
- node runtime-agent-ci/tests/build-runner-config.test.js
- npm test from runtime-agent-ci/

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified the runtime workflow profile input path.