### PR TITLE
Add an extension-owned Playwright browser utility

### DIFF
--- a/nodejs/docs/browser-bench-helpers.md
+++ b/nodejs/docs/browser-bench-helpers.md
@@ -3,6 +3,43 @@
 Browser benchmark workloads can import the helper path exported by
 `HOMEBOY_NODEJS_BROWSER_BENCH_HELPER`.
 
+## Extension-Owned Playwright
+
+The Node.js extension owns a pinned Playwright package and its Chromium setup.
+Install or inspect it through the extension actions:
+
+```sh
+homeboy extension action nodejs browser.playwright.setup
+homeboy extension action nodejs browser.playwright.status
+```
+
+The utility stores JavaScript dependencies under the runner cache and lets
+Playwright use its normal runner-wide browser cache. It never installs into a
+project workspace. Browser modules can run without project `node_modules`:
+
+```sh
+homeboy extension action nodejs browser.playwright.execute --data '[{"module":"/absolute/scripts/capture.mjs","args":[]}]'
+```
+
+The module can use `import { chromium } from 'playwright'` or CommonJS
+`require('playwright')`. This explicit utility always resolves the pinned
+extension runtime so its package and Chromium revisions remain paired.
+Project-local Playwright workflows outside this utility are unchanged. Pass
+module arguments after the module path when invoking the wrapper script
+directly: `playwright.sh execute scripts/capture.mjs --target https://example.test/`.
+
+Node.js `>=20.6.0` is required because the wrapper uses `node:module`
+`register()`. The utility verifies that its runtime directory is same-UID,
+non-symlinked, and private before use. This is a same-UID runner trust boundary;
+it does not isolate code that can already run as that user.
+
+For Lab or CI integration coverage, run the real browser check after setup:
+
+```sh
+homeboy extension action nodejs browser.playwright.setup
+HOMEBOY_RUN_PLAYWRIGHT_INTEGRATION=1 bash nodejs/scripts/bench/nodejs-browser-helper-smoke.sh
+```
+
 ```js
 const { buildBrowserBenchResult, runBrowserPageScenario } = await import(process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER);
 

--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -1,12 +1,12 @@
 {
   "name": "Node.js",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "icon": "server.rack",
   "description": "Node.js project type — discovery, audit grammar, and npm release lifecycle",
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["js", "jsx", "ts", "tsx", "mjs", "cjs", "json"],
-    "capabilities": ["format", "validate", "fuzz"]
+    "capabilities": ["format", "validate", "fuzz", "playwright-browser"]
   },
   "source_snapshot": {
     "sync_excludes": ["node_modules/", "node_modules/**"]
@@ -396,6 +396,29 @@
       "payload": {
         "release": "{{payload.release}}",
         "config": "{{payload.config}}"
+      }
+    },
+    {
+      "id": "browser.playwright.setup",
+      "label": "Install Playwright browser utility",
+      "type": "command",
+      "command": "bash \"{{extension_path}}/scripts/browser/playwright.sh\" setup",
+      "payload": {}
+    },
+    {
+      "id": "browser.playwright.status",
+      "label": "Show Playwright browser utility readiness",
+      "type": "command",
+      "command": "bash \"{{extension_path}}/scripts/browser/playwright.sh\" status",
+      "payload": {}
+    },
+    {
+      "id": "browser.playwright.execute",
+      "label": "Execute a Playwright module",
+      "type": "command",
+      "command": "bash \"{{extension_path}}/scripts/browser/playwright.sh\" action-execute",
+      "payload": {
+        "selected": "{{selected}}"
       }
     }
   ]

--- a/nodejs/runtime/playwright/package-lock.json
+++ b/nodejs/runtime/playwright/package-lock.json
@@ -1,0 +1,44 @@
+{
+  "name": "@homeboy/nodejs-playwright-runtime",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@homeboy/nodejs-playwright-runtime",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "engines": { "node": ">=20.6.0" }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": ["darwin"],
+      "engines": { "node": "^8.16.0 || ^10.6.0 || >=11.0.0" }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": { "playwright-core": "1.61.1" },
+      "bin": { "playwright": "cli.js" },
+      "engines": { "node": ">=18" },
+      "optionalDependencies": { "fsevents": "2.3.2" }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": { "playwright-core": "cli.js" },
+      "engines": { "node": ">=18" }
+    }
+  }
+}

--- a/nodejs/runtime/playwright/package.json
+++ b/nodejs/runtime/playwright/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@homeboy/nodejs-playwright-runtime",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Extension-owned Playwright runtime for Homeboy Node.js browser utilities",
+  "dependencies": {
+    "playwright": "1.61.1"
+  },
+  "engines": {
+    "node": ">=20.6.0"
+  }
+}

--- a/nodejs/scripts/bench/browser-helper.mjs
+++ b/nodejs/scripts/bench/browser-helper.mjs
@@ -2,7 +2,9 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { performance } from 'node:perf_hooks';
+import { execFileSync } from 'node:child_process';
 import {
     collectBrowserPhases,
     buildBrowserBenchResult,
@@ -1125,17 +1127,32 @@ function finitePositiveNumber(value) {
 
 async function loadPlaywright() {
     const require = createRequire(import.meta.url);
-    const searchPaths = [process.cwd()];
-    if (process.env.HOMEBOY_COMPONENT_PATH) searchPaths.push(process.env.HOMEBOY_COMPONENT_PATH);
+    const utility = fileURLToPath(new URL('../browser/playwright.sh', import.meta.url));
+    let readiness;
+    try {
+        readiness = JSON.parse(execFileSync('bash', [utility, 'status', '--json'], {
+            encoding: 'utf8',
+            env: process.env,
+        }));
+    } catch (error) {
+        throw new Error(`Playwright runtime readiness check failed. Run: homeboy extension action nodejs browser.playwright.setup\n${error.message}`);
+    }
+    if (readiness.package?.state !== 'ready' || readiness.chromium?.state !== 'ready') {
+        throw new Error([
+            'Playwright is required for runBrowserBench but the extension runtime is not ready.',
+            `Package: ${readiness.package?.state || 'unknown'}; Chromium: ${readiness.chromium?.state || 'unknown'}.`,
+            'Run: homeboy extension action nodejs browser.playwright.setup',
+        ].join('\n'));
+    }
 
     let resolved;
     try {
-        resolved = require.resolve('playwright', { paths: searchPaths });
+        resolved = createRequire(`${readiness.runtime_package_dir}/package.json`).resolve('playwright');
     } catch (err) {
         throw new Error([
             'Playwright is required for runBrowserBench but was not found.',
-            'Install it in the benchmarked project with: npm i -D playwright',
-            'Then install browser binaries with: npx playwright install chromium',
+            'Install the Node.js extension browser utility with:',
+            '  homeboy extension action nodejs browser.playwright.setup',
             `Resolution error: ${err.message}`,
         ].join('\n'));
     }
@@ -1154,7 +1171,7 @@ async function launchBrowser(browserType, config) {
     } catch (err) {
         throw new Error([
             'Playwright browser launch failed.',
-            'If browser binaries are missing, run: npx playwright install chromium',
+            'If browser binaries are missing, run: homeboy extension action nodejs browser.playwright.setup',
             'If system dependencies are missing, run Playwright\'s dependency installer for your platform.',
             `Launch error: ${err.message}`,
         ].join('\n'));

--- a/nodejs/scripts/bench/nodejs-browser-helper-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-browser-helper-smoke.sh
@@ -60,10 +60,18 @@ if [ "$MISSING_DEPS_EXIT" -ne 42 ]; then
     echo "$MISSING_DEPS_OUTPUT" >&2
     exit 1
 fi
-if [[ "$MISSING_DEPS_OUTPUT" != *"npm i -D playwright"* ]] || [[ "$MISSING_DEPS_OUTPUT" != *"npx playwright install chromium"* ]]; then
+if [[ "$MISSING_DEPS_OUTPUT" != *"homeboy extension action nodejs browser.playwright.setup"* ]]; then
     echo "missing dependency error did not include actionable setup guidance" >&2
     echo "$MISSING_DEPS_OUTPUT" >&2
     exit 1
+fi
+
+# Browser installation is an opt-in integration check. The deterministic
+# extension utility smoke covers resolution and setup decisions without npm or
+# browser downloads, so ordinary extension test runs stay network-free.
+if [ "${HOMEBOY_RUN_PLAYWRIGHT_INTEGRATION:-0}" != "1" ]; then
+    echo "Node.js browser helper integration smoke skipped (set HOMEBOY_RUN_PLAYWRIGHT_INTEGRATION=1 to run)."
+    exit 0
 fi
 
 if ! npm --prefix "$PROJECT_DIR" install --no-audit --no-fund --silent; then

--- a/nodejs/scripts/bench/nodejs-browser-helper-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-browser-helper-smoke.sh
@@ -32,7 +32,7 @@ EOF
 PROJECT_DIR="$TMP_DIR/project"
 mkdir -p "$PROJECT_DIR/bench" "$PROJECT_DIR/artifacts"
 cat > "$PROJECT_DIR/package.json" <<'EOF'
-{"name":"homeboy-node-browser-bench-smoke","private":true,"devDependencies":{"playwright":"^1.56.0"}}
+{"name":"homeboy-node-browser-bench-smoke","private":true,"type":"module"}
 EOF
 
 NO_DEPS_PROJECT="$TMP_DIR/no-deps-project"
@@ -42,7 +42,7 @@ cat > "$NO_DEPS_PROJECT/package.json" <<'EOF'
 EOF
 
 set +e
-MISSING_DEPS_OUTPUT="$(HOMEBOY_COMPONENT_PATH="$NO_DEPS_PROJECT" HELPER_UNDER_TEST="$SCRIPT_DIR/browser-helper.mjs" node --input-type=module - <<'EOF' 2>&1
+MISSING_DEPS_OUTPUT="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$TMP_DIR/empty-runtime" HOMEBOY_COMPONENT_PATH="$NO_DEPS_PROJECT" HELPER_UNDER_TEST="$SCRIPT_DIR/browser-helper.mjs" node --input-type=module - <<'EOF' 2>&1
 const { runBrowserBench } = await import(process.env.HELPER_UNDER_TEST);
 try {
   await runBrowserBench({ action: async () => {} });
@@ -66,25 +66,14 @@ if [[ "$MISSING_DEPS_OUTPUT" != *"homeboy extension action nodejs browser.playwr
     exit 1
 fi
 
-# Browser installation is an opt-in integration check. The deterministic
-# extension utility smoke covers resolution and setup decisions without npm or
-# browser downloads, so ordinary extension test runs stay network-free.
+# Browser launch is an opt-in integration check. It uses the extension-owned
+# runtime already prepared on the runner and never materializes project deps.
 if [ "${HOMEBOY_RUN_PLAYWRIGHT_INTEGRATION:-0}" != "1" ]; then
     echo "Node.js browser helper integration smoke skipped (set HOMEBOY_RUN_PLAYWRIGHT_INTEGRATION=1 to run)."
     exit 0
 fi
 
-if ! npm --prefix "$PROJECT_DIR" install --no-audit --no-fund --silent; then
-    echo "Failed to install Playwright for browser helper smoke." >&2
-    echo "Run manually in a benchmark project with: npm i -D playwright && npx playwright install chromium" >&2
-    exit 1
-fi
-
-if ! npm --prefix "$PROJECT_DIR" exec -- playwright install chromium >/dev/null; then
-    echo "Failed to install Playwright Chromium browser for browser helper smoke." >&2
-    echo "Run manually in a benchmark project with: npx playwright install chromium" >&2
-    exit 1
-fi
+test ! -e "$PROJECT_DIR/node_modules" || { echo "integration project must not have node_modules" >&2; exit 1; }
 
 cat > "$PROJECT_DIR/bench/browser.bench.mjs" <<'EOF'
 import { createServer } from 'node:http';

--- a/nodejs/scripts/browser/execute-playwright-module.mjs
+++ b/nodejs/scripts/browser/execute-playwright-module.mjs
@@ -1,0 +1,8 @@
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+const [modulePath, ...args] = process.argv.slice(2);
+if (!modulePath) throw new Error('A module path is required.');
+
+process.argv = [process.argv[0], modulePath, ...args];
+await import(pathToFileURL(resolve(modulePath)).href);

--- a/nodejs/scripts/browser/playwright-esm-facade.mjs
+++ b/nodejs/scripts/browser/playwright-esm-facade.mjs
@@ -1,0 +1,18 @@
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+const runtimePackageDir = process.env.HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR;
+if (!runtimePackageDir) throw new Error('HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR is required.');
+
+const playwright = createRequire(join(runtimePackageDir, 'package.json'))('playwright');
+
+export default playwright;
+export const chromium = playwright.chromium;
+export const firefox = playwright.firefox;
+export const webkit = playwright.webkit;
+export const _electron = playwright._electron;
+export const _android = playwright._android;
+export const devices = playwright.devices;
+export const selectors = playwright.selectors;
+export const request = playwright.request;
+export const errors = playwright.errors;

--- a/nodejs/scripts/browser/playwright-loader.mjs
+++ b/nodejs/scripts/browser/playwright-loader.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 
 const runtimePackageDir = process.env.HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR;
@@ -9,6 +8,15 @@ export async function resolve(specifier, context, nextResolve) {
     }
 
     if (!runtimePackageDir) throw new Error('HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR is required.');
-    const require = createRequire(`${runtimePackageDir}/package.json`);
-    return { url: pathToFileURL(require.resolve(specifier)).href, shortCircuit: true };
+    if (specifier === 'playwright') {
+        // Playwright's CommonJS entrypoint assigns some exports dynamically.
+        // A facade preserves the documented ESM named exports for consumers.
+        return { url: new URL('./playwright-esm-facade.mjs', import.meta.url).href, shortCircuit: true };
+    }
+    // Resolve subpaths through Node's package resolver using the pinned runtime
+    // package as the parent rather than returning a raw CommonJS file URL.
+    return nextResolve(specifier, {
+        ...context,
+        parentURL: pathToFileURL(`${runtimePackageDir}/package.json`).href,
+    });
 }

--- a/nodejs/scripts/browser/playwright-loader.mjs
+++ b/nodejs/scripts/browser/playwright-loader.mjs
@@ -1,0 +1,14 @@
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const runtimePackageDir = process.env.HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR;
+
+export async function resolve(specifier, context, nextResolve) {
+    if (specifier !== 'playwright' && !specifier.startsWith('playwright/')) {
+        return nextResolve(specifier, context);
+    }
+
+    if (!runtimePackageDir) throw new Error('HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR is required.');
+    const require = createRequire(`${runtimePackageDir}/package.json`);
+    return { url: pathToFileURL(require.resolve(specifier)).href, shortCircuit: true };
+}

--- a/nodejs/scripts/browser/playwright-require.cjs
+++ b/nodejs/scripts/browser/playwright-require.cjs
@@ -1,0 +1,25 @@
+const Module = require('node:module');
+const path = require('node:path');
+
+const runtimePackageDir = process.env.HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR;
+const runtimeRequire = runtimePackageDir
+    ? Module.createRequire(path.join(runtimePackageDir, 'package.json'))
+    : null;
+const resolveFilename = Module._resolveFilename;
+const runtimeParent = runtimePackageDir ? new Module(path.join(runtimePackageDir, 'package.json')) : null;
+if (runtimeParent) {
+    runtimeParent.filename = path.join(runtimePackageDir, 'package.json');
+    runtimeParent.paths = Module._nodeModulePaths(runtimePackageDir);
+}
+
+Module._resolveFilename = function homeboyPlaywrightResolve(request, parent, isMain, options) {
+    if (runtimeRequire && (request === 'playwright' || request.startsWith('playwright/'))) {
+        return resolveFilename.call(this, request, runtimeParent, false, options);
+    }
+    try {
+        return resolveFilename.call(this, request, parent, isMain, options);
+    } catch (error) {
+        if (!runtimeRequire || (request !== 'playwright' && !request.startsWith('playwright/'))) throw error;
+        return runtimeRequire.resolve(request);
+    }
+};

--- a/nodejs/scripts/browser/playwright.sh
+++ b/nodejs/scripts/browser/playwright.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SOURCE_DIR="${EXTENSION_PATH}/runtime/playwright"
+RUNTIME_DIR="${HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/homeboy/nodejs-playwright}"
+PACKAGE_DIR="${RUNTIME_DIR}/package"
+NODE_BIN="${HOMEBOY_NODEJS_PLAYWRIGHT_NODE:-node}"
+NPM_BIN="${HOMEBOY_NODEJS_PLAYWRIGHT_NPM:-npm}"
+ACTION="${1:-status}"
+
+setup_command() { printf 'homeboy extension action nodejs browser.playwright.setup'; }
+hash_sources() { ( cat "$SOURCE_DIR/package.json"; cat "$SOURCE_DIR/package-lock.json" ) | shasum -a 256 | awk '{print $1}'; }
+
+require_node() {
+    "$NODE_BIN" -e "const [major, minor] = process.versions.node.split('.').map(Number); process.exit(major > 20 || (major === 20 && minor >= 6) ? 0 : 1)" || {
+        echo "Node.js >=20.6.0 is required for the Playwright utility (node:module register()). Install a compatible Node.js runtime." >&2
+        exit 69
+    }
+}
+
+assert_safe_path() {
+    local path="$1"
+    [ ! -L "$path" ] || { echo "Refusing symlinked Playwright runtime path: $path" >&2; return 1; }
+    if [ -e "$path" ]; then
+        local owner mode
+        owner="$(stat -f '%u' "$path" 2>/dev/null || stat -c '%u' "$path")"
+        [ "$owner" = "$(id -u)" ] || { echo "Refusing runtime path not owned by this user: $path" >&2; return 1; }
+        mode="$(stat -f '%Lp' "$path" 2>/dev/null || stat -c '%a' "$path")"
+        [ $(( 8#$mode & 8#022 )) -eq 0 ] || { echo "Refusing group/world-writable runtime path: $path" >&2; return 1; }
+    fi
+}
+
+assert_runtime_tree() {
+    local target="$1" current="$RUNTIME_DIR" relative
+    assert_safe_path "$current" || return
+    relative="${target#"${RUNTIME_DIR}"/}"
+    [ "$relative" = "$target" ] && { assert_safe_path "$target"; return; }
+    local segment
+    IFS=/ read -r -a segments <<< "$relative"
+    for segment in "${segments[@]}"; do
+        current="${current}/${segment}"
+        [ ! -e "$current" ] || assert_safe_path "$current" || return
+    done
+}
+
+package_state() {
+    local expected="$1"
+    [ -d "$PACKAGE_DIR" ] || { printf 'missing'; return; }
+    if ! assert_runtime_tree "$PACKAGE_DIR" || ! assert_runtime_tree "$PACKAGE_DIR/node_modules" || ! assert_runtime_tree "$PACKAGE_DIR/node_modules/playwright"; then
+        printf 'invalid'; return
+    fi
+    if "$NODE_BIN" - "$PACKAGE_DIR" "$expected" "$SOURCE_DIR/package.json" <<'NODE' >/dev/null 2>&1
+const fs = require('node:fs'); const path = require('node:path');
+const [dir, expected, source] = process.argv.slice(2);
+try {
+  for (const entry of ['package.json', 'package-lock.json', '.homeboy-runtime-sha256', 'node_modules/playwright/package.json', 'node_modules/playwright/cli.js']) {
+    const file = path.join(dir, entry); if (fs.lstatSync(file).isSymbolicLink()) throw new Error('symlink');
+  }
+  if (fs.readFileSync(path.join(dir, '.homeboy-runtime-sha256'), 'utf8').trim() !== expected) throw new Error('hash');
+  const wanted = JSON.parse(fs.readFileSync(source)).dependencies.playwright;
+  if (JSON.parse(fs.readFileSync(path.join(dir, 'node_modules/playwright/package.json'))).version !== wanted) throw new Error('version');
+} catch { process.exit(1); }
+NODE
+    then printf 'ready'; else printf 'invalid'; fi
+}
+
+browser_state() {
+    [ "$1" = ready ] || { printf 'missing'; return; }
+    if "$NODE_BIN" - "$PACKAGE_DIR" <<'NODE' >/dev/null 2>&1
+const { createRequire } = require('node:module'); const { lstatSync } = require('node:fs'); const { spawnSync } = require('node:child_process'); const path = require('node:path');
+try { const p = createRequire(path.join(process.argv[2], 'package.json'))('playwright'); const bin = p.chromium.executablePath(); if (lstatSync(bin).isSymbolicLink()) throw 0; const result = spawnSync(bin, ['--version'], { encoding: 'utf8' }); process.exit(result.status === 0 ? 0 : 1); } catch { process.exit(1); }
+NODE
+    then printf 'ready'; else printf 'invalid'; fi
+}
+
+status() {
+    require_node
+    local hash package browser
+    hash="$(hash_sources)"; package="$(package_state "$hash")"; browser="$(browser_state "$package")"
+    if [ "${2:-}" = --json ]; then
+        "$NODE_BIN" - "$package" "$browser" "$PACKAGE_DIR" "$(setup_command)" <<'NODE'
+const [packageState, chromiumState, runtimePackageDir, setupCommand] = process.argv.slice(2);
+const reason = (state, kind) => state === 'ready' ? null : state === 'missing' ? `${kind} missing` : `${kind} invalid, corrupt, or version-mismatched`;
+console.log(JSON.stringify({ package: { state: packageState, reason: reason(packageState, 'package') }, chromium: { state: chromiumState, reason: reason(chromiumState, 'Chromium') }, runtime_package_dir: runtimePackageDir, setup_command: setupCommand }));
+NODE
+    else
+        printf 'Playwright package: %s\nChromium: %s\n' "$package" "$browser"
+        [ "$package" = ready ] && [ "$browser" = ready ] || printf 'Setup: %s\n' "$(setup_command)"
+    fi
+}
+
+setup() {
+    require_node; assert_safe_path "$RUNTIME_DIR"; mkdir -p "$RUNTIME_DIR"; chmod 700 "$RUNTIME_DIR"; assert_safe_path "$RUNTIME_DIR"
+    local hash state tmp
+    hash="$(hash_sources)"; state="$(package_state "$hash")"
+    if [ "$state" != ready ]; then
+        tmp="${RUNTIME_DIR}/.package.tmp.$$"; rm -rf "$tmp"; mkdir -m 700 "$tmp"
+        cp "$SOURCE_DIR/package.json" "$SOURCE_DIR/package-lock.json" "$tmp/"; "$NPM_BIN" ci --prefix "$tmp" --ignore-scripts
+        printf '%s\n' "$hash" > "$tmp/.homeboy-runtime-sha256"; chmod -R go-rwx "$tmp"
+        local installed_package_dir="$PACKAGE_DIR"; PACKAGE_DIR="$tmp"
+        [ "$(package_state "$hash")" = ready ] || { rm -rf "$tmp"; echo 'Installed Playwright runtime failed validation.' >&2; exit 1; }
+        PACKAGE_DIR="$installed_package_dir"; rm -rf "${RUNTIME_DIR}/.package.previous"; [ ! -e "$PACKAGE_DIR" ] || mv "$PACKAGE_DIR" "${RUNTIME_DIR}/.package.previous"; mv "$tmp" "$PACKAGE_DIR"; rm -rf "${RUNTIME_DIR}/.package.previous"
+    fi
+    local package browser; package="$(package_state "$hash")"; browser="$(browser_state "$package")"
+    if [ "$browser" != ready ]; then "$NODE_BIN" "$PACKAGE_DIR/node_modules/playwright/cli.js" install chromium; fi
+    status status
+}
+
+execute() {
+    require_node; local module="${1:-}"; shift || true; [ -n "$module" ] || { echo 'usage: playwright.sh execute <module> [args...]' >&2; exit 64; }
+    local hash package browser; hash="$(hash_sources)"; package="$(package_state "$hash")"; browser="$(browser_state "$package")"
+    [ "$package" = ready ] && [ "$browser" = ready ] || { echo "Playwright utility is not ready. Run: $(setup_command)" >&2; exit 69; }
+    HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR="$PACKAGE_DIR" "$NODE_BIN" --require "$SCRIPT_DIR/playwright-require.cjs" --import "$SCRIPT_DIR/register-playwright-loader.mjs" "$SCRIPT_DIR/execute-playwright-module.mjs" "$module" "$@"
+}
+
+action_execute() {
+    local -a argv=()
+    while IFS= read -r -d '' arg; do argv+=("$arg"); done < <("$NODE_BIN" -e '
+const payload = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || "{}");
+if (!Array.isArray(payload.selected) || payload.selected.length !== 1) throw new Error("selected must contain exactly one row");
+const row = payload.selected[0];
+if (!row || typeof row !== "object" || Array.isArray(row)) throw new Error("selected row must be an object");
+if (typeof row.module !== "string" || row.module.length === 0) throw new Error("selected row module must be a non-empty string");
+if (row.args !== undefined && (!Array.isArray(row.args) || !row.args.every((value) => typeof value === "string"))) throw new Error("selected row args must be an array of strings");
+for (const value of [row.module, ...(row.args || [])]) process.stdout.write(value + "\0");
+')
+    [ "${#argv[@]}" -gt 0 ] || { echo 'selected row did not provide a module' >&2; exit 64; }
+    execute "${argv[@]}"
+}
+
+case "$ACTION" in
+ setup) setup ;; status) status "$@" ;; execute) shift; execute "$@" ;; action-execute) action_execute ;; *) echo "unknown Playwright utility action: $ACTION" >&2; exit 64 ;; esac

--- a/nodejs/scripts/browser/playwright.sh
+++ b/nodejs/scripts/browser/playwright.sh
@@ -8,6 +8,7 @@ RUNTIME_DIR="${HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR:-${XDG_CACHE_HOME:-${HOME}/
 PACKAGE_DIR="${RUNTIME_DIR}/package"
 NODE_BIN="${HOMEBOY_NODEJS_PLAYWRIGHT_NODE:-node}"
 NPM_BIN="${HOMEBOY_NODEJS_PLAYWRIGHT_NPM:-npm}"
+STAT_BIN="${HOMEBOY_NODEJS_PLAYWRIGHT_STAT:-stat}"
 ACTION="${1:-status}"
 
 setup_command() { printf 'homeboy extension action nodejs browser.playwright.setup'; }
@@ -24,10 +25,19 @@ assert_safe_path() {
     local path="$1"
     [ ! -L "$path" ] || { echo "Refusing symlinked Playwright runtime path: $path" >&2; return 1; }
     if [ -e "$path" ]; then
-        local owner mode
-        owner="$(stat -f '%u' "$path" 2>/dev/null || stat -c '%u' "$path")"
+        local owner mode stat_version
+        stat_version="$("$STAT_BIN" --version 2>&1 || true)"
+        case "$stat_version" in
+            *GNU*)
+                owner="$("$STAT_BIN" -c '%u' "$path")"
+                mode="$("$STAT_BIN" -c '%a' "$path")"
+                ;;
+            *)
+                owner="$("$STAT_BIN" -f '%u' "$path")"
+                mode="$("$STAT_BIN" -f '%Lp' "$path")"
+                ;;
+        esac
         [ "$owner" = "$(id -u)" ] || { echo "Refusing runtime path not owned by this user: $path" >&2; return 1; }
-        mode="$(stat -f '%Lp' "$path" 2>/dev/null || stat -c '%a' "$path")"
         [ $(( 8#$mode & 8#022 )) -eq 0 ] || { echo "Refusing group/world-writable runtime path: $path" >&2; return 1; }
     fi
 }

--- a/nodejs/scripts/browser/playwright.sh
+++ b/nodejs/scripts/browser/playwright.sh
@@ -25,18 +25,23 @@ assert_safe_path() {
     local path="$1"
     [ ! -L "$path" ] || { echo "Refusing symlinked Playwright runtime path: $path" >&2; return 1; }
     if [ -e "$path" ]; then
-        local owner mode stat_version
-        stat_version="$("$STAT_BIN" --version 2>&1 || true)"
-        case "$stat_version" in
-            *GNU*)
-                owner="$("$STAT_BIN" -c '%u' "$path")"
-                mode="$("$STAT_BIN" -c '%a' "$path")"
-                ;;
-            *)
-                owner="$("$STAT_BIN" -f '%u' "$path")"
-                mode="$("$STAT_BIN" -f '%Lp' "$path")"
-                ;;
-        esac
+        local owner mode probe_owner probe_mode
+        if probe_owner="$("$STAT_BIN" -c '%u' "$path" 2>/dev/null)" \
+            && [[ "$probe_owner" =~ ^[0-9]+$ ]] \
+            && probe_mode="$("$STAT_BIN" -c '%a' "$path" 2>/dev/null)" \
+            && [[ "$probe_mode" =~ ^[0-7]+$ ]]; then
+            owner="$probe_owner"
+            mode="$probe_mode"
+        elif probe_owner="$("$STAT_BIN" -f '%u' "$path" 2>/dev/null)" \
+            && [[ "$probe_owner" =~ ^[0-9]+$ ]] \
+            && probe_mode="$("$STAT_BIN" -f '%Lp' "$path" 2>/dev/null)" \
+            && [[ "$probe_mode" =~ ^[0-7]+$ ]]; then
+            owner="$probe_owner"
+            mode="$probe_mode"
+        else
+            echo "Unable to read numeric owner and mode for runtime path: $path" >&2
+            return 1
+        fi
         [ "$owner" = "$(id -u)" ] || { echo "Refusing runtime path not owned by this user: $path" >&2; return 1; }
         [ $(( 8#$mode & 8#022 )) -eq 0 ] || { echo "Refusing group/world-writable runtime path: $path" >&2; return 1; }
     fi

--- a/nodejs/scripts/browser/register-playwright-loader.mjs
+++ b/nodejs/scripts/browser/register-playwright-loader.mjs
@@ -1,0 +1,3 @@
+import { register } from 'node:module';
+
+register(new URL('./playwright-loader.mjs', import.meta.url), import.meta.url);

--- a/nodejs/tests/fixtures/playwright-1.61.1-root-exports.json
+++ b/nodejs/tests/fixtures/playwright-1.61.1-root-exports.json
@@ -1,0 +1,11 @@
+[
+  "_android",
+  "_electron",
+  "chromium",
+  "devices",
+  "errors",
+  "firefox",
+  "request",
+  "selectors",
+  "webkit"
+]

--- a/nodejs/tests/playwright-utility-smoke.sh
+++ b/nodejs/tests/playwright-utility-smoke.sh
@@ -56,7 +56,7 @@ HOMEBOY_TEST_CLI_LOG="$CLI_LOG" \
 STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" status --json)"
 node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "ready" || status.chromium.state !== "ready") process.exit(1)' "$STATUS"
 
-for dialect in gnu bsd; do
+for dialect in gnu uutils bsd; do
     FAKE_STAT="$TMP_DIR/stat-$dialect"
     STAT_LOG="$TMP_DIR/stat-$dialect.log"
     cat > "$FAKE_STAT" <<EOF
@@ -65,14 +65,15 @@ set -euo pipefail
 printf '%s\\n' "\$*" >> "$STAT_LOG"
 case "\$1" in
   --version)
-    $([ "$dialect" = gnu ] && printf 'printf "stat (GNU coreutils) 9.0\\n"' || printf 'exit 1')
+    case "$dialect" in gnu) printf 'stat (GNU coreutils) 9.0\\n' ;; uutils) printf 'stat (uutils coreutils) 0.8.0\\n' ;; *) exit 1 ;; esac
     ;;
   -c)
-    [ "$dialect" = gnu ] || exit 64
+    { [ "$dialect" = gnu ] || [ "$dialect" = uutils ]; } || exit 64
     case "\$2" in '%u') id -u ;; '%a') printf '700\\n' ;; *) exit 64 ;; esac
     ;;
   -f)
     if [ "$dialect" = gnu ]; then printf 'filesystem-data\\n'; exit 0; fi
+    [ "$dialect" = bsd ] || exit 64
     case "\$2" in '%u') id -u ;; '%Lp') printf '700\\n' ;; *) exit 64 ;; esac
     ;;
   *) exit 64 ;;
@@ -81,10 +82,11 @@ EOF
     chmod +x "$FAKE_STAT"
     DIALECT_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" HOMEBOY_NODEJS_PLAYWRIGHT_STAT="$FAKE_STAT" bash "$UTILITY" status --json)"
     node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "ready") process.exit(1)' "$DIALECT_STATUS"
-    if [ "$dialect" = gnu ]; then
-        ! grep -q '^-f ' "$STAT_LOG" || { echo 'GNU stat used BSD -f probe' >&2; exit 1; }
+    if [ "$dialect" = gnu ] || [ "$dialect" = uutils ]; then
+        ! grep -q '^-f ' "$STAT_LOG" || { echo "$dialect stat used BSD -f probe" >&2; exit 1; }
     else
-        ! grep -q '^-c ' "$STAT_LOG" || { echo 'BSD stat used GNU -c probe' >&2; exit 1; }
+        grep -q '^-c ' "$STAT_LOG" || { echo 'BSD stat did not receive GNU compatibility probe' >&2; exit 1; }
+        grep -q '^-f ' "$STAT_LOG" || { echo 'BSD stat did not receive BSD fallback probe' >&2; exit 1; }
     fi
 done
 

--- a/nodejs/tests/playwright-utility-smoke.sh
+++ b/nodejs/tests/playwright-utility-smoke.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-playwright-utility.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+RUNTIME_DIR="$TMP_DIR/runtime"
+NPM_LOG="$TMP_DIR/npm.log"
+CLI_LOG="$TMP_DIR/cli.log"
+FAKE_NPM="$TMP_DIR/npm"
+
+cat > "$FAKE_NPM" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'npm ci\n' >> "$HOMEBOY_TEST_NPM_LOG"
+prefix=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--prefix" ]; then prefix="$2"; shift 2; continue; fi
+    shift
+done
+mkdir -p "$prefix/node_modules/playwright"
+cat > "$prefix/node_modules/playwright/package.json" <<'PKG'
+{"name":"playwright","version":"1.61.1","main":"index.js"}
+PKG
+cat > "$prefix/node_modules/playwright/index.js" <<'JS'
+const path = require('node:path');
+exports.chromium = { executablePath: () => path.join(__dirname, 'chromium-ready') };
+JS
+cat > "$prefix/node_modules/playwright/cli.js" <<'JS'
+const fs = require('node:fs');
+const path = require('node:path');
+const browser = path.join(__dirname, 'chromium-ready');
+fs.writeFileSync(browser, '#!/bin/sh\necho Chromium fake\n');
+fs.chmodSync(browser, 0o700);
+fs.appendFileSync(process.env.HOMEBOY_TEST_CLI_LOG, 'install chromium\n');
+JS
+EOF
+chmod +x "$FAKE_NPM"
+
+UTILITY="$ROOT_DIR/scripts/browser/playwright.sh"
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" \
+HOMEBOY_NODEJS_PLAYWRIGHT_NPM="$FAKE_NPM" \
+HOMEBOY_TEST_NPM_LOG="$NPM_LOG" \
+HOMEBOY_TEST_CLI_LOG="$CLI_LOG" \
+    bash "$UTILITY" setup >/dev/null
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" \
+HOMEBOY_NODEJS_PLAYWRIGHT_NPM="$FAKE_NPM" \
+HOMEBOY_TEST_NPM_LOG="$NPM_LOG" \
+HOMEBOY_TEST_CLI_LOG="$CLI_LOG" \
+    bash "$UTILITY" setup >/dev/null
+[ "$(wc -l < "$NPM_LOG" | tr -d ' ')" = "1" ] || { echo 'setup reran npm ci' >&2; exit 1; }
+[ "$(wc -l < "$CLI_LOG" | tr -d ' ')" = "1" ] || { echo 'setup reran Chromium installation' >&2; exit 1; }
+
+STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" status --json)"
+node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "ready" || status.chromium.state !== "ready") process.exit(1)' "$STATUS"
+
+PROJECT_DIR="$TMP_DIR/fresh-project"
+mkdir -p "$PROJECT_DIR"
+cat > "$PROJECT_DIR/extension-runtime.mjs" <<'EOF'
+import { chromium } from 'playwright';
+if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('extension Playwright was not resolved');
+EOF
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$PROJECT_DIR/extension-runtime.mjs"
+
+cat > "$PROJECT_DIR/action-runtime.mjs" <<'EOF'
+import { chromium } from 'playwright';
+if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('action did not use extension runtime');
+if (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(['--literal', 'a b', 'line one\nline two'])) throw new Error(`action args changed: ${JSON.stringify(process.argv)}`);
+EOF
+
+mkdir -p "$PROJECT_DIR/node_modules/playwright"
+cat > "$PROJECT_DIR/node_modules/playwright/package.json" <<'EOF'
+{"name":"playwright","version":"0.0.0-local","type":"module","exports":"./index.js"}
+EOF
+cat > "$PROJECT_DIR/node_modules/playwright/index.js" <<'EOF'
+export const chromium = { executablePath: () => 'project-local' };
+EOF
+cat > "$PROJECT_DIR/project-local.mjs" <<'EOF'
+import { chromium } from 'playwright';
+if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('utility did not force its pinned Playwright runtime');
+EOF
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$PROJECT_DIR/project-local.mjs"
+
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" \
+HOMEBOY_SETTINGS_JSON="{\"selected\":[{\"module\":\"$PROJECT_DIR/action-runtime.mjs\",\"args\":[\"--literal\",\"a b\",\"line one\\nline two\"]}]}" \
+    bash "$UTILITY" action-execute
+
+for invalid_settings in \
+    '{"selected":[]}' \
+    "{\"selected\":[{\"module\":\"$PROJECT_DIR/action-runtime.mjs\"},{\"module\":\"$PROJECT_DIR/action-runtime.mjs\"}]}" \
+    '{"selected":["not-an-object"]}' \
+    '{"selected":[{"module":"","args":[]}]}' \
+    '{"selected":[{"module":"module.mjs","args":[1]}]}'
+do
+    if HOMEBOY_SETTINGS_JSON="$invalid_settings" bash "$UTILITY" action-execute >/dev/null 2>&1; then
+        echo "invalid selected-row action payload was accepted: $invalid_settings" >&2
+        exit 1
+    fi
+done
+
+MISSING_RUNTIME="$TMP_DIR/missing-runtime"
+MISSING_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$MISSING_RUNTIME" bash "$UTILITY" status --json)"
+node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "missing" || status.chromium.state !== "missing" || !status.setup_command) process.exit(1)' "$MISSING_STATUS"
+
+mkdir -p "$MISSING_RUNTIME/package/node_modules/playwright"
+printf '{"name":"playwright","version":"1.61.1"}\n' > "$MISSING_RUNTIME/package/node_modules/playwright/package.json"
+PACKAGE_ONLY_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$MISSING_RUNTIME" bash "$UTILITY" status --json)"
+node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "invalid" || status.chromium.state !== "missing") process.exit(1)' "$PACKAGE_ONLY_STATUS"
+
+printf 'not executable\n' > "$RUNTIME_DIR/package/node_modules/playwright/chromium-ready"
+chmod 600 "$RUNTIME_DIR/package/node_modules/playwright/chromium-ready"
+INVALID_BROWSER_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" status --json)"
+node -e 'const status = JSON.parse(process.argv[1]); if (status.chromium.state !== "invalid" || !status.chromium.reason) process.exit(1)' "$INVALID_BROWSER_STATUS"
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" HOMEBOY_NODEJS_PLAYWRIGHT_NPM="$FAKE_NPM" HOMEBOY_TEST_NPM_LOG="$NPM_LOG" HOMEBOY_TEST_CLI_LOG="$CLI_LOG" bash "$UTILITY" setup >/dev/null
+
+printf 'stale-runtime-identity\n' > "$RUNTIME_DIR/package/.homeboy-runtime-sha256"
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" HOMEBOY_NODEJS_PLAYWRIGHT_NPM="$FAKE_NPM" HOMEBOY_TEST_NPM_LOG="$NPM_LOG" HOMEBOY_TEST_CLI_LOG="$CLI_LOG" bash "$UTILITY" setup >/dev/null
+[ "$(wc -l < "$NPM_LOG" | tr -d ' ')" = "2" ] || { echo 'stale runtime identity did not rerun npm ci' >&2; exit 1; }
+
+chmod 770 "$RUNTIME_DIR"
+WRITABLE_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" status --json)"
+node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "invalid") process.exit(1)' "$WRITABLE_STATUS"
+chmod 700 "$RUNTIME_DIR"
+ln -s "$RUNTIME_DIR/package/node_modules/playwright" "$RUNTIME_DIR/package/node_modules/playwright-link"
+mv "$RUNTIME_DIR/package/node_modules/playwright" "$RUNTIME_DIR/package/node_modules/playwright-real"
+mv "$RUNTIME_DIR/package/node_modules/playwright-link" "$RUNTIME_DIR/package/node_modules/playwright"
+SYMLINK_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" status --json)"
+node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "invalid") process.exit(1)' "$SYMLINK_STATUS"
+rm "$RUNTIME_DIR/package/node_modules/playwright"
+mv "$RUNTIME_DIR/package/node_modules/playwright-real" "$RUNTIME_DIR/package/node_modules/playwright"
+
+cat > "$PROJECT_DIR/commonjs-runtime.cjs" <<'EOF'
+const { chromium } = require('playwright');
+if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('CommonJS did not use extension runtime');
+EOF
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$PROJECT_DIR/commonjs-runtime.cjs"
+
+node <<'NODE'
+const fs = require('node:fs');
+const manifest = JSON.parse(fs.readFileSync('nodejs/nodejs.json'));
+const action = manifest.actions.find(({ id }) => id === 'browser.playwright.execute');
+if (!action || !action.command.endsWith(' action-execute') || action.payload.selected !== '{{selected}}') process.exit(1);
+const docs = fs.readFileSync('nodejs/docs/browser-bench-helpers.md', 'utf8');
+if (!docs.includes("browser.playwright.execute --data '[{")) process.exit(1);
+NODE
+
+LINKED_ROOT="$TMP_DIR/linked-extension"
+ln -s "$ROOT_DIR" "$LINKED_ROOT"
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$LINKED_ROOT/scripts/browser/playwright.sh" execute "$PROJECT_DIR/project-local.mjs"
+
+echo "Node.js Playwright utility smoke passed."

--- a/nodejs/tests/playwright-utility-smoke.sh
+++ b/nodejs/tests/playwright-utility-smoke.sh
@@ -56,6 +56,38 @@ HOMEBOY_TEST_CLI_LOG="$CLI_LOG" \
 STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" status --json)"
 node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "ready" || status.chromium.state !== "ready") process.exit(1)' "$STATUS"
 
+for dialect in gnu bsd; do
+    FAKE_STAT="$TMP_DIR/stat-$dialect"
+    STAT_LOG="$TMP_DIR/stat-$dialect.log"
+    cat > "$FAKE_STAT" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "\$*" >> "$STAT_LOG"
+case "\$1" in
+  --version)
+    $([ "$dialect" = gnu ] && printf 'printf "stat (GNU coreutils) 9.0\\n"' || printf 'exit 1')
+    ;;
+  -c)
+    [ "$dialect" = gnu ] || exit 64
+    case "\$2" in '%u') id -u ;; '%a') printf '700\\n' ;; *) exit 64 ;; esac
+    ;;
+  -f)
+    if [ "$dialect" = gnu ]; then printf 'filesystem-data\\n'; exit 0; fi
+    case "\$2" in '%u') id -u ;; '%Lp') printf '700\\n' ;; *) exit 64 ;; esac
+    ;;
+  *) exit 64 ;;
+esac
+EOF
+    chmod +x "$FAKE_STAT"
+    DIALECT_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" HOMEBOY_NODEJS_PLAYWRIGHT_STAT="$FAKE_STAT" bash "$UTILITY" status --json)"
+    node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "ready") process.exit(1)' "$DIALECT_STATUS"
+    if [ "$dialect" = gnu ]; then
+        ! grep -q '^-f ' "$STAT_LOG" || { echo 'GNU stat used BSD -f probe' >&2; exit 1; }
+    else
+        ! grep -q '^-c ' "$STAT_LOG" || { echo 'BSD stat used GNU -c probe' >&2; exit 1; }
+    fi
+done
+
 PROJECT_DIR="$TMP_DIR/fresh-project"
 mkdir -p "$PROJECT_DIR"
 cat > "$PROJECT_DIR/extension-runtime.mjs" <<'EOF'

--- a/nodejs/tests/playwright-utility-smoke.sh
+++ b/nodejs/tests/playwright-utility-smoke.sh
@@ -26,7 +26,10 @@ cat > "$prefix/node_modules/playwright/package.json" <<'PKG'
 PKG
 cat > "$prefix/node_modules/playwright/index.js" <<'JS'
 const path = require('node:path');
-exports.chromium = { executablePath: () => path.join(__dirname, 'chromium-ready') };
+exports.chromium = {
+  executablePath: () => path.join(__dirname, 'chromium-ready'),
+  launch: async () => ({ close: async () => {} }),
+};
 JS
 cat > "$prefix/node_modules/playwright/cli.js" <<'JS'
 const fs = require('node:fs');
@@ -97,6 +100,15 @@ import { chromium } from 'playwright';
 if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('extension Playwright was not resolved');
 EOF
 HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$PROJECT_DIR/extension-runtime.mjs"
+
+cat > "$PROJECT_DIR/dynamic-runtime.mjs" <<'EOF'
+const p = await import('playwright');
+if (!p.chromium || typeof p.chromium.launch !== 'function') throw new Error('dynamic import did not expose chromium');
+const browser = await p.chromium.launch();
+await browser.close();
+if (p.default?.chromium !== p.chromium) throw new Error('default export did not preserve the Playwright module');
+EOF
+HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$PROJECT_DIR/dynamic-runtime.mjs"
 
 cat > "$PROJECT_DIR/action-runtime.mjs" <<'EOF'
 import { chromium } from 'playwright';
@@ -178,6 +190,23 @@ const action = manifest.actions.find(({ id }) => id === 'browser.playwright.exec
 if (!action || !action.command.endsWith(' action-execute') || action.payload.selected !== '{{selected}}') process.exit(1);
 const docs = fs.readFileSync('nodejs/docs/browser-bench-helpers.md', 'utf8');
 if (!docs.includes("browser.playwright.execute --data '[{")) process.exit(1);
+NODE
+
+node <<'NODE'
+const fs = require('node:fs');
+const expected = JSON.parse(fs.readFileSync('nodejs/tests/fixtures/playwright-1.61.1-root-exports.json', 'utf8')).sort();
+const facade = fs.readFileSync('nodejs/scripts/browser/playwright-esm-facade.mjs', 'utf8');
+const actual = [...facade.matchAll(/^export const ([A-Za-z_$][\w$]*) = playwright\./gm)].map((match) => match[1]).sort();
+if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+  throw new Error(`Playwright 1.61.1 root facade exports drifted: ${JSON.stringify(actual)}`);
+}
+if (/export const (test|expect|defineConfig)\b/.test(facade)) {
+  throw new Error('playwright/test exports must not be exposed by the root facade');
+}
+const loader = fs.readFileSync('nodejs/scripts/browser/playwright-loader.mjs', 'utf8');
+if (!loader.includes("specifier.startsWith('playwright/')") || !loader.includes('nextResolve(specifier')) {
+  throw new Error('Playwright subpath resolution must use Node package resolution.');
+}
 NODE
 
 LINKED_ROOT="$TMP_DIR/linked-extension"


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `homeboy-extensions-2254-esm-facade` into review-ready branch `feat/nodejs-playwright-utility`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:homeboy-extensions-2254-esm-facade`
- **Homeboy run ID:** `homeboy-extensions-2254-esm-facade`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `feat/nodejs-playwright-utility`

## Source refs
- https://github.com/Extra-Chill/homeboy-extensions/pull/2256

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Runtime guardrails
- **Why this is not broader than the packet evidence:** Only extension-owned Playwright ESM fallback changes.
- **Evidence discriminators preserved:** import playwright exposes chromium launch and the pinned 1.61.1 named export set
- **Nearby contracts preserved:** CommonJS require and Playwright subpath imports remain runtime-isolated

## Attempt summary
The Figma provider exposed CommonJS-to-ESM named export loss; a pinned facade now matches Playwright 1.61.1 root exports and keeps subpaths runtime-isolated.

## Gate results
- independent-review: passed (targeted)

## Verification capability
- `targeted_checks_run`: `bash nodejs/tests/playwright-utility-smoke.sh`, `node --check nodejs/scripts/browser/playwright-esm-facade.mjs`, `git diff --check`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: none recorded
- `manual_reviewer_check`: none recorded

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- nodejs/scripts/browser/playwright-esm-facade.mjs
- nodejs/scripts/browser/playwright-loader.mjs
- nodejs/tests/fixtures/
- nodejs/tests/playwright-utility-smoke.sh

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `feat/nodejs-playwright-utility`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed ESM interop from the real Figma provider and implemented an exact pinned facade.
