### PR TITLE
fix(rust): run full-scope tests across the whole workspace

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -330,6 +330,19 @@ TEST_ARGS=(
     --manifest-path "${PROJECT_PATH}/Cargo.toml"
 )
 
+# For a full/workspace run, test every workspace member -- not just the root
+# package. At a hybrid root (a Cargo.toml that is both [package] and [workspace]),
+# `cargo test` without `--workspace` only runs the root package's tests, silently
+# skipping every member crate. Only add it for full-scope runs and only when the
+# scope args don't already select specific packages (e.g. a changed-files scope
+# that passes `-p <crate>`).
+if [ "$SCOPE_KIND" = "workspace" ] || [ "$SCOPE_KIND" = "full" ]; then
+    case " $(printf '%s' "$SCOPE_JSON" | jq -r '.args[]?' | tr '\n' ' ') " in
+        *" -p "* | *" --package "* | *" --workspace "* | *" --exclude "*) ;;
+        *) TEST_ARGS+=(--workspace) ;;
+    esac
+fi
+
 if [ -n "${HOMEBOY_TEST_SCOPE_MESSAGE:-}" ]; then
     echo "$HOMEBOY_TEST_SCOPE_MESSAGE"
 fi


### PR DESCRIPTION
## Summary
At a **hybrid Cargo root** (a `Cargo.toml` that is both `[package]` and `[workspace]`), `cargo test` / `cargo nextest run` without `--workspace` runs **only the root package's** tests and **silently skips every workspace member crate** — with no failure signal.

This bit homeboy directly: after extracting the engine into `homeboy-core` and the CLI into `homeboy-cli`, the ~5,700+ tests that moved into those member crates **stopped running in CI** while the Test gate stayed green (it was only ever testing the thin root `homeboy` package). Broken test initializers even landed on `main` unnoticed because the tests weren't compiled.

## Fix
For full/workspace-scope runs, add `--workspace` to the test invocation (carried through to nextest via the shared arg builder).

**Guarded so it's safe and targeted:**
- Only when `SCOPE_KIND` is `workspace` / `full` (the default full-run scope).
- Skipped when the scope args already select packages (`-p` / `--package` / `--workspace` / `--exclude`) — so changed-files / selective scopes are unaffected.
- `--workspace` is a no-op for single-crate projects.

## Verification
- `bash -n` syntax check passes.
- Logic table verified: `workspace`/`full` + no selector → adds `--workspace`; `workspace` + `-p <crate>` → unchanged; `changed` scope → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)