### PR TITLE
Generate the agent-task provider contract from core

### DIFF
--- a/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
+++ b/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
@@ -86,6 +86,8 @@
   "enums": {
     "aggregate_status": [
       "succeeded",
+      "candidate_recoverable",
+      "partial_recoverable",
       "partial_failure",
       "failed",
       "cancelled"
@@ -108,6 +110,8 @@
       "provider",
       "transient",
       "timeout",
+      "stalled",
+      "rate_limited",
       "policy_denied",
       "capability_missing",
       "invalid_input",
@@ -130,6 +134,7 @@
       "unable_to_remediate",
       "provider_error",
       "timeout",
+      "candidate_recoverable",
       "failed",
       "follow_up_issue",
       "cancelled"
@@ -138,6 +143,8 @@
       "queued",
       "running",
       "succeeded",
+      "candidate_recoverable",
+      "partial_recoverable",
       "partial_failure",
       "failed",
       "cancelled"
@@ -150,7 +157,8 @@
       "succeeded",
       "failed",
       "cancelled",
-      "timed_out"
+      "timed_out",
+      "candidate_recoverable"
     ],
     "workflow_step_status": [
       "pending",
@@ -164,6 +172,7 @@
   "orchestration": {
     "agent_task_outcome_to_fanout_record_status": {
       "cancelled": "failed",
+      "candidate_recoverable": "failed",
       "failed": "failed",
       "follow_up_issue": "failed",
       "no_op": "completed",
@@ -220,6 +229,8 @@
       "provider",
       "transient",
       "timeout",
+      "stalled",
+      "rate_limited",
       "policy_denied",
       "capability_missing",
       "invalid_input",
@@ -233,6 +244,7 @@
       "unable_to_remediate",
       "provider_error",
       "timeout",
+      "candidate_recoverable",
       "failed",
       "follow_up_issue",
       "cancelled"
@@ -297,8 +309,7 @@
       "set-cookie",
       "x-api-key",
       "x-auth-token",
-      "x-csrf-token",
-      "x-wp-nonce"
+      "x-csrf-token"
     ],
     "sensitive_keys": [
       "api_key",

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -253,6 +253,7 @@
         "unable_to_remediate",
         "provider_error",
         "timeout",
+        "candidate_recoverable",
         "failed",
         "follow_up_issue",
         "cancelled"
@@ -261,6 +262,8 @@
         "provider",
         "transient",
         "timeout",
+        "stalled",
+        "rate_limited",
         "policy_denied",
         "capability_missing",
         "invalid_input",

--- a/agent-task-contracts/agent-task-provider-contract.generated.json
+++ b/agent-task-contracts/agent-task-provider-contract.generated.json
@@ -1,0 +1,50 @@
+{
+  "_generated_by": "agent-runtimes/fixtures/homeboy-agent-task-core-contract.json",
+  "core_contract_schema": "homeboy/agent-task-core-contract/v1",
+  "provider_capability": {
+    "failure_classifications": [
+      "provider",
+      "transient",
+      "timeout",
+      "stalled",
+      "rate_limited",
+      "policy_denied",
+      "capability_missing",
+      "invalid_input",
+      "execution_failed",
+      "unknown"
+    ],
+    "outcome_statuses": [
+      "succeeded",
+      "no_op",
+      "unable_to_remediate",
+      "provider_error",
+      "timeout",
+      "candidate_recoverable",
+      "failed",
+      "follow_up_issue",
+      "cancelled"
+    ],
+    "redacted_metadata_keys": [
+      "secret_env_values",
+      "secretEnvValues",
+      "secrets"
+    ],
+    "request_required_fields": [
+      "schema",
+      "task_id",
+      "executor.backend",
+      "instructions"
+    ]
+  },
+  "schema": "homeboy/agent-task-provider-contract-export/v1",
+  "schemas": {
+    "artifact": "homeboy/agent-task-artifact/v1",
+    "artifact_declaration": "homeboy/agent-task-artifact-declaration/v1",
+    "evidence_ref": "homeboy/agent-task-evidence-ref/v1",
+    "outcome": "homeboy/agent-task-outcome/v1",
+    "provider": "homeboy/agent-task-executor-provider/v1",
+    "request": "homeboy/agent-task-request/v1",
+    "secret_env_requirement": "homeboy/secret-env-requirement/v1"
+  }
+}

--- a/agent-task-contracts/agent-task-provider-contract.js
+++ b/agent-task-contracts/agent-task-provider-contract.js
@@ -1,43 +1,18 @@
 'use strict';
 
-const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
-const AGENT_TASK_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
-const AGENT_TASK_ARTIFACT_SCHEMA = 'homeboy/agent-task-artifact/v1';
-const AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA = 'homeboy/agent-task-artifact-declaration/v1';
-const AGENT_TASK_EVIDENCE_REF_SCHEMA = 'homeboy/agent-task-evidence-ref/v1';
-const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA = 'homeboy/agent-task-executor-provider/v1';
-const SECRET_ENV_REQUIREMENT_SCHEMA = 'homeboy/secret-env-requirement/v1';
+const coreContract = require('./agent-task-provider-contract.generated.json');
 
-const AGENT_TASK_REQUEST_REQUIRED_FIELDS = ['schema', 'task_id', 'executor.backend', 'instructions'];
-
-const AGENT_TASK_OUTCOME_STATUSES = [
-  'succeeded',
-  'no_op',
-  'unable_to_remediate',
-  'provider_error',
-  'timeout',
-  'failed',
-  'follow_up_issue',
-  'cancelled',
-];
-
-const AGENT_TASK_FAILURE_CLASSIFICATIONS = [
-  'provider',
-  'provider_quota',
-  'transient',
-  'timeout',
-  'policy_denied',
-  'capability_missing',
-  'invalid_input',
-  'execution_failed',
-  'unknown',
-];
-
-const AGENT_TASK_REDACTED_METADATA_KEYS = [
-  'secret_env_values',
-  'secretEnvValues',
-  'secrets',
-];
+const AGENT_TASK_REQUEST_SCHEMA = coreContract.schemas.request;
+const AGENT_TASK_OUTCOME_SCHEMA = coreContract.schemas.outcome;
+const AGENT_TASK_ARTIFACT_SCHEMA = coreContract.schemas.artifact;
+const AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA = coreContract.schemas.artifact_declaration;
+const AGENT_TASK_EVIDENCE_REF_SCHEMA = coreContract.schemas.evidence_ref;
+const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA = coreContract.schemas.provider;
+const SECRET_ENV_REQUIREMENT_SCHEMA = coreContract.schemas.secret_env_requirement;
+const AGENT_TASK_REQUEST_REQUIRED_FIELDS = coreContract.provider_capability.request_required_fields;
+const AGENT_TASK_OUTCOME_STATUSES = coreContract.provider_capability.outcome_statuses;
+const AGENT_TASK_FAILURE_CLASSIFICATIONS = coreContract.provider_capability.failure_classifications;
+const AGENT_TASK_REDACTED_METADATA_KEYS = coreContract.provider_capability.redacted_metadata_keys;
 
 const AGENT_TASK_SECRET_SELECTOR_PATHS = [
   'executor.config.provider',

--- a/agent-task-contracts/generate-agent-task-provider-contract.cjs
+++ b/agent-task-contracts/generate-agent-task-provider-contract.cjs
@@ -1,0 +1,95 @@
+'use strict';
+
+// Generates the core-owned provider vocabulary consumed by extension runtimes
+// from the pinned core contract fixture. Runtime-specific tool and capability
+// policy remains in agent-task-provider-contract.js.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const OUTPUT_PATH = path.join(__dirname, 'agent-task-provider-contract.generated.json');
+const CORE_CONTRACT_PATH = path.join(
+  __dirname,
+  '..',
+  'agent-runtimes',
+  'fixtures',
+  'homeboy-agent-task-core-contract.json'
+);
+const CORE_CONTRACT_SCHEMA = 'homeboy/agent-task-core-contract/v1';
+const GENERATED_SCHEMA = 'homeboy/agent-task-provider-contract-export/v1';
+
+function readPinnedCoreContract() {
+  return JSON.parse(fs.readFileSync(CORE_CONTRACT_PATH, 'utf8'));
+}
+
+function buildProviderContract(coreContract) {
+  assert.equal(coreContract?.schema, CORE_CONTRACT_SCHEMA, 'Unexpected core agent-task contract schema');
+  const providerCapability = coreContract.provider_capability;
+  assert.ok(providerCapability && typeof providerCapability === 'object', 'Core provider capability contract is required');
+
+  return {
+    _generated_by: 'agent-runtimes/fixtures/homeboy-agent-task-core-contract.json',
+    core_contract_schema: coreContract.schema,
+    provider_capability: {
+      failure_classifications: providerCapability.failure_classifications,
+      outcome_statuses: providerCapability.outcome_statuses,
+      redacted_metadata_keys: providerCapability.redacted_metadata_keys,
+      request_required_fields: providerCapability.request_required_fields,
+    },
+    schema: GENERATED_SCHEMA,
+    schemas: {
+      artifact: coreContract.schemas.artifact,
+      artifact_declaration: coreContract.schemas.artifact_declaration,
+      evidence_ref: coreContract.schemas.evidence_ref,
+      outcome: coreContract.schemas.outcome,
+      provider: coreContract.schemas.provider,
+      request: coreContract.schemas.request,
+      secret_env_requirement: coreContract.schemas.secret_env_requirement,
+    },
+  };
+}
+
+function canonicalJson(value) {
+  return `${JSON.stringify(sortKeysDeep(value), null, 2)}\n`;
+}
+
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value).sort().reduce((sorted, key) => {
+      sorted[key] = sortKeysDeep(value[key]);
+      return sorted;
+    }, {});
+  }
+  return value;
+}
+
+function main(argv) {
+  const generated = canonicalJson(buildProviderContract(readPinnedCoreContract()));
+  if (argv.includes('--check')) {
+    if (fs.readFileSync(OUTPUT_PATH, 'utf8') !== generated) {
+      throw new Error(`Drift detected: regenerate with node ${path.relative(process.cwd(), __filename)}`);
+    }
+    process.stdout.write('Agent task provider contract is in sync with core.\n');
+    return;
+  }
+  fs.writeFileSync(OUTPUT_PATH, generated);
+  process.stdout.write(`Wrote ${path.relative(process.cwd(), OUTPUT_PATH)}\n`);
+}
+
+module.exports = {
+  CORE_CONTRACT_PATH,
+  CORE_CONTRACT_SCHEMA,
+  GENERATED_SCHEMA,
+  OUTPUT_PATH,
+  buildProviderContract,
+  canonicalJson,
+  readPinnedCoreContract,
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/agent-task-contracts/generic-agent-task-plan.js
+++ b/agent-task-contracts/generic-agent-task-plan.js
@@ -4,9 +4,10 @@ const {
   agentTaskRequestFromRunnerSpec,
   agentTaskRunnerSpec,
 } = require('./agent-task-runner-contract');
+const { AGENT_TASK_REQUEST_SCHEMA } = require('./agent-task-provider-contract');
 
 const GENERIC_AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
-const GENERIC_AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const GENERIC_AGENT_TASK_REQUEST_SCHEMA = AGENT_TASK_REQUEST_SCHEMA;
 const GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 
 function genericAgentTaskRunnerSpec(options = {}) {

--- a/agent-task-contracts/package.json
+++ b/agent-task-contracts/package.json
@@ -4,6 +4,10 @@
   "version": "1.0.0",
   "private": true,
   "main": "index.js",
+  "scripts": {
+    "generate": "node generate-agent-task-provider-contract.cjs",
+    "generate:check": "node generate-agent-task-provider-contract.cjs --check"
+  },
   "exports": {
     ".": "./index.js"
   },

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -159,6 +159,13 @@ copying schema strings or selector paths into each backend. Domain policy, such
 as project-specific defaults, belongs in the caller/runtime package and not in
 the generic adapter.
 
+`agent-task-contracts/agent-task-provider-contract.generated.json` is generated
+from the pinned core fixture and carries both its own export schema and the
+source core-contract schema. Run
+`npm --prefix agent-task-contracts run generate:check` to verify it. The core
+contract drift test validates both generated artifacts against
+`homeboy agent-task contract --format json` when Homeboy is available.
+
 ## Host Orchestration Contract
 
 The published Homeboy core fixture is

--- a/wordpress/tests/agent-task-core-contract-drift.test.js
+++ b/wordpress/tests/agent-task-core-contract-drift.test.js
@@ -15,6 +15,7 @@ const {
   AGENT_TASK_REDACTED_METADATA_KEYS,
   AGENT_TASK_REQUEST_SCHEMA,
   agentTaskProviderContractFields,
+  providerSecretEnvRequirement,
 } = require('../../agent-task-contracts');
 const {
   FANOUT_RECONCILE_PLAN_SCHEMA,
@@ -36,9 +37,20 @@ const {
   canonicalJson,
   fetchCoreContractData,
 } = require('../../agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs');
+const {
+  CORE_CONTRACT_SCHEMA,
+  CORE_CONTRACT_PATH,
+  GENERATED_SCHEMA,
+  OUTPUT_PATH,
+  buildProviderContract,
+  canonicalJson: canonicalProviderContractJson,
+  readPinnedCoreContract,
+} = require('../../agent-task-contracts/generate-agent-task-provider-contract.cjs');
 
 const committedFixtureText = fs.readFileSync(FIXTURE_PATH, 'utf8');
 const contract = JSON.parse(committedFixtureText);
+const committedProviderContractText = fs.readFileSync(OUTPUT_PATH, 'utf8');
+const generatedProviderContract = JSON.parse(committedProviderContractText);
 const wpCodeboxManifest = JSON.parse(fs.readFileSync(path.join(
   __dirname,
   '..',
@@ -51,12 +63,26 @@ const wpCodeboxProvider = wpCodeboxManifest.agent_task_executors[0];
 const providerFields = contract.provider_capability;
 
 assert.equal(contract.schema, 'homeboy/agent-task-core-contract/v1');
+assert.equal(CORE_CONTRACT_PATH, FIXTURE_PATH);
+assert.deepEqual(readPinnedCoreContract(), contract);
+assert.equal(generatedProviderContract.schema, GENERATED_SCHEMA);
+assert.equal(generatedProviderContract.core_contract_schema, CORE_CONTRACT_SCHEMA);
+assert.deepEqual(generatedProviderContract.provider_capability, {
+  failure_classifications: AGENT_TASK_FAILURE_CLASSIFICATIONS,
+  outcome_statuses: AGENT_TASK_OUTCOME_STATUSES,
+  redacted_metadata_keys: AGENT_TASK_REDACTED_METADATA_KEYS,
+  request_required_fields: providerFields.request_required_fields,
+});
 assert.equal(AGENT_TASK_REQUEST_SCHEMA, contract.schemas.request);
 assert.equal(AGENT_TASK_OUTCOME_SCHEMA, contract.schemas.outcome);
 assert.equal(AGENT_TASK_ARTIFACT_SCHEMA, contract.schemas.artifact);
 assert.equal(AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA, contract.schemas.artifact_declaration);
 assert.equal(AGENT_TASK_EVIDENCE_REF_SCHEMA, contract.schemas.evidence_ref);
 assert.equal(AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA, contract.schemas.provider);
+assert.equal(
+  providerSecretEnvRequirement('example', 'EXAMPLE_TOKEN').schema,
+  contract.schemas.secret_env_requirement
+);
 assert.equal(GENERIC_FANOUT_RECONCILE_CONFIG_SCHEMA, contract.schemas.fanout_reconcile_config);
 assert.equal(FANOUT_RECONCILE_PLAN_SCHEMA, contract.schemas.fanout_reconcile_plan);
 assert.equal(FANOUT_RECONCILE_RUN_SCHEMA, contract.schemas.fanout_reconcile_run);
@@ -122,6 +148,19 @@ if (coreData === null) {
     canonicalJson(expectedFixture),
     'Fixture serialization drifted from the generator: regenerate with '
       + 'node agent-runtimes/fixtures/generate-homeboy-agent-task-core-contract.cjs'
+  );
+  const expectedProviderContract = buildProviderContract(coreData);
+  assert.deepEqual(
+    generatedProviderContract,
+    expectedProviderContract,
+    'Provider contract drifted from core: regenerate with '
+      + 'node agent-task-contracts/generate-agent-task-provider-contract.cjs'
+  );
+  assert.equal(
+    committedProviderContractText,
+    canonicalProviderContractJson(expectedProviderContract),
+    'Provider contract serialization drifted from the generator: regenerate with '
+      + 'node agent-task-contracts/generate-agent-task-provider-contract.cjs'
   );
   process.stdout.write('Agent task core contract drift check passed (verified against core)\n');
 }


### PR DESCRIPTION
## Summary
Replace hand-maintained JavaScript agent-task schema constants with a versioned artifact generated from the pinned Homeboy core contract.

## What changed
- Add a deterministic generator and committed provider contract, consume generated values in the JS adapter, and make CI validate both source and exported schema versions against live core.

## How to test
1. Run `npm --prefix agent-task-contracts run generate:check`; expect The committed provider contract matches deterministic generation..
2. Run `npm run test:agent-task-core-contract-drift`; expect The pinned and live core contracts remain aligned..

## Compatibility
Provider consumers now receive current core vocabulary, including candidate\_recoverable, stalled, and rate\_limited. This is the intended contract alignment; no extension path is removed.

## Evidence
- Base unchanged since verification: main remains at 98ac697e2ae3eaa2aa4325eb7cdf38b3600885e3.
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2160
- Verified finalization base: main at 98ac697e2ae3eaa2aa4325eb7cdf38b3600885e3
- drift-test: Passed
- generation: Passed
- syntax: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Completed the generated contract pipeline, drift coverage, and verification with Chris.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2160
