### PR TITLE
Advertise run-scoped scratch for OpenCode

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -49,6 +49,7 @@ const OPENCODE_CAPABILITIES = [
 	'provider_owned_session',
 	'provider_owned_cancellation',
 	'nested_orchestrator',
+	'run_scoped_scratch',
 ];
 
 const OPENCODE_COMMAND = 'node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs';

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,7 +9,7 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.1.1',
+		version: '1.2.0',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
 		contract_producers: [
 			{

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "contract_producers": [
     {
@@ -102,7 +102,8 @@
         "provider_owned_auth",
         "provider_owned_session",
         "provider_owned_cancellation",
-        "nested_orchestrator"
+        "nested_orchestrator",
+        "run_scoped_scratch"
       ],
       "workspace_materialization": {
         "cwd": "git_checkout",

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -58,6 +58,7 @@ assert.deepEqual(provider.role_aliases, OPENCODE_ROLE_ALIASES);
 assert.equal(provider.redacted_metadata_keys.includes('opencode_auth'), true);
 assert.equal(provider.capabilities.includes('repo_workspace'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
+assert.equal(provider.capabilities.includes('run_scoped_scratch'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'opencode.json'), 'utf8'));
@@ -202,6 +203,50 @@ process.exit(0);
 		},
 	}, { env: fixtureEnv });
 	assert.equal(modelResult.status, 'succeeded');
+
+	const scratchAttempts = [
+		{ id: 'run-2250-attempt-1', status: 0 },
+		{ id: 'run-2250-attempt-2', status: 17 },
+	];
+	for (const attempt of scratchAttempts) {
+		const scratchRoot = path.join(root, 'scratch', attempt.id);
+		fs.mkdirSync(scratchRoot, { recursive: true });
+		const scratchCliPath = path.join(root, `mock-opencode-scratch-${attempt.status}.cjs`);
+		fs.writeFileSync(scratchCliPath, `#!/usr/bin/env node
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+assert.equal(process.env.TMPDIR, ${JSON.stringify(scratchRoot)});
+assert.equal(process.env.UNRELATED_RUNTIME_ENV, 'preserved-for-provider');
+fs.writeFileSync(path.join(process.env.TMPDIR, 'provider-scratch.txt'), process.env.TMPDIR);
+process.exit(${attempt.status});
+`);
+		const scratchResult = await executeOpenCodeAgentTask({
+			...request,
+			task_id: attempt.id,
+			executor: {
+				...request.executor,
+				config: {
+					...request.executor.config,
+					command_args: [scratchCliPath],
+					runtime_env: {
+						TMPDIR: scratchRoot,
+						UNRELATED_RUNTIME_ENV: 'preserved-for-provider',
+					},
+				},
+			},
+		}, { env: fixtureEnv });
+		assert.equal(scratchResult.status, attempt.status === 0 ? 'succeeded' : 'failed');
+		assert.equal(fs.readFileSync(path.join(scratchRoot, 'provider-scratch.txt'), 'utf8'), scratchRoot);
+	}
+	assert.equal(
+		fs.existsSync(path.join(root, 'scratch', 'run-2250-attempt-1', 'provider-scratch.txt')),
+		true
+	);
+	assert.equal(
+		fs.existsSync(path.join(root, 'scratch', 'run-2250-attempt-2', 'provider-scratch.txt')),
+		true
+	);
 
 	const missingArtifactResult = await executeOpenCodeAgentTask({
 		...request,

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -232,6 +232,17 @@ must add that key to `redacted_metadata_keys`, preferably with
 
 ## Capability Declarations
 
+### Run-scoped scratch
+
+Runtimes that advertise the `run_scoped_scratch` capability consume the controller-provided
+attempt scratch root through `executor.config.runtime_env.TMPDIR`. The runtime passes that value
+to its provider process without replacing it with an ambient shared temporary directory.
+
+Homeboy owns scratch allocation, run and attempt ownership metadata, active leases, evidence
+promotion ordering, retention, and cleanup preview/apply reporting. A runtime does not create,
+delete, lease, or retain the root: that would duplicate controller lifecycle state and could
+remove an active attempt's scratch.
+
 Capabilities are selection and orchestration promises. Declare a capability only
 when the provider can satisfy it for every request accepted by that provider.
 


### PR DESCRIPTION
## Summary
Advertise and enforce the OpenCode runtime boundary for Homeboy-owned run-scoped scratch without duplicating lifecycle ownership in the extension.

## What changed
- Add the run\_scoped\_scratch capability and bump the OpenCode runtime manifest contract from 1.1.1 to 1.2.0.
- Prove injected runtime\_env.TMPDIR reaches provider processes unchanged on success and failure, preserves unrelated runtime environment values, and remains untouched by extension cleanup.

## How to test
1. Run `npm --prefix agent-runtimes/opencode run test:opencode-agent-task-executor-boundary`; expect OpenCode executor boundary passes for success and failure scratch pass-through.
2. Run `npm --prefix agent-runtimes/opencode run check:runtime-manifest`; expect generated and checked runtime manifests match.
3. Run `npm --prefix runtime-agent-ci test`; expect complete runtime-agent CI contract suite passes.
4. Run `git diff --check`; expect no whitespace errors.

## Compatibility
Additive runtime capability and minor manifest version bump. The private npm package version is unchanged. Older core versions that do not inject TMPDIR leave existing execution behavior unchanged; allocation, leases, retention, and cleanup remain exclusively owned by landed Homeboy core.

## Evidence
- CI expected: GitHub Actions
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2250
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8121
- diff\_check: Passed
- executor\_boundary: Passed
- runtime\_agent\_ci: Passed
- runtime\_manifest: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode and Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared and rebased the runtime capability candidate, reviewed the core/extension ownership boundary, and orchestrated signed promotion and deterministic verification with Chris.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2250
