### PR TITLE
fix(opencode): disable agent task titles

### DIFF
--- a/agent-runtimes/opencode/README.md
+++ b/agent-runtimes/opencode/README.md
@@ -37,8 +37,16 @@ For deterministic run-scoped selection, the executor also injects
 
 - `model` and `agent.build.model` from `executor.config.model`,
   `executor.model`, or top-level `model`.
-- `small_model` and `agent.title.model` from `executor.config.small_model`
-  or `executor.config.smallModel` when provided.
+- `small_model` from `executor.config.small_model` or
+  `executor.config.smallModel` when provided.
+- `agent.title.disable: true` for every agent-task run, after ambient config
+  content is layered. Homeboy owns durable task, run, and pull request identity,
+  so OpenCode session-title generation is not used. There is no title opt-in in
+  this executor; a provider title failure therefore cannot affect coding work.
+
+The title-disable overlay does not change the requested primary build model.
+Ambient `agent.title` configuration may supply other fields, but cannot re-enable
+title generation for an agent-task run.
 
 Direct runtime verification can be done with a temporary config overlay, without
 editing global OpenCode config:

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -237,9 +237,6 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 	const config = request.executor?.config || {};
 	const model = config.model || request.executor?.model || request.model;
 	const smallModel = config.small_model || config.smallModel;
-	if (!model && !smallModel) {
-		return '';
-	}
 
 	const content = parseOpenCodeConfigContent(existingContent);
 	content.$schema = content.$schema || 'https://opencode.ai/config.json';
@@ -254,8 +251,11 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 
 	if (smallModel) {
 		content.small_model = smallModel;
-		content.agent.title = { ...objectValue(content.agent.title), model: smallModel };
 	}
+
+	// Homeboy owns durable task identity, so OpenCode must not create a competing
+	// provider session title from an ambient or run-scoped configuration layer.
+	content.agent.title = { ...objectValue(content.agent.title), disable: true };
 
 	return JSON.stringify(content);
 }

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -97,6 +97,8 @@ assert.equal(process.argv.at(-1), 'Prove the OpenCode provider boundary without 
 assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN, 'refresh-token-must-not-leak');
 assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN, 'access-token-must-not-leak');
 assert.equal(process.env.UNDECLARED_SECRET, undefined);
+const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
+assert.equal(config.agent.title.disable, true);
 process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
 process.stderr.write(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN || 'missing secret');
 process.exit(0);
@@ -159,7 +161,8 @@ assert.equal(config.$schema, 'https://opencode.ai/config.json');
 assert.equal(config.model, 'opencode-go/kimi-k2.7-code');
 assert.equal(config.agent.build.model, 'opencode-go/kimi-k2.7-code');
 assert.equal(config.small_model, 'zai-coding-plan/glm-5.2');
-assert.equal(config.agent.title.model, 'zai-coding-plan/glm-5.2');
+assert.equal(config.agent.title.disable, true);
+assert.equal(config.agent.title.model, 'ambient-title-model-must-not-change');
 assert.deepEqual(config.mcp, { example: { type: 'local' } });
 assert.equal(Object.hasOwn(config, 'agents'), false);
 process.exit(0);
@@ -178,6 +181,7 @@ process.exit(0);
 					OPENCODE_CONFIG_CONTENT: JSON.stringify({
 						mcp: { example: { type: 'local' } },
 						agents: { build: { model: 'invalid-plural-key/must-not-survive' } },
+						agent: { title: { disable: false, model: 'ambient-title-model-must-not-change' } },
 					}),
 				},
 				small_model: 'zai-coding-plan/glm-5.2',


### PR DESCRIPTION
## Summary
- disable OpenCode session-title generation for every agent-task run
- preserve primary build-model pinning and existing config layering
- keep `small_model` from configuring the title agent and cover the boundary

## Testing
- `npm run test:opencode-agent-task-executor`
- `npm run check:runtime-manifest`

Closes #2221

## AI Disclosure
Implemented with OpenCode using `openai/gpt-5.6-terra`.