### PR TITLE
Test nodejs helper packaged shared assets

### DIFF
--- a/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
+++ b/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
@@ -2,13 +2,22 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-NODE_HELPERS="${ROOT_DIR}/scripts/lib/node-helpers.sh"
-PROJECT_SCRIPTS="${ROOT_DIR}/../scripts/lib/project-scripts.sh"
+REPO_ROOT="$(cd "${ROOT_DIR}/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+INSTALL_ROOT="$TMP_DIR/home/.config/homeboy/extensions"
+mkdir -p "$INSTALL_ROOT"
+cp -R "$ROOT_DIR" "$INSTALL_ROOT/nodejs"
+cp -R "$REPO_ROOT/scripts" "$INSTALL_ROOT/scripts"
+cp -R "$REPO_ROOT/dependency-adapters" "$INSTALL_ROOT/dependency-adapters"
+
+NODE_HELPERS="${INSTALL_ROOT}/nodejs/scripts/lib/node-helpers.sh"
+PROJECT_SCRIPTS="${INSTALL_ROOT}/scripts/lib/project-scripts.sh"
+
 test -f "$NODE_HELPERS"
 test -f "$PROJECT_SCRIPTS"
+test -f "${INSTALL_ROOT}/dependency-adapters/examples/nodejs.json"
 
 bash -c '
     source "$1"


### PR DESCRIPTION
## Summary\n- update the nodejs helper smoke to build a Lab-style installed extension tree\n- verify nodejs resolves shared `scripts/lib/project-scripts.sh` and dependency adapters from `~/.config/homeboy/extensions` layout\n\nFixes #1032.\n\n## Verification\n- `bash nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`\n- `bash tests/runtime-helpers-smoke.sh`\n- `bash tests/project-scripts-pnpm-workspace-smoke.sh`\n- `bash tests/nodejs-deps-provider-smoke.sh`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenCode, openai/gpt-5.5\n- **Used for:** Investigated the Lab packaging failure, updated regression coverage, ran verification, and prepared the PR. Chris remains responsible for review and merge.