### PR TITLE
Declare source snapshot sync excludes

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -1,12 +1,15 @@
 {
   "name": "Node.js",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "icon": "server.rack",
   "description": "Node.js project type — discovery, audit grammar, and npm release lifecycle",
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["js", "jsx", "ts", "tsx", "mjs", "cjs", "json"],
     "capabilities": ["format", "validate", "fuzz"]
+  },
+  "source_snapshot": {
+    "sync_excludes": ["node_modules/", "node_modules/**"]
   },
   "structured_sidecars": {
     "lint.findings": true,

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,12 +1,15 @@
 {
   "name": "Rust",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["rs"],
     "capabilities": ["fingerprint", "refactor", "format", "validate"]
+  },
+  "source_snapshot": {
+    "sync_excludes": ["target/", "target/**"]
   },
   "structured_sidecars": {
     "lint.findings": true,

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.23.38",
+  "version": "3.23.39",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
@@ -10,6 +10,9 @@
   "provides": {
     "file_extensions": ["php", "css", "ts", "tsx", "js", "jsx", "json"],
     "capabilities": ["fingerprint", "refactor", "crossref", "validate", "fuzz"]
+  },
+  "source_snapshot": {
+    "sync_excludes": ["vendor/", "vendor/**"]
   },
   "structured_sidecars": {
     "lint.findings": true,


### PR DESCRIPTION
## Summary
- Declare source snapshot sync excludes in the Node.js, Rust, and WordPress extension manifests.
- Bump the touched extension manifest versions for the additive manifest contract change.

## Paired PR
- Paired core PR: https://github.com/Extra-Chill/homeboy/pull/7726

## Merge order
- Merge this PR before the paired Extra-Chill/homeboy core PR so installed/declared extensions can provide language build-directory excludes before core stops carrying them as defaults.

## Verification
- Validated changed JSON manifests with Node JSON parsing.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT 5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Moved audited hardcoded sync excludes to declared/generic policy; human reviews every line.