### PR TITLE
fix(discord): require scoped routes

### DIFF
--- a/discord/README.md
+++ b/discord/README.md
@@ -2,7 +2,7 @@
 
 `discord` is an outbound-only Homeboy notification transport. It posts a run-completion message through Discord's REST API but does not own inbound interactions, buttons, or an orchestration lifecycle. Homeboy's durable run/daemon lifecycle remains authoritative.
 
-Requires Homeboy `>=0.281.20`, which provides `HOMEBOY_NOTIFY_COMMAND` and `runs watch --notify`.
+Requires a Homeboy version with typed notification transport registry support.
 
 ## Setup
 
@@ -11,33 +11,26 @@ Install the extension and select exactly one authentication mode. Keep credentia
 ```sh
 homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id discord
 
-# Bot REST delivery to a channel.
+# Bot REST delivery. This optional channel is used only for route-less operations
+# notifications; a run-scoped route always takes precedence.
 export DISCORD_BOT_TOKEN='...'
-export DISCORD_CHANNEL_ID='123456789012345678'
+export DISCORD_OPERATIONS_CHANNEL_ID='123456789012345678'
 
-# Legacy single-thread bot delivery. Do not also set DISCORD_CHANNEL_ID.
-# This is not the default for concurrently orchestrated runs.
-export DISCORD_THREAD_ID='123456789012345678'
-
-# Or webhook delivery. DISCORD_THREAD_ID is optional for webhook thread routing.
+# Or webhook delivery to its configured default channel.
 export DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/...'
 ```
 
-Set `HOMEBOY_NOTIFY_COMMAND` to the installed helper. Placeholders are expanded by Homeboy as separate argv values, so titles and bodies containing spaces are supported.
-
-```sh
-export HOMEBOY_NOTIFY_COMMAND='node ~/.config/homeboy/extensions/discord/scripts/notify.mjs --run-id {run_id} --status {status} --title {title} --body {body} --route={route}'
-```
+Homeboy discovers the `discord.run-completion` transport from this extension's
+manifest. Select it as the notification transport in Homeboy configuration or
+with the corresponding CLI option; Homeboy invokes the typed command with each
+run's caller context.
 
 ## Usage
 
-Notify after a watched run settles:
-
-```sh
-homeboy runs watch run-123 --notify
-```
-
-A Homeboy daemon uses the same `HOMEBOY_NOTIFY_COMMAND` completion-notification seam. For a Discord-originated run, create it with the current thread route before detaching. The route is non-secret and versioned: `discord:v1:thread:<guild-id>:<thread-id>` (or `discord:v1:channel:<guild-id>:<channel-id>`). Homeboy persists that opaque route with the run; when the detached daemon sees its terminal event, this transport posts to that route.
+A Discord-originated run must carry its non-secret, versioned route when it is
+created: `discord:v1:thread:<guild-id>:<thread-id>` or
+`discord:v1:channel:<guild-id>:<channel-id>`. Homeboy persists that opaque
+route with the run, so concurrent detached runs deliver independently.
 
 ```sh
 homeboy --notification-transport discord.run-completion \
@@ -66,6 +59,11 @@ node ~/.config/homeboy/extensions/discord/scripts/notify.mjs \
 
 Discord content is bounded to 2,000 characters. The helper retries a Discord `429` at most twice, using the service's `retry_after` value capped at five seconds. Authentication and destination/input rejections are reported as typed `auth_error` or `input_error` results; credentials, webhook URLs, and destination IDs are never included in diagnostics. Result evidence exposes only a route kind and a safe destination classification.
 
-`DISCORD_CHANNEL_ID` is an optional fallback operations channel only when a run has no route. An explicit route always wins. `DISCORD_THREAD_ID` remains supported for legacy single-thread mode; use run-scoped routes for orchestration. Bot tokens remain service-level authentication and never appear in routes.
+`DISCORD_OPERATIONS_CHANNEL_ID` is an optional bot-mode operations fallback only
+when a run has no route. Without a route or this explicit fallback, bot delivery
+fails closed. Webhooks use their configured default channel without a route, or
+an explicit dynamic thread route; webhook delivery never reads ambient thread
+configuration. Bot tokens remain service-level authentication and never appear
+in routes.
 
 `DISCORD_API_BASE_URL` is an optional HTTP(S) API base override for deterministic local testing only. Production bot delivery defaults to `https://discord.com/api/v10`.

--- a/discord/discord.json
+++ b/discord/discord.json
@@ -1,7 +1,7 @@
 {
   "name": "Discord Notifications",
   "id": "discord",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "icon": "message.circle",
   "description": "Outbound Discord run-completion notification delivery for Homeboy",
   "author": "Extra Chill",

--- a/discord/scripts/notify.mjs
+++ b/discord/scripts/notify.mjs
@@ -102,10 +102,9 @@ function validate(args, env) {
   const parsedRoute = route === undefined ? undefined : parseRoute(route);
   if (parsedRoute?.error) return { ok: false, error: parsedRoute.error };
 
-  const channelId = value(env.DISCORD_CHANNEL_ID);
-  let threadId = value(env.DISCORD_THREAD_ID);
+  const operationsChannelId = value(env.DISCORD_OPERATIONS_CHANNEL_ID);
   if (botToken) {
-    const resolved = resolveBotDestination(parsedRoute, channelId, threadId);
+    const resolved = resolveBotDestination(parsedRoute, operationsChannelId);
     if (resolved.error) return { ok: false, error: resolved.error };
     const apiBase = value(env.DISCORD_API_BASE_URL) || 'https://discord.com/api/v10';
     let url;
@@ -118,10 +117,8 @@ function validate(args, env) {
     return { ok: true, mode: 'bot', ...resolved, url, headers: { authorization: `Bot ${botToken}`, 'content-type': 'application/json' } };
   }
 
-  if (channelId) return { ok: false, error: 'Webhook mode does not use DISCORD_CHANNEL_ID.' };
+  if (operationsChannelId) return { ok: false, error: 'Webhook mode does not use DISCORD_OPERATIONS_CHANNEL_ID.' };
   if (parsedRoute?.kind === 'channel') return { ok: false, error: 'A channel route requires DISCORD_BOT_TOKEN; webhook delivery can only target its configured webhook channel or a thread.' };
-  if (parsedRoute?.kind === 'thread') threadId = parsedRoute.id;
-  if (threadId && !isSnowflake(threadId)) return { ok: false, error: 'DISCORD_THREAD_ID must be a Discord snowflake.' };
   let url;
   try {
     url = new URL(webhookUrl);
@@ -130,27 +127,22 @@ function validate(args, env) {
   }
   if (!isHttp(url)) return { ok: false, error: 'DISCORD_WEBHOOK_URL must be an HTTP(S) URL.' };
   url.searchParams.set('wait', 'true');
-  if (threadId) url.searchParams.set('thread_id', threadId);
+  if (parsedRoute?.kind === 'thread') url.searchParams.set('thread_id', parsedRoute.id);
   return {
     ok: true,
     mode: 'webhook',
-    route_kind: parsedRoute?.kind || (threadId ? 'legacy' : 'fallback'),
-    destination: parsedRoute ? 'dynamic_thread' : (threadId ? 'legacy_thread' : 'webhook_default'),
+    route_kind: parsedRoute?.kind || 'webhook',
+    destination: parsedRoute ? 'dynamic_thread' : 'webhook_default',
     url,
     headers: { 'content-type': 'application/json' },
   };
 }
 
-function resolveBotDestination(route, channelId, threadId) {
+function resolveBotDestination(route, operationsChannelId) {
   if (route) return { id: route.id, route_kind: route.kind, destination: `dynamic_${route.kind}` };
-  if (Boolean(channelId) === Boolean(threadId)) {
-    return { error: 'Bot mode without --route requires exactly one destination: DISCORD_CHANNEL_ID or DISCORD_THREAD_ID.' };
-  }
-  const id = threadId || channelId;
-  if (!isSnowflake(id)) return { error: `${threadId ? 'DISCORD_THREAD_ID' : 'DISCORD_CHANNEL_ID'} must be a Discord snowflake.` };
-  return threadId
-    ? { id, route_kind: 'legacy', destination: 'legacy_thread' }
-    : { id, route_kind: 'fallback', destination: 'fallback_channel' };
+  if (!operationsChannelId) return { error: 'Bot mode without --route requires DISCORD_OPERATIONS_CHANNEL_ID.' };
+  if (!isSnowflake(operationsChannelId)) return { error: 'DISCORD_OPERATIONS_CHANNEL_ID must be a Discord snowflake.' };
+  return { id: operationsChannelId, route_kind: 'operations', destination: 'operations_channel' };
 }
 
 function parseRoute(route) {

--- a/discord/tests/notify.test.mjs
+++ b/discord/tests/notify.test.mjs
@@ -16,8 +16,8 @@ const threadTwoId = '423456789012345678';
 
 await testConcurrentThreadRoutesDoNotCrossDeliver();
 await testDynamicChannelRoute();
-await testFallbackChannelDelivery();
-await testLegacyThreadDelivery();
+await testOperationsChannelDelivery();
+await testRouteLessBotFailsClosed();
 await testWebhookDelivery();
 await testRateLimitRetry();
 await testMalformedRouteBeforeNetwork();
@@ -50,38 +50,43 @@ async function testConcurrentThreadRoutesDoNotCrossDeliver() {
 
 async function testDynamicChannelRoute() {
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: channelRoute(channelId) });
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_OPERATIONS_CHANNEL_ID: threadOneId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: channelRoute(channelId) });
     assert.equal(result.delivery.route_kind, 'channel');
     assert.equal(result.delivery.destination, 'dynamic_channel');
     assert.equal(requests[0].url, `/api/v10/channels/${channelId}/messages`);
   });
 }
 
-async function testFallbackChannelDelivery() {
+async function testOperationsChannelDelivery() {
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: channelId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: '' });
-    assert.equal(result.delivery.route_kind, 'fallback');
-    assert.equal(result.delivery.destination, 'fallback_channel');
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_OPERATIONS_CHANNEL_ID: channelId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: '' });
+    assert.equal(result.delivery.route_kind, 'operations');
+    assert.equal(result.delivery.destination, 'operations_channel');
     assert.equal(requests[0].url, `/api/v10/channels/${channelId}/messages`);
   });
 }
 
-async function testLegacyThreadDelivery() {
+async function testRouteLessBotFailsClosed() {
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_THREAD_ID: threadOneId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
-    assert.equal(result.delivery.route_kind, 'legacy');
-    assert.equal(result.delivery.destination, 'legacy_thread');
-    assert.equal(requests[0].url, `/api/v10/channels/${threadOneId}/messages`);
+    const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
+    assert.equal(run.code, 1);
+    assert.equal(JSON.parse(run.stdout).error.kind, 'input_error');
+    assert.equal(requests.length, 0);
   });
 }
 
 async function testWebhookDelivery() {
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_WEBHOOK_URL: `${baseUrl}${secretWebhook}`, DISCORD_THREAD_ID: threadTwoId });
-    assert.equal(result.status, 'delivered');
-    assert.equal(result.delivery.mode, 'webhook');
-    assert.equal(result.delivery.destination, 'legacy_thread');
-    assert.equal(requests[0].url, `${secretWebhook}?wait=true&thread_id=${threadTwoId}`);
+    const [defaultResult, threadResult] = await Promise.all([
+      notify({ DISCORD_WEBHOOK_URL: `${baseUrl}${secretWebhook}` }),
+      notify({ DISCORD_WEBHOOK_URL: `${baseUrl}${secretWebhook}` }, { route: threadRoute(threadTwoId) }),
+    ]);
+    assert.equal(defaultResult.delivery.destination, 'webhook_default');
+    assert.equal(threadResult.delivery.destination, 'dynamic_thread');
+    assert.deepEqual(requests.map((request) => request.url).sort(), [
+      `${secretWebhook}?wait=true`,
+      `${secretWebhook}?wait=true&thread_id=${threadTwoId}`,
+    ]);
     assert.equal(requests[0].headers.authorization, undefined);
   });
 }
@@ -120,7 +125,7 @@ async function testCrossModeRouteBeforeNetwork() {
 
 async function testAuthFailureClassification() {
   await withServer(async ({ baseUrl }) => {
-    const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: channelId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` });
+    const run = await notifyRaw({ DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: channelRoute(channelId) });
     assert.equal(run.code, 1);
     assert.equal(JSON.parse(run.stdout).error.kind, 'auth_error');
   }, (_request, response) => response.writeHead(401).end('{}'));
@@ -128,7 +133,7 @@ async function testAuthFailureClassification() {
 
 async function testTruncation() {
   await withServer(async ({ baseUrl, requests }) => {
-    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_CHANNEL_ID: channelId, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { body: 'x'.repeat(3000) });
+    const result = await notify({ DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` }, { route: channelRoute(channelId), body: 'x'.repeat(3000) });
     assert.equal(result.delivery.content_length, 2000);
     assert.equal(result.delivery.truncated, true);
     assert.equal(requests[0].body.content.length, 2000);
@@ -137,12 +142,17 @@ async function testTruncation() {
 }
 
 async function testRedactionAndDryRun() {
-  const run = await notifyRaw({ DISCORD_WEBHOOK_URL: `https://example.invalid${secretWebhook}` }, { dryRun: true });
-  assert.equal(run.code, 0);
-  assert.doesNotMatch(run.stdout, /webhook-secret-456|bot-secret-123|example\.invalid/);
-  const result = JSON.parse(run.stdout);
-  assert.equal(result.status, 'dry_run');
-  assert.equal(result.attempts, 0);
+  for (const env of [
+    { DISCORD_BOT_TOKEN: secretToken, DISCORD_OPERATIONS_CHANNEL_ID: channelId },
+    { DISCORD_WEBHOOK_URL: `https://example.invalid${secretWebhook}` },
+  ]) {
+    const run = await notifyRaw(env, { dryRun: true });
+    assert.equal(run.code, 0);
+    assert.doesNotMatch(run.stdout, /webhook-secret-456|bot-secret-123|example\.invalid/);
+    const result = JSON.parse(run.stdout);
+    assert.equal(result.status, 'dry_run');
+    assert.equal(result.attempts, 0);
+  }
 }
 
 async function withServer(test, responder = (_request, response) => response.writeHead(200).end('{}')) {
@@ -176,7 +186,7 @@ function notifyRaw(env, overrides = {}) {
   if (overrides.dryRun) args.push('--dry-run');
   return new Promise((resolve, reject) => {
     const childEnv = { ...process.env };
-    for (const name of ['DISCORD_BOT_TOKEN', 'DISCORD_WEBHOOK_URL', 'DISCORD_CHANNEL_ID', 'DISCORD_THREAD_ID', 'DISCORD_API_BASE_URL']) delete childEnv[name];
+    for (const name of ['DISCORD_BOT_TOKEN', 'DISCORD_WEBHOOK_URL', 'DISCORD_OPERATIONS_CHANNEL_ID', 'DISCORD_API_BASE_URL']) delete childEnv[name];
     const child = spawn(process.execPath, [helper, ...args], { env: { ...childEnv, ...env } });
     let stdout = '';
     let stderr = '';


### PR DESCRIPTION
## Summary
- Remove static Discord thread and channel configuration paths; only versioned dynamic routes can target threads.
- Add `DISCORD_OPERATIONS_CHANNEL_ID` as the explicit bot-mode route-less operations fallback and fail closed without it.
- Keep webhook delivery limited to its default channel or an explicit dynamic thread route, with updated typed delivery evidence and docs.

## Verification
- `bash discord/scripts/validate.sh`
- `node tests/extension-shape-lint.mjs`

Closes #2223

Related: Extra-Chill/homeboy#7804

## AI assistance
AI assistance: Yes
Tool: OpenCode (`openai/gpt-5.6-terra`)
Used for: implementation, tests, documentation, validation, and PR preparation.