### PR TITLE
fix(wordpress): resolve PHPStan dependency paths from component

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -1071,8 +1071,15 @@ _homeboy_report_resolved_dependency() {
 
 homeboy_resolve_validation_dependency_path() {
     local dependency="${1:-}"
+    local direct_path="$dependency"
 
     [ -z "$dependency" ] && return 1
+
+    # Settings are component configuration. Resolve relative paths from that
+    # component rather than the runner's transient working directory.
+    if [[ "$direct_path" != /* ]] && [ -n "${_HOMEBOY_DEP_PLUGIN_PATH:-}" ]; then
+        direct_path="${_HOMEBOY_DEP_PLUGIN_PATH%/}/${direct_path#./}"
+    fi
 
     local lab_mapped
     lab_mapped=$(_homeboy_resolve_lab_mapped_dependency_path "$dependency" || true)
@@ -1081,13 +1088,27 @@ homeboy_resolve_validation_dependency_path() {
         return 0
     fi
 
-    # 1. Direct path (absolute or relative directory)
-    if [ -d "$dependency" ]; then
-        _homeboy_report_resolved_dependency "$dependency" "direct path" "$dependency"
-        _homeboy_warn_if_dependency_stale "$dependency" "$dependency"
-        printf '%s\n' "$dependency"
+    # 1. Direct path. Relative settings paths are anchored to the component
+    # workspace, then canonicalized before callers embed them in generated
+    # config files that may live outside that workspace.
+    if [ -d "$direct_path" ]; then
+        direct_path=$(cd "$direct_path" && pwd -P)
+        _homeboy_report_resolved_dependency "$dependency" "direct path" "$direct_path"
+        _homeboy_warn_if_dependency_stale "$dependency" "$direct_path"
+        printf '%s\n' "$direct_path"
         return 0
     fi
+
+    # An explicitly relative or absolute path is not a dependency slug. Return
+    # its component-rooted location so the consuming validation tool can report
+    # the missing path instead of silently treating a configuration typo as an
+    # unresolved plugin name.
+    case "$dependency" in
+        /*|./*|../*)
+            printf '%s\n' "$direct_path"
+            return 0
+            ;;
+    esac
 
     # 2. Prefer the consumer's Composer-locked plugin package when available.
     # This keeps validation aligned with the dependency ref the component actually

--- a/wordpress/tests/phpstan-relative-dependency-path-smoke.sh
+++ b/wordpress/tests/phpstan-relative-dependency-path-smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHPSTAN_RUNNER="${ROOT_DIR}/scripts/lint/phpstan-runner.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+COMPONENT_DIR="${TMP_ROOT}/component"
+CONFIG_TMPDIR="${TMP_ROOT}/generated-config"
+OUTPUT_FILE="${TMP_ROOT}/phpstan-output.txt"
+RESOLVE_CONTEXT_HELPER="${TMP_ROOT}/resolve-context.sh"
+SIDECAR_WRITER_HELPER="${TMP_ROOT}/sidecar-writer.sh"
+
+mkdir -p "${COMPONENT_DIR}/bbpress" "$CONFIG_TMPDIR"
+
+cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
+homeboy_resolve_context() {
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+    COMPONENT_PATH="$HOMEBOY_COMPONENT_PATH"
+    PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+    COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-phpstan-relative-dependency-path}"
+}
+SH
+
+cat > "$SIDECAR_WRITER_HELPER" <<'SH'
+homeboy_sidecar_merge_json_array() {
+    return 0
+}
+SH
+
+cat > "${COMPONENT_DIR}/plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: PHPStan Relative Dependency Fixture
+ */
+PHP
+
+cat > "${COMPONENT_DIR}/bbpress/bbpress.php" <<'PHP'
+<?php
+
+class PHPStan_Relative_Dependency_Fixture {}
+PHP
+
+if [ ! -x "${ROOT_DIR}/vendor/bin/phpstan" ]; then
+    echo "FAIL: PHPStan is not installed. Run composer install in ${ROOT_DIR}." >&2
+    exit 1
+fi
+
+set +e
+HOMEBOY_EXTENSION_PATH="$ROOT_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="phpstan-relative-dependency-path" \
+HOMEBOY_SETTINGS_JSON='{"validation_dependencies":"bbpress"}' \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_PHPSTAN_THREADS=1 \
+TMPDIR="$CONFIG_TMPDIR" \
+"$PHPSTAN_RUNNER" >"$OUTPUT_FILE" 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+    echo "FAIL: component-relative dependency path should be resolved from the workspace" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if grep -F "${CONFIG_TMPDIR}/bbpress" "$OUTPUT_FILE" >/dev/null; then
+    echo "FAIL: generated PHPStan config resolved bbpress from its temp directory" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+set +e
+HOMEBOY_EXTENSION_PATH="$ROOT_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="phpstan-relative-dependency-path" \
+HOMEBOY_SETTINGS_JSON='{"validation_dependencies":"./missing-bbpress"}' \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_PHPSTAN_THREADS=1 \
+TMPDIR="$CONFIG_TMPDIR" \
+"$PHPSTAN_RUNNER" >"$OUTPUT_FILE" 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -eq 0 ]; then
+    echo "FAIL: explicitly missing component-relative dependency should fail PHPStan" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if ! grep -F "${COMPONENT_DIR}/missing-bbpress" "$OUTPUT_FILE" >/dev/null; then
+    echo "FAIL: missing dependency error should name the component-rooted path" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if grep -F "${CONFIG_TMPDIR}/missing-bbpress" "$OUTPUT_FILE" >/dev/null; then
+    echo "FAIL: missing dependency error should not name the generated config directory" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+echo "PHPStan relative dependency path smoke passed"


### PR DESCRIPTION
Closes #2237

## Root Cause
The PHPStan dependency config is generated under `/tmp`, but validation dependency paths such as `bbpress` were emitted relative. PHPStan resolved that `scanDirectories` entry relative to the generated config, producing `/tmp/bbpress` instead of the component workspace path.

## Before / After
Before, configured relative dependency paths depended on the runner CWD and were written unchanged into the temporary PHPStan config.

After, relative paths are resolved from the component workspace and canonicalized before configuration generation. Explicit missing relative or absolute paths now remain component-rooted so PHPStan reports the actionable missing path.

## Tests
- `bash wordpress/tests/phpstan-relative-dependency-path-smoke.sh`
- `bash wordpress/tests/phpstan-integrity-guard-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `bash wordpress/scripts/lint/phpcs-warnings-gate-smoke.sh`

`wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh` is currently blocked by its existing dependency on an adjacent Homeboy core checkout; tracked separately in #2238.