### PR TITLE
fix: guard agent-task-contracts shared-asset materialization

### DIFF
--- a/tests/shared-assets-runtime-materialization-contract.mjs
+++ b/tests/shared-assets-runtime-materialization-contract.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Regression guard for Extra-Chill/homeboy#7736.
+ *
+ * The three CLI agent-task executor runtimes (opencode/codex/claude-code, plus
+ * wp-codebox and pi) each `require('../../../agent-task-contracts')`, which from
+ * an installed runtime at `~/.config/homeboy/agent-runtimes/<runtime>/lib/`
+ * resolves to `~/.config/homeboy/agent-task-contracts/`. That directory only
+ * exists on an install if `agent-task-contracts` is declared as a shared asset
+ * that Homeboy core materializes alongside `agent-runtimes` and
+ * `runtime-agent-ci`.
+ *
+ * The materialization copy loop itself lives in the Rust `Extra-Chill/homeboy`
+ * binary; this repo owns the declarative enumeration in
+ * `homeboy-extension-root.json` `shared_assets`. When `agent-task-contracts`
+ * was missing from that enumeration (or from core's transitional fallback list)
+ * the package never landed on the install and every CLI backend crashed with
+ * `MODULE_NOT_FOUND` before the agent ran (confirming run id
+ * `agent-task-ed341028-b0db-424e-a165-986241430ad7`).
+ *
+ * This test derives the required shared-asset set from the actual cross-package
+ * `require()` graph rather than hardcoding it, so any new top-level shared
+ * package a runtime reaches for must be declared in `shared_assets` or this
+ * test fails.
+ */
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const rootManifest = JSON.parse(
+	fs.readFileSync(path.join(repoRoot, 'homeboy-extension-root.json'), 'utf8')
+);
+
+assert.ok(
+	Array.isArray(rootManifest.shared_assets),
+	'homeboy-extension-root.json must declare a shared_assets array'
+);
+const declaredSharedAssets = new Set(rootManifest.shared_assets);
+
+// The runtime packages whose require graphs must resolve on an install. These
+// are themselves declared shared assets that Homeboy core materializes.
+const runtimeSharedAssets = ['agent-runtimes', 'runtime-agent-ci'];
+for (const asset of runtimeSharedAssets) {
+	assert.ok(
+		declaredSharedAssets.has(asset),
+		`shared_assets must declare the "${asset}" runtime package`
+	);
+}
+
+// Recursively collect the runtime JS/CJS/MJS files inside a shared-asset
+// package, skipping vendored dependencies, fixtures, and tests. Only runtime
+// code is materialized onto an install and executed by Homeboy core, so only
+// runtime requires define the co-materialization invariant; test files may
+// reach into repo-only paths (e.g. CI scripts under .github) that never ship.
+function collectSourceFiles(dir) {
+	const files = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		if (
+			entry.name === 'node_modules' ||
+			entry.name === '.git' ||
+			entry.name === 'tests' ||
+			entry.name === 'fixtures'
+		) {
+			continue;
+		}
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...collectSourceFiles(full));
+		} else if (/\.(js|cjs|mjs)$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+			files.push(full);
+		}
+	}
+	return files;
+}
+
+// Extract require() specifiers from a source file.
+const REQUIRE_PATTERN = /require\(\s*['"]([^'"]+)['"]\s*\)/g;
+function requireSpecifiers(file) {
+	const source = fs.readFileSync(file, 'utf8');
+	const specifiers = [];
+	let match;
+	while ((match = REQUIRE_PATTERN.exec(source)) !== null) {
+		specifiers.push(match[1]);
+	}
+	return specifiers;
+}
+
+// Walk every runtime shared-asset package and record which OTHER top-level
+// repo directories it reaches into via relative requires. Any such directory
+// must itself be a declared shared asset so core co-materializes it.
+const referencedSharedAssets = new Set();
+for (const asset of runtimeSharedAssets) {
+	const assetDir = path.join(repoRoot, asset);
+	for (const file of collectSourceFiles(assetDir)) {
+		for (const specifier of requireSpecifiers(file)) {
+			if (!specifier.startsWith('.')) {
+				continue; // package/builtin, not a repo-relative reference
+			}
+			const resolvedDir = path.resolve(path.dirname(file), specifier);
+			const relFromRoot = path.relative(repoRoot, resolvedDir);
+			if (relFromRoot.startsWith('..') || path.isAbsolute(relFromRoot)) {
+				continue; // escapes the repo — not our concern here
+			}
+			const topLevel = relFromRoot.split(path.sep)[0];
+			if (!topLevel || topLevel === asset) {
+				continue; // intra-package reference
+			}
+			referencedSharedAssets.add(topLevel);
+		}
+	}
+}
+
+// Every top-level directory a runtime shared asset requires must be declared as
+// a shared asset itself. This is the invariant that broke in #7736:
+// agent-runtimes and runtime-agent-ci both require agent-task-contracts, so
+// agent-task-contracts must be a declared shared asset.
+for (const referenced of [...referencedSharedAssets].sort()) {
+	assert.ok(
+		declaredSharedAssets.has(referenced),
+		`runtime shared assets require top-level "${referenced}", so it must be declared in ` +
+			'homeboy-extension-root.json shared_assets for Homeboy core to co-materialize it. ' +
+			'Dropping it recreates Extra-Chill/homeboy#7736 (MODULE_NOT_FOUND before the agent runs).'
+	);
+}
+
+// The specific package that regressed in #7736.
+assert.ok(
+	referencedSharedAssets.has('agent-task-contracts'),
+	'expected the runtime shared assets to require agent-task-contracts'
+);
+assert.ok(
+	declaredSharedAssets.has('agent-task-contracts'),
+	'agent-task-contracts must remain a declared shared asset (Extra-Chill/homeboy#7736)'
+);
+
+// Prove the CLI agent-task executor require graphs actually resolve against the
+// intended installed layout: agent-task-contracts and runtime-agent-ci are
+// siblings under the install root, exactly as they are siblings under repoRoot.
+const executorEntrypoints = [
+	'agent-runtimes/lib/cli-agent-task-executor.js',
+	'agent-runtimes/opencode/lib/opencode-agent-task-executor.js',
+	'agent-runtimes/codex/lib/codex-agent-task-executor.js',
+	'agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js',
+	'agent-runtimes/pi/lib/pi-agent-task-executor.js',
+];
+for (const entrypoint of executorEntrypoints) {
+	const full = path.join(repoRoot, entrypoint);
+	assert.doesNotThrow(
+		() => require(full),
+		`${entrypoint} must load with agent-task-contracts resolvable as a sibling shared asset`
+	);
+}
+
+// The contract package must expose the surface the executors import from it.
+const contractsIndex = path.join(repoRoot, 'agent-task-contracts', 'index.js');
+assert.ok(
+	fs.existsSync(contractsIndex),
+	'agent-task-contracts/index.js must exist as the materialized package entrypoint'
+);
+const contracts = require(contractsIndex);
+for (const symbol of ['AGENT_TASK_REQUEST_SCHEMA', 'AGENT_TASK_OUTCOME_SCHEMA']) {
+	assert.ok(
+		symbol in contracts,
+		`agent-task-contracts must export ${symbol} for runtime executors`
+	);
+}
+
+console.log('shared-assets runtime materialization contract passed');


### PR DESCRIPTION
## Summary

Fixes the class of failure in Extra-Chill/homeboy#7736 where every CLI
agent-task backend (opencode/claude-code/codex) crashes with
`MODULE_NOT_FOUND` before the agent runs because the `agent-task-contracts`
shared runtime package is never materialized into `~/.config/homeboy/`.

## Root cause

The CLI agent-task executor runtimes each do:

```js
require('../../../agent-task-contracts')   // per-runtime executors
require('../../agent-task-contracts')       // agent-runtimes/lib/cli-agent-task-executor.js
```

From an installed runtime under
`~/.config/homeboy/agent-runtimes/<runtime>/lib/`, that resolves to
`~/.config/homeboy/agent-task-contracts/`. That directory only exists on an
install when `agent-task-contracts` is materialized as a sibling shared asset
alongside `agent-runtimes` and `runtime-agent-ci`. Its sibling
`runtime-agent-ci` **was** materialized; `agent-task-contracts` was **not**,
so the executor process dies with empty stdout and Homeboy reports
`provider_error`. Confirming run id:
`agent-task-ed341028-b0db-424e-a165-986241430ad7`.

`runtime-agent-ci` itself also `require('../../agent-task-contracts')`, so even
routing through it fails. The three-package set (`agent-runtimes`,
`runtime-agent-ci`, `agent-task-contracts`) must be co-materialized or the
whole CLI agent-task surface breaks.

## This is a materialization gap, not a source path bug

The source tree is correct. `agent-task-contracts/` exists as a real package
(`agent-task-provider-contract.js`, `agent-task-runner-contract.js`,
`generic-agent-task-plan.js`, `index.js`, `package.json`) and every executor
`require()` path is correct relative to the intended installed layout. Loading
the executors from source resolves cleanly. The break is purely in whether the
package lands on the install.

## Where the enumeration lives — and what changed

The declarative enumeration this repo owns is
`homeboy-extension-root.json` → `shared_assets`, added in #2175 (declaring core
seam data for Extra-Chill/homeboy#7563). Per homeboy#7563, Homeboy core's
install + durable-refresh step "copy/symlink only declared shared assets, with
the current list retained as a **transitional fallback** when no root manifest
exists." The root manifest here **already lists** `agent-task-contracts` — but:

- The live install was materialized **before** the manifest existed, from core's
  transitional fallback hardcoded list, which **omitted** `agent-task-contracts`
  while including `runtime-agent-ci`. That is the true source of the live break.
- Nothing in this repo guarded the `shared_assets` invariant, so it could
  silently regress and take the CLI agent-task surface down again.

## What this PR changes

Adds `tests/shared-assets-runtime-materialization-contract.mjs`, a regression
guard that:

1. **Derives** the required shared-asset set from the real cross-package
   `require()` graph of the runtime shared assets (`agent-runtimes`,
   `runtime-agent-ci`) — not a hardcoded list — and asserts every top-level
   package they reach for is declared in `homeboy-extension-root.json`
   `shared_assets`. Removing `agent-task-contracts` from `shared_assets` now
   **fails** the test (verified locally).
2. Proves each CLI executor require graph (`cli-agent-task-executor`, opencode,
   codex, claude-code, pi) resolves against the intended installed layout, i.e.
   `agent-task-contracts` and `runtime-agent-ci` as siblings.
3. Asserts `agent-task-contracts/index.js` exists and exports the symbols the
   executors import (`AGENT_TASK_REQUEST_SCHEMA`, `AGENT_TASK_OUTCOME_SCHEMA`).

It follows the existing `tests/*-contract.mjs` convention (same discovery path
as `architectural-boundary-contract.mjs` / `agent-task-provider-contract-smoke.mjs`).

## Out of scope (Rust-side, `Extra-Chill/homeboy` binary)

- **The actual copy loop / transitional fallback list.** The materialization
  copy-or-symlink loop lives in the Rust homeboy binary, not in this repo. Its
  fallback list omitting `agent-task-contracts` is the live-break fix and must
  be corrected in `Extra-Chill/homeboy` (or the fallback removed now that the
  root manifest declares the full set). This repo can only ensure the
  declarative enumeration stays correct, which this PR does.
- **The second issue** — `homeboy agent-task doctor --runner local --backend
  opencode` reporting a green "Cook is ready" verdict despite the fatal missing
  package. The readiness preflight does not resolve the executor require graph;
  that check is Rust-side and is out of scope for this repo.

## Test evidence

```
$ node tests/shared-assets-runtime-materialization-contract.mjs
shared-assets runtime materialization contract passed

# regression proof: drop agent-task-contracts from shared_assets ->
AssertionError: runtime shared assets require top-level "agent-task-contracts",
so it must be declared in homeboy-extension-root.json shared_assets ...

$ node tests/extension-shape-lint.mjs            # Extension shape lint passed for 6 extensions.
$ node tests/agent-task-provider-contract-smoke.mjs   # agent task provider contract smoke passed
$ node tests/architectural-boundary-contract.mjs      # architectural boundary contract passed
```

Refs Extra-Chill/homeboy#7736