### PR TITLE
Make OpenCode executor own required artifacts

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -473,24 +473,27 @@ function collectOpenCodeArtifacts(context = {}) {
 	const request = context.request || {};
 	const artifactDir = resolveArtifactDir(context);
 	if (!artifactDir) {
-		return {};
+		return artifactCaptureFailure('OpenCode artifact directory could not be resolved.');
 	}
 
-	const requirements = uniqueDeclaredArtifactRequirements(request);
-	if (requirements.length === 0) {
-		return {};
-	}
+	const requirements = canonicalArtifactRequirements(request);
 
 	const artifacts = [];
 	const evidence_refs = [];
+	const captureErrors = [];
 	const addArtifact = (requirement, filename, content, fallbackKind) => {
 		if (content === undefined || content === null) {
 			return;
 		}
 		const artifactContent = String(content);
 		const filePath = path.join(artifactDir, filename);
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, artifactContent);
+		try {
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, artifactContent);
+		} catch (error) {
+			captureErrors.push({ artifact: requirement.name, message: error.message });
+			return;
+		}
 		const artifact = {
 			id: requirement.name,
 			name: requirement.name,
@@ -506,12 +509,17 @@ function collectOpenCodeArtifacts(context = {}) {
 	const stdout = redactKnownSecrets(String(spawnResult.stdout || ''), context.spawnExtra?.env);
 	const stderr = redactKnownSecrets(String(spawnResult.stderr || ''), context.spawnExtra?.env);
 	const transcript = [stdout, stderr].filter(Boolean).join('\n');
-	const patch = gitDiff(context.cwd);
+	const patchCapture = gitDiff(context.cwd);
+	if (patchCapture.error) {
+		captureErrors.push({ artifact: 'patch', message: patchCapture.error });
+	}
+	const patch = patchCapture.content;
 	const policyDenial = detectOpenCodePolicyDenial(context);
+	const resultStatus = policyDenial ? 'failed' : (spawnResult.status === 0 ? 'succeeded' : 'failed');
 	const resultEnvelope = JSON.stringify({
 		schema: 'homeboy/opencode-agent-result/v1',
 		task_id: request.task_id,
-		status: policyDenial ? 'failed' : 'succeeded',
+		status: resultStatus,
 		...(policyDenial ? {
 			failure_classification: 'policy_denied',
 			failure_code: 'agent_task.opencode_policy_denied',
@@ -537,7 +545,13 @@ function collectOpenCodeArtifacts(context = {}) {
 		}
 	}
 
-	return { artifacts, evidence_refs };
+	return captureErrors.length === 0
+		? { artifacts, evidence_refs }
+		: { artifacts, evidence_refs, artifact_capture_errors: captureErrors };
+}
+
+function artifactCaptureFailure(message) {
+	return { artifacts: [], evidence_refs: [], artifact_capture_errors: [{ artifact: 'artifact_root', message }] };
 }
 
 function collectOpenCodeRuntimeLogs(context = {}) {
@@ -589,13 +603,54 @@ function sessionMetadata(context = {}) {
 
 function gitDiff(cwd) {
 	if (!cwd) {
-		return '';
+		return { content: '', error: 'OpenCode workspace path was not available for patch capture.' };
 	}
-	const result = spawnSync('git', ['diff', '--no-ext-diff', '--binary'], { cwd, encoding: 'utf8' });
+	const result = spawnSync('git', ['diff', '--no-ext-diff', '--binary', 'HEAD'], { cwd, encoding: 'utf8' });
 	if (result.status !== 0 || result.error) {
-		return '';
+		return { content: '', error: result.error?.message || String(result.stderr || 'git diff failed').trim() };
 	}
-	return String(result.stdout || '');
+	let content = String(result.stdout || '');
+	const untracked = spawnSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], { cwd, encoding: 'utf8' });
+	if (untracked.status !== 0 || untracked.error) {
+		return { content, error: untracked.error?.message || String(untracked.stderr || 'git ls-files failed').trim() };
+	}
+	for (const relativePath of String(untracked.stdout || '').split('\0').filter(Boolean)) {
+		const untrackedDiff = spawnSync('git', ['diff', '--no-ext-diff', '--binary', '--no-index', '--', '/dev/null', relativePath], { cwd, encoding: 'utf8' });
+		if (![0, 1].includes(untrackedDiff.status) || untrackedDiff.error) {
+			return { content, error: untrackedDiff.error?.message || String(untrackedDiff.stderr || `failed to capture untracked file ${relativePath}`).trim() };
+		}
+		content += String(untrackedDiff.stdout || '');
+	}
+	return { content, error: null };
+}
+
+function canonicalArtifactRequirements(request = {}) {
+	const canonical = [
+		{ name: 'patch', kind: 'git-diff', required: true },
+		{ name: 'transcript', kind: 'agent-runtime-transcript', required: true },
+		{ name: 'agent_result', kind: 'json', required: true },
+	];
+	const declared = uniqueDeclaredArtifactRequirements(request);
+	return [...canonical, ...declared].filter((requirement, index, all) => (
+		all.findIndex((candidate) => candidate.name === requirement.name) === index
+	));
+}
+
+function withArtifactCaptureFailure(terminal = {}) {
+	const errors = arrayValue(terminal.artifact_capture_errors);
+	if (errors.length === 0) {
+		return terminal;
+	}
+	const message = `OpenCode artifact capture failed: ${errors.map((error) => `${error.artifact}: ${error.message}`).join('; ')}`;
+	return {
+		...terminal,
+		status: 'provider_error',
+		failure_classification: 'provider',
+		failure_code: 'agent_task.opencode_artifact_capture_failed',
+		summary: message,
+		diagnostics: [...arrayValue(terminal.diagnostics), { class: 'opencode.artifact_capture_failed', classification: 'provider', message, data: { errors } }],
+		metadata: { ...(terminal.metadata || {}), artifact_capture_errors: errors },
+	};
 }
 
 function uniqueDeclaredArtifactRequirements(request = {}) {
@@ -728,7 +783,7 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 		});
 	}
 
-	const terminal = spawnResult.status === 0 ? opencodeSuccessOutcome(context) : opencodeFailureOutcome(context);
+	const terminal = withArtifactCaptureFailure(spawnResult.status === 0 ? opencodeSuccessOutcome(context) : opencodeFailureOutcome(context));
 	return outcome(request, { ...terminal, ...mergeEvidence(terminal, runtimeLogs) });
 }
 

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -123,6 +123,7 @@ process.exit(0);
 			},
 		},
 		instructions: 'Prove the OpenCode provider boundary without leaking secrets.',
+		artifacts_path: path.join(root, 'default-artifacts'),
 	};
 	const runResult = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
@@ -147,6 +148,18 @@ process.exit(0);
 
 	const modelWorkspace = path.join(root, 'model-workspace');
 	fs.mkdirSync(modelWorkspace, { recursive: true });
+	spawnSync('git', ['init'], { cwd: modelWorkspace, encoding: 'utf8' });
+	spawnSync('git', ['commit', '--allow-empty', '-m', 'initial'], {
+		cwd: modelWorkspace,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Homeboy Test',
+			GIT_AUTHOR_EMAIL: 'homeboy@example.test',
+			GIT_COMMITTER_NAME: 'Homeboy Test',
+			GIT_COMMITTER_EMAIL: 'homeboy@example.test',
+		},
+	});
 	const realModelWorkspace = fs.realpathSync(modelWorkspace);
 	const modelCliPath = path.join(root, 'mock-opencode-model.cjs');
 	fs.writeFileSync(modelCliPath, `#!/usr/bin/env node
@@ -216,10 +229,14 @@ process.exit(0);
 
 	const artifactCliPath = path.join(root, 'mock-opencode-artifact.cjs');
 	fs.writeFileSync(artifactCliPath, `#!/usr/bin/env node
-const fs = require('node:fs');
-fs.writeFileSync('README.md', 'after\\n');
-process.stdout.write('transcript output ' + process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN);
-process.exit(0);
+	const fs = require('node:fs');
+	const { spawnSync } = require('node:child_process');
+	fs.writeFileSync('README.md', 'after\\n');
+	spawnSync('git', ['add', 'README.md']);
+	fs.writeFileSync('NEW.md', 'untracked\\n');
+	process.stdout.write('transcript output ' + process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN);
+	process.stderr.write('provider stderr output');
+	process.exit(0);
 `);
 	const artifactResult = await executeOpenCodeAgentTask({
 		...request,
@@ -236,10 +253,14 @@ process.exit(0);
 		},
 	}, { env: fixtureEnv });
 	assert.equal(artifactResult.status, 'succeeded');
-	assert.deepEqual(artifactResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stdout', 'patch', 'transcript']);
-	assert.match(fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'patch').path, 'utf8'), /after/);
+	assert.deepEqual(artifactResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stderr', 'opencode-runtime-stdout', 'patch', 'transcript']);
+	const editingPatch = fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'patch').path, 'utf8');
+	assert.match(editingPatch, /after/);
+	assert.match(editingPatch, /NEW\.md/);
+	assert.match(editingPatch, /untracked/);
 	const transcript = fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'transcript').path, 'utf8');
 	assert.match(transcript, /transcript output/);
+	assert.match(transcript, /provider stderr output/);
 	assert.equal(transcript.includes('refresh-token-must-not-leak'), false);
 	assert.match(transcript, /\[redacted\]/);
 	assert.equal(artifactResult.artifacts.some((artifact) => artifact.name === 'opencode-runtime-stdout'), true);
@@ -297,6 +318,35 @@ process.exit(0);
 	assert.equal(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'transcript').path, 'utf8'), '');
 	const quietAgentResult = JSON.parse(fs.readFileSync(quietResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
 	assert.deepEqual(quietAgentResult.artifacts, { patch: false, transcript: false });
+	assert.equal(quietAgentResult.status, 'succeeded');
+
+	const blockedArtifactPath = path.join(root, 'artifact-root-is-a-file');
+	fs.mkdirSync(blockedArtifactPath);
+	const captureFailureCliPath = path.join(root, 'mock-opencode-break-artifact-root.cjs');
+	fs.writeFileSync(captureFailureCliPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.rmSync(${JSON.stringify(blockedArtifactPath)}, { recursive: true, force: true });
+fs.writeFileSync(${JSON.stringify(blockedArtifactPath)}, 'not a directory');
+process.exit(0);
+`);
+	const captureFailureResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-artifact-capture-failure',
+		workspace_path: quietWorkspace,
+		artifacts_path: blockedArtifactPath,
+		expected_artifacts: ['patch', 'transcript', 'agent_result'],
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				command_args: [captureFailureCliPath],
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(captureFailureResult.status, 'provider_error');
+	assert.equal(captureFailureResult.failure_code, 'agent_task.opencode_artifact_capture_failed');
+	assert.equal(captureFailureResult.metadata.artifact_capture_errors.length, 3);
+	assert.equal(captureFailureResult.diagnostics.some((diagnostic) => diagnostic.class === 'opencode.artifact_capture_failed'), true);
 
 	const deniedWorkspace = path.join(root, 'denied-workspace');
 	const deniedArtifactDir = path.join(root, 'denied-artifacts');
@@ -418,6 +468,7 @@ setTimeout(() => {}, 10000);
 		...request,
 		task_id: 'opencode-implicit-artifact-dir',
 		workspace_path: quietWorkspace,
+		artifacts_path: undefined,
 		expected_artifacts: ['patch', 'transcript', 'agent_result'],
 		executor: {
 			...request.executor,
@@ -438,6 +489,7 @@ setTimeout(() => {}, 10000);
 	const workspaceRootResult = await executeOpenCodeAgentTask({
 		...request,
 		task_id: 'opencode-workspace-root-artifact-dir',
+		artifacts_path: undefined,
 		workspace: {
 			mode: 'existing',
 			root: quietWorkspace,


### PR DESCRIPTION
## Summary
- deterministically capture patch, transcript, normalized agent result, stdout, and stderr from OpenCode runs
- preserve tracked and untracked workspace changes without agent-side artifact ceremony
- emit explicit empty artifacts for successful no-op runs and actionable provider errors for capture failures

Refs Extra-Chill/homeboy#7011

## Validation
- OpenCode executor boundary tests cover exit-0 no-op, tracked and untracked edits, transcript redaction, stderr capture, and artifact-root failure
- DMC #340 Lab cook with Sol is the end-to-end acceptance run

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Implementation, tests, and Lab acceptance setup under Chris Huber direction.