### PR TITLE
Expand runtime workload profile defaults

### DIFF
--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -162,7 +162,7 @@ function buildConfig(env) {
     component_id: componentId,
     component_path: componentPath,
     workload_id: workload.id || workloadId,
-    workload_label: workload.label || workload.name || env.WORKLOAD_LABEL || `Run ${workloadId}`,
+    workload_label: workload.label || workload.name || env.WORKLOAD_LABEL || workloadProfile.workload_label || `Run ${workloadId}`,
     workload,
     validation_dependencies: validationDependencies.paths,
     runtime_id: runtime.id,
@@ -181,7 +181,7 @@ function buildConfig(env) {
     workload_run_after: parseJsonInput('workload_run_after', env.WORKLOAD_RUN_AFTER || '[]', 'array', []),
     required_abilities: parseJsonInput('required_abilities', env.REQUIRED_ABILITIES || '[]', 'array', []),
     success_requires_pr: env.SUCCESS_REQUIRES_PR !== 'false',
-    proof_profile: env.PROOF_PROFILE || 'artifact_only',
+    proof_profile: env.PROOF_PROFILE || workloadProfile.proof_profile || 'artifact_only',
     success_completion_outcomes: parseJsonInput('success_completion_outcomes', env.SUCCESS_COMPLETION_OUTCOMES || '[]', 'array', []),
     provider: env.PROVIDER || '',
     model: env.MODEL || '',
@@ -222,10 +222,10 @@ function buildConfig(env) {
     allowed_repos: allowedRepos.length > 0 ? allowedRepos : appTokenRepos.length > 0 ? appTokenRepos : [targetRepo],
     engine_key: env.ENGINE_KEY || '',
     tool_results_key: env.TOOL_RESULTS_KEY || 'tool_results',
-    max_turns: Number(env.MAX_TURNS || 12),
+    max_turns: numberDefault(env.MAX_TURNS, workloadProfile.max_turns, 12),
     prompt: env.PROMPT || '',
-    step_budget: Number(env.STEP_BUDGET || 16),
-    time_budget_ms: Number(env.TIME_BUDGET_MS || 600000),
+    step_budget: numberDefault(env.STEP_BUDGET, workloadProfile.step_budget, 16),
+    time_budget_ms: numberDefault(env.TIME_BUDGET_MS, workloadProfile.time_budget_ms, 600000),
     ...(Object.keys(loopPolicy).length > 0 ? { loop_policy: loopPolicy } : {}),
     expected_artifacts: parseJsonInput('expected_artifacts', env.EXPECTED_ARTIFACTS || '[]', 'array', []),
     artifact_declarations: runtimeProjection.artifact_declarations,
@@ -288,9 +288,14 @@ function parseRuntimeWorkloadProfile(value) {
       runtime: stringDefault(profile.runtime),
       profile: stringDefault(profile.profile),
       workload_id: stringDefault(profile.workload_id),
+      workload_label: stringDefault(profile.workload_label),
       workload: objectDefault(profile.workload),
       tool_profile: objectDefault(profile.tool_profile),
       loop_policy: objectDefault(profile.loop_policy),
+      proof_profile: stringDefault(profile.proof_profile),
+      max_turns: positiveNumber(profile.max_turns),
+      step_budget: positiveNumber(profile.step_budget),
+      time_budget_ms: positiveNumber(profile.time_budget_ms),
     };
   } catch (error) {
     if (error instanceof SyntaxError) {
@@ -317,6 +322,13 @@ function objectDefault(value) {
 function positiveNumber(value) {
   const parsed = Number(value || 0);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function numberDefault(explicitValue, profileValue, fallback) {
+  if (explicitValue !== undefined && explicitValue !== '') {
+    return Number(explicitValue);
+  }
+  return profileValue > 0 ? profileValue : fallback;
 }
 
 function providerBenchEnvFromManifest(runtime, provider, env) {

--- a/runtime-agent-ci/tests/build-runner-config.test.js
+++ b/runtime-agent-ci/tests/build-runner-config.test.js
@@ -57,13 +57,22 @@ assert.deepEqual(parseRuntimeWorkloadProfile(JSON.stringify({
   workload: { id: 'profile-workload', label: 'Profile workload' },
   tool_profile: { workspace_tools: { inspect: { command: 'git status --short' } } },
   loop_policy: { mode: 'duration', max_revolutions: 2 },
+  proof_profile: 'cook_to_pr',
+  max_turns: 7,
+  step_budget: 9,
+  time_budget_ms: 120000,
 })), {
   runtime: 'local-shell',
   profile: 'profile-default',
   workload_id: '',
+  workload_label: '',
   workload: { id: 'profile-workload', label: 'Profile workload' },
   tool_profile: { workspace_tools: { inspect: { command: 'git status --short' } } },
   loop_policy: { mode: 'duration', max_revolutions: 2 },
+  proof_profile: 'cook_to_pr',
+  max_turns: 7,
+  step_budget: 9,
+  time_budget_ms: 120000,
 });
 
 assert.throws(
@@ -193,9 +202,14 @@ try {
       runtime: 'local-shell',
       profile: 'profile-default',
       workload_id: 'profile-workload',
+      workload_label: 'Profile scalar workload',
       workload: { label: 'Profile workload' },
       tool_profile: { workspace_tools: { inspect: { command: 'git status --short' } } },
       loop_policy: { mode: 'duration', max_revolutions: 2 },
+      proof_profile: 'cook_to_pr',
+      max_turns: 7,
+      step_budget: 9,
+      time_budget_ms: 120000,
     }),
   });
 
@@ -203,6 +217,10 @@ try {
   assert.equal(config.runtime_profile, 'profile-default');
   assert.equal(config.workload_id, 'profile-workload');
   assert.equal(config.workload_label, 'Profile workload');
+  assert.equal(config.proof_profile, 'cook_to_pr');
+  assert.equal(config.max_turns, 7);
+  assert.equal(config.step_budget, 9);
+  assert.equal(config.time_budget_ms, 120000);
   assert.deepEqual(config.loop_policy, { mode: 'duration', max_revolutions: 2 });
 } finally {
   fs.rmSync(profileTmpRoot, { recursive: true, force: true });
@@ -222,12 +240,20 @@ try {
     WORKLOAD: '{"label":"Explicit workload"}',
     LOOP_POLICY: '{"mode":"revolution"}',
     MAX_REVOLUTIONS: '5',
+    PROOF_PROFILE: 'artifact_only',
+    MAX_TURNS: '12',
+    STEP_BUDGET: '16',
+    TIME_BUDGET_MS: '600000',
     RUNTIME_WORKLOAD_PROFILE_JSON: JSON.stringify({
       runtime: 'other-runtime',
       profile: 'profile-default',
       workload_id: 'profile-workload',
       workload: { label: 'Profile workload' },
       loop_policy: { mode: 'duration', max_revolutions: 2 },
+      proof_profile: 'cook_to_pr',
+      max_turns: 7,
+      step_budget: 9,
+      time_budget_ms: 120000,
     }),
   });
 
@@ -235,6 +261,10 @@ try {
   assert.equal(config.runtime_profile, 'explicit-profile');
   assert.equal(config.workload_id, 'explicit-workload');
   assert.equal(config.workload_label, 'Explicit workload');
+  assert.equal(config.proof_profile, 'artifact_only');
+  assert.equal(config.max_turns, 12);
+  assert.equal(config.step_budget, 16);
+  assert.equal(config.time_budget_ms, 600000);
   assert.deepEqual(config.loop_policy, { mode: 'revolution', max_revolutions: 5 });
 } finally {
   fs.rmSync(explicitProfileTmpRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Accept additional non-secret runtime workload profile defaults for workload label, proof profile, max turns, step budget, and time budget.
- Preserve explicit env/input precedence over profile defaults.
- Extend profile parser/config tests for new defaults and precedence.

## Tests
- node runtime-agent-ci/tests/runtime-agent-full-run-control-plane.test.js
- node runtime-agent-ci/tests/build-runner-config.test.js
- npm test from runtime-agent-ci/

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Expanded and verified runtime workload profile defaults.