### PR TITLE
Fix nodejs helper dev-overlay shared scripts path

### DIFF
--- a/nodejs/scripts/lib/node-helpers.sh
+++ b/nodejs/scripts/lib/node-helpers.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_SCRIPTS_HELPER="${HOMEBOY_RUNTIME_PROJECT_SCRIPTS:-${SCRIPT_DIR}/../../../scripts/lib/project-scripts.sh}"
+if [ -n "${HOMEBOY_RUNTIME_PROJECT_SCRIPTS:-}" ]; then
+    PROJECT_SCRIPTS_HELPER="$HOMEBOY_RUNTIME_PROJECT_SCRIPTS"
+elif [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -f "${HOMEBOY_EXTENSION_PATH}/../scripts/lib/project-scripts.sh" ]; then
+    PROJECT_SCRIPTS_HELPER="${HOMEBOY_EXTENSION_PATH}/../scripts/lib/project-scripts.sh"
+else
+    PROJECT_SCRIPTS_HELPER="${SCRIPT_DIR}/../../../scripts/lib/project-scripts.sh"
+fi
 # shellcheck source=/dev/null
 source "$PROJECT_SCRIPTS_HELPER"
 

--- a/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
+++ b/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
@@ -27,6 +27,22 @@ bash -c '
     type homeboy_require_package_json >/dev/null
 ' _ "$NODE_HELPERS"
 
+DEV_ROOT="$TMP_DIR/dev-overlay-src"
+mkdir -p "$DEV_ROOT"
+cp -R "$ROOT_DIR" "$DEV_ROOT/nodejs"
+DEV_NODE_HELPERS="${DEV_ROOT}/nodejs/scripts/lib/node-helpers.sh"
+
+test -f "$DEV_NODE_HELPERS"
+
+bash -c '
+    export HOMEBOY_EXTENSION_PATH="$1/nodejs"
+    source "$2"
+    type homeboy_project_init >/dev/null
+    type homeboy_project_has_script >/dev/null
+    type homeboy_project_run_script_command >/dev/null
+    type homeboy_require_package_json >/dev/null
+' _ "$INSTALL_ROOT" "$DEV_NODE_HELPERS"
+
 PNPM_PROJECT="$TMP_DIR/pnpm-project"
 mkdir -p "$PNPM_PROJECT/subdir"
 cat > "$PNPM_PROJECT/package.json" <<'EOF'


### PR DESCRIPTION
## Summary\n- Resolve nodejs shared project helper via `HOMEBOY_RUNTIME_PROJECT_SCRIPTS`, then installed `HOMEBOY_EXTENSION_PATH`, then packaged relative fallback.\n- Add a dev-overlay-style smoke case where nodejs helper source lives outside the installed extensions root while shared `scripts/lib/project-scripts.sh` remains installed.\n\nFixes #1032.\n\n## Testing\n- `bash nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`\n- `bash tests/project-scripts-pnpm-workspace-smoke.sh`\n- `bash tests/nodejs-deps-provider-smoke.sh`\n- `bash tests/runtime-helpers-smoke.sh`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 via OpenCode\n- **Used for:** Investigated the Homeboy Extensions nodejs helper path regression, implemented the fix and regression smoke coverage, and ran local verification.