### PR TITLE
fix(wordpress): guard lint gate against corrupted phpstan.phar

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -204,6 +204,28 @@ if [ ! -f "$PHPSTAN_BIN" ]; then
     exit 0
 fi
 
+# Integrity guard (homeboy-extensions#2233): a corrupted/truncated phpstan.phar
+# makes Phar::loadPhar() throw a fatal ("manifest cannot be larger than 100 MB")
+# that kills the whole lint gate with an opaque PHP error instead of a clean
+# skip. Probing with `--version` is the cheapest check that loads the phar
+# manifest, so a failing probe means the binary is unusable. Returns 0 when the
+# binary starts and non-zero otherwise.
+homeboy_phpstan_probe() {
+    "$1" --version >/dev/null 2>&1
+}
+
+if ! homeboy_phpstan_probe "$PHPSTAN_BIN"; then
+    echo "Warning: PHPStan binary at $PHPSTAN_BIN failed to start (likely a corrupted phpstan.phar)."
+    echo "         Skipping PHPStan static analysis. Reinstall the wordpress extension"
+    echo "         (run \`composer install\` in the extension directory) to refresh the phar."
+    echo "         See homeboy-extensions#2233 for background."
+    exit 0
+fi
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: PHPStan probe ok: $("$PHPSTAN_BIN" --version 2>&1 | head -1)"
+fi
+
 if [ ! -f "$PHPSTAN_DEFAULT_CONFIG" ]; then
     echo "Warning: phpstan.neon.dist not found at $PHPSTAN_DEFAULT_CONFIG, skipping static analysis"
     exit 0

--- a/wordpress/tests/phpstan-integrity-guard-smoke.sh
+++ b/wordpress/tests/phpstan-integrity-guard-smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHPSTAN_RUNNER="${ROOT_DIR}/scripts/lint/phpstan-runner.sh"
+
+assert() {
+    local condition="$1"
+    local message="$2"
+    if ! eval "$condition"; then
+        echo "FAIL: ${message}" >&2
+        exit 1
+    fi
+}
+
+# The guard must exist in the runner: probe function, --version probe, and an
+# actionable skip message referencing the tracking issue.
+grep -q "homeboy_phpstan_probe" "$PHPSTAN_RUNNER"
+grep -q -- '--version' "$PHPSTAN_RUNNER"
+grep -q '#2233' "$PHPSTAN_RUNNER"
+grep -q "Reinstall the wordpress extension" "$PHPSTAN_RUNNER"
+
+# Extract and exercise the probe function in isolation, the same way
+# phpstan-temp-config-suffix-smoke.sh extracts homeboy_mktemp.
+function_body=$(awk '/^homeboy_phpstan_probe\(\)/,/^}$/' "$PHPSTAN_RUNNER")
+assert "[ -n \"\$function_body\" ]" "homeboy_phpstan_probe function should exist in runner"
+eval "$function_body"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Healthy binary (exit 0) → probe passes.
+healthy_bin="${tmpdir}/phpstan-ok"
+cat > "$healthy_bin" <<'SH'
+#!/usr/bin/env bash
+echo "PHPStan - PHP Static Analysis Tool 2.1.51"
+exit 0
+SH
+chmod +x "$healthy_bin"
+assert "homeboy_phpstan_probe \"\$healthy_bin\"" "probe should pass for a healthy phpstan binary"
+
+# Corrupted binary (non-zero exit, simulating the PharException fatal) → probe fails.
+broken_bin="${tmpdir}/phpstan-broken"
+cat > "$broken_bin" <<'SH'
+#!/usr/bin/env bash
+echo "PharException: manifest cannot be larger than 100 MB in phar" >&2
+exit 255
+SH
+chmod +x "$broken_bin"
+if homeboy_phpstan_probe "$broken_bin"; then
+    echo "FAIL: probe should fail for a corrupted phpstan binary" >&2
+    exit 1
+fi
+
+echo "phpstan integrity guard smoke passed"


### PR DESCRIPTION
Closes #2233

## Problem

Every `homeboy review <component> lint` run dies during the phpstan leg before analysis starts:

```
PHP Fatal error:  Uncaught PharException: manifest cannot be larger than 100 MB in phar ".../extensions/wordpress/vendor/phpstan/phpstan/phpstan.phar" (phpstan:6, Phar::loadPhar())
```

The phar on disk is ~26 MB, so the file is not actually oversized — this is the known PHP quirk where `Phar::loadPhar()` misreads the manifest from a corrupted/truncated phar. Because the lint gate treats this as a hard failure, the phpstan leg is permanently red and forces `--skip-checks=lint` on every release.

## Root cause (investigation)

- `wordpress/vendor/` is **gitignored** (`vendor/` in `wordpress/.gitignore`), so phpstan/phpstan is **not** committed to the repo — it is resolved at `composer install` time on the host.
- This means the corruption is **install-time on the host** (the VPS install at `/home/opencode/.config/homeboy/extensions/wordpress`), not something carried in git history. Re-vendoring in the repo would therefore not fix it — the next `composer install` on a flaky/hostile environment could reproduce it.
- The source phar is healthy: probing the worktree's vendored binary on PHP 8.4 returns a clean version:
  ```
  $ php vendor/phpstan/phpstan/phpstan --version
  PHPStan - PHP Static Analysis Tool 2.1.51
  ```
  Pinned version (composer.lock): `phpstan/phpstan` 2.1.51 (`^2.0` in composer.json).

## Fix

Add an **integrity guard** to `wordpress/scripts/lint/phpstan-runner.sh`, placed right after the existing "PHPStan not found" soft-skip check. Before any analysis run, it probes the binary with `--version` (the cheapest invocation that still triggers `Phar::loadPhar()` and loads the manifest). If the probe fails, PHPStan is **skipped cleanly** with an actionable message naming the reinstall path and the tracking issue — instead of crashing the whole gate with a raw PHP fatal.

This matches the codebase's existing soft-skip precedent:
- PHPStan binary missing → `exit 0` with a warning.
- Parallel-worker failure persisting after single-process retry → `exit 0` with a warning (#207).

A corrupted phar is the same class of problem (PHPStan unavailable through no fault of the code under analysis), so it gets the same treatment.

The probe is factored as `homeboy_phpstan_probe()` so it can be exercised in isolation by the smoke test (mirroring how `phpstan-temp-config-suffix-smoke.sh` extracts `homeboy_mktemp`).

## Verification

```
$ bash -n scripts/lint/phpstan-runner.sh && echo OK
OK
$ bash -n tests/phpstan-integrity-guard-smoke.sh && echo OK
OK
$ bash tests/phpstan-integrity-guard-smoke.sh
phpstan integrity guard smoke passed
$ php vendor/phpstan/phpstan/phpstan --version   # source phar is healthy
PHPStan - PHP Static Analysis Tool 2.1.51
```

The smoke test asserts the guard is present in the runner and exercises the extracted `homeboy_phpstan_probe()` against a healthy fake binary (probe passes) and a corrupted fake binary that mimics the `PharException` fatal (probe fails).

## Notes

- No CHANGELOG/version bump (homeboy owns those).
- The smoke test follows the precedent of the sibling phpstan smoke tests (`phpstan-temp-config-suffix-smoke.sh`, `phpstan-wordpress-api-stubs-smoke.sh`) — placed under `tests/`, not registered in `homeboy.json`, auto-discovered by the glob test runner.
- Follow-up (not in scope here): a checksum guard at extension install time would catch phar corruption before any lint run, as suggested in the issue.