### PR TITLE
feat(discord): route notifications per run

### DIFF
--- a/discord/README.md
+++ b/discord/README.md
@@ -15,7 +15,8 @@ homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id
 export DISCORD_BOT_TOKEN='...'
 export DISCORD_CHANNEL_ID='123456789012345678'
 
-# Or bot REST delivery to a thread. Do not also set DISCORD_CHANNEL_ID.
+# Legacy single-thread bot delivery. Do not also set DISCORD_CHANNEL_ID.
+# This is not the default for concurrently orchestrated runs.
 export DISCORD_THREAD_ID='123456789012345678'
 
 # Or webhook delivery. DISCORD_THREAD_ID is optional for webhook thread routing.
@@ -25,7 +26,7 @@ export DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/...'
 Set `HOMEBOY_NOTIFY_COMMAND` to the installed helper. Placeholders are expanded by Homeboy as separate argv values, so titles and bodies containing spaces are supported.
 
 ```sh
-export HOMEBOY_NOTIFY_COMMAND='node ~/.config/homeboy/extensions/discord/scripts/notify.mjs --run-id {run_id} --status {status} --title {title} --body {body}'
+export HOMEBOY_NOTIFY_COMMAND='node ~/.config/homeboy/extensions/discord/scripts/notify.mjs --run-id {run_id} --status {status} --title {title} --body {body} --route={route}'
 ```
 
 ## Usage
@@ -36,7 +37,15 @@ Notify after a watched run settles:
 homeboy runs watch run-123 --notify
 ```
 
-A Homeboy daemon uses the same `HOMEBOY_NOTIFY_COMMAND` completion-notification seam. Start the daemon normally after setting the environment in its service definition or shell:
+A Homeboy daemon uses the same `HOMEBOY_NOTIFY_COMMAND` completion-notification seam. For a Discord-originated run, create it with the current thread route before detaching. The route is non-secret and versioned: `discord:v1:thread:<guild-id>:<thread-id>` (or `discord:v1:channel:<guild-id>:<channel-id>`). Homeboy persists that opaque route with the run; when the detached daemon sees its terminal event, this transport posts to that route.
+
+```sh
+homeboy --notification-transport discord.run-completion \
+  --notification-route 'discord:v1:thread:123456789012345678:234567890123456789' \
+  --detach-after-handoff test
+```
+
+Start the daemon after setting its service environment or shell:
 
 ```sh
 homeboy daemon start
@@ -45,7 +54,7 @@ homeboy daemon start
 The helper emits one typed JSON envelope to stdout, for example:
 
 ```json
-{"schema":"homeboy/discord-notification-result/v1","status":"delivered","delivery":{"mode":"bot","destination":"thread","content_length":74,"truncated":false},"attempts":1}
+{"schema":"homeboy/discord-notification-result/v1","status":"delivered","delivery":{"mode":"bot","route_kind":"thread","destination":"dynamic_thread","content_length":74,"truncated":false},"attempts":1}
 ```
 
 Use `--dry-run` to validate arguments and configuration shape without network I/O or secret output:
@@ -55,6 +64,8 @@ node ~/.config/homeboy/extensions/discord/scripts/notify.mjs \
   --run-id run-123 --status pass --title 'homeboy run pass' --body 'Run completed' --dry-run
 ```
 
-Discord content is bounded to 2,000 characters. The helper retries a Discord `429` at most twice, using the service's `retry_after` value capped at five seconds. Authentication and destination/input rejections are reported as typed `auth_error` or `input_error` results; credentials and webhook URLs are never included in diagnostics.
+Discord content is bounded to 2,000 characters. The helper retries a Discord `429` at most twice, using the service's `retry_after` value capped at five seconds. Authentication and destination/input rejections are reported as typed `auth_error` or `input_error` results; credentials, webhook URLs, and destination IDs are never included in diagnostics. Result evidence exposes only a route kind and a safe destination classification.
+
+`DISCORD_CHANNEL_ID` is an optional fallback operations channel only when a run has no route. An explicit route always wins. `DISCORD_THREAD_ID` remains supported for legacy single-thread mode; use run-scoped routes for orchestration. Bot tokens remain service-level authentication and never appear in routes.
 
 `DISCORD_API_BASE_URL` is an optional HTTP(S) API base override for deterministic local testing only. Production bot delivery defaults to `https://discord.com/api/v10`.

--- a/discord/discord.json
+++ b/discord/discord.json
@@ -1,7 +1,7 @@
 {
   "name": "Discord Notifications",
   "id": "discord",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "icon": "message.circle",
   "description": "Outbound Discord run-completion notification delivery for Homeboy",
   "author": "Extra Chill",
@@ -17,7 +17,7 @@
     {
       "schema": "homeboy/notification-transport-command/v1",
       "id": "discord.run-completion",
-      "command": "node {{extension_path}}/scripts/notify.mjs --run-id {run_id} --status {status} --title {title} --body {body}",
+      "command": "node {{extension_path}}/scripts/notify.mjs --run-id {run_id} --status {status} --title {title} --body {body} --route={route}",
       "contract": {
         "event": "homeboy/run-completion/v1",
         "outbound_only": true,

--- a/discord/scripts/notify.mjs
+++ b/discord/scripts/notify.mjs
@@ -14,6 +14,7 @@ async function main() {
   const rendered = renderContent(args);
   const proof = {
     mode: validation.mode,
+    route_kind: validation.route_kind,
     destination: validation.destination,
     content_length: rendered.content.length,
     truncated: rendered.truncated,
@@ -63,20 +64,25 @@ async function main() {
 
 function parseArgs(tokens) {
   const args = { dryRun: false };
-  const names = new Set(['run-id', 'status', 'title', 'body']);
+  const names = new Set(['run-id', 'status', 'title', 'body', 'route']);
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
     if (token === '--dry-run') {
       args.dryRun = true;
       continue;
     }
-    if (!token.startsWith('--') || !names.has(token.slice(2)) || index + 1 >= tokens.length) {
-      args.error = 'Expected --run-id, --status, --title, and --body; --dry-run is optional.';
+    if (!token.startsWith('--')) {
+      args.error = 'Expected --run-id, --status, --title, and --body; --route and --dry-run are optional.';
       return args;
     }
-    const name = token.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
-    args[name] = tokens[index + 1];
-    index += 1;
+    const [flag, inlineValue] = token.slice(2).split(/=(.*)/s, 2);
+    if (!names.has(flag) || (inlineValue === undefined && index + 1 >= tokens.length)) {
+      args.error = 'Expected --run-id, --status, --title, and --body; --route and --dry-run are optional.';
+      return args;
+    }
+    const name = flag.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    args[name] = inlineValue === undefined ? tokens[index + 1] : inlineValue;
+    if (inlineValue === undefined) index += 1;
   }
   return args;
 }
@@ -92,25 +98,30 @@ function validate(args, env) {
     return { ok: false, error: 'Configure exactly one auth mode: DISCORD_BOT_TOKEN or DISCORD_WEBHOOK_URL.' };
   }
 
+  const route = value(args.route);
+  const parsedRoute = route === undefined ? undefined : parseRoute(route);
+  if (parsedRoute?.error) return { ok: false, error: parsedRoute.error };
+
   const channelId = value(env.DISCORD_CHANNEL_ID);
-  const threadId = value(env.DISCORD_THREAD_ID);
+  let threadId = value(env.DISCORD_THREAD_ID);
   if (botToken) {
-    if (Boolean(channelId) === Boolean(threadId)) {
-      return { ok: false, error: 'Bot mode requires exactly one destination: DISCORD_CHANNEL_ID or DISCORD_THREAD_ID.' };
-    }
-    const destination = threadId ? 'thread' : 'channel';
+    const resolved = resolveBotDestination(parsedRoute, channelId, threadId);
+    if (resolved.error) return { ok: false, error: resolved.error };
     const apiBase = value(env.DISCORD_API_BASE_URL) || 'https://discord.com/api/v10';
     let url;
     try {
-      url = new URL(`channels/${encodeURIComponent(threadId || channelId)}/messages`, ensureApiBase(apiBase));
+      url = new URL(`channels/${encodeURIComponent(resolved.id)}/messages`, ensureApiBase(apiBase));
     } catch {
       return { ok: false, error: 'DISCORD_API_BASE_URL must be a valid HTTP(S) URL.' };
     }
     if (!isHttp(url)) return { ok: false, error: 'DISCORD_API_BASE_URL must be an HTTP(S) URL.' };
-    return { ok: true, mode: 'bot', destination, url, headers: { authorization: `Bot ${botToken}`, 'content-type': 'application/json' } };
+    return { ok: true, mode: 'bot', ...resolved, url, headers: { authorization: `Bot ${botToken}`, 'content-type': 'application/json' } };
   }
 
   if (channelId) return { ok: false, error: 'Webhook mode does not use DISCORD_CHANNEL_ID.' };
+  if (parsedRoute?.kind === 'channel') return { ok: false, error: 'A channel route requires DISCORD_BOT_TOKEN; webhook delivery can only target its configured webhook channel or a thread.' };
+  if (parsedRoute?.kind === 'thread') threadId = parsedRoute.id;
+  if (threadId && !isSnowflake(threadId)) return { ok: false, error: 'DISCORD_THREAD_ID must be a Discord snowflake.' };
   let url;
   try {
     url = new URL(webhookUrl);
@@ -120,7 +131,32 @@ function validate(args, env) {
   if (!isHttp(url)) return { ok: false, error: 'DISCORD_WEBHOOK_URL must be an HTTP(S) URL.' };
   url.searchParams.set('wait', 'true');
   if (threadId) url.searchParams.set('thread_id', threadId);
-  return { ok: true, mode: 'webhook', destination: threadId ? 'thread' : 'webhook', url, headers: { 'content-type': 'application/json' } };
+  return {
+    ok: true,
+    mode: 'webhook',
+    route_kind: parsedRoute?.kind || (threadId ? 'legacy' : 'fallback'),
+    destination: parsedRoute ? 'dynamic_thread' : (threadId ? 'legacy_thread' : 'webhook_default'),
+    url,
+    headers: { 'content-type': 'application/json' },
+  };
+}
+
+function resolveBotDestination(route, channelId, threadId) {
+  if (route) return { id: route.id, route_kind: route.kind, destination: `dynamic_${route.kind}` };
+  if (Boolean(channelId) === Boolean(threadId)) {
+    return { error: 'Bot mode without --route requires exactly one destination: DISCORD_CHANNEL_ID or DISCORD_THREAD_ID.' };
+  }
+  const id = threadId || channelId;
+  if (!isSnowflake(id)) return { error: `${threadId ? 'DISCORD_THREAD_ID' : 'DISCORD_CHANNEL_ID'} must be a Discord snowflake.` };
+  return threadId
+    ? { id, route_kind: 'legacy', destination: 'legacy_thread' }
+    : { id, route_kind: 'fallback', destination: 'fallback_channel' };
+}
+
+function parseRoute(route) {
+  const match = /^discord:v1:(channel|thread):(\d{17,20}):(\d{17,20})$/.exec(route);
+  if (!match) return { error: 'route must be discord:v1:<channel|thread>:<guild-id>:<destination-id> with Discord snowflake IDs.' };
+  return { kind: match[1], guildId: match[2], id: match[3] };
 }
 
 function renderContent(args) {
@@ -189,6 +225,10 @@ function nonEmpty(input) {
 
 function isHttp(url) {
   return url.protocol === 'https:' || url.protocol === 'http:';
+}
+
+function isSnowflake(input) {
+  return typeof input === 'string' && /^\d{17,20}$/.test(input);
 }
 
 function sleep(milliseconds) {

--- a/discord/tests/notify.test.mjs
+++ b/discord/tests/notify.test.mjs
@@ -9,35 +9,79 @@ const extensionPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)),
 const helper = path.join(extensionPath, 'scripts/notify.mjs');
 const secretToken = 'bot-secret-123';
 const secretWebhook = '/webhooks/webhook-id/webhook-secret-456';
+const guildId = '123456789012345678';
+const channelId = '223456789012345678';
+const threadOneId = '323456789012345678';
+const threadTwoId = '423456789012345678';
 
-await testBotThreadDelivery();
+await testConcurrentThreadRoutesDoNotCrossDeliver();
+await testDynamicChannelRoute();
+await testFallbackChannelDelivery();
+await testLegacyThreadDelivery();
 await testWebhookDelivery();
 await testRateLimitRetry();
-await testValidationBeforeNetwork();
+await testMalformedRouteBeforeNetwork();
+await testCrossModeRouteBeforeNetwork();
 await testAuthFailureClassification();
 await testTruncation();
 await testRedactionAndDryRun();
 console.log('discord notification tests passed');
 
-async function testBotThreadDelivery() {
+async function testConcurrentThreadRoutesDoNotCrossDeliver() {
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_THREAD_ID: 'thread-1', DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
-    assert.equal(result.status, 'delivered');
-    assert.equal(result.delivery.mode, 'bot');
-    assert.equal(result.delivery.destination, 'thread');
-    assert.equal(requests.length, 1);
-    assert.equal(requests[0].url, '/api/v10/channels/thread-1/messages');
-    assert.equal(requests[0].headers.authorization, `Bot ${secretToken}`);
+    const env = { DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` };
+    const [first, second] = await Promise.all([
+      notify(env, { route: threadRoute(threadOneId), runId: 'run-one' }),
+      notify(env, { route: threadRoute(threadTwoId), runId: 'run-two' }),
+    ]);
+    assert.equal(first.delivery.route_kind, 'thread');
+    assert.equal(second.delivery.route_kind, 'thread');
+    assert.equal(first.delivery.destination, 'dynamic_thread');
+    assert.equal(second.delivery.destination, 'dynamic_thread');
+    assert.deepEqual(
+      requests.map((request) => [request.url, request.body.content.includes('run-one') ? 'run-one' : 'run-two']).sort(),
+      [
+        [`/api/v10/channels/${threadOneId}/messages`, 'run-one'],
+        [`/api/v10/channels/${threadTwoId}/messages`, 'run-two'],
+      ],
+    );
+  });
+}
+
+async function testDynamicChannelRoute() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: channelRoute(channelId) });
+    assert.equal(result.delivery.route_kind, 'channel');
+    assert.equal(result.delivery.destination, 'dynamic_channel');
+    assert.equal(requests[0].url, `/api/v10/channels/${channelId}/messages`);
+  });
+}
+
+async function testFallbackChannelDelivery() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: channelId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: '' });
+    assert.equal(result.delivery.route_kind, 'fallback');
+    assert.equal(result.delivery.destination, 'fallback_channel');
+    assert.equal(requests[0].url, `/api/v10/channels/${channelId}/messages`);
+  });
+}
+
+async function testLegacyThreadDelivery() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_THREAD_ID: threadOneId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
+    assert.equal(result.delivery.route_kind, 'legacy');
+    assert.equal(result.delivery.destination, 'legacy_thread');
+    assert.equal(requests[0].url, `/api/v10/channels/${threadOneId}/messages`);
   });
 }
 
 async function testWebhookDelivery() {
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_WEBHOOK_URL: `${baseUrl}${secretWebhook}`, DISCORD_THREAD_ID: 'thread-2' });
+    const result = await notify({ DISCORD_WEBHOOK_URL: `${baseUrl}${secretWebhook}`, DISCORD_THREAD_ID: threadTwoId });
     assert.equal(result.status, 'delivered');
     assert.equal(result.delivery.mode, 'webhook');
-    assert.equal(result.delivery.destination, 'thread');
-    assert.equal(requests[0].url, `${secretWebhook}?wait=true&thread_id=thread-2`);
+    assert.equal(result.delivery.destination, 'legacy_thread');
+    assert.equal(requests[0].url, `${secretWebhook}?wait=true&thread_id=${threadTwoId}`);
     assert.equal(requests[0].headers.authorization, undefined);
   });
 }
@@ -45,7 +89,7 @@ async function testWebhookDelivery() {
 async function testRateLimitRetry() {
   let calls = 0;
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: 'channel-1', DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: channelRoute(channelId) });
     assert.equal(result.status, 'delivered');
     assert.equal(result.attempts, 2);
     assert.equal(requests.length, 2);
@@ -56,17 +100,27 @@ async function testRateLimitRetry() {
   });
 }
 
-async function testValidationBeforeNetwork() {
-  const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_WEBHOOK_URL: 'https://discord.invalid/webhook', DISCORD_CHANNEL_ID: 'channel-1' });
-  assert.equal(run.code, 1);
-  const result = JSON.parse(run.stdout);
-  assert.equal(result.status, 'failed');
-  assert.equal(result.error.kind, 'input_error');
+async function testMalformedRouteBeforeNetwork() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: 'discord:v1:thread:not-a-guild:not-a-thread' });
+    assert.equal(run.code, 1);
+    assert.equal(JSON.parse(run.stdout).error.kind, 'input_error');
+    assert.equal(requests.length, 0);
+  });
+}
+
+async function testCrossModeRouteBeforeNetwork() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const run = await notifyRaw({ DISCORD_WEBHOOK_URL: `${baseUrl}${secretWebhook}` }, { route: channelRoute(channelId) });
+    assert.equal(run.code, 1);
+    assert.equal(JSON.parse(run.stdout).error.kind, 'input_error');
+    assert.equal(requests.length, 0);
+  });
 }
 
 async function testAuthFailureClassification() {
   await withServer(async ({ baseUrl }) => {
-    const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: 'channel-1', DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
+    const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: channelId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
     assert.equal(run.code, 1);
     assert.equal(JSON.parse(run.stdout).error.kind, 'auth_error');
   }, (_request, response) => response.writeHead(401).end('{}'));
@@ -74,7 +128,7 @@ async function testAuthFailureClassification() {
 
 async function testTruncation() {
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: 'channel-1', DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { body: 'x'.repeat(3000) });
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: channelId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { body: 'x'.repeat(3000) });
     assert.equal(result.delivery.content_length, 2000);
     assert.equal(result.delivery.truncated, true);
     assert.equal(requests[0].body.content.length, 2000);
@@ -117,10 +171,13 @@ function notify(env, overrides = {}) {
 }
 
 function notifyRaw(env, overrides = {}) {
-  const args = ['--run-id', 'run-123', '--status', 'pass', '--title', 'homeboy run pass', '--body', overrides.body || 'Run completed'];
+  const args = ['--run-id', overrides.runId || 'run-123', '--status', 'pass', '--title', 'homeboy run pass', '--body', overrides.body || 'Run completed'];
+  if (overrides.route !== undefined) args.push('--route', overrides.route);
   if (overrides.dryRun) args.push('--dry-run');
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [helper, ...args], { env: { ...process.env, ...env } });
+    const childEnv = { ...process.env };
+    for (const name of ['DISCORD_BOT_TOKEN', 'DISCORD_WEBHOOK_URL', 'DISCORD_CHANNEL_ID', 'DISCORD_THREAD_ID', 'DISCORD_API_BASE_URL']) delete childEnv[name];
+    const child = spawn(process.execPath, [helper, ...args], { env: { ...childEnv, ...env } });
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (chunk) => { stdout += chunk; });
@@ -128,4 +185,12 @@ function notifyRaw(env, overrides = {}) {
     child.once('error', reject);
     child.once('close', (code) => resolve({ code, stdout, stderr }));
   });
+}
+
+function channelRoute(id) {
+  return `discord:v1:channel:${guildId}:${id}`;
+}
+
+function threadRoute(id) {
+  return `discord:v1:thread:${guildId}:${id}`;
 }


### PR DESCRIPTION
## Summary
- Add a versioned non-secret Discord route encoding for independent per-run channel and thread delivery.
- Resolve and validate each route before I/O, preserving operations-channel fallback and legacy static-thread behavior.
- Add deterministic fake-server coverage for concurrent route isolation, channel routing, malformed/cross-mode rejection, fallback, retry, and legacy delivery.

## Dependency
- Depends on Extra-Chill/homeboy#7803, which provides the run-scoped `{route}` notification placeholder.

## Verification
- `bash discord/scripts/validate.sh`
- `node tests/extension-shape-lint.mjs`

Closes #2219

## AI assistance
AI assistance: Yes
Tool: OpenCode (`openai/gpt-5.6-terra`)
Used for: implementation, tests, documentation, and validation.