### PR TITLE
Fix OpenCode large patch artifact capture

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -37,6 +37,10 @@ const OPENCODE_FATAL_LOG_PATTERNS = [
 	},
 ];
 const OPENCODE_PERMISSION_DENIED_PATTERN = /user rejected permission|permission policy rejected|policy denied|permission request denied/i;
+const OPENCODE_GIT_CAPTURE_OPTIONS = {
+	encoding: 'utf8',
+	maxBuffer: 16 * 1024 * 1024,
+};
 
 const OPENCODE_CAPABILITIES = [
 	'cli_runtime',
@@ -605,7 +609,7 @@ function gitRevision(cwd) {
 	if (!cwd) {
 		return { revision: '', error: 'OpenCode workspace path was not available for patch capture.' };
 	}
-	const result = spawnSync('git', ['rev-parse', '--verify', 'HEAD'], { cwd, encoding: 'utf8' });
+	const result = spawnSync('git', ['rev-parse', '--verify', 'HEAD'], { cwd, ...OPENCODE_GIT_CAPTURE_OPTIONS });
 	if (result.status !== 0 || result.error) {
 		return { revision: '', error: result.error?.message || String(result.stderr || 'git rev-parse failed').trim() };
 	}
@@ -619,17 +623,17 @@ function gitDiff(cwd, initialRevision = {}) {
 	if (!initialRevision.revision) {
 		return { content: '', error: initialRevision.error || 'OpenCode workspace initial revision was not available for patch capture.' };
 	}
-	const result = spawnSync('git', ['diff', '--no-ext-diff', '--binary', initialRevision.revision], { cwd, encoding: 'utf8' });
+	const result = spawnSync('git', ['diff', '--no-ext-diff', '--binary', initialRevision.revision], { cwd, ...OPENCODE_GIT_CAPTURE_OPTIONS });
 	if (result.status !== 0 || result.error) {
 		return { content: '', error: result.error?.message || String(result.stderr || 'git diff failed').trim() };
 	}
 	let content = String(result.stdout || '');
-	const untracked = spawnSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], { cwd, encoding: 'utf8' });
+	const untracked = spawnSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], { cwd, ...OPENCODE_GIT_CAPTURE_OPTIONS });
 	if (untracked.status !== 0 || untracked.error) {
 		return { content, error: untracked.error?.message || String(untracked.stderr || 'git ls-files failed').trim() };
 	}
 	for (const relativePath of String(untracked.stdout || '').split('\0').filter(Boolean)) {
-		const untrackedDiff = spawnSync('git', ['diff', '--no-ext-diff', '--binary', '--no-index', '--', '/dev/null', relativePath], { cwd, encoding: 'utf8' });
+		const untrackedDiff = spawnSync('git', ['diff', '--no-ext-diff', '--binary', '--no-index', '--', '/dev/null', relativePath], { cwd, ...OPENCODE_GIT_CAPTURE_OPTIONS });
 		if (![0, 1].includes(untrackedDiff.status) || untrackedDiff.error) {
 			return { content, error: untrackedDiff.error?.message || String(untrackedDiff.stderr || `failed to capture untracked file ${relativePath}`).trim() };
 		}

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -336,6 +336,31 @@ process.exit(${attempt.status});
 	assert.equal(agentResult.opencode_session.status, 'not_discovered');
 	assert.equal(artifactResult.metadata.missing_declared_artifacts, undefined);
 
+	const largePatchCliPath = path.join(root, 'mock-opencode-large-patch.cjs');
+	fs.writeFileSync(largePatchCliPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+fs.writeFileSync('LARGE.md', 'x'.repeat(2 * 1024 * 1024) + '\\n');
+spawnSync('git', ['add', 'LARGE.md']);
+process.exit(0);
+`);
+	const largePatchResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-large-patch-artifact',
+		workspace_path: workspace,
+		artifacts_path: path.join(root, 'large-patch-artifacts'),
+		expected_artifacts: ['patch'],
+		executor: {
+			...request.executor,
+			config: { ...request.executor.config, command_args: [largePatchCliPath] },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(largePatchResult.status, 'succeeded');
+	const largePatch = fs.readFileSync(largePatchResult.artifacts.find((artifact) => artifact.name === 'patch').path, 'utf8');
+	const largePatchContent = 'x'.repeat(2 * 1024 * 1024);
+	assert.ok(Buffer.byteLength(largePatch) > 1024 * 1024);
+	assert.equal(largePatch.includes(`+${largePatchContent}`), true);
+
 	const committedWorkspace = path.join(root, 'committed-workspace');
 	fs.mkdirSync(committedWorkspace, { recursive: true });
 	spawnSync('git', ['init'], { cwd: committedWorkspace, encoding: 'utf8' });


### PR DESCRIPTION
## Summary
Give OpenCode patch capture an explicit 16 MiB Git output budget so successful normal-size agent changes are not reclassified by Node's implicit spawnSync limit.

## What changed
- Applied one shared explicit buffer policy to revision, tracked diff, untracked listing, and untracked binary diff capture; added a deterministic patch regression above Node's default buffer.

## How to test
1. Run `npm run test:opencode-agent-task-executor-boundary`; expect The OpenCode executor boundary suite passes, including the above-default-buffer patch..
2. Run `npm run check:runtime-manifest`; expect The runtime manifest check passes..

## Compatibility
Internal runtime behavior only. Existing artifact schemas and fail-closed Git diagnostics are preserved; the explicit maximum is now 16 MiB.

## Evidence
- CI expected: CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2267
- diff-check: Passed
- focused-boundary-test: Passed
- runtime-manifest: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed, implemented, and verified the large-patch artifact capture repair; Chris reviews and owns the change.

## Source relationships
- Closes #2267
