### PR TITLE
Fix nodejs helper symlinked extension parent

### DIFF
--- a/nodejs/scripts/lib/node-helpers.sh
+++ b/nodejs/scripts/lib/node-helpers.sh
@@ -3,8 +3,8 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ -n "${HOMEBOY_RUNTIME_PROJECT_SCRIPTS:-}" ]; then
     PROJECT_SCRIPTS_HELPER="$HOMEBOY_RUNTIME_PROJECT_SCRIPTS"
-elif [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -f "${HOMEBOY_EXTENSION_PATH}/../scripts/lib/project-scripts.sh" ]; then
-    PROJECT_SCRIPTS_HELPER="${HOMEBOY_EXTENSION_PATH}/../scripts/lib/project-scripts.sh"
+elif [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -f "$(dirname "$HOMEBOY_EXTENSION_PATH")/scripts/lib/project-scripts.sh" ]; then
+    PROJECT_SCRIPTS_HELPER="$(dirname "$HOMEBOY_EXTENSION_PATH")/scripts/lib/project-scripts.sh"
 else
     PROJECT_SCRIPTS_HELPER="${SCRIPT_DIR}/../../../scripts/lib/project-scripts.sh"
 fi

--- a/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
+++ b/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
@@ -30,7 +30,9 @@ bash -c '
 DEV_ROOT="$TMP_DIR/dev-overlay-src"
 mkdir -p "$DEV_ROOT"
 cp -R "$ROOT_DIR" "$DEV_ROOT/nodejs"
-DEV_NODE_HELPERS="${DEV_ROOT}/nodejs/scripts/lib/node-helpers.sh"
+rm -rf "$INSTALL_ROOT/nodejs"
+ln -s "$DEV_ROOT/nodejs" "$INSTALL_ROOT/nodejs"
+DEV_NODE_HELPERS="${INSTALL_ROOT}/nodejs/scripts/lib/node-helpers.sh"
 
 test -f "$DEV_NODE_HELPERS"
 


### PR DESCRIPTION
## Summary\n- Preserve the installed extensions root when `HOMEBOY_EXTENSION_PATH` points at a symlinked dev overlay.\n- Resolve shared `scripts/lib/project-scripts.sh` from `dirname ""` instead of traversing through `/..`, which follows the symlink target first on Linux.\n- Extend the node helper smoke test to simulate the Lab dev-overlay symlink layout.\n\nFollow-up to #2197 after runner verification exposed the symlink-parent edge. Fixes #1032.\n\n## Testing\n- `bash nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`\n- `bash tests/project-scripts-pnpm-workspace-smoke.sh`\n- `bash tests/nodejs-deps-provider-smoke.sh`\n- `bash tests/runtime-helpers-smoke.sh`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 via OpenCode\n- **Used for:** Verified the merged dev-overlay fix on the Lab runner, diagnosed the symlink-parent path behavior, implemented the follow-up fix and regression coverage, and ran local verification.