### PR TITLE
Slim WP Codebox artifact normalization

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -593,7 +593,7 @@ function fanoutWorkerRuntimeTaskDefaults(worker = {}, request = {}, config = {},
 function expectedArtifactsForCodeboxTask(request, artifactDeclarations = []) {
   const declarationNames = artifactDeclarations
     .filter((declaration) => declaration && declaration.required === true)
-    .map((declaration) => typedArtifactNameFromDeclaration(declaration))
+    .map((declaration) => artifactNameFromDeclaration(declaration))
     .filter(Boolean);
   if (declarationNames.length > 0) {
     return Array.from(new Set(declarationNames));
@@ -619,7 +619,7 @@ function runtimeAbilityRequirements(runtimeTask, request = {}, config = {}, inpu
 function codeboxTaskArtifactDeclarations(artifactDeclarations = []) {
   const declarations = normalizeArray(artifactDeclarations);
   const taskSpecificDeclarations = declarations.filter((declaration) => {
-    const name = typedArtifactNameFromDeclaration(declaration);
+    const name = artifactNameFromDeclaration(declaration);
     return name && !WP_CODEBOX_BUILTIN_ARTIFACT_DECLARATION_NAMES.has(name);
   });
   return taskSpecificDeclarations.length > 0 ? taskSpecificDeclarations : declarations;
@@ -690,7 +690,7 @@ function artifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs =
 function uniqueArtifactDeclarations(declarations) {
   const seen = new Set();
   return declarations.filter((declaration) => {
-    const name = typedArtifactNameFromDeclaration(declaration);
+    const name = artifactNameFromDeclaration(declaration);
     const schema = declaration?.artifact_schema || declaration?.artifactSchema || declaration?.schema || '';
     const key = `${name}:${schema}`;
     if (!name || seen.has(key)) {
@@ -1062,7 +1062,7 @@ function relativeRuntimePackagePath(value) {
 function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, inputs) {
   input = runtimePackageInputWithInlineBundle(input, config, inputs);
   const declarations = codeboxTaskArtifactDeclarations(artifactDeclarationsFromAgentTaskRequest(request, config, inputs))
-    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && typedArtifactNameFromDeclaration(declaration));
+    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && artifactNameFromDeclaration(declaration));
   if (declarations.length === 0) {
     return {
       ...input,
@@ -1137,7 +1137,7 @@ function runtimePackageRequiredArtifacts(requiredArtifacts, artifactDeclarations
     ...normalizeArray(requiredArtifacts),
     ...artifactDeclarations
       .filter((declaration) => declaration && declaration.required === true)
-      .map((declaration) => typedArtifactNameFromDeclaration(declaration))
+      .map((declaration) => artifactNameFromDeclaration(declaration))
       .filter(Boolean),
   ]));
 }
@@ -2550,21 +2550,17 @@ function codeboxBundleDirectoryFromResult(result) {
   return artifactBundle?.path || artifactBundle?.uri || '';
 }
 
-function typedArtifactNameFromDeclaration(declaration) {
-  return artifactNameFromDeclaration(declaration);
-}
-
 function requiredArtifactDeclarationsFromRequest(request) {
   const config = request.executor?.config || {};
   return codeboxTaskArtifactDeclarations(artifactDeclarationsFromAgentTaskRequest(request, config, request.inputs || {}))
-    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && typedArtifactNameFromDeclaration(declaration));
+    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && artifactNameFromDeclaration(declaration));
 }
 
 function requiredArtifactDeclarationsFromResultTaskInput(result) {
   const taskInput = result?.task_input || result?.taskInput || {};
   return normalizeArray(taskInput.artifact_declarations || taskInput.artifactDeclarations)
     .map((declaration) => wpCodeboxArtifactDeclarationFromHomeboy(declaration))
-    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && typedArtifactNameFromDeclaration(declaration));
+    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && artifactNameFromDeclaration(declaration));
 }
 
 function requiredArtifactDeclarationsForResult(request, result) {
@@ -2574,7 +2570,7 @@ function requiredArtifactDeclarationsForResult(request, result) {
   ];
   const seen = new Set();
   return declarations.filter((declaration) => {
-    const key = `${typedArtifactNameFromDeclaration(declaration)}:${declaration.artifact_schema || declaration.artifactSchema || declaration.schema || ''}`;
+    const key = `${artifactNameFromDeclaration(declaration)}:${declaration.artifact_schema || declaration.artifactSchema || declaration.schema || ''}`;
     if (seen.has(key)) {
       return false;
     }
@@ -2598,7 +2594,7 @@ function missingRequiredTypedArtifactDiagnostic(request, outputs) {
     : {};
   const missing = required
     .map((declaration) => ({
-      name: typedArtifactNameFromDeclaration(declaration),
+      name: artifactNameFromDeclaration(declaration),
       type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType || '',
       artifact_schema: declaration.artifact_schema || declaration.artifactSchema || declaration.schema || '',
     }))
@@ -2618,7 +2614,7 @@ function invalidRequiredTypedArtifactDiagnostic(request, outputs) {
     ? outputs.typed_artifacts
     : {};
   const invalid = requiredArtifactDeclarationsFromRequest(request)
-    .map((declaration) => typedArtifactNameFromDeclaration(declaration))
+    .map((declaration) => artifactNameFromDeclaration(declaration))
     .filter((name) => name && unexecutedWorkspaceToolCallArtifact(typedArtifacts[name]));
   if (invalid.length === 0) {
     return null;

--- a/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
+++ b/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
@@ -40,6 +40,8 @@ const executorSource = fs.readFileSync(path.join(runtimeRoot, 'lib', 'codebox-ag
 assert.doesNotMatch(executorSource, /function defaultRuntimeRequirements/);
 assert.doesNotMatch(executorSource, /slug: 'agents-api'/);
 assert.doesNotMatch(executorSource, /pluginFile: 'agents-api\/agents-api\.php'/);
+assert.doesNotMatch(executorSource, /function typedArtifactNameFromDeclaration/);
+assert.match(executorSource, /artifactNameFromDeclaration\(declaration\)/);
 
 assert.deepEqual(wpCodeboxProviderPluginPathsFromEnv({
   WP_CODEBOX_PROVIDER_PLUGIN_PATHS: JSON.stringify(['/tmp/provider-a', '/tmp/provider-b']),
@@ -53,7 +55,10 @@ assert.equal(wpCodeboxBinaryDiagnostic('').class, 'wp-codebox.config.missing_bin
 assert.equal(wpCodeboxBinaryDiagnostic('wp-codebox'), null);
 assert.deepEqual(wpCodeboxResolveCommand('/tmp/wp-codebox.cjs', ['run-agent-task']).args, ['/tmp/wp-codebox.cjs', 'run-agent-task']);
 assert.equal(wpCodeboxBin({
-	env: { HOMEBOY_WP_CODEBOX_BIN: '/tmp/env-wp-codebox' },
+	env: {
+		HOMEBOY_WP_CODEBOX_BIN: '/tmp/env-wp-codebox',
+		HOMEBOY_WP_CODEBOX_INSTALL_DIR: path.join(__dirname, '.missing-wp-codebox-install'),
+	},
 	settings: { wp_codebox_bin: '/tmp/settings-wp-codebox' },
 }), '/tmp/env-wp-codebox');
 


### PR DESCRIPTION
## Summary
- Remove the executor-local typed artifact declaration name wrapper.
- Use the artifact contract's existing artifactNameFromDeclaration helper directly.
- Add boundary coverage to keep the duplicated helper out and make the adapter test hermetic against local managed WP Codebox installs.

## Tests
- node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
- npm run test:wp-codebox-runtime-contract-source
- npm run test:wp-codebox-adapter-contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified a focused WP Codebox adapter slimming cleanup.