### PR TITLE
Add Node.js fuzz runner capability

### DIFF
--- a/nodejs/dependency-adapters/examples/nodejs.json
+++ b/nodejs/dependency-adapters/examples/nodejs.json
@@ -1,0 +1,147 @@
+{
+  "schema": "homeboy-extension/dependency-adapter-manifest/v1",
+  "id": "nodejs-package-managers",
+  "version": 2,
+  "ecosystem": "nodejs",
+  "description": "Declarative Node.js package manager selection and dependency materialization outputs.",
+  "project_signals": {
+    "root_files": ["package.json"],
+    "optional_files": ["pnpm-workspace.yaml", "pnpm-lock.yaml", "yarn.lock", "package-lock.json"]
+  },
+  "lockfile_priority": ["pnpm-lock.yaml", "yarn.lock", "package-lock.json"],
+  "capabilities": {
+    "discover_project_root": true,
+    "select_package_manager": true,
+    "install_dependencies": true,
+    "run_named_scripts": true,
+    "execute_bins": true,
+    "prepare_runtime_helpers": false
+  },
+  "package_managers": [
+    {
+      "id": "pnpm",
+      "selection": {
+        "priority": 1,
+        "search": "upward",
+        "files": ["pnpm-workspace.yaml", "pnpm-lock.yaml"]
+      },
+      "install": {
+        "intent": "frozen-lockfile",
+        "command": "pnpm install --frozen-lockfile"
+      },
+      "commands": {
+        "status": {
+          "command": "pnpm install --frozen-lockfile --offline",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "install": {
+          "command": "pnpm install --frozen-lockfile",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "update": {
+          "command": "pnpm install --lockfile-only",
+          "success_exit_codes": [0],
+          "produces_lockfile": true
+        }
+      },
+      "scripts": {
+        "manifest": "package.json",
+        "run_command": "pnpm run",
+        "exec_command": "pnpm exec"
+      },
+      "package_identity": {
+        "manifest": "package.json",
+        "name": "name",
+        "version": "version",
+        "dependencies": ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]
+      },
+      "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
+    },
+    {
+      "id": "yarn",
+      "selection": {
+        "priority": 2,
+        "search": "project-root",
+        "files": ["yarn.lock"]
+      },
+      "install": {
+        "intent": "frozen-lockfile",
+        "command": "yarn install --frozen-lockfile"
+      },
+      "commands": {
+        "status": {
+          "command": "yarn install --frozen-lockfile --offline",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "install": {
+          "command": "yarn install --frozen-lockfile",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "update": {
+          "command": "yarn install --mode=update-lockfile",
+          "success_exit_codes": [0],
+          "produces_lockfile": true
+        }
+      },
+      "scripts": {
+        "manifest": "package.json",
+        "run_command": "yarn",
+        "exec_command": "yarn"
+      },
+      "package_identity": {
+        "manifest": "package.json",
+        "name": "name",
+        "version": "version",
+        "dependencies": ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]
+      },
+      "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
+    },
+    {
+      "id": "npm",
+      "selection": {
+        "priority": 3,
+        "search": "project-root",
+        "default": true,
+        "files": ["package-lock.json"]
+      },
+      "install": {
+        "intent": "locked-or-refresh",
+        "command": "npm ci",
+        "fallback_command": "npm install"
+      },
+      "commands": {
+        "status": {
+          "command": "npm ci --dry-run",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "install": {
+          "command": "npm ci",
+          "success_exit_codes": [0],
+          "requires_lockfile": true
+        },
+        "update": {
+          "command": "npm install --package-lock-only",
+          "success_exit_codes": [0],
+          "produces_lockfile": true
+        }
+      },
+      "scripts": {
+        "manifest": "package.json",
+        "run_command": "npm run",
+        "exec_command": "npx"
+      },
+      "package_identity": {
+        "manifest": "package.json",
+        "name": "name",
+        "version": "version",
+        "dependencies": ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]
+      },
+      "outputs": [{ "kind": "directory", "path": "node_modules", "required": true }]
+    }
+  ]
+}

--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -1,12 +1,12 @@
 {
   "name": "Node.js",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "icon": "server.rack",
   "description": "Node.js project type — discovery, audit grammar, and npm release lifecycle",
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["js", "jsx", "ts", "tsx", "mjs", "cjs", "json"],
-    "capabilities": ["format", "validate"]
+    "capabilities": ["format", "validate", "fuzz"]
   },
   "structured_sidecars": {
     "lint.findings": true,
@@ -58,6 +58,18 @@
       "produces": [
         { "kind": "artifact", "name": "trace.results" },
         { "kind": "artifact", "name": "trace.artifacts" }
+      ]
+    },
+    {
+      "id": "nodejs.fuzz-results",
+      "phase": "result",
+      "invocation": { "script": "scripts/fuzz/fuzz-runner.sh" },
+      "produces": [
+        {
+          "kind": "artifact",
+          "name": "fuzz.results",
+          "schema": "homeboy/fuzz-campaign/v1"
+        }
       ]
     }
   ],
@@ -112,6 +124,13 @@
       "type": "object",
       "default": {},
       "description": "Additional non-secret environment values consumed by Node.js bench workloads."
+    },
+    {
+      "id": "fuzz_script",
+      "label": "Fuzz Script",
+      "type": "string",
+      "default": "",
+      "description": "Package.json script to run when Node.js fuzz is invoked without a rig workload path. Defaults to scripts.fuzz when present."
     },
     {
       "id": "local_workspace_dependencies",
@@ -294,6 +313,27 @@
   },
   "trace": {
     "extension_script": "scripts/trace/trace-runner.sh"
+  },
+  "fuzz": {
+    "extension_script": "scripts/fuzz/fuzz-runner.sh",
+    "capabilities": ["nodejs-fuzz-workload"],
+    "env": [
+      "HOMEBOY_FUZZ_RESULTS_FILE",
+      "HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE",
+      "HOMEBOY_FUZZ_SEQUENCE_PLAN_FILE",
+      "HOMEBOY_FUZZ_ARTIFACTS_DIR",
+      "HOMEBOY_FUZZ_WORKLOAD_ID",
+      "HOMEBOY_FUZZ_WORKLOAD_PATH",
+      "HOMEBOY_FUZZ_WORKLOAD_ROOT",
+      "HOMEBOY_FUZZ_RUN_ID",
+      "HOMEBOY_FUZZ_SEED",
+      "HOMEBOY_FUZZ_INVENTORY_FILE",
+      "HOMEBOY_FUZZ_SHARED_STATE",
+      "HOMEBOY_FUZZ_MAX_DURATION",
+      "HOMEBOY_FUZZ_GATE_PROFILE",
+      "HOMEBOY_FUZZ_ALLOW_DESTRUCTIVE",
+      "HOMEBOY_FUZZ_ISOLATION"
+    ]
   },
   "actions": [
     {

--- a/nodejs/scripts/fuzz/fuzz-runner.sh
+++ b/nodejs/scripts/fuzz/fuzz-runner.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js fuzz runner for `homeboy fuzz`.
+#
+# Execution order:
+#   1. HOMEBOY_NODE_FUZZ_COMMAND full command override.
+#   2. HOMEBOY_FUZZ_WORKLOAD_PATH script file or JSON descriptor from a rig.
+#   3. Configured package script (HOMEBOY_NODE_FUZZ_SCRIPT / settings.fuzz_script).
+#   4. package.json scripts.fuzz.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${EXTENSION_DIR}/../scripts/lib" && pwd)}"
+SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SHARED_LIB_DIR}/settings.sh}"
+
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:?Homeboy core must provide HOMEBOY_RUNTIME_BASH_PREFLIGHT}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:?HOMEBOY_RUNTIME_RESOLVE_CONTEXT is required}"
+# shellcheck source=/dev/null
+source "$RESOLVE_CONTEXT_HELPER"
+homeboy_resolve_context
+# shellcheck source=/dev/null
+source "$SETTINGS_HELPER"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/node-helpers.sh"
+homeboy_require_package_json
+homeboy_detect_package_manager
+
+RESULTS_FILE="${HOMEBOY_FUZZ_RESULTS_FILE:?HOMEBOY_FUZZ_RESULTS_FILE is required}"
+ARTIFACTS_DIR="${HOMEBOY_FUZZ_ARTIFACTS_DIR:-$(dirname "$RESULTS_FILE")/artifacts}"
+RUNNER_ARGS=("$@")
+
+mkdir -p "$(dirname "$RESULTS_FILE")" "$ARTIFACTS_DIR"
+export HOMEBOY_FUZZ_RESULTS_FILE="$RESULTS_FILE"
+export HOMEBOY_FUZZ_ARTIFACTS_DIR="$ARTIFACTS_DIR"
+export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"
+export HOMEBOY_COMPONENT_PATH="$PROJECT_PATH"
+
+homeboy_node_fuzz_script_runner() {
+    local workload_path="$1"
+    case "$workload_path" in
+        *.ts|*.tsx)
+            if [ -x "${PROJECT_PATH}/node_modules/.bin/tsx" ]; then
+                printf '%s' "${PROJECT_PATH}/node_modules/.bin/tsx"
+            elif command -v tsx >/dev/null 2>&1; then
+                printf '%s' "tsx"
+            elif command -v npx >/dev/null 2>&1; then
+                printf '%s' "npx --yes tsx"
+            else
+                echo "Error: TypeScript fuzz workload '${workload_path}' requires tsx in the project, PATH, or npx." >&2
+                return 1
+            fi
+            ;;
+        *)
+            printf '%s' "node"
+            ;;
+    esac
+}
+
+homeboy_node_run_script_workload() {
+    local workload_path="$1"
+    local runner
+    runner="$(homeboy_node_fuzz_script_runner "$workload_path")"
+    # shellcheck disable=SC2086 # word-splitting is intentional for npx --yes tsx.
+    $runner "$workload_path" "${RUNNER_ARGS[@]}"
+}
+
+homeboy_node_run_json_workload() {
+    local workload_path="$1"
+    local descriptor_file command_path script_name command
+    descriptor_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-node-fuzz-descriptor.XXXXXX")"
+    trap 'rm -f "$descriptor_file"' RETURN
+
+    node --input-type=module - "$workload_path" > "$descriptor_file" <<'EOF'
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const workloadPath = process.argv[2];
+const workload = JSON.parse(readFileSync(workloadPath, 'utf8'));
+const args = Array.isArray(workload.args) ? workload.args.map(String) : [];
+const value = {
+  command: typeof workload.command === 'string' ? workload.command.trim() : '',
+  script: typeof workload.script === 'string' ? workload.script.trim() : '',
+  path: typeof workload.path === 'string' ? resolve(process.cwd(), workload.path) : '',
+  args,
+};
+process.stdout.write(JSON.stringify(value));
+EOF
+
+    command="$(node -e "const fs=require('fs'); const value=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(value.command || '')" "$descriptor_file")"
+    script_name="$(node -e "const fs=require('fs'); const value=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(value.script || '')" "$descriptor_file")"
+    command_path="$(node -e "const fs=require('fs'); const value=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(value.path || '')" "$descriptor_file")"
+    mapfile -t DESCRIPTOR_ARGS < <(node -e "const fs=require('fs'); const value=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); for (const arg of value.args || []) console.log(arg)" "$descriptor_file")
+    RUNNER_ARGS=("${DESCRIPTOR_ARGS[@]}" "${RUNNER_ARGS[@]}")
+
+    if [ -n "$command" ]; then
+        bash -c "$command \"\$@\"" _ "${RUNNER_ARGS[@]}"
+    elif [ -n "$script_name" ]; then
+        if ! homeboy_has_npm_script "$script_name"; then
+            echo "Error: Node.js fuzz script '${script_name}' from ${workload_path} is not defined in package.json" >&2
+            return 1
+        fi
+        command="$(homeboy_project_run_script_command "$script_name")"
+        bash -c "$command -- \"\$@\"" _ "${RUNNER_ARGS[@]}"
+    elif [ -n "$command_path" ]; then
+        if [ ! -f "$command_path" ]; then
+            echo "Error: Node.js fuzz workload path '${command_path}' from ${workload_path} does not exist" >&2
+            return 1
+        fi
+        homeboy_node_run_script_workload "$command_path"
+    else
+        echo "Error: Node.js fuzz workload JSON '${workload_path}' must define command, script, or path" >&2
+        return 1
+    fi
+}
+
+homeboy_node_configured_fuzz_script() {
+    local configured_script="${HOMEBOY_NODE_FUZZ_SCRIPT:-}"
+    if [ -z "$configured_script" ]; then
+        configured_script="$(homeboy_setting node_fuzz_script '.node_fuzz_script // .fuzz_script // .fuzz.script // empty')"
+    fi
+    if [ -n "$configured_script" ]; then
+        printf '%s' "$configured_script"
+        return 0
+    fi
+    if homeboy_has_npm_script "fuzz"; then
+        printf '%s' "fuzz"
+        return 0
+    fi
+    return 1
+}
+
+echo "Running Node.js fuzz..."
+echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
+echo "  Results:   ${RESULTS_FILE}"
+
+cd "$PROJECT_PATH"
+
+if [ -n "${HOMEBOY_NODE_FUZZ_COMMAND:-}" ]; then
+    echo "  Command:   ${HOMEBOY_NODE_FUZZ_COMMAND}"
+    bash -c "$HOMEBOY_NODE_FUZZ_COMMAND \"\$@\"" _ "${RUNNER_ARGS[@]}"
+elif [ -n "${HOMEBOY_FUZZ_WORKLOAD_PATH:-}" ]; then
+    WORKLOAD_PATH="$HOMEBOY_FUZZ_WORKLOAD_PATH"
+    if [ ! -f "$WORKLOAD_PATH" ]; then
+        echo "Error: Node.js fuzz workload not found at ${WORKLOAD_PATH}" >&2
+        exit 2
+    fi
+    echo "  Workload:  ${WORKLOAD_PATH}"
+    case "$WORKLOAD_PATH" in
+        *.json)
+            homeboy_node_run_json_workload "$WORKLOAD_PATH"
+            ;;
+        *)
+            homeboy_node_run_script_workload "$WORKLOAD_PATH"
+            ;;
+    esac
+elif FUZZ_SCRIPT="$(homeboy_node_configured_fuzz_script)"; then
+    if ! homeboy_has_npm_script "$FUZZ_SCRIPT"; then
+        echo "Error: configured Node.js fuzz script '${FUZZ_SCRIPT}' is not defined in package.json" >&2
+        exit 1
+    fi
+    FUZZ_CMD="$(homeboy_project_run_script_command "$FUZZ_SCRIPT")"
+    echo "  Script:    ${FUZZ_SCRIPT}"
+    bash -c "$FUZZ_CMD -- \"\$@\"" _ "${RUNNER_ARGS[@]}"
+else
+    echo "Error: No Node.js fuzz workload or package script configured." >&2
+    echo "Declare a rig fuzz workload path, set nodejs.fuzz_script/HOMEBOY_NODE_FUZZ_SCRIPT, or add package.json scripts.fuzz." >&2
+    exit 1
+fi
+
+if [ ! -f "$RESULTS_FILE" ]; then
+    echo "Error: Node.js fuzz completed without writing ${RESULTS_FILE}" >&2
+    exit 1
+fi
+
+echo ""
+echo "Node.js fuzz run complete."

--- a/nodejs/scripts/fuzz/nodejs-fuzz-runner-smoke.sh
+++ b/nodejs/scripts/fuzz/nodejs-fuzz-runner-smoke.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_DIR}/../.." && pwd)/homeboy}"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
+MANIFEST="${EXTENSION_DIR}/nodejs.json"
+RUNNER="${SCRIPT_DIR}/fuzz-runner.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-fuzz.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$BASH_PREFLIGHT_HELPER" ]; then
+    echo "Missing bash preflight helper: $BASH_PREFLIGHT_HELPER" >&2
+    exit 1
+fi
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
+    exit 1
+fi
+
+assert_json() {
+    local file="$1"
+    local script="$2"
+    node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); ${script}" "$file"
+}
+
+make_project() {
+    local name="$1"
+    local project_dir="$TMP_DIR/$name"
+    mkdir -p "$project_dir"
+    cat > "$project_dir/package.json" <<'JSON'
+{"name":"node-fuzz-smoke","scripts":{"fuzz":"node fuzz-package.mjs","fuzz:configured":"node configured-fuzz.mjs"}}
+JSON
+    printf '%s\n' "$project_dir"
+}
+
+run_fuzz() {
+    local project_dir="$1"
+    local results_file="$2"
+    local workload_path="${3:-}"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$project_dir" \
+    HOMEBOY_COMPONENT_ID="node-fuzz-smoke" \
+    HOMEBOY_FUZZ_RESULTS_FILE="$results_file" \
+    HOMEBOY_FUZZ_ARTIFACTS_DIR="$TMP_DIR/artifacts" \
+    HOMEBOY_FUZZ_WORKLOAD_PATH="$workload_path" \
+    HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+        bash "$RUNNER" --flag
+}
+
+node - "$MANIFEST" "$RUNNER" <<'NODE'
+const fs = require('fs');
+const [manifestPath, runnerPath] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const runner = fs.readFileSync(runnerPath, 'utf8');
+if (!manifest.provides?.capabilities?.includes('fuzz')) throw new Error('Node.js manifest does not advertise fuzz capability');
+if (manifest.fuzz?.extension_script !== 'scripts/fuzz/fuzz-runner.sh') throw new Error('fuzz runner path is not declared in nodejs.json');
+if (!manifest.fuzz?.capabilities?.includes('nodejs-fuzz-workload')) throw new Error('Node.js fuzz workload capability missing');
+for (const token of [
+  'HOMEBOY_FUZZ_RESULTS_FILE',
+  'HOMEBOY_FUZZ_WORKLOAD_PATH',
+  'HOMEBOY_FUZZ_ARTIFACTS_DIR',
+  'HOMEBOY_NODE_FUZZ_SCRIPT',
+  'HOMEBOY_NODE_FUZZ_COMMAND',
+]) {
+  if (!runner.includes(token)) throw new Error(`runner missing env contract token ${token}`);
+}
+NODE
+
+SCRIPT_PROJECT="$(make_project script-workload)"
+WORKLOAD_SCRIPT="$SCRIPT_PROJECT/rig-fuzz.mjs"
+cat > "$WORKLOAD_SCRIPT" <<'JS'
+import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.HOMEBOY_FUZZ_RESULTS_FILE, JSON.stringify({
+  schema: 'homeboy/fuzz-campaign/v1',
+  status: 'pass',
+  source: 'script-workload',
+  args: process.argv.slice(2),
+}, null, 2));
+JS
+SCRIPT_RESULTS="$TMP_DIR/script-results.json"
+run_fuzz "$SCRIPT_PROJECT" "$SCRIPT_RESULTS" "$WORKLOAD_SCRIPT" >/dev/null
+assert_json "$SCRIPT_RESULTS" '
+if (data.schema !== "homeboy/fuzz-campaign/v1") throw new Error("script workload schema missing");
+if (data.source !== "script-workload") throw new Error("script workload did not run");
+if (data.args.join(",") !== "--flag") throw new Error(`script args not forwarded: ${data.args.join(",")}`);
+'
+
+PACKAGE_PROJECT="$(make_project package-script)"
+cat > "$PACKAGE_PROJECT/fuzz-package.mjs" <<'JS'
+import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.HOMEBOY_FUZZ_RESULTS_FILE, JSON.stringify({
+  schema: 'homeboy/fuzz-campaign/v1',
+  status: 'pass',
+  source: 'package-script',
+  args: process.argv.slice(2),
+}, null, 2));
+JS
+PACKAGE_RESULTS="$TMP_DIR/package-results.json"
+run_fuzz "$PACKAGE_PROJECT" "$PACKAGE_RESULTS" >/dev/null
+assert_json "$PACKAGE_RESULTS" '
+if (data.source !== "package-script") throw new Error("package scripts.fuzz did not run");
+if (data.args.join(",") !== "--flag") throw new Error(`package args not forwarded: ${data.args.join(",")}`);
+'
+
+CONFIG_PROJECT="$(make_project configured-script)"
+cat > "$CONFIG_PROJECT/configured-fuzz.mjs" <<'JS'
+import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.HOMEBOY_FUZZ_RESULTS_FILE, JSON.stringify({
+  schema: 'homeboy/fuzz-campaign/v1',
+  status: 'pass',
+  source: 'configured-script',
+}, null, 2));
+JS
+CONFIG_RESULTS="$TMP_DIR/config-results.json"
+HOMEBOY_NODE_FUZZ_SCRIPT="fuzz:configured" run_fuzz "$CONFIG_PROJECT" "$CONFIG_RESULTS" >/dev/null
+assert_json "$CONFIG_RESULTS" '
+if (data.source !== "configured-script") throw new Error("configured fuzz script did not run");
+'
+
+JSON_PROJECT="$(make_project json-workload)"
+cat > "$JSON_PROJECT/json-fuzz.mjs" <<'JS'
+import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.HOMEBOY_FUZZ_RESULTS_FILE, JSON.stringify({
+  schema: 'homeboy/fuzz-campaign/v1',
+  status: 'pass',
+  source: 'json-workload',
+  args: process.argv.slice(2),
+}, null, 2));
+JS
+JSON_WORKLOAD="$JSON_PROJECT/workload.json"
+cat > "$JSON_WORKLOAD" <<'JSON'
+{"path":"json-fuzz.mjs","args":["--from-json"]}
+JSON
+JSON_RESULTS="$TMP_DIR/json-results.json"
+run_fuzz "$JSON_PROJECT" "$JSON_RESULTS" "$JSON_WORKLOAD" >/dev/null
+assert_json "$JSON_RESULTS" '
+if (data.source !== "json-workload") throw new Error("json workload path did not run");
+if (data.args.join(",") !== "--from-json,--flag") throw new Error(`json workload args not forwarded: ${data.args.join(",")}`);
+'
+
+echo "Node.js fuzz runner smoke passed."

--- a/nodejs/scripts/lib/node-helpers.sh
+++ b/nodejs/scripts/lib/node-helpers.sh
@@ -1,7 +1,29 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_SCRIPTS_HELPER="${HOMEBOY_RUNTIME_PROJECT_SCRIPTS:-${SCRIPT_DIR}/../../../scripts/lib/project-scripts.sh}"
+homeboy_node_project_scripts_helper() {
+    if [ -n "${HOMEBOY_RUNTIME_PROJECT_SCRIPTS:-}" ]; then
+        printf '%s\n' "$HOMEBOY_RUNTIME_PROJECT_SCRIPTS"
+        return 0
+    fi
+
+    local _candidate
+    for _candidate in \
+        "${SCRIPT_DIR}/../../../scripts/lib/project-scripts.sh" \
+        "${SCRIPT_DIR}/project-scripts.sh"; do
+        if [ -f "$_candidate" ]; then
+            printf '%s\n' "$_candidate"
+            return 0
+        fi
+    done
+
+    echo "Error: Unable to locate Homeboy project script helpers for Node.js extension." >&2
+    echo "Expected shared helper at ${SCRIPT_DIR}/../../../scripts/lib/project-scripts.sh or packaged helper at ${SCRIPT_DIR}/project-scripts.sh." >&2
+    return 1
+}
+
+PROJECT_SCRIPTS_HELPER="$(homeboy_node_project_scripts_helper)"
 # shellcheck source=/dev/null
 source "$PROJECT_SCRIPTS_HELPER"
 

--- a/nodejs/scripts/lib/project-scripts.sh
+++ b/nodejs/scripts/lib/project-scripts.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+
+# Generic project script helpers for extension runners.
+#
+# Extensions select an ecosystem adapter with homeboy_project_init, then use the
+# project helpers instead of hand-rolling package-manager or script checks.
+
+homeboy_project_find_file_upward() {
+    local _dir="$1"
+    local _file="$2"
+    while [ "$_dir" != "/" ] && [ "$_dir" != "." ]; do
+        if [ -f "$_dir/$_file" ]; then
+            printf '%s\n' "$_dir"
+            return 0
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+    return 1
+}
+
+homeboy_project_adapter_manifest_file() {
+    local _ecosystem="$1"
+    local _base_dir="${HOMEBOY_DEPENDENCY_ADAPTERS_PATH:-}"
+    if [ -z "$_base_dir" ]; then
+        _base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/dependency-adapters/examples"
+    fi
+
+    case "$_ecosystem" in
+        node|nodejs)
+            printf '%s\n' "$_base_dir/nodejs.json"
+            ;;
+        composer|php)
+            printf '%s\n' "$_base_dir/composer.json"
+            ;;
+        wordpress|wp)
+            printf '%s\n' "$_base_dir/wordpress.json"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+homeboy_project_manifest_value() {
+    local _manifest="$1"
+    local _path="$2"
+    MANIFEST_FILE="$_manifest" MANIFEST_PATH="$_path" node -e '
+        const fs = require("fs");
+        let value = JSON.parse(fs.readFileSync(process.env.MANIFEST_FILE, "utf8"));
+        for (const part of process.env.MANIFEST_PATH.split(".")) {
+            value = value && value[part];
+        }
+        if (value === undefined || value === null) process.exit(1);
+        if (Array.isArray(value)) console.log(value.join("\n"));
+        else console.log(String(value));
+    '
+}
+
+homeboy_project_find_manifest_root_upward() {
+    local _dir="$1"
+    local _manifest="$2"
+    local _match
+    local _files
+    _match="$(homeboy_project_manifest_value "$_manifest" "project_signals.root_match" 2>/dev/null || printf 'any')"
+    _files="$(homeboy_project_manifest_value "$_manifest" "project_signals.root_files")" || return 1
+
+    while [ "$_dir" != "/" ] && [ "$_dir" != "." ]; do
+        local _found=0
+        local _missing=0
+        while IFS= read -r _file; do
+            [ -z "$_file" ] && continue
+            if [ -e "$_dir/$_file" ]; then
+                _found=1
+            else
+                _missing=1
+            fi
+        done <<EOF
+$_files
+EOF
+        if { [ "$_match" = "all" ] && [ "$_missing" -eq 0 ]; } || { [ "$_match" != "all" ] && [ "$_found" -eq 1 ]; }; then
+            printf '%s\n' "$_dir"
+            return 0
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+    return 1
+}
+
+homeboy_project_select_package_manager() {
+    local _manifest="$1"
+    local _root="$2"
+    MANIFEST_FILE="$_manifest" PROJECT_ROOT="$_root" node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_FILE, 'utf8'));
+const root = process.env.PROJECT_ROOT;
+const managers = [...(manifest.package_managers || [])].sort((a, b) => a.selection.priority - b.selection.priority);
+
+function findUpward(files) {
+    let dir = root;
+    while (dir && dir !== path.dirname(dir)) {
+        if (files.some((file) => fs.existsSync(path.join(dir, file)))) return dir;
+        dir = path.dirname(dir);
+    }
+    return null;
+}
+
+let fallback = null;
+for (const manager of managers) {
+    const selection = manager.selection || {};
+    if (selection.default) fallback = manager;
+    const files = selection.files || [];
+    const selectedRoot = selection.search === 'upward' ? findUpward(files) : (files.some((file) => fs.existsSync(path.join(root, file))) ? root : null);
+    if (selectedRoot) {
+        console.log(`${manager.id}\t${selectedRoot}`);
+        process.exit(0);
+    }
+}
+
+if (fallback) {
+    console.log(`${fallback.id}\t${root}`);
+    process.exit(0);
+}
+
+process.exit(1);
+NODE
+}
+
+homeboy_project_package_manager_value() {
+    local _manifest="$1"
+    local _manager="$2"
+    local _path="$3"
+    MANIFEST_FILE="$_manifest" PACKAGE_MANAGER="$_manager" MANAGER_PATH="$_path" node -e '
+        const fs = require("fs");
+        const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_FILE, "utf8"));
+        const manager = (manifest.package_managers || []).find((item) => item.id === process.env.PACKAGE_MANAGER);
+        let value = manager;
+        for (const part of process.env.MANAGER_PATH.split(".")) {
+            value = value && value[part];
+        }
+        if (value === undefined || value === null) process.exit(1);
+        console.log(String(value));
+    '
+}
+
+homeboy_project_init() {
+    local _ecosystem=""
+    local _dir="${PROJECT_PATH:-.}"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --ecosystem)
+                _ecosystem="${2:-}"
+                shift 2
+                ;;
+            --path)
+                _dir="${2:-}"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown homeboy_project_init argument: $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    if [ -z "$_ecosystem" ]; then
+            echo "Error: homeboy_project_init requires --ecosystem" >&2
+            return 1
+    fi
+
+    homeboy_project_init_manifest "$_ecosystem" "$_dir"
+}
+
+homeboy_project_init_manifest() {
+    local _ecosystem="$1"
+    local _dir="$2"
+    local _manifest
+    local _root
+    local _selection
+    local _script_manifest
+
+    if ! _manifest="$(homeboy_project_adapter_manifest_file "$_ecosystem")" || [ ! -f "$_manifest" ]; then
+        echo "Error: Unsupported Homeboy project ecosystem: $_ecosystem" >&2
+        return 1
+    fi
+
+    if ! _root="$(homeboy_project_find_manifest_root_upward "$_dir" "$_manifest")"; then
+        echo "Error: No $(homeboy_project_manifest_value "$_manifest" "project_signals.root_files" | tr '\n' '/' | sed 's:/$::') found at or above ${_dir}" >&2
+        echo "Not a $(homeboy_project_manifest_value "$_manifest" "ecosystem") project -- cannot run." >&2
+        return 1
+    fi
+
+    HOMEBOY_PROJECT_ADAPTER_MANIFEST="$_manifest"
+    HOMEBOY_PROJECT_ECOSYSTEM="$(homeboy_project_manifest_value "$_manifest" "ecosystem")"
+    HOMEBOY_PROJECT_ROOT="$_root"
+    HOMEBOY_PROJECT_DEPENDENCY_ROOT="$_root"
+
+    if _selection="$(homeboy_project_select_package_manager "$_manifest" "$_root")"; then
+        HOMEBOY_PROJECT_PACKAGE_MANAGER="${_selection%%$'\t'*}"
+        HOMEBOY_PROJECT_DEPENDENCY_ROOT="${_selection#*$'\t'}"
+        _script_manifest="$(homeboy_project_package_manager_value "$_manifest" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "scripts.manifest" 2>/dev/null || true)"
+        HOMEBOY_PROJECT_RUN_CMD="$(homeboy_project_package_manager_value "$_manifest" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "scripts.run_command" 2>/dev/null || true)"
+        HOMEBOY_PROJECT_EXEC_CMD="$(homeboy_project_package_manager_value "$_manifest" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "scripts.exec_command" 2>/dev/null || true)"
+        if [ -n "$_script_manifest" ]; then
+            HOMEBOY_PROJECT_SCRIPT_FILE="${_root}/${_script_manifest}"
+        else
+            HOMEBOY_PROJECT_SCRIPT_FILE=""
+        fi
+    else
+        HOMEBOY_PROJECT_PACKAGE_MANAGER=""
+        HOMEBOY_PROJECT_RUN_CMD=""
+        HOMEBOY_PROJECT_EXEC_CMD=""
+        HOMEBOY_PROJECT_SCRIPT_FILE=""
+    fi
+
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: Dependency adapter manifest: $HOMEBOY_PROJECT_ADAPTER_MANIFEST" >&2
+        echo "DEBUG: Project ecosystem: $HOMEBOY_PROJECT_ECOSYSTEM" >&2
+        echo "DEBUG: Project root: $HOMEBOY_PROJECT_ROOT" >&2
+        echo "DEBUG: Dependency root: $HOMEBOY_PROJECT_DEPENDENCY_ROOT" >&2
+        echo "DEBUG: Package manager: $HOMEBOY_PROJECT_PACKAGE_MANAGER" >&2
+    fi
+}
+
+homeboy_project_require_script_file() {
+    if [ -z "${HOMEBOY_PROJECT_SCRIPT_FILE:-}" ] || [ ! -f "$HOMEBOY_PROJECT_SCRIPT_FILE" ]; then
+        echo "Error: homeboy_project_init must be called before project script helpers" >&2
+        return 1
+    fi
+}
+
+homeboy_project_has_script() {
+    local _script="$1"
+    homeboy_project_require_script_file || return 1
+
+    case "${HOMEBOY_PROJECT_ECOSYSTEM:-}" in
+        nodejs|php)
+            HOMEBOY_PROJECT_SCRIPT_NAME="$_script" \
+            HOMEBOY_PROJECT_SCRIPT_JSON="$HOMEBOY_PROJECT_SCRIPT_FILE" \
+                node -e '
+                    const pkg = require(process.env.HOMEBOY_PROJECT_SCRIPT_JSON);
+                    const script = process.env.HOMEBOY_PROJECT_SCRIPT_NAME;
+                    process.exit(pkg.scripts && pkg.scripts[script] ? 0 : 1);
+                ' 2>/dev/null
+            ;;
+        *)
+            echo "Error: Unsupported Homeboy project ecosystem: ${HOMEBOY_PROJECT_ECOSYSTEM:-}" >&2
+            return 1
+            ;;
+    esac
+}
+
+homeboy_project_run_script_command() {
+    local _script="$1"
+    if [ -z "${HOMEBOY_PROJECT_RUN_CMD:-}" ]; then
+        echo "Error: homeboy_project_init must be called before project script helpers" >&2
+        return 1
+    fi
+    printf '%s %s' "$HOMEBOY_PROJECT_RUN_CMD" "$_script"
+}
+
+homeboy_project_exec_command() {
+    local _binary="$1"
+    shift || true
+    if [ -z "${HOMEBOY_PROJECT_EXEC_CMD:-}" ]; then
+        echo "Error: homeboy_project_init must be called before project script helpers" >&2
+        return 1
+    fi
+    printf '%s %s' "$HOMEBOY_PROJECT_EXEC_CMD" "$_binary"
+    if [ $# -gt 0 ]; then
+        printf ' %s' "$@"
+    fi
+}
+
+homeboy_project_run_script() {
+    local _script="$1"
+    shift || true
+    homeboy_project_require_script_file || return 1
+    (cd "$HOMEBOY_PROJECT_ROOT" && $(homeboy_project_run_script_command "$_script") "$@")
+}
+
+homeboy_project_exec() {
+    local _binary="$1"
+    shift || true
+    if [ -z "${HOMEBOY_PROJECT_ROOT:-}" ]; then
+        echo "Error: homeboy_project_init must be called before project script helpers" >&2
+        return 1
+    fi
+    (cd "$HOMEBOY_PROJECT_ROOT" && $HOMEBOY_PROJECT_EXEC_CMD "$_binary" "$@")
+}
+
+homeboy_project_ensure_dependencies() {
+    local _dir="${HOMEBOY_PROJECT_DEPENDENCY_ROOT:-${HOMEBOY_PROJECT_ROOT:-}}"
+    if [ -z "$_dir" ]; then
+        echo "Error: homeboy_project_init must be called before dependency helpers" >&2
+        return 1
+    fi
+
+    if [ "${HOMEBOY_PROJECT_ECOSYSTEM:-}" = "wordpress" ]; then
+        local _status=0
+        if [ -f "$_dir/composer.json" ]; then
+            (homeboy_project_init --ecosystem composer --path "$_dir" && homeboy_project_ensure_dependencies) || _status=$?
+        fi
+        if [ -f "$_dir/package.json" ]; then
+            (homeboy_project_init --ecosystem nodejs --path "$_dir" && homeboy_project_ensure_dependencies) || _status=$?
+        fi
+        return "$_status"
+    fi
+
+    if [ -z "${HOMEBOY_PROJECT_ADAPTER_MANIFEST:-}" ] || [ -z "${HOMEBOY_PROJECT_PACKAGE_MANAGER:-}" ]; then
+        echo "Error: Dependency installation is not implemented for ecosystem: ${HOMEBOY_PROJECT_ECOSYSTEM:-}" >&2
+        return 1
+    fi
+
+    local _output_path
+    _output_path="$(homeboy_project_package_manager_value "$HOMEBOY_PROJECT_ADAPTER_MANIFEST" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "outputs.0.path" 2>/dev/null || true)"
+    if [ -n "$_output_path" ] && [ -e "$_dir/$_output_path" ]; then
+        return 0
+    fi
+
+    local _intent
+    local _command
+    local _fallback_command
+    _intent="$(homeboy_project_package_manager_value "$HOMEBOY_PROJECT_ADAPTER_MANIFEST" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "install.intent")"
+    _command="$(homeboy_project_package_manager_value "$HOMEBOY_PROJECT_ADAPTER_MANIFEST" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "install.command" 2>/dev/null || true)"
+    _fallback_command="$(homeboy_project_package_manager_value "$HOMEBOY_PROJECT_ADAPTER_MANIFEST" "$HOMEBOY_PROJECT_PACKAGE_MANAGER" "install.fallback_command" 2>/dev/null || true)"
+
+    echo "Installing ${HOMEBOY_PROJECT_ECOSYSTEM} dependencies with ${HOMEBOY_PROJECT_PACKAGE_MANAGER}..."
+    if [ "$_intent" = "locked-or-refresh" ] && [ -n "$_fallback_command" ]; then
+        local _lockfile=""
+        case "$HOMEBOY_PROJECT_PACKAGE_MANAGER" in
+            npm) _lockfile="package-lock.json" ;;
+            composer) _lockfile="composer.lock" ;;
+        esac
+        if [ -n "$_lockfile" ] \
+            && [ -f "$_dir/$_lockfile" ] \
+            && command -v git >/dev/null 2>&1 \
+            && git -C "$_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+            && git -C "$_dir" ls-files --error-unmatch "$_lockfile" >/dev/null 2>&1; then
+            (cd "$_dir" && $_command)
+        else
+            (cd "$_dir" && $_fallback_command)
+        fi
+    else
+        (cd "$_dir" && $_command)
+    fi
+}

--- a/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
+++ b/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
@@ -4,11 +4,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 NODE_HELPERS="${ROOT_DIR}/scripts/lib/node-helpers.sh"
 PROJECT_SCRIPTS="${ROOT_DIR}/../scripts/lib/project-scripts.sh"
+PACKAGED_PROJECT_SCRIPTS="${ROOT_DIR}/scripts/lib/project-scripts.sh"
+PACKAGED_NODE_ADAPTER="${ROOT_DIR}/dependency-adapters/examples/nodejs.json"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 test -f "$NODE_HELPERS"
 test -f "$PROJECT_SCRIPTS"
+test -f "$PACKAGED_PROJECT_SCRIPTS"
+test -f "$PACKAGED_NODE_ADAPTER"
 
 bash -c '
     source "$1"
@@ -52,3 +56,21 @@ bash -c '
     [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
     [ "$(homeboy_project_run_script_command test)" = "pnpm run test" ]
 ' _ "$PROJECT_SCRIPTS" "$WORKSPACE_PROJECT"
+
+INSTALLED_ROOT="$TMP_DIR/installed/extensions"
+mkdir -p "$INSTALLED_ROOT"
+cp -R "$ROOT_DIR" "$INSTALLED_ROOT/nodejs"
+INSTALLED_NODE_HELPERS="$INSTALLED_ROOT/nodejs/scripts/lib/node-helpers.sh"
+
+test ! -e "$INSTALLED_ROOT/scripts/lib/project-scripts.sh"
+
+bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem nodejs --path "$2/packages/plugin/subdir"
+    [ "$PROJECT_SCRIPTS_HELPER" = "$3/scripts/lib/project-scripts.sh" ]
+    [ "$HOMEBOY_DEPENDENCY_ADAPTERS_PATH" = "" ]
+    [ "$HOMEBOY_PROJECT_ROOT" = "$2/packages/plugin" ]
+    [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
+    [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
+    [ "$(homeboy_project_run_script_command test)" = "pnpm run test" ]
+' _ "$INSTALLED_NODE_HELPERS" "$WORKSPACE_PROJECT" "$INSTALLED_ROOT/nodejs"

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -332,6 +332,7 @@ done
 
 for runner in \
     nodejs/scripts/bench/bench-runner.sh \
+    nodejs/scripts/fuzz/fuzz-runner.sh \
     nodejs/scripts/trace/trace-runner.sh \
     rust/scripts/bench/bench-runner.sh \
     wordpress/scripts/bench/bench-runner.sh; do
@@ -341,6 +342,7 @@ done
 for runner in \
     nodejs/scripts/bench/bench-runner.sh \
     nodejs/scripts/format.sh \
+    nodejs/scripts/fuzz/fuzz-runner.sh \
     nodejs/scripts/trace/trace-runner.sh \
     nodejs/scripts/validate.sh \
     rust/scripts/bench/bench-runner.sh \
@@ -366,6 +368,7 @@ for runner in \
 done
 
 for runner in \
+    nodejs/scripts/fuzz/fuzz-runner.sh \
     nodejs/scripts/test/test-runner.sh \
     rust/scripts/bench/bench-runner.sh \
     rust/scripts/test-runner.sh \


### PR DESCRIPTION
## Summary
- advertise fuzz support from the Node.js extension manifest and bump the Node.js extension version to 3.4.0
- add a generic Node.js fuzz runner for rig workload scripts, JSON workload descriptors, configured package scripts, and default `scripts.fuzz`
- package Node.js helper dependencies so `node-helpers.sh` resolves project-script helpers from monorepo source installs and single-extension installed/dev-overlay layouts
- cover the runner and helper resolution with Node.js fuzz smoke tests, runtime-helper contract checks, and installed-layout helper resolution smoke coverage

## Testing
- `bash nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`
- `bash nodejs/scripts/fuzz/nodejs-fuzz-runner-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`
- `shellcheck nodejs/scripts/lib/node-helpers.sh nodejs/scripts/lib/project-scripts.sh nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh nodejs/scripts/fuzz/fuzz-runner.sh nodejs/scripts/fuzz/nodejs-fuzz-runner-smoke.sh`
- `node tests/extension-shape-lint.mjs`
- `bash tests/nodejs-deps-provider-smoke.sh`
- `bash nodejs/tests/local-workspace-deps-smoke.sh`
- `bash tests/project-scripts-pnpm-workspace-smoke.sh`

## Caveats
- Did not run destructive Studio fuzz locally; only local smoke fixtures and shell/static checks were run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented and verified the Node.js fuzz extension, packaged helper resolution fix, tests, and PR preparation in collaboration with Chris.
