### PR TITLE
Fix #2231: Forward Node bench workload progress

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -1,6 +1,6 @@
 {
   "name": "Node.js",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "icon": "server.rack",
   "description": "Node.js project type — discovery, audit grammar, and npm release lifecycle",
   "author": "Extra Chill",

--- a/nodejs/scripts/bench/lib/workload-utils.mjs
+++ b/nodejs/scripts/bench/lib/workload-utils.mjs
@@ -12,6 +12,9 @@ export { createRunId } from './artifact-context.mjs';
 export { redactText, sanitizeArtifactFile, sanitizeArtifactValue, sanitizeUrl } from './redaction.mjs';
 
 const DEFAULT_SETTINGS_PREFIX = 'HOMEBOY_SETTINGS_';
+const RUNNER_PROGRESS_LINE_PREFIX = 'HOMEBOY_RUNNER_PROGRESS ';
+const RUNNER_PROGRESS_SCHEMA = 'homeboy/runner-progress/v1';
+const RUNNER_PROGRESS_FIELDS = new Set(['schema', 'phase', 'current_item', 'completed', 'total', 'metadata']);
 
 export function settings(env = process.env) {
     try {
@@ -125,6 +128,7 @@ export function runCommand(command, args = [], options = {}) {
         let settled = false;
         let stdout = '';
         let stderr = '';
+        let stdoutLineRemainder = '';
         const child = spawn(command, args, {
             cwd: options.cwd || process.env.HOMEBOY_COMPONENT_PATH || process.cwd(),
             env: { ...process.env, ...(options.env || {}) },
@@ -142,7 +146,16 @@ export function runCommand(command, args = [], options = {}) {
             : undefined;
 
         child.stdout?.on('data', (chunk) => {
-            stdout += String(chunk);
+            const output = String(chunk);
+            stdout += output;
+            stdoutLineRemainder += output;
+            const lines = stdoutLineRemainder.split('\n');
+            stdoutLineRemainder = lines.pop();
+            for (const line of lines) {
+                if (isCanonicalRunnerProgressLine(line)) {
+                    process.stdout.write(`${line}\n`);
+                }
+            }
         });
         child.stderr?.on('data', (chunk) => {
             stderr += String(chunk);
@@ -173,6 +186,49 @@ export function runCommand(command, args = [], options = {}) {
             resolve(returned);
         });
     });
+}
+
+function isCanonicalRunnerProgressLine(line) {
+    if (!line.startsWith(RUNNER_PROGRESS_LINE_PREFIX)) return false;
+
+    let envelope;
+    try {
+        envelope = JSON.parse(line.slice(RUNNER_PROGRESS_LINE_PREFIX.length));
+    } catch {
+        return false;
+    }
+
+    if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) return false;
+    if (Object.keys(envelope).some((field) => !RUNNER_PROGRESS_FIELDS.has(field))) return false;
+    if (envelope.schema !== RUNNER_PROGRESS_SCHEMA) return false;
+    if (!isValidProgressString(envelope.phase, 2048)) return false;
+    if (!isValidProgressString(envelope.current_item, 8192)) return false;
+    if (!isValidProgressCount(envelope.completed) || !isValidProgressCount(envelope.total)) return false;
+    if (
+        Number.isSafeInteger(envelope.completed)
+        && Number.isSafeInteger(envelope.total)
+        && envelope.completed > envelope.total
+    ) {
+        return false;
+    }
+
+    return envelope.phase !== undefined && envelope.phase !== null
+        || envelope.current_item !== undefined && envelope.current_item !== null
+        || envelope.completed !== undefined && envelope.completed !== null
+        || envelope.total !== undefined && envelope.total !== null
+        || envelope.metadata !== undefined && envelope.metadata !== null;
+}
+
+function isValidProgressString(value, maxBytes) {
+    return value === undefined
+        || value === null
+        || (typeof value === 'string' && value.trim() !== '' && Buffer.byteLength(value) <= maxBytes);
+}
+
+function isValidProgressCount(value) {
+    return value === undefined
+        || value === null
+        || (Number.isSafeInteger(value) && value >= 0);
 }
 
 export function runNode(args, options = {}) {

--- a/nodejs/scripts/bench/nodejs-workload-progress-forwarding-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-workload-progress-forwarding-smoke.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-workload-progress.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+RELEASE_FILE="$TMP_DIR/release"
+CAPTURE_FILE="$TMP_DIR/capture"
+FORWARDED_FILE="$TMP_DIR/forwarded"
+DRIVER_FILE="$TMP_DIR/driver.mjs"
+
+cat > "$DRIVER_FILE" <<'JS'
+import { writeFile } from 'node:fs/promises';
+
+const { runCommand } = await import(process.env.WORKLOAD_UTILS_UNDER_TEST);
+const prefix = 'HOMEBOY_RUNNER_PROGRESS ';
+const validOne = `${prefix}{"schema":"homeboy/runner-progress/v1","phase":"import","completed":1,"total":2}`;
+const validTwo = `${prefix}{"schema":"homeboy/runner-progress/v1","phase":"render","current_item":"home"}`;
+const malformed = `${prefix}{not-json}`;
+const invalid = `${prefix}{"schema":"homeboy/runner-progress/v1","phase":"done","status":"succeeded"}`;
+const empty = `${prefix}{"schema":"homeboy/runner-progress/v1","metadata":null}`;
+const partial = `${prefix}{"schema":"homeboy/runner-progress/v1","phase":"partial"}`;
+const expected = `ordinary before\n${validOne}\n${malformed}\n${invalid}\n${empty}\n${validTwo}\nordinary after\n${partial}`;
+const child = `
+  import { existsSync } from 'node:fs';
+  const chunks = ${JSON.stringify([
+    'ordinary before\nHOMEBOY_RUNNER_PRO',
+    'GRESS {"schema":"homeboy/runner-progress/v1","phase":"import","completed":1,"total":2}\nHOMEBOY_RUNNER_PROGRESS {not-json}\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"done","status":"succeeded"}\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","metadata":null}\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"render","current_item":"home"}\nordinary after\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"partial"}',
+  ])};
+  for (const chunk of chunks) process.stdout.write(chunk);
+  const wait = setInterval(() => {
+    if (existsSync(process.env.RELEASE_FILE)) clearInterval(wait);
+  }, 10);
+`;
+
+const result = await runCommand(process.execPath, ['--input-type=module', '--eval', child], {
+  env: { RELEASE_FILE: process.env.RELEASE_FILE },
+  redact: false,
+});
+await writeFile(process.env.CAPTURE_FILE, result.stdout);
+if (result.stdout !== expected) {
+  throw new Error(`captured stdout changed: ${JSON.stringify(result.stdout)}`);
+}
+JS
+
+WORKLOAD_UTILS_UNDER_TEST="$SCRIPT_DIR/lib/workload-utils.mjs" \
+RELEASE_FILE="$RELEASE_FILE" \
+CAPTURE_FILE="$CAPTURE_FILE" \
+    node "$DRIVER_FILE" >"$FORWARDED_FILE" &
+DRIVER_PID=$!
+
+for _ in $(seq 1 100); do
+    if [ -s "$FORWARDED_FILE" ]; then
+        break
+    fi
+    sleep 0.01
+done
+
+EXPECTED_FORWARDED=$'HOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"import","completed":1,"total":2}\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"render","current_item":"home"}'
+if [ "$(<"$FORWARDED_FILE")" != "$EXPECTED_FORWARDED" ]; then
+    echo "Expected only complete canonical progress before child exit:" >&2
+    cat "$FORWARDED_FILE" >&2
+    touch "$RELEASE_FILE"
+    wait "$DRIVER_PID" || true
+    exit 1
+fi
+
+touch "$RELEASE_FILE"
+wait "$DRIVER_PID"
+
+EXPECTED_CAPTURE=$'ordinary before\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"import","completed":1,"total":2}\nHOMEBOY_RUNNER_PROGRESS {not-json}\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"done","status":"succeeded"}\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","metadata":null}\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"render","current_item":"home"}\nordinary after\nHOMEBOY_RUNNER_PROGRESS {"schema":"homeboy/runner-progress/v1","phase":"partial"}'
+if [ "$(<"$CAPTURE_FILE")" != "$EXPECTED_CAPTURE" ]; then
+    echo "Captured stdout was not preserved exactly:" >&2
+    cat "$CAPTURE_FILE" >&2
+    exit 1
+fi
+
+echo "Node.js workload progress forwarding smoke passed."


### PR DESCRIPTION
## Summary
- forward complete, validated `HOMEBOY_RUNNER_PROGRESS ` envelopes from Node bench child commands immediately
- preserve child stdout exactly in the final captured result while ignoring malformed, ordinary, empty, and incomplete records for live forwarding
- add deterministic coverage for chunk boundaries, multiple records, pre-exit delivery, and capture compatibility

Closes #2231

## Testing
1. `for test in nodejs/scripts/bench/nodejs-*-smoke.sh; do bash "$test"; done`
2. `bash tests/nodejs-bench-metadata-smoke.sh`
3. `bash tests/nodejs-browser-bench-normalization-smoke.sh`
4. `shellcheck nodejs/scripts/bench/nodejs-workload-progress-forwarding-smoke.sh`
5. `node --check nodejs/scripts/bench/lib/workload-utils.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and openai/gpt-5.6-sol
- **Used for:** Collaboratively implemented the forwarding path, added deterministic test coverage, and ran the listed validation checks.