### PR TITLE
Retry crates.io publication rate limits

### DIFF
--- a/rust/scripts/publish-crates.sh
+++ b/rust/scripts/publish-crates.sh
@@ -208,6 +208,92 @@ wait_for_registry_visibility() {
   return 1
 }
 
+is_crates_io_rate_limited() {
+  local output
+  for output in "$@"; do
+    if grep -qi 'crates\.io' "${output}" && grep -Eqi '(^|[^0-9])429([^0-9]|$)|rate limit' "${output}"; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+crates_io_retry_delay() {
+  local output retry_after retry_after_epoch now delay
+  local fallback_delay="${HOMEBOY_CRATES_IO_PUBLISH_RETRY_DELAY_SECONDS:-60}"
+  local safety_margin="${HOMEBOY_CRATES_IO_PUBLISH_RETRY_SAFETY_MARGIN_SECONDS:-5}"
+  local max_delay="${HOMEBOY_CRATES_IO_PUBLISH_RETRY_MAX_DELAY_SECONDS:-300}"
+
+  if ! [[ "${fallback_delay}" =~ ^[0-9]+$ && "${safety_margin}" =~ ^[0-9]+$ && "${max_delay}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Invalid crates.io publish retry delay configuration." >&2
+    return 1
+  fi
+
+  retry_after=""
+  while IFS= read -r output; do
+    if [[ "${output}" =~ Please[[:space:]]try[[:space:]]again[[:space:]]after[[:space:]]+([A-Z][a-z][a-z],[[:space:]][0-9]{1,2}[[:space:]][A-Z][a-z][a-z][[:space:]][0-9]{4}[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]]GMT) ]]; then
+      retry_after="${BASH_REMATCH[1]}"
+      break
+    fi
+  done < <(cat "$@")
+
+  delay="${fallback_delay}"
+  if [[ -n "${retry_after}" ]] && { retry_after_epoch="$(date -u -j -f '%a, %d %b %Y %H:%M:%S %Z' "${retry_after}" +%s 2>/dev/null)" || retry_after_epoch="$(date -u -d "${retry_after}" +%s 2>/dev/null)"; }; then
+    now="$(date +%s)"
+    if (( retry_after_epoch > now )); then
+      delay=$((retry_after_epoch - now + safety_margin))
+    fi
+  fi
+
+  if (( delay > max_delay )); then
+    delay="${max_delay}"
+  fi
+
+  printf '%s\n' "${delay}"
+}
+
+publish_package() {
+  local package_name="$1"
+  local attempts="${HOMEBOY_CRATES_IO_PUBLISH_ATTEMPTS:-3}"
+  local attempt status delay stdout stderr
+
+  if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Invalid HOMEBOY_CRATES_IO_PUBLISH_ATTEMPTS value: ${attempts}" >&2
+    return 1
+  fi
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    stdout="$(mktemp)"
+    stderr="$(mktemp)"
+
+    if cargo publish --package "${package_name}" --locked --allow-dirty >"${stdout}" 2>"${stderr}"; then
+      cat "${stdout}"
+      cat "${stderr}" >&2
+      rm -f "${stdout}" "${stderr}"
+      return 0
+    else
+      status=$?
+    fi
+
+    cat "${stdout}"
+    cat "${stderr}" >&2
+
+    if ! is_crates_io_rate_limited "${stdout}" "${stderr}" || [[ "${attempt}" -eq "${attempts}" ]]; then
+      rm -f "${stdout}" "${stderr}"
+      return "${status}"
+    fi
+
+    delay="$(crates_io_retry_delay "${stdout}" "${stderr}")" || {
+      rm -f "${stdout}" "${stderr}"
+      return 1
+    }
+    rm -f "${stdout}" "${stderr}"
+    echo "crates.io rate limited ${package_name}; retrying in ${delay}s (${attempt}/${attempts})..." >&2
+    sleep "${delay}"
+  done
+}
+
 if ! command -v jq &>/dev/null; then
   echo "Error: jq is required for Rust workspace publishing." >&2
   exit 1
@@ -222,7 +308,7 @@ while IFS=$'\t' read -r package_name package_version; do
   fi
 
   echo "Publishing ${package_name} v${package_version} to crates.io..."
-  cargo publish --package "${package_name}" --locked --allow-dirty
+  publish_package "${package_name}"
   wait_for_registry_visibility "${package_name}" "${package_version}"
 done < <(workspace_packages)
 

--- a/rust/scripts/test-publish-crates-workspace.sh
+++ b/rust/scripts/test-publish-crates-workspace.sh
@@ -26,6 +26,9 @@ JSON
         exit 0
         ;;
       app@1.0.0)
+        if [[ -f "${CARGO_STATE}/app-published" ]]; then
+          exit 0
+        fi
         count_file="${CARGO_STATE}/app-info-count"
         count=0
         if [[ -f "${count_file}" ]]; then
@@ -33,7 +36,7 @@ JSON
         fi
         count=$((count + 1))
         printf '%s' "${count}" > "${count_file}"
-        if [[ "${count}" -ge 3 ]]; then
+        if [[ "${CARGO_SCENARIO:-workspace}" == "workspace" && "${count}" -ge 3 ]]; then
           exit 0
         fi
         exit 1
@@ -44,6 +47,30 @@ JSON
   publish)
     printf 'publish %s\n' "$*" >> "${CARGO_LOG}"
     [[ "$*" == *'--package app'* ]]
+    count_file="${CARGO_STATE}/app-publish-count"
+    count=0
+    [[ -f "${count_file}" ]] && count="$(<"${count_file}")"
+    count=$((count + 1))
+    printf '%s' "${count}" > "${count_file}"
+    case "${CARGO_SCENARIO:-workspace}" in
+      rate-success)
+        if [[ "${count}" -eq 1 ]]; then
+          printf 'failed to publish to https://crates.io: HTTP 429 Too Many Requests. Please try again after Wed, 15 Jul 2026 07:28:56 GMT\n' >&2
+          exit 1
+        fi
+        ;;
+      rate-exhaust)
+        printf 'failed to publish to https://crates.io: HTTP 429 Too Many Requests. Please try again after Wed, 15 Jul 2026 07:28:56 GMT\n' >&2
+        exit 1
+        ;;
+      hard-failure)
+        printf 'publish failed\n' >&2
+        exit 1
+        ;;
+    esac
+    if [[ "${CARGO_SCENARIO:-workspace}" != "workspace" ]]; then
+      touch "${CARGO_STATE}/app-published"
+    fi
     ;;
   *)
     printf 'unexpected cargo command: %s\n' "$*" >&2
@@ -52,6 +79,16 @@ JSON
 esac
 SH
 chmod +x "${BIN_DIR}/cargo"
+
+cat > "${BIN_DIR}/date" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == *'-j -f'* ]]; then
+  printf '110\n'
+else
+  printf '100\n'
+fi
+SH
+chmod +x "${BIN_DIR}/date"
 
 cat > "${BIN_DIR}/sleep" <<'SH'
 #!/usr/bin/env bash
@@ -78,21 +115,30 @@ if grep -q 'private' "${CARGO_LOG}"; then
   exit 1
 fi
 
-FAIL_BIN_DIR="${TMP_DIR}/failure-bin"
-mkdir -p "${FAIL_BIN_DIR}"
-cat > "${FAIL_BIN_DIR}/cargo" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-case "$1" in
-  metadata) printf '{"workspace_members":["broken 1.0.0"],"packages":[{"id":"broken 1.0.0","name":"broken","version":"1.0.0","publish":null}],"resolve":{"nodes":[{"id":"broken 1.0.0","deps":[]}]}}' ;;
-  info) exit 1 ;;
-  publish) printf 'publish failed\n' >&2; exit 1 ;;
-esac
-SH
-chmod +x "${FAIL_BIN_DIR}/cargo"
+rm -f "${CARGO_STATE}"/* "${CARGO_LOG}"
+CARGO_SCENARIO=rate-success HOMEBOY_CRATES_IO_PUBLISH_RETRY_SAFETY_MARGIN_SECONDS=5 bash "${SCRIPT_DIR}/publish-crates.sh" >"${TMP_DIR}/rate-success.out" 2>"${TMP_DIR}/rate-success.err"
+if ! grep -qx 'sleep 15' "${CARGO_LOG}" || ! grep -q 'HTTP 429 Too Many Requests' "${TMP_DIR}/rate-success.err"; then
+  printf 'rate-limit retry did not retain output and wait for Retry-After\n' >&2
+  exit 1
+fi
 
-if PATH="${FAIL_BIN_DIR}:${PATH}" bash "${SCRIPT_DIR}/publish-crates.sh" >/dev/null 2>&1; then
-  printf 'publish failure did not fail the release script\n' >&2
+rm -f "${CARGO_STATE}"/* "${CARGO_LOG}"
+if CARGO_SCENARIO=rate-exhaust HOMEBOY_CRATES_IO_PUBLISH_ATTEMPTS=2 bash "${SCRIPT_DIR}/publish-crates.sh" >/dev/null 2>&1; then
+  printf 'rate-limit retry exhaustion did not fail the release script\n' >&2
+  exit 1
+fi
+if [[ "$(grep -c '^publish ' "${CARGO_LOG}")" -ne 2 ]] || [[ "$(grep -c '^sleep ' "${CARGO_LOG}")" -ne 1 ]]; then
+  printf 'rate-limit retry exhaustion did not honor the attempt limit\n' >&2
+  exit 1
+fi
+
+rm -f "${CARGO_STATE}"/* "${CARGO_LOG}"
+if CARGO_SCENARIO=hard-failure HOMEBOY_CRATES_IO_PUBLISH_ATTEMPTS=3 bash "${SCRIPT_DIR}/publish-crates.sh" >/dev/null 2>&1; then
+  printf 'non-rate-limit publish failure did not fail the release script\n' >&2
+  exit 1
+fi
+if [[ "$(grep -c '^publish ' "${CARGO_LOG}")" -ne 1 ]] || grep -q '^sleep ' "${CARGO_LOG}"; then
+  printf 'non-rate-limit publish failure retried\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Honor crates.io retry-after windows inside generic Rust workspace publication.

## What changed
- Retry only explicit crates.io HTTP 429 publication failures with bounded configurable attempts.
- Parse server retry-after timestamps across GNU/Linux and macOS, retain full cargo output, and use a bounded fallback delay.

## How to test
1. Run `bash rust/scripts/test-publish-crates-workspace.sh`; expect proves 429 retry-after success, idempotent continuation, bounded exhaustion, and immediate non-429 failure.

## Compatibility
Non-rate-limit cargo failures remain terminal; successful and already-published package behavior is unchanged.

## Evidence
- CI expected: Audit
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2261#issuecomment-4977979331
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29391444930
- rate-limit-retry: Passed
- shellcheck: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed live crates.io quota responses, implemented bounded retry-after handling, and drafted deterministic fake-registry coverage; Chris owns the change.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2261
