### PR TITLE
Resolve nodejs browser helpers from local extension lib

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -54,7 +54,7 @@ import { pathToFileURL } from 'node:url';
 import {
     normalizeBenchArtifact,
     normalizeBrowserBenchWorkloadResult,
-} from '../../../scripts/lib/browser-result-shapes.mjs';
+} from '../lib/browser-result-shapes.mjs';
 
 const helperPath = process.env.HOMEBOY_RUNTIME_BENCH_HELPER_JS;
 if (!helperPath) {

--- a/nodejs/scripts/bench/browser-helper.mjs
+++ b/nodejs/scripts/bench/browser-helper.mjs
@@ -9,7 +9,7 @@ import {
     normalizeBrowserArtifact,
     normalizeBrowserBottleneck,
     normalizeBrowserPerformanceProfile,
-} from '../../../scripts/lib/browser-result-shapes.mjs';
+} from '../lib/browser-result-shapes.mjs';
 
 export { buildBrowserBenchResult };
 

--- a/nodejs/scripts/trace/lib/browser-waterfall.mjs
+++ b/nodejs/scripts/trace/lib/browser-waterfall.mjs
@@ -5,7 +5,7 @@ import {
     normalizeBrowserProfileTimings,
     normalizeBrowserTiming,
     stableJson,
-} from '../../../../scripts/lib/browser-result-shapes.mjs';
+} from '../../lib/browser-result-shapes.mjs';
 
 export async function collectBrowserWaterfall(page, options = {}) {
     if (!page || typeof page.evaluate !== 'function') {

--- a/nodejs/scripts/trace/lib/timeline.mjs
+++ b/nodejs/scripts/trace/lib/timeline.mjs
@@ -7,7 +7,7 @@ import {
     normalizeTraceAssertion,
     normalizeTraceEnvelope,
     normalizeTraceEvent,
-} from '../../../../scripts/lib/browser-result-shapes.mjs';
+} from '../../lib/browser-result-shapes.mjs';
 
 export class TraceRecorder {
     constructor(options = {}) {

--- a/nodejs/tests/nodejs-dev-overlay-browser-result-shapes-smoke.sh
+++ b/nodejs/tests/nodejs-dev-overlay-browser-result-shapes-smoke.sh
@@ -8,12 +8,11 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 DEV_EXTENSION_ROOT="$TMP_DIR/dev-extensions/nodejs"
 SNAPSHOT_DIR="$DEV_EXTENSION_ROOT/c976416565de9af3"
 
-mkdir -p "$DEV_EXTENSION_ROOT/scripts/lib" "$SNAPSHOT_DIR/scripts/bench"
-cp "$ROOT_DIR/scripts/lib/browser-result-shapes.mjs" "$DEV_EXTENSION_ROOT/scripts/lib/browser-result-shapes.mjs"
-cp "$ROOT_DIR/scripts/lib/browser-result-shapes.cjs" "$DEV_EXTENSION_ROOT/scripts/lib/browser-result-shapes.cjs"
-cp "$ROOT_DIR/scripts/bench/bench-runner.mjs" "$SNAPSHOT_DIR/scripts/bench/bench-runner.mjs"
+mkdir -p "$DEV_EXTENSION_ROOT"
+cp -R "$ROOT_DIR/." "$SNAPSHOT_DIR"
+test ! -e "$DEV_EXTENSION_ROOT/scripts/lib/browser-result-shapes.mjs"
 
-node --input-type=module - "$SNAPSHOT_DIR/scripts/bench/bench-runner.mjs" <<'NODE'
+node --input-type=module - "$SNAPSHOT_DIR/scripts/bench/bench-runner.mjs" "$SNAPSHOT_DIR" <<'NODE'
 import { readFile } from 'node:fs/promises';
 
 const runner = await readFile(process.argv[2], 'utf8');
@@ -37,5 +36,13 @@ const normalized = shapes.normalizeBrowserBenchWorkloadResult({
 });
 if (normalized.browser_profile?.page_url !== 'https://example.test/') {
     throw new Error('browser result normalization returned an invalid shape');
+}
+
+for (const relativeModule of [
+    'scripts/bench/browser-helper.mjs',
+    'scripts/trace/lib/browser-waterfall.mjs',
+    'scripts/trace/lib/timeline.mjs',
+]) {
+    await import(new URL(relativeModule, `file://${process.argv[3]}/`).href);
 }
 NODE


### PR DESCRIPTION
## Summary\n- Point Node.js bench/trace browser-result-shapes imports at the extension-local `scripts/lib` helper copy.\n- Tighten the dev-overlay regression to simulate actual `runner dev-sync` hash snapshot layout without an overlay-root `scripts/lib`.\n- Import all Node.js browser-result-shapes consumers from that hash snapshot.\n\nFixes #2208.\n\n## Tests\n- `bash nodejs/tests/nodejs-dev-overlay-browser-result-shapes-smoke.sh`\n- `bash nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`\n- `git diff --check`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** GPT-5.5 via OpenCode\n- **Used for:** Investigated the runner dev-overlay import failure after PR #2209, corrected Node.js helper import paths, and strengthened regression coverage.