### PR TITLE
Declare WP Codebox staged package-shadow preflight

### DIFF
--- a/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
+++ b/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
@@ -29,6 +29,11 @@ assert.doesNotMatch(descriptorSource, /run-agent-task', '--help/);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'wp-codebox.json'), 'utf8'));
 assert.equal(manifest.component_path_defaults, undefined);
+const runtimePreflightCheck = manifest.agent_task_executors[0].runtime_contract.preflight_checks.find((check) => check.id === 'wp-codebox.provider_plugin.runtime_package_shadow');
+assert.equal(runtimePreflightCheck.enforcement, 'error');
+assert.deepEqual(runtimePreflightCheck.target.component.metadata_equals, { loadAs: 'plugin' });
+assert.deepEqual(runtimePreflightCheck.target.component.metadata_any_equals, { activate: true });
+assert.deepEqual(runtimePreflightCheck.path_probes.exists.map((probe) => probe.path), ['vendor/automattic/php-ai-client']);
 const providerPreflight = manifest.agent_task_executors[0].config_preflights.find((preflight) => preflight.id === 'recipe-command-compatibility');
 assert.equal(providerPreflight.label, 'WP Codebox recipe command compatibility');
 assert.deepEqual(providerPreflight.required_values.keys, ['command']);

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -357,6 +357,39 @@
       "workspace_materialization": {
         "cwd": "git_checkout"
       },
+      "runtime_contract": {
+        "preflight_checks": [
+          {
+            "id": "wp-codebox.provider_plugin.runtime_package_shadow",
+            "label": "WP Codebox provider plugin runtime package shadow check",
+            "enforcement": "error",
+            "target": {
+              "component": {
+                "metadata_equals": {
+                  "loadAs": "plugin"
+                },
+                "metadata_any_equals": {
+                  "activate": true
+                }
+              }
+            },
+            "path_probes": {
+              "exists": [
+                {
+                  "id": "wp-codebox.php-ai-client",
+                  "path": "vendor/automattic/php-ai-client",
+                  "subject": "automattic/php-ai-client",
+                  "owner": "wp-codebox WordPress runtime",
+                  "message": "Provider component `{component}` includes `{subject}` (owned by `{owner}`) at `{path}`.",
+                  "remediation": "Rebuild the provider component without the vendored runtime package so the WP Codebox runtime-provided copy is used."
+                }
+              ]
+            },
+            "message": "Homeboy refused dispatch: runtime preflight `{check}` found {conflict_count} component path conflict(s). A declared runtime-owned package would be shadowed by the selected component before the provider run starts.",
+            "remediation": "Remove declared runtime-owned packages from staged WP Codebox provider plugins before dispatch."
+          }
+        ]
+      },
       "runner_readiness": [
         {
           "id": "wp-codebox.executable",


### PR DESCRIPTION
## Summary
- Declare the WP Codebox provider-component package-shadow preflight in the runtime manifest.
- Keep the change additive and inert until Homeboy core consumes runtime_contract.preflight_checks.
- Cover the manifest declaration in the WP Codebox adapter boundary test.

Fixes #2201

## Merge order
- Merge this PR first.
- Pairing core PR: Extra-Chill/homeboy#7724.

## Verification
- `node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT 5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Implemented the audited genericity eviction; human reviews every line.