### PR TITLE
feat(discord): add run completion notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ when a reusable integration needs documentation outside its owning project.
 | `go` | Go project type — Cargo-equivalent CLI integration for services and binaries |
 | `swift` | Swift project type — testing infrastructure for macOS, iOS, and Swift CLI projects |
 | `managed-preview` | Provider command helpers for Homeboy managed service public previews |
+| `discord` | Outbound Discord run-completion notifications via Homeboy's transport-agnostic notify command |
 
 ## Scope
 
@@ -61,6 +62,7 @@ Install extensions one at a time. Homeboy clones this repo, detects the monorepo
 homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id wordpress
 homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id rust
 homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id nodejs
+homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id discord
 ```
 
 Remote runners need the same extension IDs installed on the runner host before

--- a/discord/README.md
+++ b/discord/README.md
@@ -1,0 +1,60 @@
+# Discord Notifications Extension
+
+`discord` is an outbound-only Homeboy notification transport. It posts a run-completion message through Discord's REST API but does not own inbound interactions, buttons, or an orchestration lifecycle. Homeboy's durable run/daemon lifecycle remains authoritative.
+
+Requires Homeboy `>=0.281.20`, which provides `HOMEBOY_NOTIFY_COMMAND` and `runs watch --notify`.
+
+## Setup
+
+Install the extension and select exactly one authentication mode. Keep credentials in your shell secret manager or service environment; the helper never writes them or includes them in its JSON result.
+
+```sh
+homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id discord
+
+# Bot REST delivery to a channel.
+export DISCORD_BOT_TOKEN='...'
+export DISCORD_CHANNEL_ID='123456789012345678'
+
+# Or bot REST delivery to a thread. Do not also set DISCORD_CHANNEL_ID.
+export DISCORD_THREAD_ID='123456789012345678'
+
+# Or webhook delivery. DISCORD_THREAD_ID is optional for webhook thread routing.
+export DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/...'
+```
+
+Set `HOMEBOY_NOTIFY_COMMAND` to the installed helper. Placeholders are expanded by Homeboy as separate argv values, so titles and bodies containing spaces are supported.
+
+```sh
+export HOMEBOY_NOTIFY_COMMAND='node ~/.config/homeboy/extensions/discord/scripts/notify.mjs --run-id {run_id} --status {status} --title {title} --body {body}'
+```
+
+## Usage
+
+Notify after a watched run settles:
+
+```sh
+homeboy runs watch run-123 --notify
+```
+
+A Homeboy daemon uses the same `HOMEBOY_NOTIFY_COMMAND` completion-notification seam. Start the daemon normally after setting the environment in its service definition or shell:
+
+```sh
+homeboy daemon start
+```
+
+The helper emits one typed JSON envelope to stdout, for example:
+
+```json
+{"schema":"homeboy/discord-notification-result/v1","status":"delivered","delivery":{"mode":"bot","destination":"thread","content_length":74,"truncated":false},"attempts":1}
+```
+
+Use `--dry-run` to validate arguments and configuration shape without network I/O or secret output:
+
+```sh
+node ~/.config/homeboy/extensions/discord/scripts/notify.mjs \
+  --run-id run-123 --status pass --title 'homeboy run pass' --body 'Run completed' --dry-run
+```
+
+Discord content is bounded to 2,000 characters. The helper retries a Discord `429` at most twice, using the service's `retry_after` value capped at five seconds. Authentication and destination/input rejections are reported as typed `auth_error` or `input_error` results; credentials and webhook URLs are never included in diagnostics.
+
+`DISCORD_API_BASE_URL` is an optional HTTP(S) API base override for deterministic local testing only. Production bot delivery defaults to `https://discord.com/api/v10`.

--- a/discord/discord.json
+++ b/discord/discord.json
@@ -1,0 +1,28 @@
+{
+  "name": "Discord Notifications",
+  "id": "discord",
+  "version": "0.1.0",
+  "icon": "message.circle",
+  "description": "Outbound Discord run-completion notification delivery for Homeboy",
+  "author": "Extra Chill",
+  "homeboy_version_target": ">=0.281.20",
+  "provides": {
+    "file_extensions": ["mjs"],
+    "capabilities": ["run-completion-notifications"]
+  },
+  "scripts": {
+    "validate": "scripts/validate.sh"
+  },
+  "notification_transports": [
+    {
+      "schema": "homeboy/notification-transport-command/v1",
+      "id": "discord.run-completion",
+      "command": "node {{extension_path}}/scripts/notify.mjs --run-id {run_id} --status {status} --title {title} --body {body}",
+      "contract": {
+        "event": "homeboy/run-completion/v1",
+        "outbound_only": true,
+        "owns_orchestration_lifecycle": false
+      }
+    }
+  ]
+}

--- a/discord/homeboy.json
+++ b/discord/homeboy.json
@@ -1,0 +1,10 @@
+{
+  "id": "discord",
+  "changelog_target": "docs/CHANGELOG.md",
+  "version_targets": [
+    {
+      "file": "discord.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    }
+  ]
+}

--- a/discord/scripts/notify.mjs
+++ b/discord/scripts/notify.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+const DISCORD_CONTENT_LIMIT = 2000;
+const MAX_RETRIES = 2;
+const MAX_RETRY_DELAY_MS = 5000;
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const validation = validate(args, process.env);
+  if (!validation.ok) {
+    return finish(failure('input_error', validation.error));
+  }
+
+  const rendered = renderContent(args);
+  const proof = {
+    mode: validation.mode,
+    destination: validation.destination,
+    content_length: rendered.content.length,
+    truncated: rendered.truncated,
+  };
+
+  if (args.dryRun) {
+    return finish({
+      schema: 'homeboy/discord-notification-result/v1',
+      status: 'dry_run',
+      delivery: proof,
+      attempts: 0,
+    });
+  }
+
+  let attempts = 0;
+  for (;;) {
+    attempts += 1;
+    let response;
+    try {
+      response = await fetch(validation.url, {
+        method: 'POST',
+        headers: validation.headers,
+        body: JSON.stringify({ content: rendered.content }),
+      });
+    } catch {
+      return finish(failure('delivery_error', 'Discord request could not be completed.', proof, attempts));
+    }
+
+    if (response.ok) {
+      return finish({
+        schema: 'homeboy/discord-notification-result/v1',
+        status: 'delivered',
+        delivery: proof,
+        attempts,
+      });
+    }
+
+    if (response.status === 429 && attempts <= MAX_RETRIES) {
+      const retryAfterMs = await retryAfter(response);
+      await sleep(retryAfterMs);
+      continue;
+    }
+
+    return finish(failure(classify(response.status), errorFor(response.status), proof, attempts, response.status));
+  }
+}
+
+function parseArgs(tokens) {
+  const args = { dryRun: false };
+  const names = new Set(['run-id', 'status', 'title', 'body']);
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    if (!token.startsWith('--') || !names.has(token.slice(2)) || index + 1 >= tokens.length) {
+      args.error = 'Expected --run-id, --status, --title, and --body; --dry-run is optional.';
+      return args;
+    }
+    const name = token.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    args[name] = tokens[index + 1];
+    index += 1;
+  }
+  return args;
+}
+
+function validate(args, env) {
+  if (args.error || !nonEmpty(args.runId) || !nonEmpty(args.status) || !nonEmpty(args.title) || !nonEmpty(args.body)) {
+    return { ok: false, error: args.error || 'run-id, status, title, and body must be non-empty.' };
+  }
+
+  const botToken = value(env.DISCORD_BOT_TOKEN);
+  const webhookUrl = value(env.DISCORD_WEBHOOK_URL);
+  if (Boolean(botToken) === Boolean(webhookUrl)) {
+    return { ok: false, error: 'Configure exactly one auth mode: DISCORD_BOT_TOKEN or DISCORD_WEBHOOK_URL.' };
+  }
+
+  const channelId = value(env.DISCORD_CHANNEL_ID);
+  const threadId = value(env.DISCORD_THREAD_ID);
+  if (botToken) {
+    if (Boolean(channelId) === Boolean(threadId)) {
+      return { ok: false, error: 'Bot mode requires exactly one destination: DISCORD_CHANNEL_ID or DISCORD_THREAD_ID.' };
+    }
+    const destination = threadId ? 'thread' : 'channel';
+    const apiBase = value(env.DISCORD_API_BASE_URL) || 'https://discord.com/api/v10';
+    let url;
+    try {
+      url = new URL(`channels/${encodeURIComponent(threadId || channelId)}/messages`, ensureApiBase(apiBase));
+    } catch {
+      return { ok: false, error: 'DISCORD_API_BASE_URL must be a valid HTTP(S) URL.' };
+    }
+    if (!isHttp(url)) return { ok: false, error: 'DISCORD_API_BASE_URL must be an HTTP(S) URL.' };
+    return { ok: true, mode: 'bot', destination, url, headers: { authorization: `Bot ${botToken}`, 'content-type': 'application/json' } };
+  }
+
+  if (channelId) return { ok: false, error: 'Webhook mode does not use DISCORD_CHANNEL_ID.' };
+  let url;
+  try {
+    url = new URL(webhookUrl);
+  } catch {
+    return { ok: false, error: 'DISCORD_WEBHOOK_URL must be a valid HTTP(S) URL.' };
+  }
+  if (!isHttp(url)) return { ok: false, error: 'DISCORD_WEBHOOK_URL must be an HTTP(S) URL.' };
+  url.searchParams.set('wait', 'true');
+  if (threadId) url.searchParams.set('thread_id', threadId);
+  return { ok: true, mode: 'webhook', destination: threadId ? 'thread' : 'webhook', url, headers: { 'content-type': 'application/json' } };
+}
+
+function renderContent(args) {
+  const content = `[${compact(args.status)}] ${compact(args.title)}\nRun: ${compact(args.runId)}\n${compact(args.body)}`;
+  if (content.length <= DISCORD_CONTENT_LIMIT) return { content, truncated: false };
+  let bounded = '';
+  for (const character of content) {
+    if (bounded.length + character.length > DISCORD_CONTENT_LIMIT - 3) break;
+    bounded += character;
+  }
+  return { content: `${bounded}...`, truncated: true };
+}
+
+async function retryAfter(response) {
+  let retryAfterSeconds = 0;
+  try {
+    const body = await response.json();
+    retryAfterSeconds = Number(body.retry_after);
+  } catch {}
+  return Math.min(MAX_RETRY_DELAY_MS, Math.max(0, Number.isFinite(retryAfterSeconds) ? retryAfterSeconds * 1000 : 0));
+}
+
+function classify(status) {
+  if (status === 401 || status === 403) return 'auth_error';
+  if (status === 400 || status === 404 || status === 405 || status === 413 || status === 422) return 'input_error';
+  return 'delivery_error';
+}
+
+function errorFor(status) {
+  if (status === 401 || status === 403) return 'Discord rejected the configured credentials.';
+  if (status === 400 || status === 404 || status === 405 || status === 413 || status === 422) return 'Discord rejected the notification input or destination.';
+  if (status === 429) return 'Discord rate limit retries were exhausted.';
+  return 'Discord returned an unexpected delivery failure.';
+}
+
+function failure(kind, error, delivery = undefined, attempts = 0, httpStatus = undefined) {
+  return {
+    schema: 'homeboy/discord-notification-result/v1',
+    status: 'failed',
+    error: { kind, message: error, ...(httpStatus === undefined ? {} : { http_status: httpStatus }) },
+    ...(delivery === undefined ? {} : { delivery }),
+    attempts,
+  };
+}
+
+function finish(result) {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exitCode = result.status === 'failed' ? 1 : 0;
+}
+
+function ensureApiBase(base) {
+  return base.endsWith('/') ? base : `${base}/`;
+}
+
+function compact(text) {
+  return String(text).replace(/\s+/g, ' ').trim();
+}
+
+function value(input) {
+  return typeof input === 'string' && input.trim() ? input.trim() : undefined;
+}
+
+function nonEmpty(input) {
+  return value(input) !== undefined;
+}
+
+function isHttp(url) {
+  return url.protocol === 'https:' || url.protocol === 'http:';
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+await main();

--- a/discord/scripts/validate.sh
+++ b/discord/scripts/validate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "$SCRIPT_DIR/../tests/notify.test.mjs"

--- a/discord/tests/notify.test.mjs
+++ b/discord/tests/notify.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const extensionPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const helper = path.join(extensionPath, 'scripts/notify.mjs');
+const secretToken = 'bot-secret-123';
+const secretWebhook = '/webhooks/webhook-id/webhook-secret-456';
+
+await testBotThreadDelivery();
+await testWebhookDelivery();
+await testRateLimitRetry();
+await testValidationBeforeNetwork();
+await testAuthFailureClassification();
+await testTruncation();
+await testRedactionAndDryRun();
+console.log('discord notification tests passed');
+
+async function testBotThreadDelivery() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_THREAD_ID: 'thread-1', DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
+    assert.equal(result.status, 'delivered');
+    assert.equal(result.delivery.mode, 'bot');
+    assert.equal(result.delivery.destination, 'thread');
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, '/api/v10/channels/thread-1/messages');
+    assert.equal(requests[0].headers.authorization, `Bot ${secretToken}`);
+  });
+}
+
+async function testWebhookDelivery() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify({ DISCORD_WEBHOOK_URL: `${baseUrl}${secretWebhook}`, DISCORD_THREAD_ID: 'thread-2' });
+    assert.equal(result.status, 'delivered');
+    assert.equal(result.delivery.mode, 'webhook');
+    assert.equal(result.delivery.destination, 'thread');
+    assert.equal(requests[0].url, `${secretWebhook}?wait=true&thread_id=thread-2`);
+    assert.equal(requests[0].headers.authorization, undefined);
+  });
+}
+
+async function testRateLimitRetry() {
+  let calls = 0;
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: 'channel-1', DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
+    assert.equal(result.status, 'delivered');
+    assert.equal(result.attempts, 2);
+    assert.equal(requests.length, 2);
+  }, (_request, response) => {
+    calls += 1;
+    if (calls === 1) return response.writeHead(429, { 'content-type': 'application/json' }).end('{"retry_after":0}');
+    response.writeHead(200).end('{}');
+  });
+}
+
+async function testValidationBeforeNetwork() {
+  const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_WEBHOOK_URL: 'https://discord.invalid/webhook', DISCORD_CHANNEL_ID: 'channel-1' });
+  assert.equal(run.code, 1);
+  const result = JSON.parse(run.stdout);
+  assert.equal(result.status, 'failed');
+  assert.equal(result.error.kind, 'input_error');
+}
+
+async function testAuthFailureClassification() {
+  await withServer(async ({ baseUrl }) => {
+    const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: 'channel-1', DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
+    assert.equal(run.code, 1);
+    assert.equal(JSON.parse(run.stdout).error.kind, 'auth_error');
+  }, (_request, response) => response.writeHead(401).end('{}'));
+}
+
+async function testTruncation() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: 'channel-1', DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { body: 'x'.repeat(3000) });
+    assert.equal(result.delivery.content_length, 2000);
+    assert.equal(result.delivery.truncated, true);
+    assert.equal(requests[0].body.content.length, 2000);
+    assert.equal(requests[0].body.content.endsWith('...'), true);
+  });
+}
+
+async function testRedactionAndDryRun() {
+  const run = await notifyRaw({ DISCORD_WEBHOOK_URL: `https://example.invalid${secretWebhook}` }, { dryRun: true });
+  assert.equal(run.code, 0);
+  assert.doesNotMatch(run.stdout, /webhook-secret-456|bot-secret-123|example\.invalid/);
+  const result = JSON.parse(run.stdout);
+  assert.equal(result.status, 'dry_run');
+  assert.equal(result.attempts, 0);
+}
+
+async function withServer(test, responder = (_request, response) => response.writeHead(200).end('{}')) {
+  const requests = [];
+  const server = http.createServer(async (request, response) => {
+    let raw = '';
+    for await (const chunk of request) raw += chunk;
+    requests.push({ url: request.url, headers: request.headers, body: JSON.parse(raw) });
+    responder(request, response);
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  try {
+    await test({ baseUrl: `http://127.0.0.1:${server.address().port}`, requests });
+  } finally {
+    server.close();
+    await once(server, 'close');
+  }
+}
+
+function notify(env, overrides = {}) {
+  return notifyRaw(env, overrides).then((run) => {
+    assert.equal(run.code, 0, run.stderr);
+    return JSON.parse(run.stdout);
+  });
+}
+
+function notifyRaw(env, overrides = {}) {
+  const args = ['--run-id', 'run-123', '--status', 'pass', '--title', 'homeboy run pass', '--body', overrides.body || 'Run completed'];
+  if (overrides.dryRun) args.push('--dry-run');
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [helper, ...args], { env: { ...process.env, ...env } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}

--- a/tests/extension-shape-lint.mjs
+++ b/tests/extension-shape-lint.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
 const extensionIds = new Set([
+  'discord',
   'go',
   'managed-preview',
   'nodejs',


### PR DESCRIPTION
## Summary
- add a standalone, dependency-free Discord outbound notification extension for Homeboy completion events
- support bot channel/thread and webhook/thread delivery with validation, redaction, truncation, typed results, and bounded rate-limit retries
- document `runs watch --notify` and daemon setup; register the extension with repository shape validation

## Verification
- `bash discord/scripts/validate.sh`
- `node tests/extension-shape-lint.mjs`
- `node --check discord/scripts/notify.mjs`
- JSON parse checks and `git diff --check`

Closes #2217

## AI Assistance
AI assistance: Yes
Tool: OpenCode (`openai/gpt-5.6-terra`)
Used for: implementation, tests, documentation, and validation.