### PR TITLE
Fix nested Node.js fuzz workloads

### DIFF
--- a/nodejs/scripts/fuzz/fuzz-runner.sh
+++ b/nodejs/scripts/fuzz/fuzz-runner.sh
@@ -85,11 +85,20 @@ import { resolve } from 'node:path';
 
 const workloadPath = process.argv[2];
 const workload = JSON.parse(readFileSync(workloadPath, 'utf8'));
-const args = Array.isArray(workload.args) ? workload.args.map(String) : [];
+const nestedWorkload = workload && typeof workload.workload === 'object' && workload.workload !== null ? workload.workload : {};
+const stringField = (name) => {
+  const nestedValue = nestedWorkload[name];
+  if (typeof nestedValue === 'string' && nestedValue.trim()) return nestedValue.trim();
+  const topLevelValue = workload[name];
+  return typeof topLevelValue === 'string' ? topLevelValue.trim() : '';
+};
+const rawArgs = Array.isArray(nestedWorkload.args) ? nestedWorkload.args : workload.args;
+const args = Array.isArray(rawArgs) ? rawArgs.map(String) : [];
+const path = stringField('path');
 const value = {
-  command: typeof workload.command === 'string' ? workload.command.trim() : '',
-  script: typeof workload.script === 'string' ? workload.script.trim() : '',
-  path: typeof workload.path === 'string' ? resolve(process.cwd(), workload.path) : '',
+  command: stringField('command'),
+  script: stringField('script'),
+  path: path ? resolve(process.cwd(), path) : '',
   args,
 };
 process.stdout.write(JSON.stringify(value));

--- a/nodejs/scripts/fuzz/nodejs-fuzz-runner-smoke.sh
+++ b/nodejs/scripts/fuzz/nodejs-fuzz-runner-smoke.sh
@@ -143,4 +143,33 @@ if (data.source !== "json-workload") throw new Error("json workload path did not
 if (data.args.join(",") !== "--from-json,--flag") throw new Error(`json workload args not forwarded: ${data.args.join(",")}`);
 '
 
+NESTED_JSON_PROJECT="$(make_project nested-json-workload)"
+cat > "$NESTED_JSON_PROJECT/nested-json-fuzz.mjs" <<'JS'
+import { existsSync, writeFileSync } from 'node:fs';
+writeFileSync(process.env.HOMEBOY_FUZZ_RESULTS_FILE, JSON.stringify({
+  schema: 'homeboy/fuzz-campaign/v1',
+  status: 'pass',
+  source: 'nested-json-workload',
+  args: process.argv.slice(2),
+  injectedFileExists: existsSync('nested-injected'),
+}, null, 2));
+JS
+NESTED_JSON_WORKLOAD="$NESTED_JSON_PROJECT/nested-workload.json"
+cat > "$NESTED_JSON_WORKLOAD" <<'JSON'
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "workload": {
+    "path": "nested-json-fuzz.mjs",
+    "args": ["--from-nested", "value with spaces", "; touch nested-injected"]
+  }
+}
+JSON
+NESTED_JSON_RESULTS="$TMP_DIR/nested-json-results.json"
+run_fuzz "$NESTED_JSON_PROJECT" "$NESTED_JSON_RESULTS" "$NESTED_JSON_WORKLOAD" >/dev/null
+assert_json "$NESTED_JSON_RESULTS" '
+if (data.source !== "nested-json-workload") throw new Error("nested json workload path did not run");
+if (data.args.join("|") !== "--from-nested|value with spaces|; touch nested-injected|--flag") throw new Error(`nested json workload args not forwarded safely: ${data.args.join("|")}`);
+if (data.injectedFileExists) throw new Error("nested json workload args were evaluated by the shell");
+'
+
 echo "Node.js fuzz runner smoke passed."


### PR DESCRIPTION
## Summary
- Teach the Node.js fuzz runner JSON descriptor parser to read nested `workload.command`, `workload.script`, `workload.path`, and `workload.args` from `homeboy/fuzz-workload/v1` payloads.
- Preserve existing top-level `command`, `script`, `path`, and `args` compatibility.
- Add smoke coverage for nested workload path + args, including a shell-looking arg that must be forwarded literally.

## Tests
- `bash nodejs/scripts/fuzz/nodejs-fuzz-runner-smoke.sh`
- `node tests/extension-shape-lint.mjs`
- `shellcheck nodejs/scripts/fuzz/fuzz-runner.sh nodejs/scripts/fuzz/nodejs-fuzz-runner-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Inspected the Node.js fuzz runner, implemented nested workload parsing support, added smoke coverage, and ran local verification gates.