### PR TITLE
Harden WP Codebox PHPUnit diagnostic artifacts

### DIFF
--- a/wordpress/scripts/test/playground-db-activation-smoke.sh
+++ b/wordpress/scripts/test/playground-db-activation-smoke.sh
@@ -39,6 +39,8 @@ RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${CORE_RUNTIME_DIR}/r
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${CORE_RUNTIME_DIR}/runner-steps.sh}"
 HOST_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/test-db-activation-host"
 DEP_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-db-activation-dep"
+ARTIFACTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-db-activation.XXXXXX")"
+trap 'rm -rf "$ARTIFACTS_DIR"' EXIT
 
 for core_helper in "$RUNNER_PRELUDE_HELPER" "$RESOLVE_CONTEXT_HELPER" "$RUNNER_STEPS_HELPER"; do
     if [ ! -f "$core_helper" ]; then
@@ -78,14 +80,37 @@ echo "Host fixture: $HOST_FIXTURE_DIR"
 echo "Dep fixture:  $DEP_FIXTURE_DIR"
 echo ""
 
-HOMEBOY_COMPONENT_ID=test-db-activation-host \
-HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
-HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
-HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
-HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
-HOMEBOY_RUNTIME_RUNNER_STEPS="$RUNNER_STEPS_HELPER" \
-HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
-    bash "${SCRIPT_DIR}/test-runner.sh"
+source_hash_before=$(tar -C "$(dirname "$HOST_FIXTURE_DIR")" -cf - "$(basename "$HOST_FIXTURE_DIR")" | shasum -a 256)
+runner_output=$(HOMEBOY_COMPONENT_ID=test-db-activation-host \
+    HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$RUNNER_STEPS_HELPER" \
+    HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="$ARTIFACTS_DIR" \
+    bash "${SCRIPT_DIR}/test-runner.sh" 2>&1)
+printf '%s\n' "$runner_output"
+
+if [[ "$runner_output" != *"WP Codebox test run complete."* ]]; then
+    echo "ERROR: expected WP Codebox PHPUnit runner success classification" >&2
+    exit 1
+fi
+run_artifacts_dir=""
+for candidate in "${ARTIFACTS_DIR}"/wp-codebox-phpunit.*; do
+    [ -d "$candidate" ] && run_artifacts_dir="$candidate"
+done
+runtime_artifact_directory=$(jq -r '.paths.runtimeDirectory // empty' "${run_artifacts_dir}/latest-runtime.json")
+result_artifact="${run_artifacts_dir}/${runtime_artifact_directory}/files/phpunit/.pg-test-result.txt"
+if [ ! -f "$result_artifact" ] || ! grep -q '^STAGE_BEGIN:run_tests' "$result_artifact"; then
+    echo "ERROR: expected WP Codebox structured PHPUnit diagnostic artifact" >&2
+    exit 1
+fi
+source_hash_after=$(tar -C "$(dirname "$HOST_FIXTURE_DIR")" -cf - "$(basename "$HOST_FIXTURE_DIR")" | shasum -a 256)
+if [ "$source_hash_before" != "$source_hash_after" ]; then
+    echo "ERROR: readonly WP Codebox PHPUnit source fixture changed" >&2
+    exit 1
+fi
 
 echo ""
 echo "============================================"

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -1299,13 +1299,31 @@ rm -f "$RECIPE_FILE" "$RECIPE_OPTIONS_FILE" "$PHPUNIT_RECIPE_BUILDER_STDERR"
 WP_CODEBOX_OUTPUT=$(cat "$WP_CODEBOX_TMPFILE")
 PHPUNIT_OUTPUT=""
 RESULT_FILE=""
-runtime_artifact_directory=$(jq -r '.paths.runtimeDirectory // empty' "${WP_CODEBOX_RUN_ARTIFACTS_DIR}/latest-runtime.json" 2>/dev/null || true)
-case "$runtime_artifact_directory" in
-    runtime-*)
-        candidate_result_file="${WP_CODEBOX_RUN_ARTIFACTS_DIR}/${runtime_artifact_directory}/files/phpunit/.pg-test-result.txt"
-        [ -f "$candidate_result_file" ] && RESULT_FILE="$candidate_result_file"
-        ;;
-esac
+CURRENT_RUN_ARTIFACTS_DIR=""
+runtime_pointer_file="${WP_CODEBOX_RUN_ARTIFACTS_DIR}/latest-runtime.json"
+if [ -f "$runtime_pointer_file" ]; then
+    runtime_artifact_directory=$(jq -r '.paths.runtimeDirectory // empty' "$runtime_pointer_file" 2>/dev/null || true)
+    if [[ ! "$runtime_artifact_directory" =~ ^runtime-[A-Za-z0-9][A-Za-z0-9-]*$ ]]; then
+        FAILED_STEP="WP Codebox runtime artifact pointer"
+        FAILURE_OUTPUT="Invalid runtime directory in ${runtime_pointer_file}: ${runtime_artifact_directory:-<empty>}"
+        echo "ERROR: ${FAILURE_OUTPUT}. Expected a runtime-<alphanumeric-or-hyphen> basename." >&2
+        exit 1
+    fi
+
+    run_artifacts_root_real=$(php -r 'echo realpath($argv[1]) ?: "";' "$WP_CODEBOX_RUN_ARTIFACTS_DIR" 2>/dev/null || true)
+    candidate_runtime_dir="${WP_CODEBOX_RUN_ARTIFACTS_DIR}/${runtime_artifact_directory}"
+    candidate_runtime_dir_real=$(php -r 'echo realpath($argv[1]) ?: "";' "$candidate_runtime_dir" 2>/dev/null || true)
+    if [ -z "$run_artifacts_root_real" ] || [ -z "$candidate_runtime_dir_real" ] || [ "$candidate_runtime_dir_real" != "${run_artifacts_root_real}/${runtime_artifact_directory}" ]; then
+        FAILED_STEP="WP Codebox runtime artifact pointer"
+        FAILURE_OUTPUT="Runtime artifact directory escapes or is missing from ${WP_CODEBOX_RUN_ARTIFACTS_DIR}: ${runtime_artifact_directory}"
+        echo "ERROR: ${FAILURE_OUTPUT}" >&2
+        exit 1
+    fi
+
+    CURRENT_RUN_ARTIFACTS_DIR="$candidate_runtime_dir_real"
+    candidate_result_file="${CURRENT_RUN_ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"
+    [ -f "$candidate_result_file" ] && RESULT_FILE="$candidate_result_file"
+fi
 if [ -f "$RESULT_FILE" ]; then
     PHPUNIT_OUTPUT=$(cat "$RESULT_FILE")
 fi
@@ -1323,8 +1341,8 @@ fi
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"
 PARSE_FAILURES="${EXTENSION_PATH}/scripts/test/parse-test-failures.sh"
 if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
-	if [ -f "${ARTIFACTS_DIR}/files/test-results.json" ]; then
-		bash "$PARSE_RESULTS" "$ARTIFACTS_DIR" || true
+	if [ -n "$CURRENT_RUN_ARTIFACTS_DIR" ] && [ -f "${CURRENT_RUN_ARTIFACTS_DIR}/files/test-results.json" ]; then
+		bash "$PARSE_RESULTS" "$CURRENT_RUN_ARTIFACTS_DIR" || true
 	elif [ -n "$PHPUNIT_STDOUT" ]; then
 		bash "$PARSE_RESULTS" "$PHPUNIT_STDOUT_TMPFILE" || true
 	elif [ -n "$PHPUNIT_OUTPUT" ]; then
@@ -1332,8 +1350,8 @@ if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
 	fi
 fi
 if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
-	if [ -f "${ARTIFACTS_DIR}/files/test-results.json" ]; then
-		bash "$PARSE_FAILURES" "$ARTIFACTS_DIR" "${PLUGIN_PATH:-}" || true
+	if [ -n "$CURRENT_RUN_ARTIFACTS_DIR" ] && [ -f "${CURRENT_RUN_ARTIFACTS_DIR}/files/test-results.json" ]; then
+		bash "$PARSE_FAILURES" "$CURRENT_RUN_ARTIFACTS_DIR" "${PLUGIN_PATH:-}" || true
 	elif [ -n "$PHPUNIT_STDOUT" ]; then
 		bash "$PARSE_FAILURES" "$PHPUNIT_STDOUT_TMPFILE" "${PLUGIN_PATH:-}" || true
 	fi

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -850,7 +850,6 @@ PHPUNIT_ARGS_JSON=$(printf '%s\0' "${PASSTHROUGH_ARGS[@]}" | php -r '
     $parts = array_values(array_filter(explode("\0", $raw), static function ($value) { return $value !== ""; }));
     echo json_encode($parts, JSON_UNESCAPED_SLASHES);
 ' 2>/dev/null || printf '[]')
-PHPUNIT_ARGS_JSON=$(printf '%s' "$PHPUNIT_ARGS_JSON" | jq -c '. + ["--cache-result-file=/tmp/wp-codebox-phpunit.result.cache"]' 2>/dev/null || printf '["--cache-result-file=/tmp/wp-codebox-phpunit.result.cache"]')
 
 SELECTED_TEST_FILE_REL=""
 if [ -n "$SELECTED_TEST_FILE" ]; then
@@ -1019,6 +1018,7 @@ if [ -n "$DEPENDENCY_PATHS" ]; then
 fi
 
 RESULT_FILE=""
+WP_CODEBOX_RUN_ARTIFACTS_DIR=""
 WP_CODEBOX_TMPFILE=""
 PHPUNIT_STDOUT_TMPFILE=""
 RECIPE_FILE=""
@@ -1117,6 +1117,7 @@ if [ -z "$ARTIFACTS_DIR" ]; then
     ARTIFACTS_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-artifacts.XXXXXX")
 fi
 RESULT_FILE="${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"
+WP_CODEBOX_RUN_ARTIFACTS_DIR=$(mktemp -d "${ARTIFACTS_DIR}/wp-codebox-phpunit.XXXXXX")
 
 run_phpunit_prepare_steps
 
@@ -1287,7 +1288,7 @@ fi
 set +e
 NODE_OPTIONS="$WP_CODEBOX_NODE_OPTIONS" "${wp_codebox_command[@]}" recipe-run \
     --recipe "$RECIPE_FILE" \
-    --artifacts "$ARTIFACTS_DIR" \
+    --artifacts "$WP_CODEBOX_RUN_ARTIFACTS_DIR" \
     --json \
     > "$WP_CODEBOX_TMPFILE" 2>&1
 wp_codebox_exit=$?
@@ -1297,6 +1298,14 @@ rm -f "$RECIPE_FILE" "$RECIPE_OPTIONS_FILE" "$PHPUNIT_RECIPE_BUILDER_STDERR"
 
 WP_CODEBOX_OUTPUT=$(cat "$WP_CODEBOX_TMPFILE")
 PHPUNIT_OUTPUT=""
+RESULT_FILE=""
+runtime_artifact_directory=$(jq -r '.paths.runtimeDirectory // empty' "${WP_CODEBOX_RUN_ARTIFACTS_DIR}/latest-runtime.json" 2>/dev/null || true)
+case "$runtime_artifact_directory" in
+    runtime-*)
+        candidate_result_file="${WP_CODEBOX_RUN_ARTIFACTS_DIR}/${runtime_artifact_directory}/files/phpunit/.pg-test-result.txt"
+        [ -f "$candidate_result_file" ] && RESULT_FILE="$candidate_result_file"
+        ;;
+esac
 if [ -f "$RESULT_FILE" ]; then
     PHPUNIT_OUTPUT=$(cat "$RESULT_FILE")
 fi

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -176,7 +176,8 @@ const phpunitResult = resultMode === 'bootstrap-failure'
 // WP Codebox persists the sandbox VFS result to this structured artifact path.
 fs.writeFileSync(path.join(phpunitArtifacts, '.pg-test-result.txt'), phpunitResult)
 fs.writeFileSync(resultModePath, resultMode === 'passed' ? 'bootstrap-failure\n' : 'passed\n')
-fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory } }))
+const pointerRuntimeDirectory = resultMode === 'invalid-pointer' ? 'runtime-/../../other-run' : runtimeDirectory
+fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: pointerRuntimeDirectory } }))
 const filesRoot = path.join(artifactRoot, 'runtime-smoke', 'files')
 fs.mkdirSync(filesRoot, { recursive: true })
 fs.writeFileSync(path.join(filesRoot, 'test-results.json'), JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: 'passed' }, null, 2))
@@ -306,6 +307,7 @@ fi
 
 mkdir -p "${ARTIFACTS_DIR}/files/phpunit"
 printf 'NO_TEST_FILES\n' > "${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"
+printf '{"schema":"stale-caller-sidecar"}\n' > "${ARTIFACTS_DIR}/files/test-results.json"
 printf 'fail-before-diagnostic\n' > "${ARTIFACTS_DIR}/runtime-smoke-result-mode"
 set +e
 stale_output=$(run_runner 2>&1)
@@ -322,6 +324,25 @@ if [[ "$stale_output" == *"Skipping PHPUnit tests"* ]]; then
 fi
 if ! grep -q '^NO_TEST_FILES' "${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"; then
     echo "Runner must preserve unrelated caller artifacts" >&2
+    exit 1
+fi
+if ! grep -q 'stale-caller-sidecar' "${ARTIFACTS_DIR}/files/test-results.json"; then
+    echo "Runner must not consume or replace stale caller test-result sidecars" >&2
+    exit 1
+fi
+
+printf 'invalid-pointer\n' > "${ARTIFACTS_DIR}/runtime-smoke-result-mode"
+set +e
+pointer_output=$(run_runner 2>&1)
+pointer_status=$?
+set -e
+if [ "$pointer_status" -eq 0 ]; then
+    echo "Expected malformed runtime artifact pointer to fail the runner" >&2
+    exit 1
+fi
+if [[ "$pointer_output" != *"Invalid runtime directory"* ]]; then
+    echo "Expected actionable malformed runtime pointer diagnostic" >&2
+    echo "$pointer_output" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -17,6 +17,9 @@ WRITABLE_DIR="${TMPDIR}/writable"
 STUBS_DIR="${TMPDIR}/stubs"
 COMPOSER_LOG="${TMPDIR}/composer.log"
 RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
+WRITE_RESULTS_HELPER="${TMPDIR}/write-test-results-helper.sh"
+RESULTS_FILE="${TMPDIR}/parsed-results.json"
+FAILURES_FILE="${TMPDIR}/parsed-failures.json"
 mkdir -p "${PLUGIN_PATH}/tests" "${PLUGIN_PATH}/config" "${DEP_PATH}/fixtures" "${REMOTE_DEP_PATH}/fixtures" "$ARTIFACTS_DIR" "$WRITABLE_DIR" "$STUBS_DIR"
 
 cat > "${PLUGIN_PATH}/tests/OnlyTest.php" <<'PHP'
@@ -52,6 +55,15 @@ homeboy_resolve_context() {
 }
 SH
 chmod +x "$RESOLVE_CONTEXT_HELPER"
+
+cat > "$WRITE_RESULTS_HELPER" <<'SH'
+#!/usr/bin/env bash
+homeboy_write_test_results() {
+    jq -n --arg source current-runtime --argjson total "$1" --argjson passed "$2" --argjson failed "$3" --argjson skipped "$4" --arg partial "$5" \
+        '{source: $source, total: $total, passed: $passed, failed: $failed, skipped: $skipped, partial: $partial}' > "$HOMEBOY_TEST_RESULTS_FILE"
+}
+SH
+chmod +x "$WRITE_RESULTS_HELPER"
 
 cat > "$FAKE_WP_CODEBOX" <<'NODE'
 #!/usr/bin/env node
@@ -178,9 +190,13 @@ fs.writeFileSync(path.join(phpunitArtifacts, '.pg-test-result.txt'), phpunitResu
 fs.writeFileSync(resultModePath, resultMode === 'passed' ? 'bootstrap-failure\n' : 'passed\n')
 const pointerRuntimeDirectory = resultMode === 'invalid-pointer' ? 'runtime-/../../other-run' : runtimeDirectory
 fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: pointerRuntimeDirectory } }))
-const filesRoot = path.join(artifactRoot, 'runtime-smoke', 'files')
+const filesRoot = path.join(artifactRoot, runtimeDirectory, 'files')
 fs.mkdirSync(filesRoot, { recursive: true })
-fs.writeFileSync(path.join(filesRoot, 'test-results.json'), JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: 'passed' }, null, 2))
+fs.writeFileSync(path.join(filesRoot, 'test-results.json'), JSON.stringify({
+  schema: 'wp-codebox/test-results/v1',
+  status: 'passed',
+  summary: { total: 1, passed: 1, failed: 0, skipped: 0 },
+}, null, 2))
 
 process.stdout.write(JSON.stringify({
   success: true,
@@ -247,6 +263,9 @@ run_runner() {
         HOMEBOY_COMPONENT_ID="example" \
         HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
         HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
+        HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_RESULTS_HELPER" \
+        HOMEBOY_TEST_RESULTS_FILE="$RESULTS_FILE" \
+        HOMEBOY_TEST_FAILURES_FILE="$FAILURES_FILE" \
         HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$DEP_PATH" \
         HOMEBOY_LAB_OFFLOAD_JSON="$LAB_OFFLOAD_JSON" \
         HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
@@ -265,6 +284,14 @@ fi
 
 if [ ! -s "$ARGS_FILE" ]; then
     echo "Expected fake wp-codebox to capture arguments" >&2
+    exit 1
+fi
+if ! grep -q '"source": "current-runtime"' "$RESULTS_FILE"; then
+    echo "Expected current runtime test-results sidecar to be parsed" >&2
+    exit 1
+fi
+if [ ! -f "$FAILURES_FILE" ] || grep -q 'stale-caller-sidecar' "$FAILURES_FILE"; then
+    echo "Expected current runtime failure sidecar to be parsed" >&2
     exit 1
 fi
 
@@ -308,6 +335,8 @@ fi
 mkdir -p "${ARTIFACTS_DIR}/files/phpunit"
 printf 'NO_TEST_FILES\n' > "${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"
 printf '{"schema":"stale-caller-sidecar"}\n' > "${ARTIFACTS_DIR}/files/test-results.json"
+printf '{"source":"stale-caller-sidecar"}\n' > "$RESULTS_FILE"
+printf '{"source":"stale-caller-sidecar"}\n' > "$FAILURES_FILE"
 printf 'fail-before-diagnostic\n' > "${ARTIFACTS_DIR}/runtime-smoke-result-mode"
 set +e
 stale_output=$(run_runner 2>&1)

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -359,6 +359,14 @@ if ! grep -q 'stale-caller-sidecar' "${ARTIFACTS_DIR}/files/test-results.json"; 
     echo "Runner must not consume or replace stale caller test-result sidecars" >&2
     exit 1
 fi
+if ! grep -q 'stale-caller-sidecar' "$RESULTS_FILE"; then
+    echo "Runner must not overwrite exported results from stale caller sidecars" >&2
+    exit 1
+fi
+if ! grep -q 'stale-caller-sidecar' "$FAILURES_FILE"; then
+    echo "Runner must not overwrite exported failures from stale caller sidecars" >&2
+    exit 1
+fi
 
 printf 'invalid-pointer\n' > "${ARTIFACTS_DIR}/runtime-smoke-result-mode"
 set +e

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -128,7 +128,7 @@ for (const expected of [
   'plugin-slug=example',
   'test-file=OnlyTest.php',
   'changed-tests-json=["tests/OnlyTest.php"]',
-  'phpunit-args-json=["--filter","OnlyTest","--cache-result-file=/tmp/wp-codebox-phpunit.result.cache"]',
+  'phpunit-args-json=["--filter","OnlyTest"]',
   'env-json={}',
   'wp-config-defines-json={"WP_DEBUG":true,"CUSTOM_NUMBER":7}',
   'autoload-file=/wp-codebox-vendor/autoload.php',
@@ -161,15 +161,22 @@ if (!fs.existsSync(path.join(componentPath, 'vendor/autoload.php'))) {
 }
 
 const artifactRoot = argValue('--artifacts') || path.join(path.dirname(process.env.FAKE_WP_CODEBOX_ARGS_FILE), 'artifacts')
-const phpunitArtifacts = path.join(artifactRoot, 'files', 'phpunit')
+const runtimeDirectory = 'runtime-fixture'
+const phpunitArtifacts = path.join(artifactRoot, runtimeDirectory, 'files', 'phpunit')
 fs.mkdirSync(phpunitArtifacts, { recursive: true })
-const resultModePath = path.join(artifactRoot, 'runtime-smoke-result-mode')
-const phpunitResult = fs.existsSync(resultModePath)
+const resultModePath = path.join(path.dirname(artifactRoot), 'runtime-smoke-result-mode')
+const resultMode = fs.existsSync(resultModePath) ? fs.readFileSync(resultModePath, 'utf8').trim() : 'passed'
+if (resultMode === 'fail-before-diagnostic') {
+  process.stderr.write('fixture runtime failed before persisting diagnostics\n')
+  process.exit(1)
+}
+const phpunitResult = resultMode === 'bootstrap-failure'
   ? ['STAGE_FAIL:bootstrap:fixture bootstrap failure', ''].join('\n')
   : ['STAGE_BEGIN:run_tests', 'ALL TESTS PASSED', 'TESTS: 1 FAILURES: 0 ERRORS: 0', 'STAGE_OK:run_tests', ''].join('\n')
 // WP Codebox persists the sandbox VFS result to this structured artifact path.
 fs.writeFileSync(path.join(phpunitArtifacts, '.pg-test-result.txt'), phpunitResult)
-fs.writeFileSync(resultModePath, 'bootstrap-failure\n')
+fs.writeFileSync(resultModePath, resultMode === 'passed' ? 'bootstrap-failure\n' : 'passed\n')
+fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory } }))
 const filesRoot = path.join(artifactRoot, 'runtime-smoke', 'files')
 fs.mkdirSync(filesRoot, { recursive: true })
 fs.writeFileSync(path.join(filesRoot, 'test-results.json'), JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: 'passed' }, null, 2))
@@ -270,7 +277,11 @@ if [ -e "${PLUGIN_PATH}/.pg-test-result.txt" ]; then
     echo "WP Codebox diagnostics must not write to the readonly component source" >&2
     exit 1
 fi
-if ! grep -q '^STAGE_OK:run_tests' "${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"; then
+run_artifacts_dir=""
+for candidate in "${ARTIFACTS_DIR}"/wp-codebox-phpunit.*; do
+    [ -d "$candidate" ] && run_artifacts_dir="$candidate"
+done
+if ! grep -q '^STAGE_OK:run_tests' "${run_artifacts_dir}/runtime-fixture/files/phpunit/.pg-test-result.txt"; then
     echo "Expected PHPUnit VFS diagnostic to persist under WP Codebox artifacts" >&2
     exit 1
 fi
@@ -290,6 +301,27 @@ if [[ "$failure_output" != *"BOOTSTRAP FAILURE: bootstrap:fixture bootstrap fail
 fi
 if [ -e "${PLUGIN_PATH}/.pg-test-result.txt" ]; then
     echo "Structured diagnostic failure must not write to the readonly component source" >&2
+    exit 1
+fi
+
+mkdir -p "${ARTIFACTS_DIR}/files/phpunit"
+printf 'NO_TEST_FILES\n' > "${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"
+printf 'fail-before-diagnostic\n' > "${ARTIFACTS_DIR}/runtime-smoke-result-mode"
+set +e
+stale_output=$(run_runner 2>&1)
+stale_status=$?
+set -e
+if [ "$stale_status" -eq 0 ]; then
+    echo "Expected a runtime failure without a current diagnostic to fail the runner" >&2
+    exit 1
+fi
+if [[ "$stale_output" == *"Skipping PHPUnit tests"* ]]; then
+    echo "Runner consumed a stale no-test diagnostic from a previous invocation" >&2
+    echo "$stale_output" >&2
+    exit 1
+fi
+if ! grep -q '^NO_TEST_FILES' "${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"; then
+    echo "Runner must preserve unrelated caller artifacts" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Relates to #2255 and merged #2257.

## Summary

- create a runner-owned WP Codebox artifact scope per PHPUnit invocation
- accept only a `runtime-<alphanumeric-or-hyphen>` pointer basename, resolve it canonically, and require it to remain directly under that invocation's artifact scope
- consume PHPUnit diagnostics, `test-results.json`, and failure sidecars only from the validated current runtime artifact
- preserve caller-owned artifacts, so stale caller-level `NO_TEST_FILES` and test-result sidecars cannot mask a current startup failure
- add a real readonly-source canary covering structured diagnostics, source hash stability, and no host PHPUnit cache

## Dependencies

Depends on merged Automattic/wp-codebox #1799, #1804, and #1805.

## Fresh-checkout tests

1. `cd wordpress && node tests/wp-codebox-phpunit-recipe-builder-smoke.js`
2. `cd wordpress && bash scripts/test/wp-codebox-mount-translation-smoke.sh`
3. `cd wordpress && bash -n scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-mount-translation-smoke.sh scripts/test/playground-db-activation-smoke.sh`
4. Build WP Codebox at merged `b8c4cfe`, then run `HOMEBOY_WP_CODEBOX_INSTALL_DIR=/var/empty/wp-codebox HOMEBOY_WP_CODEBOX_BIN=<wp-codebox>/packages/cli/dist/index.js HOMEBOY_WP_CODEBOX_CORE_MODULE=<wp-codebox>/packages/runtime-core/dist/recipe-builders.js HOMEBOY_CORE_DIR=<homeboy> bash wordpress/scripts/test/playground-db-activation-smoke.sh`. The empty install directory ensures the selected CLI and recipe-builder module come from that exact build.
5. `git diff --check`

## Compatibility

Readonly component sources remain immutable. Malformed or out-of-scope runtime pointers fail closed with an actionable diagnostic. PHPUnit result sidecars now come only from the validated current runtime artifact; unrelated caller artifacts remain intact.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode/openai-gpt-5.6-sol
- **Used for:** Implemented strict runtime artifact pointer validation, current-run sidecar routing, regression coverage, and merged-runtime verification; Chris reviews and owns the change.