### PR TITLE
Publish Rust workspace crates in dependency order

### DIFF
--- a/rust/scripts/publish-crates-smoke.sh
+++ b/rust/scripts/publish-crates-smoke.sh
@@ -15,13 +15,14 @@ set -euo pipefail
 
 case "$1" in
   metadata)
-    printf '{"packages":[{"name":"homeboy-smoke","version":"1.2.3"}]}'
+    printf '{"workspace_members":["homeboy-smoke 1.2.3"],"packages":[{"id":"homeboy-smoke 1.2.3","name":"homeboy-smoke","version":"1.2.3","publish":null}],"resolve":{"nodes":[{"id":"homeboy-smoke 1.2.3","deps":[]}]}}'
     ;;
-  search)
-    printf 'homeboy-smoke = "1.2.2"\n'
+  info)
+    [[ -f "${CARGO_PUBLISHED_MARKER}" ]]
     ;;
   publish)
     printf '%s\n' "$@" >"${CARGO_PUBLISH_ARGS_LOG}"
+    touch "${CARGO_PUBLISHED_MARKER}"
     ;;
   *)
     echo "unexpected cargo command: $*" >&2
@@ -33,11 +34,18 @@ chmod +x "${BIN_DIR}/cargo"
 
 export PATH="${BIN_DIR}:${PATH}"
 export CARGO_PUBLISH_ARGS_LOG="${TMP_DIR}/publish-args.log"
+export CARGO_PUBLISHED_MARKER="${TMP_DIR}/published"
 
 bash "${SCRIPT}" >/dev/null
 
 if ! grep -qx -- '--allow-dirty' "${CARGO_PUBLISH_ARGS_LOG}"; then
   echo "FAIL: cargo publish did not receive --allow-dirty" >&2
+  cat "${CARGO_PUBLISH_ARGS_LOG}" >&2
+  exit 1
+fi
+
+if ! grep -qx -- '--package' "${CARGO_PUBLISH_ARGS_LOG}" || ! grep -qx -- 'homeboy-smoke' "${CARGO_PUBLISH_ARGS_LOG}"; then
+  echo "FAIL: cargo publish did not receive the explicit package identity" >&2
   cat "${CARGO_PUBLISH_ARGS_LOG}" >&2
   exit 1
 fi

--- a/rust/scripts/publish-crates.sh
+++ b/rust/scripts/publish-crates.sh
@@ -143,25 +143,87 @@ publish_homebrew_formulae() {
   return 0
 }
 
-# Get current package info from Cargo.toml
-PACKAGE_NAME=$(cargo metadata --format-version 1 --no-deps 2>/dev/null | jq -r '.packages[0].name // empty')
-CURRENT_VERSION=$(cargo metadata --format-version 1 --no-deps 2>/dev/null | jq -r '.packages[0].version // empty')
+workspace_packages() {
+  cargo metadata --format-version 1 --locked | jq -r '
+    (.workspace_members // [.packages[].id]) as $members
+    | [.packages[]
+       | select(.id as $id | $members | index($id))
+       | select(.publish != [])
+       | { id, name, version }
+      ] as $packages
+    | ($packages | map(.id)) as $publishable_ids
+    | [ $packages[] as $package
+        | {
+            id: $package.id,
+            name: $package.name,
+            version: $package.version,
+            dependencies: [
+              (.resolve.nodes[]? | select(.id == $package.id) | .deps[]?.pkg)
+              | select(. as $dependency | $publishable_ids | index($dependency))
+            ]
+          }
+      ] as $pending
+    | { pending: $pending, published: [] }
+    | until(
+        (.pending | length) == 0;
+        . as $state
+        | ([.pending[]
+            | select((.dependencies - $state.published | length) == 0)
+          ] | sort_by(.name)) as $ready
+        | if ($ready | length) == 0 then
+            error("publishable workspace packages contain a dependency cycle")
+          else
+            .published += ($ready | map(.id))
+            | .pending -= $ready
+          end
+      )
+    | .published[] as $id
+    | $pending[] | select(.id == $id) | [.name, .version] | @tsv
+  '
+}
 
-if [[ -z "$PACKAGE_NAME" || -z "$CURRENT_VERSION" ]]; then
-  echo "Failed to read package info from Cargo.toml" >&2
+package_is_published() {
+  cargo info "$1@$2" --registry crates-io >/dev/null 2>&1
+}
+
+wait_for_registry_visibility() {
+  local package_name="$1" package_version="$2"
+  local attempts="${HOMEBOY_CRATES_IO_VISIBILITY_ATTEMPTS:-12}"
+  local delay="${HOMEBOY_CRATES_IO_VISIBILITY_DELAY_SECONDS:-5}"
+  local attempt
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if package_is_published "${package_name}" "${package_version}"; then
+      echo "${package_name} v${package_version} is available in the crates.io registry."
+      return 0
+    fi
+
+    if [[ "${attempt}" -lt "${attempts}" ]]; then
+      echo "Waiting for ${package_name} v${package_version} to become available in crates.io (${attempt}/${attempts})..."
+      sleep "${delay}"
+    fi
+  done
+
+  echo "${package_name} v${package_version} did not become available in crates.io after ${attempts} checks." >&2
+  return 1
+}
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required for Rust workspace publishing." >&2
   exit 1
 fi
 
-# Check if this version is already published on crates.io
-PUBLISHED_VERSION=$(cargo search "$PACKAGE_NAME" --limit 1 2>/dev/null | grep -oE "^$PACKAGE_NAME = \"[^\"]+\"" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+while IFS=$'\t' read -r package_name package_version; do
+  [[ -z "${package_name}" || -z "${package_version}" ]] && continue
 
-if [[ "$CURRENT_VERSION" == "$PUBLISHED_VERSION" ]]; then
-  echo "Version $CURRENT_VERSION of $PACKAGE_NAME already published to crates.io, skipping..."
-  publish_homebrew_formulae
-  exit 0
-fi
+  if package_is_published "${package_name}" "${package_version}"; then
+    echo "${package_name} v${package_version} is already published to crates.io."
+    continue
+  fi
 
-echo "Publishing $PACKAGE_NAME v$CURRENT_VERSION to crates.io..."
-cargo publish --locked --allow-dirty
+  echo "Publishing ${package_name} v${package_version} to crates.io..."
+  cargo publish --package "${package_name}" --locked --allow-dirty
+  wait_for_registry_visibility "${package_name}" "${package_version}"
+done < <(workspace_packages)
 
 publish_homebrew_formulae

--- a/rust/scripts/test-publish-crates-homebrew.sh
+++ b/rust/scripts/test-publish-crates-homebrew.sh
@@ -35,10 +35,11 @@ cat > "${BIN_DIR}/cargo" <<'SH'
 set -euo pipefail
 case "$1" in
   metadata)
-    printf '{"packages":[{"name":"homeboy","version":"1.2.3"}]}'
+    printf '{"workspace_members":["homeboy 1.2.3"],"packages":[{"id":"homeboy 1.2.3","name":"homeboy","version":"1.2.3","publish":null}],"resolve":{"nodes":[{"id":"homeboy 1.2.3","deps":[]}]}}'
     ;;
-  search)
-    printf 'homeboy = "1.2.3"    # fixture\n'
+  info)
+    printf 'cargo info %s\n' "$2" >> "${EVENT_LOG}"
+    exit 0
     ;;
   publish)
     printf 'cargo publish should not run for an already-published version\n' >&2
@@ -52,6 +53,14 @@ esac
 SH
 chmod +x "${BIN_DIR}/cargo"
 
+REAL_GIT="$(command -v git)"
+cat > "${BIN_DIR}/git" <<'SH'
+#!/usr/bin/env bash
+printf 'git %s\n' "$*" >> "${EVENT_LOG}"
+exec "${REAL_GIT}" "$@"
+SH
+chmod +x "${BIN_DIR}/git"
+
 git -C "${TAP_DIR}" init --initial-branch=main >/dev/null
 git -C "${TAP_DIR}" config user.name "Fixture"
 git -C "${TAP_DIR}" config user.email "fixture@example.com"
@@ -60,6 +69,8 @@ git -C "${TAP_DIR}" add .gitkeep
 git -C "${TAP_DIR}" commit -m initial >/dev/null
 
 cd "${PROJECT_DIR}"
+export EVENT_LOG="${TMP_DIR}/events.log"
+export REAL_GIT
 PATH="${BIN_DIR}:${PATH}" \
 HOMEBOY_HOMEBREW_TAP_DIR="${TAP_DIR}" \
 HOMEBOY_HOMEBREW_SKIP_PUSH=true \
@@ -82,6 +93,12 @@ fi
 
 if [[ "${LAST_AUTHOR}" != "Extra Chill Bot <bot@extrachill.com>" ]]; then
   printf 'unexpected tap commit author: %s\n' "${LAST_AUTHOR}" >&2
+  exit 1
+fi
+
+FIRST_EVENT="$(awk 'NF { print; exit }' "${EVENT_LOG}")"
+if [[ "${FIRST_EVENT}" != "cargo info homeboy@1.2.3" ]]; then
+  printf 'Homebrew work began before Rust package publication completed: %s\n' "${FIRST_EVENT}" >&2
   exit 1
 fi
 

--- a/rust/scripts/test-publish-crates-workspace.sh
+++ b/rust/scripts/test-publish-crates-workspace.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+BIN_DIR="${TMP_DIR}/bin"
+mkdir -p "${BIN_DIR}"
+
+cat > "${BIN_DIR}/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1" in
+  metadata)
+    cat <<'JSON'
+{"workspace_members":["app 1.0.0","contract 1.0.0","private 1.0.0"],"packages":[{"id":"app 1.0.0","name":"app","version":"1.0.0","publish":null},{"id":"contract 1.0.0","name":"contract","version":"1.0.0","publish":null},{"id":"private 1.0.0","name":"private","version":"1.0.0","publish":[]}],"resolve":{"nodes":[{"id":"app 1.0.0","deps":[{"pkg":"contract 1.0.0"}]},{"id":"contract 1.0.0","deps":[]},{"id":"private 1.0.0","deps":[]}]}}
+JSON
+    ;;
+  info)
+    identity="$2"
+    printf 'info %s\n' "${identity}" >> "${CARGO_LOG}"
+    case "${identity}" in
+      contract@1.0.0)
+        exit 0
+        ;;
+      app@1.0.0)
+        count_file="${CARGO_STATE}/app-info-count"
+        count=0
+        if [[ -f "${count_file}" ]]; then
+          count="$(<"${count_file}")"
+        fi
+        count=$((count + 1))
+        printf '%s' "${count}" > "${count_file}"
+        if [[ "${count}" -ge 3 ]]; then
+          exit 0
+        fi
+        exit 1
+        ;;
+    esac
+    exit 1
+    ;;
+  publish)
+    printf 'publish %s\n' "$*" >> "${CARGO_LOG}"
+    [[ "$*" == *'--package app'* ]]
+    ;;
+  *)
+    printf 'unexpected cargo command: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "${BIN_DIR}/cargo"
+
+cat > "${BIN_DIR}/sleep" <<'SH'
+#!/usr/bin/env bash
+printf 'sleep %s\n' "$*" >> "${CARGO_LOG}"
+SH
+chmod +x "${BIN_DIR}/sleep"
+
+export PATH="${BIN_DIR}:${PATH}"
+export CARGO_LOG="${TMP_DIR}/cargo.log"
+export CARGO_STATE="${TMP_DIR}/state"
+mkdir -p "${CARGO_STATE}"
+
+bash "${SCRIPT_DIR}/publish-crates.sh" >/dev/null
+
+expected=$'info contract@1.0.0\ninfo app@1.0.0\npublish publish --package app --locked --allow-dirty\ninfo app@1.0.0\nsleep 5\ninfo app@1.0.0'
+actual="$(<"${CARGO_LOG}")"
+if [[ "${actual}" != "${expected}" ]]; then
+  printf 'unexpected workspace publish sequence:\n%s\n' "${actual}" >&2
+  exit 1
+fi
+
+if grep -q 'private' "${CARGO_LOG}"; then
+  printf 'publish=false package was included in the release sequence\n' >&2
+  exit 1
+fi
+
+FAIL_BIN_DIR="${TMP_DIR}/failure-bin"
+mkdir -p "${FAIL_BIN_DIR}"
+cat > "${FAIL_BIN_DIR}/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  metadata) printf '{"workspace_members":["broken 1.0.0"],"packages":[{"id":"broken 1.0.0","name":"broken","version":"1.0.0","publish":null}],"resolve":{"nodes":[{"id":"broken 1.0.0","deps":[]}]}}' ;;
+  info) exit 1 ;;
+  publish) printf 'publish failed\n' >&2; exit 1 ;;
+esac
+SH
+chmod +x "${FAIL_BIN_DIR}/cargo"
+
+if PATH="${FAIL_BIN_DIR}:${PATH}" bash "${SCRIPT_DIR}/publish-crates.sh" >/dev/null 2>&1; then
+  printf 'publish failure did not fail the release script\n' >&2
+  exit 1
+fi
+
+printf 'publish-crates workspace test passed\n'


### PR DESCRIPTION
## Summary
Make generic Rust releases publish workspace crates deterministically before updating Homebrew.

## What changed
- Discover publishable workspace packages, exclude publish=false crates, and publish explicit package identities in dependency order.
- Wait for exact-version crates.io visibility before publishing dependents and keep recovery idempotent.
- Run Homebrew publication only after every Rust package has completed.

## How to test
1. Run `bash rust/scripts/test-publish-crates-workspace.sh`; expect proves explicit package identity, dependency ordering, delayed registry visibility, idempotent recovery, publish=false exclusion, and failure handling.
2. Run `bash rust/scripts/test-publish-crates-homebrew.sh`; expect proves Homebrew publication follows completed Rust publication.

## Compatibility
Preserves single-package publication while adding correct workspace behavior; no extension path is removed.

## Evidence
- CI expected: Audit
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2261
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29391444930
- homebrew-order: Passed
- shellcheck: Passed
- workspace-publish: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the generic workspace publication failure, implemented ordered idempotent publishing, and drafted deterministic shell coverage; Chris owns the change.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2261
