### PR TITLE
Add wordpress deps provider declaration

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -135,6 +135,7 @@
     "test:wordpress-fuzz-campaign": "node tests/wordpress-fuzz-campaign-smoke.js",
     "test:wordpress-fuzz-campaign-orchestrator": "node tests/wordpress-fuzz-campaign-orchestrator-smoke.js",
     "test:wordpress-dependency-materialization-recipes": "node tests/wordpress-dependency-materialization-recipes-smoke.js",
+    "test:wordpress-deps-provider": "bash tests/wordpress-deps-provider-smoke.sh",
     "test:wp-codebox-browser-metrics": "node tests/wp-codebox-browser-metrics-smoke.js",
     "test:wp-codebox-visual-compare": "node tests/wp-codebox-visual-compare-smoke.js",
     "test:wordpress-codebox-visual-parity-workload": "node tests/wordpress-codebox-visual-parity-workload-smoke.mjs",

--- a/wordpress/scripts/deps/deps-runner.sh
+++ b/wordpress/scripts/deps/deps-runner.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-${PROJECT_PATH:-$(pwd)}}"
+ACTION="${1:-status}"
+PACKAGE_FILTER="${2:-}"
+
+has_composer() {
+    [ -f "${PROJECT_PATH}/composer.json" ]
+}
+
+has_package_json() {
+    [ -f "${PROJECT_PATH}/package.json" ]
+}
+
+npm_install_command() {
+    if [ -f "${PROJECT_PATH}/package-lock.json" ]; then
+        printf '%s\n' "npm ci"
+    else
+        printf '%s\n' "npm install --no-audit --no-fund"
+    fi
+}
+
+emit_status() {
+    HOMEBOY_WORDPRESS_DEPS_PROJECT_PATH="$PROJECT_PATH" \
+    HOMEBOY_WORDPRESS_DEPS_PACKAGE_FILTER="$PACKAGE_FILTER" \
+        node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const projectPath = process.env.HOMEBOY_WORDPRESS_DEPS_PROJECT_PATH;
+const filter = process.env.HOMEBOY_WORDPRESS_DEPS_PACKAGE_FILTER || '';
+const packages = [];
+const dependencyIdentities = [];
+const lockfiles = [];
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(path.join(projectPath, file), 'utf8'));
+}
+
+function pushPackage(name, section, constraint) {
+  if (!name || (filter && filter !== name)) return;
+  packages.push({ name, manifest_section: section, constraint: String(constraint) });
+}
+
+if (fs.existsSync(path.join(projectPath, 'composer.json'))) {
+  const composer = readJson('composer.json');
+  if (composer.name) dependencyIdentities.push(String(composer.name));
+  for (const section of ['require', 'require-dev']) {
+    for (const [name, constraint] of Object.entries(composer[section] || {})) {
+      pushPackage(name, section, constraint);
+    }
+  }
+  if (fs.existsSync(path.join(projectPath, 'composer.lock'))) lockfiles.push('composer.lock');
+}
+
+if (fs.existsSync(path.join(projectPath, 'package.json'))) {
+  const pkg = readJson('package.json');
+  if (pkg.name) dependencyIdentities.push(String(pkg.name));
+  for (const section of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    for (const [name, constraint] of Object.entries(pkg[section] || {})) {
+      pushPackage(name, section, constraint);
+    }
+  }
+  for (const lockfile of ['pnpm-lock.yaml', 'yarn.lock', 'package-lock.json']) {
+    if (fs.existsSync(path.join(projectPath, lockfile))) lockfiles.push(lockfile);
+  }
+}
+
+process.stdout.write(JSON.stringify({
+  package_manager: 'wordpress',
+  dependency_identities: [...new Set(dependencyIdentities)],
+  lockfiles,
+  packages,
+  errors: [],
+}) + '\n');
+NODE
+}
+
+emit_install_command() {
+    HOMEBOY_WORDPRESS_DEPS_RUNNER="${SCRIPT_DIR}/deps-runner.sh" node <<'NODE'
+process.stdout.write(JSON.stringify({
+  command: ['bash', process.env.HOMEBOY_WORDPRESS_DEPS_RUNNER, 'install'],
+}) + '\n');
+NODE
+}
+
+run_install() {
+    local ran=0
+    if has_composer; then
+        echo "Installing WordPress PHP dependencies with composer" >&2
+        (cd "$PROJECT_PATH" && composer install --no-interaction --prefer-dist)
+        ran=1
+    fi
+    if has_package_json; then
+        local command
+        command="$(npm_install_command)"
+        echo "Installing WordPress JavaScript dependencies: ${command}" >&2
+        (cd "$PROJECT_PATH" && $command)
+        ran=1
+    fi
+    if [ "$ran" -eq 0 ]; then
+        echo "No composer.json or package.json found in ${PROJECT_PATH}; nothing to install" >&2
+    fi
+}
+
+case "$ACTION" in
+    status)
+        emit_status
+        ;;
+    install-command)
+        emit_install_command
+        ;;
+    install)
+        run_install
+        ;;
+    update)
+        echo "wordpress deps update is not implemented" >&2
+        exit 64
+        ;;
+    *)
+        echo "unknown wordpress deps action: $ACTION" >&2
+        exit 64
+        ;;
+esac

--- a/wordpress/tests/wordpress-deps-provider-smoke.sh
+++ b/wordpress/tests/wordpress-deps-provider-smoke.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PROJECT_DIR="$TMP_DIR/project"
+BIN_DIR="$TMP_DIR/bin"
+mkdir -p "$PROJECT_DIR" "$BIN_DIR"
+
+cat >"$PROJECT_DIR/composer.json" <<'JSON'
+{
+  "name": "extra-chill/fixture-wordpress-component",
+  "require": {
+    "php": ">=8.2",
+    "composer/installers": "^2.3"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^11.0"
+  }
+}
+JSON
+cat >"$PROJECT_DIR/package.json" <<'JSON'
+{
+  "name": "fixture-wordpress-component",
+  "dependencies": {
+    "@wordpress/scripts": "^30.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0"
+  }
+}
+JSON
+cat >"$PROJECT_DIR/package-lock.json" <<'JSON'
+{
+  "name": "fixture-wordpress-component",
+  "lockfileVersion": 3,
+  "packages": {}
+}
+JSON
+
+cat >"$BIN_DIR/composer" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${HOMEBOY_FAKE_COMPOSER_LOG:?}"
+exit 0
+SH
+cat >"$BIN_DIR/npm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${HOMEBOY_FAKE_NPM_LOG:?}"
+exit 0
+SH
+chmod +x "$BIN_DIR/composer" "$BIN_DIR/npm"
+
+export HOMEBOY_COMPONENT_PATH="$PROJECT_DIR"
+export HOMEBOY_FAKE_COMPOSER_LOG="$TMP_DIR/composer.log"
+export HOMEBOY_FAKE_NPM_LOG="$TMP_DIR/npm.log"
+export PATH="$BIN_DIR:$PATH"
+
+status_json="$("$ROOT_DIR/scripts/deps/deps-runner.sh" status)"
+STATUS_JSON="$status_json" node <<'NODE'
+const status = JSON.parse(process.env.STATUS_JSON);
+if (status.package_manager !== 'wordpress') throw new Error(`expected wordpress provider, got ${status.package_manager}`);
+if (!status.dependency_identities.includes('extra-chill/fixture-wordpress-component')) throw new Error('missing composer identity');
+if (!status.dependency_identities.includes('fixture-wordpress-component')) throw new Error('missing package identity');
+if (!status.packages.some((pkg) => pkg.name === 'composer/installers' && pkg.manifest_section === 'require')) throw new Error('missing composer dependency');
+if (!status.packages.some((pkg) => pkg.name === '@wordpress/scripts' && pkg.manifest_section === 'dependencies')) throw new Error('missing npm dependency');
+NODE
+
+command_json="$("$ROOT_DIR/scripts/deps/deps-runner.sh" install-command)"
+COMMAND_JSON="$command_json" ROOT_DIR="$ROOT_DIR" node <<'NODE'
+const plan = JSON.parse(process.env.COMMAND_JSON);
+const expected = ['bash', `${process.env.ROOT_DIR}/scripts/deps/deps-runner.sh`, 'install'];
+if (JSON.stringify(plan.command) !== JSON.stringify(expected)) {
+  throw new Error(`expected ${JSON.stringify(expected)}, got ${JSON.stringify(plan.command)}`);
+}
+NODE
+
+"$ROOT_DIR/scripts/deps/deps-runner.sh" install >/dev/null
+if [ "$(cat "$HOMEBOY_FAKE_COMPOSER_LOG")" != "install --no-interaction --prefer-dist" ]; then
+    echo "expected composer install command" >&2
+    exit 1
+fi
+if [ "$(cat "$HOMEBOY_FAKE_NPM_LOG")" != "ci" ]; then
+    echo "expected npm ci command" >&2
+    exit 1
+fi
+
+node <<'NODE'
+const fs = require('fs');
+const manifest = JSON.parse(fs.readFileSync('wordpress.json', 'utf8'));
+if (manifest.deps?.extension_script !== 'scripts/deps/deps-runner.sh') {
+  throw new Error('wordpress manifest does not declare deps.extension_script');
+}
+NODE
+
+echo "wordpress deps provider smoke passed"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -209,6 +209,9 @@
     "validate": "scripts/validation/validate-syntax.sh",
     "format": "scripts/format.sh"
   },
+  "deps": {
+    "extension_script": "scripts/deps/deps-runner.sh"
+  },
   "component_env": {
     "detect_script": "scripts/env/detect.sh"
   },


### PR DESCRIPTION
## Summary

Fixes Extra-Chill/homeboy#7688 by declaring the wordpress extension as a Homeboy deps provider and adding an extension-owned deps runner.

The current Homeboy core deps provider resolver is generic and expects linked extensions that support deps to expose `deps.extension_script`, matching the working nodejs extension. The wordpress extension already had dependency-related release actions but did not declare a deps runner, so `homeboy deps status wp-build` and real release `preflight.dependencies` failed with:

```text
Invalid argument 'extension': Component 'wp-build' has no linked extensions that provide deps support
```

## What Changed

- Added `wordpress.deps.extension_script` pointing to `scripts/deps/deps-runner.sh`.
- Added a wordpress deps runner that reports Composer and npm package metadata and can install both dependency sets when present.
- Added a targeted smoke test covering status, install-command, install behavior, and the manifest declaration.

## Repro Evidence

- Failing before this fix: `homeboy deps status wp-build` and `homeboy deps status data-machine` fail because the linked wordpress extension does not provide deps support.
- Working comparator: `homeboy deps status wp-codebox` succeeds because nodejs declares `deps.extension_script`.
- Integration check with this branch: a temporary Homeboy config linked to this patched wordpress extension returns `success: true`, `package_manager: wordpress`, and both Composer and npm packages for `homeboy deps status fixture-wp`.

## Tests

- `npm run test:wordpress-deps-provider`
- `npm run test:wordpress-manifest-settings`
- `cargo test extension_provider_reports_runner_safe_install_command` in `Extra-Chill/homeboy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.5 via Claude Code (subagent orchestrated by Franklin)
- **Used for:** Root-caused the deps provider resolution regression and drafted the fix with tests under Chris's direction.
