### PR TITLE
Allow standalone Node bench workloads without package metadata

### DIFF
--- a/nodejs/scripts/bench/bench-runner.sh
+++ b/nodejs/scripts/bench/bench-runner.sh
@@ -29,7 +29,37 @@ source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
 # shellcheck source=../lib/node-helpers.sh
 source "${BENCH_SCRIPT_DIR}/../lib/node-helpers.sh"
-homeboy_require_package_json
+
+homeboy_require_standalone_bench_workloads() {
+    local workloads="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
+    local workload
+    local workload_path
+    local -a standalone_workloads
+
+    IFS=':' read -r -a standalone_workloads <<< "$workloads"
+    for workload in "${standalone_workloads[@]}"; do
+        [ -n "$workload" ] || continue
+        workload_path="$workload"
+        if [[ "$workload_path" != /* ]]; then
+            workload_path="${PROJECT_PATH}/${workload_path}"
+        fi
+        if [[ "$workload_path" != *.mjs ]] || [ ! -f "$workload_path" ] || [ ! -r "$workload_path" ]; then
+            echo "Error: standalone Node.js bench workload must be a readable .mjs file: ${workload_path}" >&2
+            return 1
+        fi
+    done
+}
+
+# A rig can provide a standalone .mjs benchmark for a component that is not a
+# package, even when an ancestor belongs to an unrelated package. Ordinary
+# package-backed runs retain upward package discovery.
+if [ -f "${PROJECT_PATH}/package.json" ]; then
+    homeboy_require_package_json
+elif [ -n "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ]; then
+    homeboy_require_standalone_bench_workloads
+else
+    homeboy_require_package_json
+fi
 
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:?Homeboy core must provide HOMEBOY_RUNTIME_BENCH_HELPER_SH}"

--- a/nodejs/scripts/bench/nodejs-standalone-workload-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-standalone-workload-smoke.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-standalone-workload.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/helpers" "$TMP_DIR/bin"
+
+cat > "$TMP_DIR/helpers/preflight.sh" <<'EOF'
+homeboy_require_bash_version() { :; }
+EOF
+
+cat > "$TMP_DIR/helpers/resolve-context.sh" <<'EOF'
+homeboy_resolve_context() {
+    PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+    COMPONENT_ID="$HOMEBOY_COMPONENT_ID"
+}
+EOF
+
+cat > "$TMP_DIR/helpers/bench.sh" <<'EOF'
+homeboy_write_empty_bench_results() {
+    printf '{"component_id":"%s","iterations":%s,"scenarios":[]}' "$1" "$2" > "$3"
+}
+EOF
+
+cat > "$TMP_DIR/helpers/bench.mjs" <<'EOF'
+import { basename } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+
+export function homeboyBenchPercentile(values) {
+  return values[0] || 0;
+}
+
+export function homeboyBenchScenarioId(file, suffixPattern) {
+  return basename(file).replace(suffixPattern, '');
+}
+
+export async function homeboyWriteBenchResults(file, componentId, iterations, scenarios) {
+  await writeFile(file, JSON.stringify({ component_id: componentId, iterations, scenarios }));
+}
+EOF
+
+cat > "$TMP_DIR/bin/tsx" <<'EOF'
+#!/usr/bin/env bash
+exec node "$@"
+EOF
+chmod +x "$TMP_DIR/bin/tsx"
+
+run_bench() {
+    HOMEBOY_RUNTIME_BASH_PREFLIGHT="$TMP_DIR/helpers/preflight.sh" \
+        HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$TMP_DIR/helpers/resolve-context.sh" \
+        HOMEBOY_RUNTIME_BENCH_HELPER_SH="$TMP_DIR/helpers/bench.sh" \
+        HOMEBOY_RUNTIME_BENCH_HELPER_JS="$TMP_DIR/helpers/bench.mjs" \
+        HOMEBOY_COMPONENT_ID="standalone-workload-smoke" \
+        HOMEBOY_BENCH_ITERATIONS=1 \
+        HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
+        HOMEBOY_BENCH_RESULTS_FILE="$1" \
+        PATH="$TMP_DIR/bin:$PATH" \
+        bash "$SCRIPT_DIR/bench-runner.sh"
+}
+
+ANCESTOR_PACKAGE_DIR="$TMP_DIR/ancestor-package"
+PROJECT_DIR="$ANCESTOR_PACKAGE_DIR/standalone-project"
+mkdir -p "$PROJECT_DIR"
+printf '{"name":"unrelated-ancestor-package"}\n' > "$ANCESTOR_PACKAGE_DIR/package.json"
+cat > "$PROJECT_DIR/standalone.mjs" <<'EOF'
+export default async function () {
+  return { metrics: { standalone_runs: 1 } };
+}
+EOF
+
+RESULTS_FILE="$TMP_DIR/standalone-results.json"
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_BENCH_EXTRA_WORKLOADS="standalone.mjs" \
+    run_bench "$RESULTS_FILE" >/dev/null
+node -e '
+const fs = require("fs");
+const result = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (result.scenarios.length !== 1) throw new Error("standalone workload was not discovered");
+if (result.scenarios[0].metrics.standalone_runs !== 1) throw new Error("standalone workload was not executed");
+' "$RESULTS_FILE"
+
+ANCESTOR_PACKAGE_RESULTS="$TMP_DIR/ancestor-package-results.json"
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" run_bench "$ANCESTOR_PACKAGE_RESULTS" >/dev/null
+node -e '
+const fs = require("fs");
+const result = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (result.scenarios.length !== 0) throw new Error("ordinary package mode should use the ancestor package");
+' "$ANCESTOR_PACKAGE_RESULTS"
+
+chmod 000 "$PROJECT_DIR/standalone.mjs"
+set +e
+UNREADABLE_OUTPUT="$(HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" HOMEBOY_BENCH_EXTRA_WORKLOADS="standalone.mjs" run_bench "$TMP_DIR/unreadable-results.json" 2>&1)"
+UNREADABLE_EXIT=$?
+set -e
+chmod 644 "$PROJECT_DIR/standalone.mjs"
+if [ "$UNREADABLE_EXIT" -eq 0 ]; then
+    echo "expected unreadable standalone workload to fail" >&2
+    exit 1
+fi
+if [[ "$UNREADABLE_OUTPUT" != *'standalone Node.js bench workload must be a readable .mjs file'* ]]; then
+    echo "expected standalone workload validation error" >&2
+    echo "$UNREADABLE_OUTPUT" >&2
+    exit 1
+fi
+
+UNPACKAGED_PROJECT_DIR="$TMP_DIR/unpackaged-project"
+mkdir -p "$UNPACKAGED_PROJECT_DIR"
+set +e
+PACKAGE_OUTPUT="$(HOMEBOY_COMPONENT_PATH="$UNPACKAGED_PROJECT_DIR" run_bench "$TMP_DIR/package-results.json" 2>&1)"
+PACKAGE_EXIT=$?
+set -e
+if [ "$PACKAGE_EXIT" -eq 0 ]; then
+    echo "expected package validation to fail without a package.json" >&2
+    exit 1
+fi
+if [[ "$PACKAGE_OUTPUT" != *'Not a nodejs project -- cannot run.'* ]]; then
+    echo "expected existing package validation error" >&2
+    echo "$PACKAGE_OUTPUT" >&2
+    exit 1
+fi
+
+printf '{"name":"package-backed-bench-smoke"}\n' > "$UNPACKAGED_PROJECT_DIR/package.json"
+PACKAGE_RESULTS="$TMP_DIR/package-backed-results.json"
+HOMEBOY_COMPONENT_PATH="$UNPACKAGED_PROJECT_DIR" run_bench "$PACKAGE_RESULTS" >/dev/null
+node -e '
+const fs = require("fs");
+const result = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (result.scenarios.length !== 0) throw new Error("package-backed run should preserve empty-workload behavior");
+' "$PACKAGE_RESULTS"
+
+echo "Node.js standalone workload smoke passed."


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `homeboy-extensions-2248-recovery` into review-ready branch `fix/2248-standalone-node-bench`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:homeboy-extensions-2248-recovery`
- **Homeboy run ID:** `homeboy-extensions-2248-recovery`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/2248-standalone-node-bench`

## Source refs
- https://github.com/Extra-Chill/homeboy-extensions/issues/2248

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Package validation is bypassed only for explicit readable standalone .mjs workloads when the component root is not itself a package.
- **Evidence discriminators preserved:** explicit standalone .mjs workload with no component-root package.json
- **Nearby contracts preserved:** ordinary package-backed workloads retain upward package discovery and validation

## Attempt summary
Control-plane recovery candidate corrected after independent review and verified through extension smoke contracts.

## Gate results
- standalone-workload: passed (targeted)
- package-mode: passed (targeted)
- independent-review: passed (targeted)

## Verification capability
- `targeted_checks_run`: `bash nodejs/scripts/bench/nodejs-standalone-workload-smoke.sh`, `bash nodejs/scripts/bench/nodejs-bench-workload-context-smoke.sh`, `bash nodejs/scripts/bench/nodejs-bench-warmup-smoke.sh`, `shellcheck -x -e SC1091,SC2034 nodejs/scripts/bench/bench-runner.sh nodejs/scripts/bench/nodejs-standalone-workload-smoke.sh`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- nodejs/scripts/bench/bench-runner.sh
- nodejs/scripts/bench/nodejs-standalone-workload-smoke.sh

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/2248-standalone-node-bench`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Root-caused and implemented generic standalone Node bench support with deterministic smoke coverage.
