### PR TITLE
Extract WP Codebox source descriptors

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -68,6 +68,8 @@ const {
 const {
   wpCodeboxProviderPluginPathsFromEnv,
   wpCodeboxBin,
+  wpCodeboxRuntimePackagePackage,
+  wpCodeboxRuntimePackageSourceDescriptor,
 } = require('./wp-codebox-adapter-descriptor');
 const {
   assertProviderCredentialBoundaryNamesOnly,
@@ -965,98 +967,7 @@ function runtimePackageTaskInputForCodebox(input, options = {}) {
 }
 
 function normalizeRuntimePackageTaskPackage(packageDescriptor, options = {}) {
-  if (typeof packageDescriptor === 'string') {
-    return { package: runtimePackagePackageFromString(packageDescriptor, options) };
-  }
-  if (!packageDescriptor || typeof packageDescriptor !== 'object' || Array.isArray(packageDescriptor)) {
-    return { package: null };
-  }
-
-  const descriptor = runtimePackageDescriptorForCodebox(packageDescriptor, options);
-  const sourceKeys = ['source', 'path', 'bundle_path', 'bundlePath'];
-  const declaredSources = sourceKeys
-    .map((key) => descriptor[key])
-    .filter((value) => typeof value === 'string' && value !== '');
-  const uniqueSources = Array.from(new Set(declaredSources));
-  if (uniqueSources.length > 1) {
-    throw new Error(`WP Codebox runtime_package descriptor source fields cannot diverge: ${uniqueSources.join(', ')}`);
-  }
-
-  return { package: runtimePackagePackageFromDescriptor(descriptor, uniqueSources[0]) };
-}
-
-function runtimePackagePackageFromString(value, options = {}) {
-  const source = runtimePackageImportPath(value, options);
-  const slug = runtimePackageIdentifier(value);
-  return withoutUndefinedValues(relativeRuntimePackagePath(value) ? { slug, source } : { slug: source || slug });
-}
-
-function runtimePackagePackageFromDescriptor(descriptor, source = '') {
-  return withoutUndefinedValues({
-    ...descriptor,
-    slug: firstValue(descriptor.slug, descriptor.id, descriptor.name, runtimePackageIdentifier(source)),
-    ...(source ? { source } : {}),
-    path: undefined,
-    bundle_path: undefined,
-    bundlePath: undefined,
-    id: undefined,
-    name: undefined,
-  });
-}
-
-function runtimePackageIdentifier(value) {
-  if (typeof value === 'string') {
-    return path.basename(String(value).replace(/\/+$/, '')) || value;
-  }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return '';
-  }
-  return firstValue(value.slug, value.id, value.name, value.source, '');
-}
-
-function runtimePackageImportPath(value, options = {}) {
-  if (typeof value === 'string') {
-    return runtimePackagePathForSandbox(value, options);
-  }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return '';
-  }
-  const importPath = firstValue(value.source, value.path, value.bundle_path, value.bundlePath, '');
-  if (importPath) {
-    return runtimePackagePathForSandbox(importPath, options);
-  }
-  return firstValue(value.slug, value.id, value.name, '');
-}
-
-function runtimePackageDescriptorForCodebox(descriptor, options = {}) {
-  if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
-    return descriptor;
-  }
-  const normalized = { ...descriptor };
-  for (const key of ['source', 'path', 'bundle_path', 'bundlePath']) {
-    if (typeof normalized[key] === 'string' && normalized[key]) {
-      normalized[key] = runtimePackagePathForSandbox(normalized[key], options);
-    }
-  }
-  return normalized;
-}
-
-function runtimePackagePathForSandbox(value, options = {}) {
-  const raw = String(value || '');
-  if (!raw || !relativeRuntimePackagePath(raw)) {
-    return raw;
-  }
-  const workspaceTarget = String(options.workspaceTarget || '').replace(/\/+$/, '');
-  return workspaceTarget ? `${workspaceTarget}/${raw.replace(/^\.\//, '')}` : raw;
-}
-
-function relativeRuntimePackagePath(value) {
-  const raw = String(value || '');
-  return raw.includes('/')
-    && !raw.startsWith('/')
-    && !raw.startsWith('~/')
-    && !/^[A-Za-z]:[\\/]/.test(raw)
-    && !/^[a-z][a-z0-9+.-]*:/i.test(raw);
+  return { package: wpCodeboxRuntimePackagePackage(packageDescriptor, options) };
 }
 
 function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, inputs) {
@@ -1113,11 +1024,13 @@ function matchingInlineAgentBundleSpec(packageDescriptor, specs) {
   if (inlineSpecs.length === 0) {
     return null;
   }
-  const packageSource = firstValue(packageDescriptor.source, packageDescriptor.path, packageDescriptor.bundle_path, packageDescriptor.bundlePath, '');
-  const packageSlug = firstValue(packageDescriptor.slug, packageDescriptor.id, packageDescriptor.name, '');
+  const packageSourceDescriptor = wpCodeboxRuntimePackageSourceDescriptor(packageDescriptor, { rejectDivergentSources: false });
+  const packageSource = packageSourceDescriptor.source;
+  const packageSlug = packageSourceDescriptor.slug;
   return inlineSpecs.find((spec) => {
-    const specSource = firstValue(spec.source, spec.path, spec.bundle_path, spec.bundlePath, '');
-    const specSlug = firstValue(spec.slug, spec.id, spec.name, spec.bundle?.bundle_slug, '');
+    const specSourceDescriptor = wpCodeboxRuntimePackageSourceDescriptor({ ...spec, slug: firstValue(spec.slug, spec.id, spec.name, spec.bundle?.bundle_slug, '') }, { rejectDivergentSources: false });
+    const specSource = specSourceDescriptor.source;
+    const specSlug = specSourceDescriptor.slug;
     return (packageSource && specSource && packageSource === specSource) || (packageSlug && specSlug && packageSlug === specSlug);
   }) || inlineSpecs[0];
 }

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor.js
@@ -13,6 +13,7 @@ const {
 } = require('./wp-codebox-adapter-contract');
 
 const WP_CODEBOX_CLI_DESCRIPTOR_SCHEMA = 'wp-codebox/cli-descriptor/v1';
+const WP_CODEBOX_RUNTIME_PACKAGE_SOURCE_FIELDS = ['source', 'path', 'bundle_path', 'bundlePath'];
 
 const DEFAULT_WP_CODEBOX_CLI_DESCRIPTOR = {
   schema: WP_CODEBOX_CLI_DESCRIPTOR_SCHEMA,
@@ -252,6 +253,108 @@ function wpCodeboxProviderPluginPathsFromEnv(env = process.env) {
 	);
 }
 
+function wpCodeboxRuntimePackageSourceDescriptor(value, options = {}) {
+	if (typeof value === 'string') {
+		const source = wpCodeboxRuntimePackageImportPath(value, options);
+		const slug = wpCodeboxRuntimePackageIdentifier(value);
+		return {
+			descriptor: withoutUndefinedValues(relativeRuntimePackagePath(value) ? { slug, source } : { slug: source || slug }),
+			source,
+			slug,
+		};
+	}
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return { descriptor: null, source: '', slug: '' };
+	}
+
+	const descriptor = wpCodeboxRuntimePackageDescriptorForCodebox(value, options);
+	const declaredSources = WP_CODEBOX_RUNTIME_PACKAGE_SOURCE_FIELDS
+		.map((key) => descriptor[key])
+		.filter((source) => typeof source === 'string' && source !== '');
+	const uniqueSources = Array.from(new Set(declaredSources));
+	if (uniqueSources.length > 1 && options.rejectDivergentSources !== false) {
+		throw new Error(`WP Codebox runtime_package descriptor source fields cannot diverge: ${uniqueSources.join(', ')}`);
+	}
+	const source = uniqueSources[0] || '';
+	const slug = firstValue(descriptor.slug, descriptor.id, descriptor.name, wpCodeboxRuntimePackageIdentifier(source));
+	return { descriptor, source, slug };
+}
+
+function wpCodeboxRuntimePackagePackage(value, options = {}) {
+	const sourceDescriptor = wpCodeboxRuntimePackageSourceDescriptor(value, options);
+	if (!sourceDescriptor.descriptor) {
+		return null;
+	}
+	if (typeof value === 'string') {
+		return sourceDescriptor.descriptor;
+	}
+	return withoutUndefinedValues({
+		...sourceDescriptor.descriptor,
+		slug: sourceDescriptor.slug,
+		...(sourceDescriptor.source ? { source: sourceDescriptor.source } : {}),
+		path: undefined,
+		bundle_path: undefined,
+		bundlePath: undefined,
+		id: undefined,
+		name: undefined,
+	});
+}
+
+function wpCodeboxRuntimePackageDescriptorForCodebox(descriptor, options = {}) {
+	if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
+		return descriptor;
+	}
+	const normalized = { ...descriptor };
+	for (const key of WP_CODEBOX_RUNTIME_PACKAGE_SOURCE_FIELDS) {
+		if (typeof normalized[key] === 'string' && normalized[key]) {
+			normalized[key] = wpCodeboxRuntimePackagePathForSandbox(normalized[key], options);
+		}
+	}
+	return normalized;
+}
+
+function wpCodeboxRuntimePackageImportPath(value, options = {}) {
+	if (typeof value === 'string') {
+		return wpCodeboxRuntimePackagePathForSandbox(value, options);
+	}
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return '';
+	}
+	const importPath = firstValue(...WP_CODEBOX_RUNTIME_PACKAGE_SOURCE_FIELDS.map((key) => value[key]), '');
+	if (importPath) {
+		return wpCodeboxRuntimePackagePathForSandbox(importPath, options);
+	}
+	return firstValue(value.slug, value.id, value.name, '');
+}
+
+function wpCodeboxRuntimePackageIdentifier(value) {
+	if (typeof value === 'string') {
+		return path.basename(String(value).replace(/\/+$/, '')) || value;
+	}
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return '';
+	}
+	return firstValue(value.slug, value.id, value.name, value.source, '');
+}
+
+function wpCodeboxRuntimePackagePathForSandbox(value, options = {}) {
+	const raw = String(value || '');
+	if (!raw || !relativeRuntimePackagePath(raw)) {
+		return raw;
+	}
+	const workspaceTarget = String(options.workspaceTarget || '').replace(/\/+$/, '');
+	return workspaceTarget ? `${workspaceTarget}/${raw.replace(/^\.\//, '')}` : raw;
+}
+
+function relativeRuntimePackagePath(value) {
+	const raw = String(value || '');
+	return raw.includes('/')
+		&& !raw.startsWith('/')
+		&& !raw.startsWith('~/')
+		&& !/^[A-Za-z]:[\\/]/.test(raw)
+		&& !/^[a-z][a-z0-9+.-]*:/i.test(raw);
+}
+
 function homeboySettings(env = process.env) {
   if (!env.HOMEBOY_SETTINGS_JSON) {
     return {};
@@ -297,6 +400,10 @@ function firstValue(...values) {
   return values.find((value) => value !== undefined && value !== null && value !== '');
 }
 
+function withoutUndefinedValues(value) {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
 function firstObject(...values) {
 	return values.find((value) => value && typeof value === 'object' && !Array.isArray(value));
 }
@@ -304,7 +411,9 @@ function firstObject(...values) {
 module.exports = {
   DEFAULT_WP_CODEBOX_CLI_DESCRIPTOR,
   WP_CODEBOX_CLI_DESCRIPTOR_SCHEMA,
+	WP_CODEBOX_RUNTIME_PACKAGE_SOURCE_FIELDS,
 	parseRuntimeDescriptorJson,
+	relativeRuntimePackagePath,
 	runtimeDescriptorCommandNames,
 	runtimeDescriptorSupportsCommand,
 	homeboySettings,
@@ -316,6 +425,12 @@ module.exports = {
 	wpCodeboxCommand,
 	wpCodeboxProviderPluginPathsFromEnv,
 	wpCodeboxResolveCommand,
+	wpCodeboxRuntimePackageDescriptorForCodebox,
+	wpCodeboxRuntimePackageIdentifier,
+	wpCodeboxRuntimePackageImportPath,
+	wpCodeboxRuntimePackagePackage,
+	wpCodeboxRuntimePackagePathForSandbox,
+	wpCodeboxRuntimePackageSourceDescriptor,
 	wpCodeboxRuntimeDescriptor,
 	wpCodeboxSupportsRunAgentTaskCommand,
 };

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -35,6 +35,7 @@ const {
 	wpCodeboxBin,
 	wpCodeboxCliDescriptor,
 	wpCodeboxCommand,
+	wpCodeboxRuntimePackageSourceDescriptor,
 } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-adapter-descriptor.js'));
 
 assert.equal(WP_CODEBOX_BACKEND, 'wp-codebox');
@@ -55,6 +56,9 @@ const emptyManagedInstallDir = path.join(tmpdir(), 'homeboy-wp-codebox-empty-man
 assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_INSTALL_DIR: emptyManagedInstallDir, HOMEBOY_WP_CODEBOX_BIN: '/usr/local/bin/wp-codebox' } }), '/usr/local/bin/wp-codebox');
 assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_INSTALL_DIR: emptyManagedInstallDir }, settings: { wp_codebox_bin: '/settings/wp-codebox' } }), '/settings/wp-codebox');
 assert.deepEqual(wpCodeboxCommand('/tmp/wp-codebox.mjs'), { command: process.execPath, args: ['/tmp/wp-codebox.mjs'] });
+assert.deepEqual(wpCodeboxRuntimePackageSourceDescriptor('@extra-chill/release-runtime').descriptor, { slug: 'release-runtime', source: '@extra-chill/release-runtime' });
+assert.deepEqual(wpCodeboxRuntimePackageSourceDescriptor({ slug: 'local-runtime', source: '/local/wp-codebox/runtime' }).descriptor, { slug: 'local-runtime', source: '/local/wp-codebox/runtime' });
+assert.deepEqual(wpCodeboxRuntimePackageSourceDescriptor({ slug: 'cached-runtime', path: '/cache/homeboy/wp-codebox/source' }).descriptor, { slug: 'cached-runtime', path: '/cache/homeboy/wp-codebox/source' });
 
 const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'homeboy-wp-codebox-bin-'));
 try {

--- a/tests/wp-codebox-runtime-package-contract-smoke.mjs
+++ b/tests/wp-codebox-runtime-package-contract-smoke.mjs
@@ -16,6 +16,9 @@ const {
 	normalizeRuntimePackageTaskPackage,
 	runtimePackageTaskInputForCodebox,
 } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js'));
+const {
+	wpCodeboxRuntimePackageSourceDescriptor,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-adapter-descriptor.js'));
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-package-'));
 
@@ -101,6 +104,15 @@ try {
 			source: '/workspace/source/packages/proof-loop',
 		},
 		artifact_declarations: [],
+	});
+	assert.deepEqual(wpCodeboxRuntimePackageSourceDescriptor({ slug: 'proof-loop', source: 'packages/proof-loop' }, { workspaceTarget: '/workspace/source' }), {
+		descriptor: { slug: 'proof-loop', source: '/workspace/source/packages/proof-loop' },
+		source: '/workspace/source/packages/proof-loop',
+		slug: 'proof-loop',
+	});
+	assert.deepEqual(wpCodeboxRuntimePackageSourceDescriptor('packages/proof-loop', { workspaceTarget: '/workspace/source' }).descriptor, {
+		slug: 'proof-loop',
+		source: '/workspace/source/packages/proof-loop',
 	});
 
 	assert.throws(


### PR DESCRIPTION
## Summary
- Extract WP Codebox runtime package source/path descriptor normalization into the adapter descriptor helper module.
- Reuse the helper from runtime package normalization and inline bundle matching while preserving existing alias and divergence behavior.
- Add focused assertions for release/local/cache and workspace-relative descriptor outputs.

## Tests
- npm run test:wp-codebox-adapter-contract
- npm run test:wp-codebox-runtime-contract-source
- node ../../tests/wp-codebox-runtime-package-contract-smoke.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Extracted and verified WP Codebox source descriptor normalization.