### PR TITLE
Declare extension tool diagnostics

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -18,6 +18,25 @@
     "trace.artifacts": true,
     "annotations": false
   },
+  "diagnostics": {
+    "tools": [
+      {
+        "id": "node",
+        "version_args": ["--version"],
+        "remediation": "Install Node.js and ensure node is on PATH"
+      },
+      {
+        "id": "npm",
+        "version_args": ["--version"],
+        "remediation": "Install npm and ensure npm is on PATH"
+      },
+      {
+        "id": "pnpm",
+        "version_args": ["--version"],
+        "remediation": "Install pnpm and ensure pnpm is on PATH when the project uses pnpm"
+      }
+    ]
+  },
   "contract_producers": [
     {
       "id": "nodejs.lint-results",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -21,6 +21,30 @@
     "trace.results": true,
     "annotations": false
   },
+  "diagnostics": {
+    "tools": [
+      {
+        "id": "php",
+        "version_args": ["--version"],
+        "remediation": "Install PHP and ensure php is on PATH"
+      },
+      {
+        "id": "composer",
+        "version_args": ["--version"],
+        "remediation": "Install Composer and ensure composer is on PATH"
+      },
+      {
+        "id": "node",
+        "version_args": ["--version"],
+        "remediation": "Install Node.js and ensure node is on PATH"
+      },
+      {
+        "id": "npm",
+        "version_args": ["--version"],
+        "remediation": "Install npm and ensure npm is on PATH"
+      }
+    ]
+  },
   "contract_producers": [
     {
       "id": "wordpress.live-surface-discovery",


### PR DESCRIPTION
## Summary
- Add inert runner doctor tool diagnostic declarations to the Node.js extension manifest.
- Add inert runner doctor tool diagnostic declarations to the WordPress extension manifest.

## Merge order
- Additive/inert manifest declarations; this can merge before the Homeboy core PR.
- Homeboy core consumes these declarations after Extra-Chill/homeboy#7725 lands.

## Verification
- `node -e "const fs=require('fs'); for (const file of ['nodejs/nodejs.json','wordpress/wordpress.json']) JSON.parse(fs.readFileSync(file,'utf8'));"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT 5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Moved audited hardcoded ecosystem probes to manifest-declared diagnostics; human reviews every line.