### PR TITLE
Treat @wordpress/* runtime externals as resolvable in WordPress lint config

### DIFF
--- a/wordpress/eslint.config.mjs
+++ b/wordpress/eslint.config.mjs
@@ -24,6 +24,65 @@ export default [
       },
     },
     settings: {
+      /*
+       * WordPress script-handle packages (`@wordpress/*`, `jquery`, `lodash`,
+       * `react`, `react-dom`, `moment`) are provided at runtime by WordPress via
+       * `@wordpress/scripts`' webpack externals — they are deliberately NOT
+       * installed into a block plugin's node_modules. Without this list,
+       * `import/no-unresolved` false-flags every `import ... from '@wordpress/*'`
+       * in every block plugin we lint, which cannot be fixed from the plugin
+       * side (the packages are never on disk). Treat them as resolvable
+       * core modules so the rule only fires on genuinely unresolvable imports.
+       */
+      'import/core-modules': [
+        '@wordpress/a11y',
+        '@wordpress/annotations',
+        '@wordpress/api-fetch',
+        '@wordpress/autop',
+        '@wordpress/blob',
+        '@wordpress/block-directory',
+        '@wordpress/block-editor',
+        '@wordpress/block-library',
+        '@wordpress/block-serialization-default-parser',
+        '@wordpress/blocks',
+        '@wordpress/components',
+        '@wordpress/compose',
+        '@wordpress/core-data',
+        '@wordpress/data',
+        '@wordpress/data-controls',
+        '@wordpress/date',
+        '@wordpress/deprecated',
+        '@wordpress/dom',
+        '@wordpress/dom-ready',
+        '@wordpress/edit-post',
+        '@wordpress/editor',
+        '@wordpress/element',
+        '@wordpress/escape-html',
+        '@wordpress/hooks',
+        '@wordpress/html-entities',
+        '@wordpress/i18n',
+        '@wordpress/icons',
+        '@wordpress/keyboard-shortcuts',
+        '@wordpress/keycodes',
+        '@wordpress/media-utils',
+        '@wordpress/notices',
+        '@wordpress/plugins',
+        '@wordpress/primitives',
+        '@wordpress/priority-queue',
+        '@wordpress/private-apis',
+        '@wordpress/reusable-blocks',
+        '@wordpress/rich-text',
+        '@wordpress/server-side-render',
+        '@wordpress/url',
+        '@wordpress/viewport',
+        '@wordpress/warning',
+        '@wordpress/wordcount',
+        'jquery',
+        'lodash',
+        'moment',
+        'react',
+        'react-dom',
+      ],
       'import/resolver': {
         typescript: {
           alwaysTryTypes: true,


### PR DESCRIPTION
## Problem

The WordPress extension's `wordpress/eslint.config.mjs` enables `import/no-unresolved` but has no allowance for `@wordpress/*` packages. Those are provided at runtime by WordPress via `@wordpress/scripts`' webpack externals and are **deliberately not installed** into a block plugin's `node_modules`. As a result, `import/no-unresolved` false-flags every `import ... from '@wordpress/*'` in every block plugin the release lint gate touches.

This is not fixable from the plugin side — the packages are never on disk, so no resolver or `jsconfig.json` path mapping can satisfy the rule. It blocks the release **lint** gate for WordPress block plugins network-wide.

Discovered while trying to make `extrachill-events` pass its lint gate (had to ship v0.38.3 with `--skip-checks=lint`): 16 of its 74 lint errors were `import/no-unresolved` on `@wordpress/element`, `@wordpress/blocks`, `@wordpress/components`, etc.

## Fix

Add the standard `@wordpress/*` script-handle packages plus the common WordPress-provided externals (`jquery`, `lodash`, `moment`, `react`, `react-dom`) to `import/core-modules`, so `import/no-unresolved` treats them as resolvable built-ins and only fires on genuinely unresolvable imports.

This is the canonical approach for linting WordPress block code where `@wordpress/*` are webpack externals.

## Verification

Ran the extension's own eslint (`node_modules/.bin/eslint`) with the patched config against the full `extrachill-events` block tree:

- **Before:** 16 `import/no-unresolved` errors across the block JS.
- **After:** 0 `import/no-unresolved` errors. The remaining findings are all legitimate source issues in the plugin (dependency-group comments, JSDoc types, unused vars), which are being fixed separately in extrachill-events#226.

## Note

`import/core-modules` matches exact strings, so brand-new `@wordpress/*` packages would need adding here as they're adopted. The listed set covers the packages currently in use across the network's block plugins; a future follow-up could switch to an `@wordpress/`-scope ignore pattern if the maintenance becomes noticeable.