### PR TITLE
fix(opencode): capture agent commits in patches

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -508,7 +508,7 @@ function collectOpenCodeArtifacts(context = {}) {
 	const stdout = redactKnownSecrets(String(spawnResult.stdout || ''), context.spawnExtra?.env);
 	const stderr = redactKnownSecrets(String(spawnResult.stderr || ''), context.spawnExtra?.env);
 	const transcript = [stdout, stderr].filter(Boolean).join('\n');
-	const patchCapture = gitDiff(context.cwd);
+	const patchCapture = gitDiff(context.cwd, context.initialRevision);
 	if (patchCapture.error) {
 		captureErrors.push({ artifact: 'patch', message: patchCapture.error });
 	}
@@ -600,11 +600,25 @@ function sessionMetadata(context = {}) {
 	return explicit && typeof explicit === 'object' && !Array.isArray(explicit) ? explicit : OPENCODE_SESSION_METADATA_ABSENT;
 }
 
-function gitDiff(cwd) {
+function gitRevision(cwd) {
+	if (!cwd) {
+		return { revision: '', error: 'OpenCode workspace path was not available for patch capture.' };
+	}
+	const result = spawnSync('git', ['rev-parse', '--verify', 'HEAD'], { cwd, encoding: 'utf8' });
+	if (result.status !== 0 || result.error) {
+		return { revision: '', error: result.error?.message || String(result.stderr || 'git rev-parse failed').trim() };
+	}
+	return { revision: String(result.stdout || '').trim(), error: null };
+}
+
+function gitDiff(cwd, initialRevision = {}) {
 	if (!cwd) {
 		return { content: '', error: 'OpenCode workspace path was not available for patch capture.' };
 	}
-	const result = spawnSync('git', ['diff', '--no-ext-diff', '--binary', 'HEAD'], { cwd, encoding: 'utf8' });
+	if (!initialRevision.revision) {
+		return { content: '', error: initialRevision.error || 'OpenCode workspace initial revision was not available for patch capture.' };
+	}
+	const result = spawnSync('git', ['diff', '--no-ext-diff', '--binary', initialRevision.revision], { cwd, encoding: 'utf8' });
 	if (result.status !== 0 || result.error) {
 		return { content: '', error: result.error?.message || String(result.stderr || 'git diff failed').trim() };
 	}
@@ -747,6 +761,7 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 	const spawnExtra = { env: { ...opencodeSpawnEnv(request, options), PWD: cwd } };
 	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
 	const runtimeLogPaths = openCodeRuntimeLogPaths(request, config);
+	const initialRevision = gitRevision(cwd);
 	const spawnResult = await spawnOpenCodeStreaming(commandSpec.command, args, {
 		cwd,
 		env: spawnExtra.env,
@@ -754,7 +769,7 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 		runtimeLogPaths,
 		diagnosticLogPath: openCodeDiagnosticLogPath(config, spawnExtra.env),
 	});
-	const context = { request, config, commandSpec, cwd, spawnResult, spawnExtra, runtimeLogPaths };
+	const context = { request, config, commandSpec, cwd, initialRevision, spawnResult, spawnExtra, runtimeLogPaths };
 	const runtimeLogs = collectOpenCodeRuntimeLogs(context);
 
 	if (spawnResult.error?.code === 'ENOENT') {

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,7 +9,7 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.1.0',
+		version: '1.1.1',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
 		contract_producers: [
 			{

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "contract_producers": [
     {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -218,7 +218,8 @@ process.exit(0);
 	fs.mkdirSync(workspace, { recursive: true });
 	spawnSync('git', ['init'], { cwd: workspace, encoding: 'utf8' });
 	fs.writeFileSync(path.join(workspace, 'README.md'), 'before\n');
-	spawnSync('git', ['add', 'README.md'], { cwd: workspace, encoding: 'utf8' });
+	fs.writeFileSync(path.join(workspace, 'UNSTAGED.md'), 'before unstaged\n');
+	spawnSync('git', ['add', 'README.md', 'UNSTAGED.md'], { cwd: workspace, encoding: 'utf8' });
 	spawnSync('git', ['commit', '-m', 'initial'], {
 		cwd: workspace,
 		encoding: 'utf8',
@@ -235,9 +236,14 @@ process.exit(0);
 	fs.writeFileSync(artifactCliPath, `#!/usr/bin/env node
 	const fs = require('node:fs');
 	const { spawnSync } = require('node:child_process');
-	fs.writeFileSync('README.md', 'after\\n');
+	fs.writeFileSync('README.md', 'committed after\\n');
 	spawnSync('git', ['add', 'README.md']);
+	spawnSync('git', ['-c', 'user.name=Homeboy Test', '-c', 'user.email=homeboy@example.test', 'commit', '-m', 'agent commit']);
+	fs.writeFileSync('STAGED.md', 'staged after\\n');
+	spawnSync('git', ['add', 'STAGED.md']);
+	fs.writeFileSync('UNSTAGED.md', 'unstaged after\\n');
 	fs.writeFileSync('NEW.md', 'untracked\\n');
+	fs.writeFileSync('BINARY.bin', Buffer.from([0, 1, 2, 0, 255]));
 	process.stdout.write('transcript output ' + process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN);
 	process.stderr.write('provider stderr output');
 	process.exit(0);
@@ -259,9 +265,15 @@ process.exit(0);
 	assert.equal(artifactResult.status, 'succeeded');
 	assert.deepEqual(artifactResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stderr', 'opencode-runtime-stdout', 'patch', 'transcript']);
 	const editingPatch = fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'patch').path, 'utf8');
-	assert.match(editingPatch, /after/);
+	assert.match(editingPatch, /committed after/);
+	assert.equal(editingPatch.match(/committed after/g)?.length, 1);
+	assert.match(editingPatch, /STAGED\.md/);
+	assert.match(editingPatch, /staged after/);
+	assert.match(editingPatch, /unstaged after/);
 	assert.match(editingPatch, /NEW\.md/);
 	assert.match(editingPatch, /untracked/);
+	assert.match(editingPatch, /BINARY\.bin/);
+	assert.match(editingPatch, /GIT binary patch/);
 	const transcript = fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'transcript').path, 'utf8');
 	assert.match(transcript, /transcript output/);
 	assert.match(transcript, /provider stderr output/);
@@ -278,6 +290,46 @@ process.exit(0);
 	const agentResult = JSON.parse(fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
 	assert.equal(agentResult.opencode_session.status, 'not_discovered');
 	assert.equal(artifactResult.metadata.missing_declared_artifacts, undefined);
+
+	const committedWorkspace = path.join(root, 'committed-workspace');
+	fs.mkdirSync(committedWorkspace, { recursive: true });
+	spawnSync('git', ['init'], { cwd: committedWorkspace, encoding: 'utf8' });
+	fs.writeFileSync(path.join(committedWorkspace, 'README.md'), 'before commit\n');
+	spawnSync('git', ['add', 'README.md'], { cwd: committedWorkspace, encoding: 'utf8' });
+	spawnSync('git', ['commit', '-m', 'initial'], {
+		cwd: committedWorkspace,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Homeboy Test',
+			GIT_AUTHOR_EMAIL: 'homeboy@example.test',
+			GIT_COMMITTER_NAME: 'Homeboy Test',
+			GIT_COMMITTER_EMAIL: 'homeboy@example.test',
+		},
+	});
+	const committedCliPath = path.join(root, 'mock-opencode-committed.cjs');
+	fs.writeFileSync(committedCliPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+fs.writeFileSync('README.md', 'committed only\\n');
+spawnSync('git', ['add', 'README.md']);
+spawnSync('git', ['-c', 'user.name=Homeboy Test', '-c', 'user.email=homeboy@example.test', 'commit', '-m', 'agent commit']);
+process.exit(0);
+`);
+	const committedResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-committed-artifacts',
+		workspace_path: committedWorkspace,
+		artifacts_path: path.join(root, 'committed-artifacts'),
+		executor: {
+			...request.executor,
+			config: { ...request.executor.config, command_args: [committedCliPath] },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(committedResult.status, 'succeeded');
+	const committedPatch = fs.readFileSync(committedResult.artifacts.find((artifact) => artifact.name === 'patch').path, 'utf8');
+	assert.match(committedPatch, /committed only/);
+	assert.equal(committedPatch.match(/committed only/g)?.length, 1);
 
 	const quietWorkspace = path.join(root, 'quiet-workspace');
 	fs.mkdirSync(quietWorkspace, { recursive: true });


### PR DESCRIPTION
Closes #2228

## Summary

- snapshot the workspace `HEAD` before launching OpenCode
- build the terminal binary patch relative to that immutable revision so committed, staged, and unstaged tracked edits are represented once
- retain explicit untracked-file capture and legitimate empty patches
- bump the OpenCode runtime manifest to `1.1.1`

## Tests

- `npm run test:opencode-agent-task-executor --prefix agent-runtimes/opencode`
- `npm run check:runtime-manifest --prefix agent-runtimes/opencode`
- `npm test --prefix runtime-agent-ci`
- `git diff --check`

## AI disclosure

Implemented with OpenCode using `openai/gpt-5.6-sol`. The changes and test results were reviewed before submission.