### PR TITLE
fix(wordpress): support recursive package artifacts

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -304,17 +304,27 @@ artifacts inside the deployed plugin or theme can declare explicit include globs
 	"extensions": {
 		"wordpress": {
 			"package_artifacts": [
-				"runtime/studio-web-sandbox/packages/*.zip"
+				"runtime/**/packages/*.zip"
+			],
+			"package_excludes": [
+				"/playground-runtime/",
+				"runtime/**/source-maps/"
 			]
 		}
 	}
 }
 ```
 
-Each pattern is component-relative, must not contain `..`, and must match at
-least one file. Included package artifacts are copied into the staging directory
-after the default rsync excludes and reported with SHA-256 values in the build
-output.
+`package_artifacts` patterns are component-relative, support recursive `**`
+matching, must not contain absolute or traversal paths, and must match at least
+one regular file. Matching files are sorted, deduplicated, copied into staging
+after the default rsync excludes, and reported with SHA-256 values in the build
+output. The managed `.homeboy-build/` staging directory is never eligible.
+
+`package_excludes` adds rsync exclusions without replacing `.buildignore`, the
+defaults, or mandatory Homeboy safety exclusions. Use component-root rsync
+patterns such as `/playground-runtime/` to exclude a root directory. Exclude
+patterns are strings and cannot traverse outside the component.
 
 ### Local workspace dependency overrides
 

--- a/wordpress/scripts/build/build-package-artifacts-smoke.sh
+++ b/wordpress/scripts/build/build-package-artifacts-smoke.sh
@@ -30,7 +30,8 @@ assert_zip_not_contains() {
 }
 
 component_dir="${TMP_DIR}/package-artifact-plugin"
-mkdir -p "${component_dir}/runtime/packages" "${component_dir}/includes"
+mkdir -p "${component_dir}/runtime/packages" "${component_dir}/runtime/nested/packages" "${component_dir}/runtime/omit" "${component_dir}/includes"
+mkdir -p "${component_dir}/.git"
 
 cat > "${component_dir}/package-artifact-plugin.php" <<'PHP'
 <?php
@@ -43,6 +44,10 @@ PHP
 printf '%s\n' '<?php' > "${component_dir}/includes/bootstrap.php"
 printf '%s\n' 'accidental release zip' > "${component_dir}/accidental.zip"
 printf '%s\n' 'intentional package zip' > "${component_dir}/runtime/packages/static-site-importer.zip"
+printf '%s\n' 'nested package zip' > "${component_dir}/runtime/nested/packages/nested.zip"
+printf '%s\n' 'excluded runtime source' > "${component_dir}/runtime/omit/source.txt"
+printf '%s\n' 'ref: refs/heads/main' > "${component_dir}/.git/HEAD"
+ln -s "${component_dir}/runtime/packages/static-site-importer.zip" "${component_dir}/runtime/packages/linked.zip"
 
 (
     cd "$component_dir"
@@ -57,6 +62,7 @@ default_zip="${component_dir}/build/package-artifact-plugin.zip"
 assert_zip_contains "$default_zip" "package-artifact-plugin/package-artifact-plugin.php"
 assert_zip_not_contains "$default_zip" "package-artifact-plugin/accidental.zip"
 assert_zip_not_contains "$default_zip" "package-artifact-plugin/runtime/packages/static-site-importer.zip"
+assert_zip_not_contains "$default_zip" "package-artifact-plugin/.git/HEAD"
 
 (
     cd "$component_dir"
@@ -64,13 +70,16 @@ assert_zip_not_contains "$default_zip" "package-artifact-plugin/runtime/packages
     HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_CORE_HELPER" \
     HOMEBOY_SKIP_TESTS=1 \
-    HOMEBOY_SETTINGS_JSON='{"package_artifacts":["runtime/packages/*.zip"]}' \
+    HOMEBOY_SETTINGS_JSON='{"package_artifacts":["runtime/**/packages/*.zip","runtime/packages/*.zip"],"package_excludes":["/runtime/omit/"]}' \
         bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/included-build.out"
 )
 
 included_zip="${component_dir}/build/package-artifact-plugin.zip"
 assert_zip_contains "$included_zip" "package-artifact-plugin/runtime/packages/static-site-importer.zip"
+assert_zip_contains "$included_zip" "package-artifact-plugin/runtime/nested/packages/nested.zip"
 assert_zip_not_contains "$included_zip" "package-artifact-plugin/accidental.zip"
+assert_zip_not_contains "$included_zip" "package-artifact-plugin/runtime/omit/source.txt"
+assert_zip_not_contains "$included_zip" "package-artifact-plugin/runtime/packages/linked.zip"
 
 if ! grep -Fq '"type":"wordpress.package_artifacts"' "${TMP_DIR}/included-build.out"; then
     echo "Expected structured package artifact output" >&2
@@ -90,6 +99,27 @@ if ! grep -Eq '"sha256":"[0-9a-f]{64}"' "${TMP_DIR}/included-build.out"; then
     exit 1
 fi
 
+if [ "$(grep -Fc '"path":"runtime/packages/static-site-importer.zip"' "${TMP_DIR}/included-build.out")" -ne 1 ]; then
+    echo "Expected duplicate artifact patterns to emit one manifest entry" >&2
+    sed 's/^/  /' "${TMP_DIR}/included-build.out" >&2
+    exit 1
+fi
+
+mkdir -p "${component_dir}/.homeboy-build/stale/packages"
+printf '%s\n' 'stale staging zip' > "${component_dir}/.homeboy-build/stale/packages/stale.zip"
+(
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_CORE_HELPER" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_SETTINGS_JSON='{"package_artifacts":["**/*.zip"]}' \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/staging-build.out"
+)
+
+staging_zip="${component_dir}/build/package-artifact-plugin.zip"
+assert_zip_not_contains "$staging_zip" "package-artifact-plugin/.homeboy-build/stale/packages/stale.zip"
+
 if (
     cd "$component_dir"
     HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
@@ -107,6 +137,82 @@ fi
 if ! grep -Fq 'Declared WordPress package artifact pattern matched no files: runtime/missing/*.zip' "${TMP_DIR}/missing-build.out"; then
     echo "Expected missing artifact error" >&2
     sed 's/^/  /' "${TMP_DIR}/missing-build.out" >&2
+    exit 1
+fi
+
+if (
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_CORE_HELPER" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_SETTINGS_JSON='{"package_artifacts":["../outside/*.zip"]}' \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/traversal-build.out" 2>&1
+); then
+    echo "Expected traversal artifact pattern to fail" >&2
+    exit 1
+fi
+
+if ! grep -Fq "cannot contain '..'" "${TMP_DIR}/traversal-build.out"; then
+    echo "Expected traversal artifact error" >&2
+    sed 's/^/  /' "${TMP_DIR}/traversal-build.out" >&2
+    exit 1
+fi
+
+if (
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_CORE_HELPER" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_SETTINGS_JSON='{"package_artifacts":["/tmp/*.zip"]}' \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/absolute-build.out" 2>&1
+); then
+    echo "Expected absolute artifact pattern to fail" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'must be component-relative' "${TMP_DIR}/absolute-build.out"; then
+    echo "Expected absolute artifact error" >&2
+    sed 's/^/  /' "${TMP_DIR}/absolute-build.out" >&2
+    exit 1
+fi
+
+if (
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_CORE_HELPER" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_SETTINGS_JSON='{"package_excludes":["../outside/"]}' \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/exclude-traversal-build.out" 2>&1
+); then
+    echo "Expected traversal package exclude to fail" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'Package excludes cannot contain traversal' "${TMP_DIR}/exclude-traversal-build.out"; then
+    echo "Expected traversal package exclude error" >&2
+    sed 's/^/  /' "${TMP_DIR}/exclude-traversal-build.out" >&2
+    exit 1
+fi
+
+if (
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_CORE_HELPER" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_SETTINGS_JSON='{"package_excludes":[42]}' \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/exclude-type-build.out" 2>&1
+); then
+    echo "Expected non-string package exclude to fail" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'package_excludes entries must be non-empty strings' "${TMP_DIR}/exclude-type-build.out"; then
+    echo "Expected package exclude type error" >&2
+    sed 's/^/  /' "${TMP_DIR}/exclude-type-build.out" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -674,8 +674,41 @@ webpack.config.js
 EOF
     fi
 
+    HOMEBOY_WORDPRESS_PACKAGE_EXCLUDES_FILE="$exclude_file" \
+    php <<'PHP'
+<?php
+$settings = json_decode( getenv( 'HOMEBOY_SETTINGS_JSON' ) ?: '{}', true );
+if ( ! is_array( $settings ) ) {
+	fwrite( STDERR, "Invalid HOMEBOY_SETTINGS_JSON; expected a JSON object.\n" );
+	exit( 1 );
+}
+
+$patterns = $settings['package_excludes'] ?? [];
+if ( ! is_array( $patterns ) ) {
+	fwrite( STDERR, "extensions.wordpress.package_excludes must be an array of rsync exclude patterns.\n" );
+	exit( 1 );
+}
+
+$exclude_file = getenv( 'HOMEBOY_WORDPRESS_PACKAGE_EXCLUDES_FILE' );
+foreach ( $patterns as $pattern ) {
+	if ( ! is_string( $pattern ) || '' === trim( $pattern ) ) {
+		fwrite( STDERR, "extensions.wordpress.package_excludes entries must be non-empty strings.\n" );
+		exit( 1 );
+	}
+
+	$normalized = str_replace( '\\', '/', $pattern );
+	if ( preg_match( '#(^|/)\.\.(/|$)#', $normalized ) || str_starts_with( $normalized, '//' ) || preg_match( '#^[A-Za-z]:/#', $normalized ) ) {
+		fwrite( STDERR, "Package excludes cannot contain traversal or filesystem-absolute paths: {$pattern}\n" );
+		exit( 1 );
+	}
+
+	// A single leading slash is an rsync root anchor, relative to the component.
+	file_put_contents( $exclude_file, $normalized . "\n", FILE_APPEND );
+}
+PHP
+
     # Homeboy-managed staging must never be copied into itself. Keep this
-    # mandatory even when a project supplies a custom .buildignore.
+    # mandatory even when a project supplies custom .buildignore or excludes.
     cat >> "$exclude_file" << 'EOF'
 /.homeboy-build/
 EOF
@@ -707,9 +740,55 @@ if ( ! is_array( $patterns ) ) {
 	exit( 1 );
 }
 
-$artifacts = [];
-$seen      = [];
-$list      = '';
+$matches_by_path = [];
+
+function package_artifact_matches( $pattern ) {
+	if ( ! str_contains( $pattern, '**' ) ) {
+		return glob( $pattern, GLOB_BRACE ) ?: [];
+	}
+
+	$regex = '';
+	$length = strlen( $pattern );
+	for ( $index = 0; $index < $length; $index++ ) {
+		$character = $pattern[ $index ];
+		if ( '*' === $character && '*' === ( $pattern[ $index + 1 ] ?? '' ) ) {
+			$index++;
+			if ( '/' === ( $pattern[ $index + 1 ] ?? '' ) ) {
+				$index++;
+				$regex .= '(?:.*/)?';
+			} else {
+				$regex .= '.*';
+			}
+			continue;
+		}
+		if ( '*' === $character ) {
+			$regex .= '[^/]*';
+			continue;
+		}
+		if ( '?' === $character ) {
+			$regex .= '[^/]';
+			continue;
+		}
+		$regex .= preg_quote( $character, '#' );
+	}
+
+	$matches  = [];
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( '.', FilesystemIterator::SKIP_DOTS )
+	);
+	foreach ( $iterator as $file ) {
+		$relative = str_replace( '\\', '/', $file->getPathname() );
+		$relative = preg_replace( '#^\./#', '', $relative );
+		if ( preg_match( '#^\.homeboy-build(?:/|$)#', $relative ) ) {
+			continue;
+		}
+		if ( preg_match( '#^' . $regex . '$#', $relative ) ) {
+			$matches[] = $relative;
+		}
+	}
+
+	return $matches;
+}
 
 foreach ( $patterns as $pattern ) {
 	if ( ! is_string( $pattern ) || '' === $pattern ) {
@@ -718,18 +797,21 @@ foreach ( $patterns as $pattern ) {
 	}
 
 	$normalized = str_replace( '\\', '/', $pattern );
-	if ( str_starts_with( $normalized, '/' ) || preg_match( '#(^|/)\.\.(/|$)#', $normalized ) ) {
+	if ( str_starts_with( $normalized, '/' ) || preg_match( '#^[A-Za-z]:/#', $normalized ) || preg_match( '#(^|/)\.\.(/|$)#', $normalized ) ) {
 		fwrite( STDERR, "Package artifact patterns must be component-relative and cannot contain '..': {$pattern}\n" );
 		exit( 1 );
 	}
 
-	$matches = glob( $pattern, GLOB_BRACE ) ?: [];
+	$matches = package_artifact_matches( $normalized );
 	$files   = [];
 	foreach ( $matches as $match ) {
-		if ( is_file( $match ) ) {
+		if ( is_file( $match ) && ! is_link( $match ) ) {
 			$relative = str_replace( '\\', '/', $match );
 			if ( str_starts_with( $relative, './' ) ) {
 				$relative = substr( $relative, 2 );
+			}
+			if ( preg_match( '#^\.homeboy-build(?:/|$)#', $relative ) ) {
+				continue;
 			}
 			$files[]  = $relative;
 		}
@@ -740,20 +822,22 @@ foreach ( $patterns as $pattern ) {
 		exit( 1 );
 	}
 
-	sort( $files );
 	foreach ( $files as $relative ) {
-		if ( isset( $seen[ $relative ] ) ) {
-			continue;
-		}
-		$seen[ $relative ] = true;
-		$sha256            = hash_file( 'sha256', $relative ) ?: '';
-		$artifacts[]       = [
-			'path'    => $relative,
-			'sha256'  => $sha256,
-			'pattern' => $pattern,
-		];
-		$list .= $relative . "\t" . $sha256 . "\n";
+		$matches_by_path[ $relative ] ??= $pattern;
 	}
+}
+
+ksort( $matches_by_path, SORT_STRING );
+$artifacts = [];
+$list      = '';
+foreach ( $matches_by_path as $relative => $pattern ) {
+	$sha256      = hash_file( 'sha256', $relative ) ?: '';
+	$artifacts[] = [
+		'path'    => $relative,
+		'sha256'  => $sha256,
+		'pattern' => $pattern,
+	];
+	$list .= $relative . "\t" . $sha256 . "\n";
 }
 
 $manifest = [

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -15,6 +15,10 @@ assert.ok(
 	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
 );
 
+for (const settingId of ['package_artifacts', 'package_excludes']) {
+	assert.ok(settingIds.has(settingId), `wordpress manifest declares ${settingId}`);
+}
+
 const fuzzEnv = new Set(manifest.fuzz.env);
 for (const envKey of ['HOMEBOY_SETTINGS_JSON', 'HOMEBOY_SETTINGS_WP_CODEBOX_BIN', 'HOMEBOY_WP_CODEBOX_BIN', 'WP_CODEBOX_BIN']) {
 	assert.ok(

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1372,7 +1372,14 @@
       "label": "WordPress package artifacts",
       "type": "array",
       "default": [],
-      "description": "Component-relative glob patterns for intentional package ZIP artifacts that should be included in the production build even though arbitrary *.zip files are excluded by default. Each declared pattern must match at least one file."
+      "description": "Component-relative glob patterns for intentional package ZIP artifacts that should be included in the production build even though arbitrary *.zip files are excluded by default. Supports recursive ** matching at any depth. Each declared pattern must match at least one regular file; absolute and traversal paths are rejected."
+    },
+    {
+      "id": "package_excludes",
+      "label": "WordPress package excludes",
+      "type": "array",
+      "default": [],
+      "description": "Additional rsync exclude patterns applied with .buildignore/default excludes before Homeboy mandatory safety exclusions. Strings are required. Component-root rsync patterns such as /playground-runtime/ are supported; traversal and filesystem-absolute paths are rejected."
     },
     {
       "id": "local_workspace_dependencies",


### PR DESCRIPTION
Closes #2246\n\n## Design\n- Resolves package_artifacts with deterministic recursive ** matching, sorted deduplication, regular-file-only selection, fail-closed pattern matching, and SHA-256 evidence.\n- Adds additive package_excludes validation and rsync layering while retaining .buildignore, defaults, and mandatory .homeboy-build exclusion.\n- Documents both settings with component-relative and root-anchored rsync examples.\n\n## How to test\n1. Clone the repository and check out this branch.\n2. From wordpress, run bash scripts/build/build-package-artifacts-smoke.sh.\n3. From wordpress, run npm run test:wordpress-manifest-settings.\n4. From the repository root, run bash tests/wordpress-build-staging-syntax-smoke.sh.\n5. From wordpress, run bash tests/release-scripts-smoke.sh.\n\n## Compatibility impact\nExisting package_artifacts globs and .buildignore behavior remain supported. Recursive ** patterns and package_excludes are additive. Artifact selection now rejects symlinks and staging files, preventing unsafe package contents.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenCode/openai/gpt-5.6-sol\n- **Used for:** Implemented the WordPress build contract, tests, and documentation; Chris reviews and owns the change.