### PR TITLE
fix(wordpress): prevent recursive codebox readiness checks

### DIFF
--- a/wordpress/lib/wp-codebox-core-loader.js
+++ b/wordpress/lib/wp-codebox-core-loader.js
@@ -4,10 +4,9 @@
  * External dependencies
  */
 const path = require('node:path');
-const { existsSync, readdirSync } = require('node:fs');
+const { existsSync, readFileSync, readdirSync } = require('node:fs');
 const { homedir } = require('node:os');
 const { pathToFileURL } = require('node:url');
-const { execFileSync } = require('node:child_process');
 
 /**
  * Internal dependencies
@@ -80,16 +79,16 @@ function coreModuleCandidates(options = {}) {
 		}
 	}
 
-	// Last-resort discovery: ask the Homeboy component registry directly.
+	// Last-resort discovery: read Homeboy's non-evaluating component registry
+	// pointer directly. Do not use `homeboy component show` here: component
+	// inspection may evaluate this extension's ready_check and re-enter the
+	// loader recursively.
 	// This covers hosts where the wp-codebox checkout lives outside any
 	// workspaceRoots() guess (e.g. a Data Machine Code workspace root that
 	// differs from the wordpress extension's own parent directory) but is
-	// still registered with Homeboy via `homeboy component create`/`show`.
-	// Mirrors the same fallback already used by
-	// scripts/lib/validation-dependencies.sh (`homeboy component show`).
+	// still registered with Homeboy via `homeboy component create`.
 	// Only attempted when workspaceRoots() sibling-checkout discovery found
-	// nothing, since this shells out to the `homeboy` binary and shouldn't
-	// add latency to the already-working discovery paths.
+	// nothing, so registry metadata cannot override an already-working path.
 	if (candidates.length === candidateCountBeforeWorkspaceRoots) {
 		for (const repoPath of homeboyComponentRepoCandidates(options)) {
 			for (const entry of options.runtimeCoreEntries || DEFAULT_RUNTIME_CORE_ENTRIES) {
@@ -208,19 +207,17 @@ function homeboyComponentRepoCandidates(options = {}) {
 }
 
 function homeboyComponentLocalPath(componentId, options = {}) {
-	const homeboyBin = options.homeboyBin || process.env.HOMEBOY_BIN || 'homeboy';
+	if (!/^[A-Za-z0-9_-]+$/.test(componentId)) {
+		return null;
+	}
+
+	const registryDir = options.homeboyComponentRegistryDir || path.resolve(homedir(), '.config/homeboy/components');
 	try {
-		const stdout = execFileSync(homeboyBin, ['component', 'show', componentId], {
-			encoding: 'utf8',
-			stdio: ['ignore', 'pipe', 'ignore'],
-			timeout: 10000,
-		});
-		const parsed = JSON.parse(stdout);
-		const localPath = parsed?.data?.entity?.local_path;
+		const registration = JSON.parse(readFileSync(path.resolve(registryDir, `${componentId}.json`), 'utf8'));
+		const localPath = registration?.local_path;
 		return typeof localPath === 'string' && localPath.trim() ? localPath.trim() : null;
 	} catch {
-		// `homeboy` unavailable, component not registered, or output
-		// unparseable — this is a best-effort fallback, so fail silently
+		// Missing or invalid registry metadata is a best-effort fallback, so fail silently
 		// and let the caller continue to the next discovery mechanism.
 		return null;
 	}

--- a/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
+++ b/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
@@ -3,6 +3,9 @@
  */
 import { createRequire } from 'node:module';
 
+/**
+ * Internal dependencies
+ */
 const require = createRequire(import.meta.url);
 const {
 	coreModuleCandidates,
@@ -34,11 +37,11 @@ export async function loadCodeboxRecipeBuilder(requiredExport) {
 			`Install/build a WP Codebox recipe-builder module that exports ${requiredExport}.`,
 			'Use the public @automattic/wp-codebox-core/recipe-builders export or wp-codebox-workspace/recipe-builders.',
 			`Pass --setting wp_codebox_core_module=@automattic/wp-codebox-core/recipe-builders, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to a compatible recipe-builder module.`,
-			`Fallback discovery also checks sibling wp-codebox checkouts for packages/runtime-core/dist/recipe-builders.js and ${RUNTIME_CORE_ENTRY}, and the Homeboy component registry ('homeboy component show wp-codebox').`,
+			`Fallback discovery also checks sibling wp-codebox checkouts for packages/runtime-core/dist/recipe-builders.js and ${RUNTIME_CORE_ENTRY}, and Homeboy's non-evaluating standalone component registry.`,
 			'This is separate from HOMEBOY_WP_CODEBOX_BIN / wp_codebox_bin, which only selects the wp-codebox CLI.',
 			'Homeboy Extensions no longer falls back to bundled WP Codebox recipe builders because that stale local copy can drift from the Codebox recipe contract.',
 			`Tried ${candidates.length} candidate(s):`,
-			...errors.map((error) => `- ${error}`),
+			...errors.map((candidateError) => `- ${candidateError}`),
 		].join('\n'));
 	}
 }

--- a/wordpress/tests/wp-codebox-core-loader-component-registry-smoke.js
+++ b/wordpress/tests/wp-codebox-core-loader-component-registry-smoke.js
@@ -1,8 +1,8 @@
 'use strict';
 
 /**
- * Smoke test: wp-codebox-core-loader.js falls back to the Homeboy
- * component registry (`homeboy component show wp-codebox`) when the
+ * Smoke test: wp-codebox-core-loader.js falls back to non-evaluating
+ * Homeboy component registry metadata when the
  * checkout can't be found by any of the earlier discovery mechanisms
  * (explicit override, npm packages, HOMEBOY_WP_CODEBOX_INSTALL_DIR cache,
  * or a sibling checkout under workspaceRoots()).
@@ -11,12 +11,15 @@
  * a DMC workspace root (e.g. /var/lib/datamachine/workspace) that differs
  * from the wordpress extension's own parent directory, but where
  * `wp-codebox` is still resolvable through the Homeboy component registry.
+ * It also models the production recursion path with a bounded fake Homeboy
+ * command that would re-run the real readiness check if invoked.
  */
 
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { pathToFileURL } = require('node:url');
 
 const { coreModuleCandidates } = require('../lib/wp-codebox-core-loader');
@@ -39,26 +42,35 @@ const OPTIONS = {
 
 try {
 	// 1. Registered checkout with a valid built runtime-core entry: discovery
-	//    should include it via the fake `homeboy component show` binary.
+	//    should include it directly from Homeboy's standalone registry metadata.
 	const registeredRoot = path.join(root, 'registered-wp-codebox');
 	const runtimeCoreDist = path.join(registeredRoot, 'packages', 'runtime-core', 'dist');
 	fs.mkdirSync(runtimeCoreDist, { recursive: true });
-	fs.writeFileSync(path.join(runtimeCoreDist, 'recipe-builders.js'), 'export function buildWordPressPhpunitRecipe() { return {}; }\n');
+	fs.writeFileSync(path.join(runtimeCoreDist, 'recipe-builders.js'), 'exports.buildWordPressBenchRecipe = () => ({});\n');
 
-	const fakeHomeboyBin = path.join(root, 'fake-homeboy.sh');
-	fs.writeFileSync(fakeHomeboyBin, [
+	const homeDir = path.join(root, 'home');
+	const registryDir = path.join(homeDir, '.config', 'homeboy', 'components');
+	fs.mkdirSync(registryDir, { recursive: true });
+	fs.writeFileSync(path.join(registryDir, 'wp-codebox.json'), JSON.stringify({ local_path: registeredRoot }));
+
+	const invocationLog = path.join(root, 'homeboy-invocations.log');
+	const recursiveHomeboyBin = path.join(root, 'recursive-homeboy.sh');
+	const readyScript = path.join(__dirname, '..', 'scripts', 'build', 'check-wp-codebox-runtime-core.mjs');
+	fs.writeFileSync(recursiveHomeboyBin, [
 		'#!/bin/sh',
 		'if [ "$1" = "component" ] && [ "$2" = "show" ] && [ "$3" = "wp-codebox" ]; then',
-		`  printf '%s' '${JSON.stringify({ data: { entity: { local_path: registeredRoot } } } )}'`,
-		'  exit 0',
+		'  printf "invoked\\n" >> "$HOMEBOY_RECURSION_LOG"',
+		'  depth=${HOMEBOY_RECURSION_DEPTH:-0}',
+		'  [ "$depth" -ge 1 ] && exit 1',
+		'  HOMEBOY_RECURSION_DEPTH=$((depth + 1)) exec node "$HOMEBOY_READY_SCRIPT"',
 		'fi',
 		'exit 1',
 	].join('\n'));
-	fs.chmodSync(fakeHomeboyBin, 0o755);
+	fs.chmodSync(recursiveHomeboyBin, 0o755);
 
 	const candidates = coreModuleCandidates({
 		...OPTIONS,
-		homeboyBin: fakeHomeboyBin,
+		homeboyComponentRegistryDir: registryDir,
 		workspaceRoot: path.join(root, 'empty-workspace-root'),
 	});
 
@@ -68,38 +80,56 @@ try {
 		`expected component-registry candidate ${expectedCandidate} in ${JSON.stringify(candidates)}`
 	);
 
+	const readiness = spawnSync(process.execPath, [readyScript], {
+		cwd: path.join(__dirname, '..'),
+		encoding: 'utf8',
+		timeout: 3000,
+		killSignal: 'SIGKILL',
+		env: {
+			...process.env,
+			HOME: homeDir,
+			HOMEBOY_BIN: recursiveHomeboyBin,
+			HOMEBOY_READY_SCRIPT: readyScript,
+			HOMEBOY_RECURSION_LOG: invocationLog,
+			HOMEBOY_RECURSION_DEPTH: '0',
+			HOMEBOY_WORKSPACE_ROOT: path.join(root, 'empty-workspace-root'),
+			HOMEBOY_DEVELOPER_WORKSPACE: path.join(root, 'empty-developer-workspace'),
+			HOMEBOY_WP_CODEBOX_INSTALL_DIR: path.join(root, 'empty-install-cache'),
+			HOMEBOY_GLOBAL_NODE_MODULE_ROOT: path.join(root, 'empty-global-modules'),
+			HOMEBOY_WP_CODEBOX_CORE_MODULE: '',
+			WP_CODEBOX_CORE_MODULE: '',
+		},
+	});
+	assert.equal(readiness.error, undefined, readiness.error?.message);
+	assert.equal(readiness.status, 0, readiness.stderr);
+	assert.match(readiness.stdout, /WP Codebox runtime core ready:/);
+	assert.equal(fs.existsSync(invocationLog), false, 'readiness must not invoke component inspection');
+
 	// 2. When workspaceRoots() sibling-checkout discovery already found a
 	//    candidate, the component-registry fallback must not run (so it
-	//    can't shell out unnecessarily or override an already-found path).
+	//    can't override an already-found path).
 	const siblingWorkspaceRoot = path.join(root, 'sibling-workspace');
 	const siblingModule = path.join(siblingWorkspaceRoot, 'wp-codebox', 'packages', 'runtime-core', 'dist', 'recipe-builders.js');
 	fs.mkdirSync(path.dirname(siblingModule), { recursive: true });
 	fs.writeFileSync(siblingModule, 'export function buildWordPressPhpunitRecipe() { return {}; }\n');
 
-	const unreachableHomeboyBin = path.join(root, 'unreachable-homeboy.sh');
-	fs.writeFileSync(unreachableHomeboyBin, '#!/bin/sh\necho "should not be called" >&2\nexit 1\n');
-	fs.chmodSync(unreachableHomeboyBin, 0o755);
-
 	const siblingCandidates = coreModuleCandidates({
 		...OPTIONS,
-		homeboyBin: unreachableHomeboyBin,
+		homeboyComponentRegistryDir: registryDir,
 		workspaceRoot: siblingWorkspaceRoot,
 	});
 	const expectedSiblingCandidate = fileUrl(siblingModule);
 	assert.ok(siblingCandidates.includes(expectedSiblingCandidate), 'sibling checkout candidate should still be discovered');
+	assert.ok(!siblingCandidates.includes(expectedCandidate), 'registry fallback should not run after sibling discovery succeeds');
 
-	// 3. When `homeboy` is unavailable/unregistered, discovery degrades
+	// 3. When registry metadata is unavailable, discovery degrades
 	//    gracefully (no candidate added, no throw).
-	const missingHomeboyBin = path.join(root, 'missing-homeboy.sh');
-	fs.writeFileSync(missingHomeboyBin, '#!/bin/sh\nexit 1\n');
-	fs.chmodSync(missingHomeboyBin, 0o755);
-
 	const gracefulCandidates = coreModuleCandidates({
 		...OPTIONS,
-		homeboyBin: missingHomeboyBin,
+		homeboyComponentRegistryDir: path.join(root, 'missing-registry'),
 		workspaceRoot: path.join(root, 'another-empty-workspace-root'),
 	});
-	assert.ok(!gracefulCandidates.some((c) => c.includes('registered-wp-codebox')), 'no stray candidates when homeboy lookup fails');
+	assert.ok(!gracefulCandidates.some((c) => c.includes('registered-wp-codebox')), 'no stray candidates when registry lookup fails');
 
 	console.log('wp-codebox core loader component registry smoke passed');
 } finally {


### PR DESCRIPTION
## Summary
- replace the WP Codebox loader's `homeboy component show wp-codebox` subprocess fallback with a direct read of Homeboy's existing non-evaluating standalone component registry pointer
- preserve registry discovery for `homeboy component create` registrations while preventing component inspection from re-entering the WordPress extension readiness check
- exercise the real readiness script against a bounded recursive component-inspection harness and assert that it creates no Homeboy descendant

## Root cause

The WordPress extension readiness path was recursive:

`wordpress/scripts/build/check-wp-codebox-runtime-core.mjs` -> `wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs` -> `wordpress/lib/wp-codebox-core-loader.js` -> fallback `homeboy component show wp-codebox` -> the wp-codebox component's WordPress runtime `ready_check` -> `check-wp-codebox-runtime-core.mjs`

The fallback added in #2215 treated `component show` as a metadata-only registry read, but component inspection can evaluate the configured runtime readiness check. Each lookup therefore created another readiness process before the WP Codebox runtime or plugin ever executed. This is a Homeboy WordPress extension integration cycle, not a WP Codebox runtime bug.

## Fix

Homeboy already stores the machine-local `local_path` pointer at `~/.config/homeboy/components/<id>.json` when `homeboy component create` registers a component. The loader now reads that metadata directly instead of invoking the Homeboy command surface. This is the smallest safe boundary because the lookup cannot execute extensions, readiness checks, or descendants, while retaining the standalone registry discovery behavior introduced for #2213.

The regression test runs the actual `check-wp-codebox-runtime-core.mjs` entrypoint with a fake `homeboy component show` implementation that would re-enter that same readiness script. The fake recursion is depth-bounded, the test process has a three-second kill timeout, and the assertion verifies component inspection was never invoked.

## Compatibility

Standalone registrations created by `homeboy component create` retain registry discovery. A component available only through project attachment, with no standalone `~/.config/homeboy/components/<id>.json` pointer and no package/cache/workspace candidate, no longer resolves through this last-resort fallback. Preserving that case would require a genuinely metadata-only Homeboy command; invoking `component show` is unsafe from a readiness check.

## Tests

- `timeout --kill-after=2s 10s node tests/wp-codebox-core-loader-component-registry-smoke.js` (pass)
- `timeout --kill-after=2s 10s npm run test:wp-codebox-core-loader` (pass)
- `timeout --kill-after=5s 60s npm run test:wp-codebox-bench-recipe-builder` (pass)
- changed-file ESLint for the loader, diagnostic, and regression test (pass; tests are repository-ignored)
- changed-file `node --check`, `jq empty wordpress.json homeboy.json package.json`, and `git diff --check` (pass)
- `npm run lint:js` (repository baseline still fails with 39 errors in unrelated files; no errors are in this change)

Fixes #2265