### PR TITLE
Expose runtime source freshness metadata

### DIFF
--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -69,6 +69,7 @@ function loadRuntimeManifest(manifestPath, source = {}) {
 	}
 	return attachRuntimeSourceMetadata(manifest, {
 		...source,
+		manifest_version: manifest.version,
 		manifest_path: resolvedManifestPath,
 		source_path: source.source_path ? path.resolve(source.source_path) : path.dirname(resolvedManifestPath),
 		...gitSourceRevision(source.source_path || path.dirname(resolvedManifestPath)),
@@ -96,6 +97,7 @@ function loadRuntimePackageManifest(runtimePackage, options = {}) {
 	const manifest = loadRuntimeManifest(manifestPath, {
 		kind: 'package',
 		package: spec,
+		linked: runtimePackageLinked(spec, options),
 		source_path: packageRoot,
 	});
 	if (!manifest) {
@@ -208,11 +210,48 @@ function normalizeRuntimeSource(source = {}) {
 	return {
 		kind: firstString(source.kind, 'registry'),
 		...(source.package ? { package: source.package } : {}),
+		...(source.linked === true ? { linked: true } : {}),
 		...(sourcePath ? { source_path: sourcePath } : {}),
 		...(source.manifest_path ? { manifest_path: source.manifest_path } : {}),
+		...(source.manifest_version ? { manifest_version: source.manifest_version } : {}),
 		...(source.revision ? { revision: source.revision } : {}),
 		...(source.ref ? { ref: source.ref } : {}),
 	};
+}
+
+function runtimeSourceState(source = {}) {
+	return {
+		source_type: runtimeSourceType(source),
+		...(source.package ? { package: source.package } : {}),
+		...(source.source_path ? { source_path: source.source_path } : {}),
+		...(source.manifest_path ? { manifest_path: source.manifest_path } : {}),
+		...(source.manifest_version ? { manifest_version: source.manifest_version } : {}),
+		...(source.revision ? { revision: source.revision } : {}),
+		...(source.ref ? { ref: source.ref } : {}),
+	};
+}
+
+function runtimeSourceType(source = {}) {
+	if (source.linked === true) {
+		return 'linked';
+	}
+	if (source.kind === 'package') {
+		return 'release';
+	}
+	return 'local';
+}
+
+function runtimePackageLinked(spec, options = {}) {
+	for (const basePath of runtimePackageBasePaths(options)) {
+		try {
+			if (fs.lstatSync(path.join(basePath, 'node_modules', ...spec.split('/'))).isSymbolicLink()) {
+				return true;
+			}
+		} catch {
+			// Missing package roots are handled by require.resolve in resolveRuntimePackageRoot().
+		}
+	}
+	return false;
 }
 
 function gitSourceRevision(sourcePath) {
@@ -318,6 +357,7 @@ function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 		id,
 		requested_id: requestedId,
 		source,
+		source_state: runtimeSourceState(source),
 		manifest,
 		checkout,
 		setupCommands: normalizeCommands(materialization.setup_commands || []),

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -46,6 +46,7 @@ fs.writeFileSync(path.join(overlayPackageRoot, 'package.json'), JSON.stringify({
 fs.writeFileSync(path.join(overlayPackageRoot, 'runtime.json'), JSON.stringify({
   schema: 'homeboy/agent-runtime-manifest/v1',
   id: 'overlay-runtime',
+  version: '1.2.3',
   agent_task_executors: [{ id: 'overlay-executor', backend: 'local', invocation: { command: 'node', argv: ['node', '{{runtime_path}}/executor.js'] } }],
   workload_profiles: { default: { runtime_profile: 'default' } },
   workflow_input_projection: { adapter: { module: 'lib/workflow-inputs.cjs', export: 'renderInputs' } },
@@ -69,6 +70,13 @@ const overlayRuntime = resolveRuntimeProvider('overlay-runtime', {
 });
 const expectedOverlayPackageRoot = fs.realpathSync(overlayPackageRoot);
 assert.equal(overlayRuntime.source.source_path, expectedOverlayPackageRoot);
+assert.deepEqual(overlayRuntime.source_state, {
+  source_type: 'release',
+  package: '@example/runtime-overlay',
+  source_path: expectedOverlayPackageRoot,
+  manifest_path: path.join(expectedOverlayPackageRoot, 'runtime.json'),
+  manifest_version: '1.2.3',
+});
 assert.deepEqual(renderRuntimeWorkflowInputs({
   runtime: overlayRuntime,
   runtime_profile: 'default',
@@ -77,6 +85,53 @@ assert.deepEqual(renderRuntimeWorkflowInputs({
 const overlaySetupCalls = [];
 runtimeSetupAdapter(overlayRuntime)({ runtime: overlayRuntime, run: (...args) => overlaySetupCalls.push(args) });
 assert.deepEqual(overlaySetupCalls, [['overlay-setup', [expectedOverlayPackageRoot], { cwd: expectedOverlayPackageRoot }]]);
+
+const localManifestRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-local-manifest-'));
+const localManifestPath = path.join(localManifestRoot, 'runtime.json');
+fs.writeFileSync(localManifestPath, JSON.stringify({
+  schema: 'homeboy/agent-runtime-manifest/v1',
+  id: 'local-manifest-runtime',
+  agent_task_executors: [{ id: 'local-manifest-executor', backend: 'local', invocation: { command: 'node', argv: ['node', '{{runtime_path}}/executor.js'] } }],
+}, null, 2));
+const localManifestRuntime = resolveRuntimeProvider('local-manifest-runtime', {
+  runtimeManifests: [localManifestPath],
+  env: {},
+});
+assert.deepEqual(localManifestRuntime.source_state, {
+  source_type: 'local',
+  source_path: localManifestRoot,
+  manifest_path: localManifestPath,
+});
+
+const linkedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-linked-'));
+const linkedSourceRoot = path.join(linkedRoot, 'source-runtime');
+const linkedNodeModulesRoot = path.join(linkedRoot, 'consumer/node_modules/@example');
+const linkedPackageRoot = path.join(linkedNodeModulesRoot, 'runtime-linked');
+fs.mkdirSync(linkedSourceRoot, { recursive: true });
+fs.mkdirSync(linkedNodeModulesRoot, { recursive: true });
+fs.writeFileSync(path.join(linkedSourceRoot, 'package.json'), JSON.stringify({
+  name: '@example/runtime-linked',
+  version: '1.0.0',
+  homeboy: { agent_runtime_manifest: 'runtime.json' },
+}, null, 2));
+fs.writeFileSync(path.join(linkedSourceRoot, 'runtime.json'), JSON.stringify({
+  schema: 'homeboy/agent-runtime-manifest/v1',
+  id: 'linked-runtime',
+  version: '2.0.0',
+  agent_task_executors: [{ id: 'linked-executor', backend: 'local', invocation: { command: 'node', argv: ['node', '{{runtime_path}}/executor.js'] } }],
+}, null, 2));
+fs.symlinkSync(linkedSourceRoot, linkedPackageRoot, 'dir');
+const linkedRuntime = resolveRuntimeProvider('linked-runtime', {
+  runtimePackages: ['@example/runtime-linked'],
+  env: { AGENT_RUNTIME_PACKAGE_BASE_PATHS: path.join(linkedRoot, 'consumer') },
+});
+assert.deepEqual(linkedRuntime.source_state, {
+  source_type: 'linked',
+  package: '@example/runtime-linked',
+  source_path: fs.realpathSync(linkedSourceRoot),
+  manifest_path: path.join(fs.realpathSync(linkedSourceRoot), 'runtime.json'),
+  manifest_version: '2.0.0',
+});
 
 const setupCalls = [];
 runRuntimeSetup({ manifest: { ci_materialization: {} } }, {


### PR DESCRIPTION
## Summary
- Add `source_state` metadata to resolved runtime providers with source type, paths, manifest version, and existing git revision/ref evidence.
- Detect symlinked runtime package installs with a single package-root `lstat` during resolution.
- Cover release, local manifest, and linked runtime package metadata reporting without changing execution behavior.

## Tests
- `node runtime-agent-ci/tests/runtime-provider-boundary.test.js`
- `npm test` from `runtime-agent-ci/`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified runtime source freshness metadata reporting.
