### PR TITLE
Stop OpenCode quota retry loops

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -30,7 +30,25 @@ const OPENCODE_SECRET_ENV = [
 ];
 const OPENCODE_FATAL_LOG_PATTERNS = [
 	{
-		pattern: /Usage limit reached/i,
+		pattern: /\bAI_APICallError\b[\s\S]{0,1000}\b(?:weekly|monthly)\s+limit\s+exhausted\b/i,
+		code: 'agent_task.opencode_usage_limit',
+		summary: 'OpenCode provider usage limit was reached.',
+		classification: 'provider_quota',
+	},
+	{
+		pattern: /\bAI_APICallError\b[\s\S]{0,1000}\bquota\s+(?:is\s+)?(?:exhausted|exceeded)\b/i,
+		code: 'agent_task.opencode_usage_limit',
+		summary: 'OpenCode provider usage limit was reached.',
+		classification: 'provider_quota',
+	},
+	{
+		pattern: /\bAI_APICallError\b[\s\S]{0,1000}\b(?:rate|usage)\s+limit\s+(?:has\s+been\s+)?(?:exhausted|exceeded)\b/i,
+		code: 'agent_task.opencode_usage_limit',
+		summary: 'OpenCode provider usage limit was reached.',
+		classification: 'provider_quota',
+	},
+	{
+		pattern: /\bAI_APICallError\b[\s\S]{0,1000}\busage\s+limit\s+reached\b[\s\S]{0,200}\blimit\s+will\s+reset\b/i,
 		code: 'agent_task.opencode_usage_limit',
 		summary: 'OpenCode provider usage limit was reached.',
 		classification: 'provider_quota',
@@ -796,7 +814,11 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 			failure_classification: fatalRuntimeError?.classification || (timedOut ? 'timeout' : 'provider'),
 			failure_code: fatalRuntimeError?.code || (timedOut ? 'agent_task.opencode_timeout' : 'agent_task.opencode_spawn_failed'),
 			summary: fatalRuntimeError?.summary || (timedOut ? 'OpenCode execution timed out.' : 'OpenCode process failed to start or complete.'),
-			diagnostics: [{ classification: fatalRuntimeError?.classification || (timedOut ? 'timeout' : 'provider_setup'), message: spawnResult.error.message }],
+			diagnostics: [{
+				class: fatalRuntimeError ? 'opencode.provider_quota' : undefined,
+				classification: fatalRuntimeError?.classification || (timedOut ? 'timeout' : 'provider_setup'),
+				message: spawnResult.error.message,
+			}],
 			metadata: { opencode_session: sessionMetadata(context) },
 			...runtimeLogs,
 		});
@@ -866,10 +888,12 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 	return new Promise((resolve) => {
 		const stdoutChunks = [];
 		const stderrChunks = [];
+		const fatalStreamBuffers = { stdout: '', stderr: '' };
 		let settled = false;
 		let timedOut = false;
 		let fatalRuntimeError = null;
 		let child;
+		let timer = null;
 		let exitFallbackTimer = null;
 		let diagnosticLogTimer = null;
 		let diagnosticLogOffset = diagnosticLogInitialOffset(options.diagnosticLogPath);
@@ -878,6 +902,14 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			fs.mkdirSync(path.dirname(filePath), { recursive: true });
 			fs.writeFileSync(filePath, '');
 		}
+
+		const reportFatalRuntimeError = (detected) => {
+			if (fatalRuntimeError) {
+				return;
+			}
+			fatalRuntimeError = detected;
+			child.kill('SIGTERM');
+		};
 
 		const append = (stream, chunk) => {
 			const content = redactKnownSecrets(chunk.toString('utf8'), options.env);
@@ -889,6 +921,11 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			const filePath = options.runtimeLogPaths?.[stream];
 			if (filePath) {
 				fs.appendFileSync(filePath, content);
+			}
+			fatalStreamBuffers[stream] = `${fatalStreamBuffers[stream]}${content}`.slice(-1200);
+			const matched = findOpenCodeFatalRuntimeError(fatalStreamBuffers[stream]);
+			if (matched) {
+				reportFatalRuntimeError(matched);
 			}
 		};
 
@@ -902,6 +939,9 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			}
 			if (diagnosticLogTimer) {
 				clearInterval(diagnosticLogTimer);
+			}
+			if (timer) {
+				clearTimeout(timer);
 			}
 			resolve({
 				stdout: stdoutChunks.join(''),
@@ -918,7 +958,7 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			return;
 		}
 
-		const timer = options.timeoutMs > 0 ? setTimeout(() => {
+		timer = options.timeoutMs > 0 ? setTimeout(() => {
 			timedOut = true;
 			child.kill('SIGTERM');
 		}, options.timeoutMs) : null;
@@ -927,8 +967,7 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			initialOffset: diagnosticLogOffset,
 			env: options.env,
 			onFatal: (detected) => {
-				fatalRuntimeError = detected;
-				child.kill('SIGTERM');
+				reportFatalRuntimeError(detected);
 			},
 		});
 
@@ -951,9 +990,6 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			}, 250);
 		});
 		child.on('close', (status, signal) => {
-			if (timer) {
-				clearTimeout(timer);
-			}
 			finish({
 				status,
 				signal,
@@ -1006,15 +1042,10 @@ function startOpenCodeDiagnosticLogMonitor({ logPath, initialOffset = 0, env = p
 			fs.readSync(fd, buffer, 0, length, offset);
 			offset = stat.size;
 			const content = redactKnownSecrets(buffer.toString('utf8'), env);
-			const matched = OPENCODE_FATAL_LOG_PATTERNS.find(({ pattern }) => pattern.test(content));
+			const matched = findOpenCodeFatalRuntimeError(content);
 			if (matched) {
 				reported = true;
-				onFatal({
-					code: matched.code,
-					summary: matched.summary,
-					classification: matched.classification,
-					message: `${matched.summary} OpenCode diagnostic log reported: ${content.trim()}`,
-				});
+				onFatal(matched);
 			}
 		} finally {
 			if (fd !== undefined) {
@@ -1022,6 +1053,19 @@ function startOpenCodeDiagnosticLogMonitor({ logPath, initialOffset = 0, env = p
 			}
 		}
 	}, 1000);
+}
+
+function findOpenCodeFatalRuntimeError(content = '') {
+	const matched = OPENCODE_FATAL_LOG_PATTERNS.find(({ pattern }) => pattern.test(content));
+	if (!matched) {
+		return null;
+	}
+	return {
+		code: matched.code,
+		summary: matched.summary,
+		classification: matched.classification,
+		message: 'OpenCode reported a terminal provider quota limit. Wait for the provider limit to reset or select an available provider/model, then retry.',
+	};
 }
 
 function parseEnvCommandArgs() {

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,7 +9,7 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.2.0',
+		version: '1.2.1',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
 		contract_producers: [
 			{

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "contract_producers": [
     {
@@ -57,6 +57,7 @@
       ],
       "failure_classifications": [
         "provider",
+        "provider_quota",
         "transient",
         "timeout",
         "policy_denied",
@@ -85,9 +86,18 @@
           ],
           "when": {
             "any": [
-              { "path": "executor.config.provider", "equals": "codex" },
-              { "path": "executor.provider", "equals": "codex" },
-              { "path": "provider", "equals": "codex" }
+              {
+                "path": "executor.config.provider",
+                "equals": "codex"
+              },
+              {
+                "path": "executor.provider",
+                "equals": "codex"
+              },
+              {
+                "path": "provider",
+                "equals": "codex"
+              }
             ]
           }
         }
@@ -109,15 +119,21 @@
         "cwd": "git_checkout",
         "requires_git": true,
         "write_scope": "workspace",
-        "artifact_paths": [".homeboy/opencode"]
+        "artifact_paths": [
+          ".homeboy/opencode"
+        ]
       },
       "runner_readiness": [
         {
           "id": "opencode.executable",
           "label": "OpenCode executable",
           "executable": {
-            "candidates": ["opencode"],
-            "version_command": ["--version"],
+            "candidates": [
+              "opencode"
+            ],
+            "version_command": [
+              "--version"
+            ],
             "install_hint": "Install OpenCode or set the generic runtime_bin executor config."
           },
           "remediation": "Install OpenCode or set the generic runtime_bin executor config."
@@ -163,7 +179,10 @@
               "source": "json-file-jwt-expiration",
               "path": "~/.codex/auth.json",
               "field": "tokens.access_token",
-              "fallback_fields": ["tokens.expires_at", "tokens.expiresAt"]
+              "fallback_fields": [
+                "tokens.expires_at",
+                "tokens.expiresAt"
+              ]
             },
             "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID": {
               "source": "json-file",
@@ -189,9 +208,13 @@
             "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
             "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID"
           ],
-          "optional_secret_env": ["AI_PROVIDER_OPENAI_CODEX_FEDRAMP"],
+          "optional_secret_env": [
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+          ],
           "refresh_hook": "codex-oauth-refresh",
-          "validation_hooks": ["codex-token-expiration"],
+          "validation_hooks": [
+            "codex-token-expiration"
+          ],
           "guidance": "Refresh Codex OAuth credentials before launching OpenCode, for example by signing in with Codex locally so ~/.codex/auth.json contains current tokens, then pass the updated AI_PROVIDER_OPENAI_CODEX_* secret environment values to the OpenCode executor."
         }
       },
@@ -201,21 +224,43 @@
         "max_concurrency_default": 1
       },
       "artifact_contract": {
-        "patch": ["git-diff", "patch"],
-        "report": ["json", "markdown"]
+        "patch": [
+          "git-diff",
+          "patch"
+        ],
+        "report": [
+          "json",
+          "markdown"
+        ]
       },
       "role_aliases": {
         "artifact_kinds": {
-          "patch": ["opencode-patch", "git-diff", "patch"],
-          "transcript": ["opencode-transcript", "agent-runtime-transcript"],
-          "runtime_log": ["opencode-runtime-log"],
-          "report": ["opencode-report", "agent-runtime-report"]
+          "patch": [
+            "opencode-patch",
+            "git-diff",
+            "patch"
+          ],
+          "transcript": [
+            "opencode-transcript",
+            "agent-runtime-transcript"
+          ],
+          "runtime_log": [
+            "opencode-runtime-log"
+          ],
+          "report": [
+            "opencode-report",
+            "agent-runtime-report"
+          ]
         },
         "outputs": {
-          "provider_run_result": ["opencode_run_result"]
+          "provider_run_result": [
+            "opencode_run_result"
+          ]
         },
         "metadata": {
-          "provider_run_result": ["opencode_run_result"]
+          "provider_run_result": [
+            "opencode_run_result"
+          ]
         }
       },
       "status": "active",

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -563,32 +563,74 @@ process.exit(0);
 	assert.equal(inheritedPipeResult.status, 'succeeded');
 	assert.match(inheritedPipeResult.diagnostics[0].message, /status 0/);
 
-	const quotaLogPath = path.join(root, 'opencode-quota.log');
-	const quotaCliPath = path.join(root, 'mock-opencode-quota.cjs');
-	fs.writeFileSync(quotaCliPath, `#!/usr/bin/env node
+	const quotaVariants = [
+		'AI_APICallError: Weekly Limit Exhausted. Your limit will reset at 2026-07-20T00:00:00Z.',
+		'AI_APICallError: Monthly Limit Exhausted. Your limit will reset at 2026-08-01T00:00:00Z.',
+		'AI_APICallError: Provider quota exhausted.',
+		'AI_APICallError: Provider quota exceeded.',
+		'AI_APICallError: Rate limit exceeded.',
+		'AI_APICallError: Usage limit exhausted.',
+		'AI_APICallError: Usage limit reached for 5 hours. Your limit will reset later.',
+	];
+	for (const [index, quotaError] of quotaVariants.entries()) {
+		const quotaInvocationPath = path.join(root, `opencode-quota-${index}-invocations`);
+		const quotaTerminationPath = path.join(root, `opencode-quota-${index}-terminated`);
+		const quotaCliPath = path.join(root, `mock-opencode-quota-${index}.cjs`);
+		fs.writeFileSync(quotaCliPath, `#!/usr/bin/env node
 const fs = require('node:fs');
-fs.appendFileSync(${JSON.stringify(quotaLogPath)}, 'timestamp=2026-06-30T17:03:48.665Z level=ERROR message="stream error" error.error="AI_APICallError: Usage limit reached for 5 hour. Your limit will reset later"\\n');
-setTimeout(() => {}, 10000);
+fs.appendFileSync(${JSON.stringify(quotaInvocationPath)}, 'started\\n');
+process.on('SIGTERM', () => {
+  fs.writeFileSync(${JSON.stringify(quotaTerminationPath)}, 'SIGTERM');
+  process.exit(0);
+});
+const event = JSON.stringify({ type: 'error', error: ${JSON.stringify(quotaError)}, token: process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN }) + '\\n';
+process.stderr.write(event.slice(0, 24));
+setTimeout(() => process.stderr.write(event.slice(24)), 5);
+setInterval(() => process.stderr.write('OpenCode retrying after provider backoff\\n'), 25);
 `);
-	const quotaResult = await Promise.race([
-		executeOpenCodeAgentTask({
-			...request,
-			task_id: 'opencode-quota-fail-fast',
-			executor: {
-				...request.executor,
-				config: {
-					...request.executor.config,
-					command_args: [quotaCliPath],
-					diagnostic_log_path: quotaLogPath,
+		const quotaResult = await Promise.race([
+			executeOpenCodeAgentTask({
+				...request,
+				task_id: `opencode-quota-fail-fast-${index}`,
+				executor: {
+					...request.executor,
+					config: { ...request.executor.config, command_args: [quotaCliPath] },
 				},
-			},
-		}, { env: fixtureEnv }),
-		new Promise((_, reject) => setTimeout(() => reject(new Error('OpenCode executor did not fail fast on provider quota exhaustion')), 3000)),
-	]);
-	assert.equal(quotaResult.status, 'provider_error');
-	assert.equal(quotaResult.failure_code, 'agent_task.opencode_usage_limit');
-	assert.equal(quotaResult.failure_classification, 'provider_quota');
-	assert.match(quotaResult.diagnostics[0].message, /Usage limit reached/);
+			}, { env: fixtureEnv }),
+			new Promise((_, reject) => setTimeout(() => reject(new Error('OpenCode executor did not fail fast on provider quota exhaustion')), 2000)),
+		]);
+		assert.equal(quotaResult.status, 'provider_error');
+		assert.equal(quotaResult.failure_code, 'agent_task.opencode_usage_limit');
+		assert.equal(quotaResult.failure_classification, 'provider_quota');
+		assert.equal(quotaResult.failure_category, 'provider.quota');
+		assert.equal(quotaResult.retryable, false);
+		assert.deepEqual(quotaResult.diagnostics, [{
+			class: 'opencode.provider_quota',
+			message: 'OpenCode reported a terminal provider quota limit. Wait for the provider limit to reset or select an available provider/model, then retry.',
+			data: {},
+		}]);
+		assert.equal(fs.readFileSync(quotaInvocationPath, 'utf8'), 'started\n');
+		assert.equal(fs.readFileSync(quotaTerminationPath, 'utf8'), 'SIGTERM');
+		assert.equal(JSON.stringify(quotaResult).includes('access-token-must-not-leak'), false);
+		for (const artifact of quotaResult.artifacts) {
+			assert.equal(fs.readFileSync(artifact.path, 'utf8').includes('access-token-must-not-leak'), false);
+		}
+	}
+
+	const transientQuotaCliPath = path.join(root, 'mock-opencode-transient-rate-limit.cjs');
+	fs.writeFileSync(transientQuotaCliPath, `#!/usr/bin/env node
+process.stderr.write(JSON.stringify({ type: 'error', error: 'AI_APICallError: Rate limit reached; retrying in 1 second.' }) + '\\n');
+process.exit(0);
+`);
+	const transientQuotaResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-transient-rate-limit',
+		executor: {
+			...request.executor,
+			config: { ...request.executor.config, command_args: [transientQuotaCliPath] },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(transientQuotaResult.status, 'succeeded');
 
 	const implicitArtifactResult = await executeOpenCodeAgentTask({
 		...request,

--- a/agent-task-contracts/agent-task-provider-contract.js
+++ b/agent-task-contracts/agent-task-provider-contract.js
@@ -23,6 +23,7 @@ const AGENT_TASK_OUTCOME_STATUSES = [
 
 const AGENT_TASK_FAILURE_CLASSIFICATIONS = [
   'provider',
+  'provider_quota',
   'transient',
   'timeout',
   'policy_denied',

--- a/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
+++ b/runtime-agent-ci/lib/agent-task-outcome-normalizer.js
@@ -80,7 +80,7 @@ function normalizeProviderStatus(result = {}, exitStatus = 0) {
 }
 
 function providerFailureClassification(classification, status) {
-  if (classification === 'provider' || classification === 'transient' || classification === 'timeout' || classification === 'policy_denied' || classification === 'capability_missing' || classification === 'invalid_input' || classification === 'execution_failed' || classification === 'unknown') {
+  if (classification === 'provider' || classification === 'provider_quota' || classification === 'transient' || classification === 'timeout' || classification === 'policy_denied' || classification === 'capability_missing' || classification === 'invalid_input' || classification === 'execution_failed' || classification === 'unknown') {
     return classification;
   }
   if (classification === 'max_turns') {

--- a/runtime-agent-ci/tests/agent-task-outcome-normalizer.test.js
+++ b/runtime-agent-ci/tests/agent-task-outcome-normalizer.test.js
@@ -176,6 +176,7 @@ assert.equal(unknownProviderOutput.failure_category, 'provider.error');
 assert.equal(providerFailureClassification('task', 'failed'), 'execution_failed');
 assert.equal(providerFailureClassification('incomplete', 'failed'), 'execution_failed');
 assert.equal(providerFailureClassification('max_turns', 'timeout'), 'timeout');
+assert.equal(providerFailureClassification('provider_quota', 'provider_error'), 'provider_quota');
 assert.equal(providerFailureClassification('custom-runtime-detail', 'failed'), 'unknown');
 assert.equal(agentTaskFailureCategory({ provider_error: true }, [{ class: 'provider.rate_limit', message: 'rate limit' }], 'provider', 'provider_error'), 'provider.rate_limit');
 assert.equal(agentTaskFailureRetryable('provider.rate_limit', 'provider', 'provider_error'), true);


### PR DESCRIPTION
## Summary
Stop terminal OpenCode quota errors from masquerading as active provider work.

## What changed
- Recognize structured AI\_APICallError quota exhaustion across live stdout/stderr, terminate internal backoff promptly, return one redacted provider\_quota outcome, preserve provider\_quota through generic normalization, and bump the OpenCode runtime manifest to 1.2.1.

## How to test
1. Run `cd agent-runtimes/opencode && npm run test:opencode-agent-task-executor && npm run check:runtime-manifest`; expect The OpenCode boundary and generated runtime manifest checks pass..
2. Run `cd runtime-agent-ci && npm run test:agent-task-outcome-normalizer && npm test`; expect The provider\_quota normalizer and complete runtime-agent CI suite pass..

## Compatibility
Successful and transient OpenCode executions are unchanged. Only structured AI\_APICallError output with explicit terminal quota language now ends the provider attempt early; provider\_quota is added to the generic failure-classification contract.

## Evidence
- CI expected: repository CI
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2269
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/8421
- diff\_check: Passed
- opencode\_boundary: Passed
- outcome\_normalizer: Passed
- runtime\_agent\_ci: Passed
- runtime\_manifest: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Prepared the OpenCode quota-classification and termination repair with deterministic tests; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2269
- Relates to Extra-Chill/homeboy#8421
