### PR TITLE
Model WordPress request constants dynamically

### DIFF
--- a/wordpress/phpstan.neon.dist
+++ b/wordpress/phpstan.neon.dist
@@ -4,6 +4,16 @@ includes:
 parameters:
     customRulesetUsed: false
 
+    # WordPress defines these request-context flags at runtime. Treating a
+    # value observed by the analysis bootstrap as immutable creates false
+    # always-true findings for canonical `defined() && CONSTANT` guards.
+    dynamicConstantNames:
+        - DOING_AJAX
+        - DOING_CRON
+        - REST_REQUEST
+        - WP_IMPORTING
+        - XMLRPC_REQUEST
+
     # Don't treat unmatched ignoreErrors patterns as failures.
     # These are config hygiene issues, not component code problems.
     # Reporting them as errors creates false failure signals (see #137).

--- a/wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh
+++ b/wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh
@@ -67,6 +67,14 @@ function homeboy_issue_393_caller(): array {
 	);
 	return array_values( $post_types );
 }
+
+function homeboy_runtime_request_guard(): bool {
+	if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+		return true;
+	}
+
+	return defined( 'REST_REQUEST' ) && REST_REQUEST;
+}
 PHP
 
 # Fake host-smoke stub that historically shadowed wordpress-stubs.php through


### PR DESCRIPTION
## Summary
- model request-context WordPress constants as dynamic values in the shared PHPStan profile
- preserve analysis of canonical `defined() && CONSTANT` runtime guards
- add an end-to-end regression to the existing WordPress API stub harness

Closes #2278.

## How to test
1. Run `composer install --no-interaction` in `wordpress/`.
2. Resolve Homeboy runtime helpers with `homeboy runtime helper path HOMEBOY_RUNTIME_RESOLVE_CONTEXT --plain` and `homeboy runtime helper path HOMEBOY_RUNTIME_SIDECAR_WRITER --plain`.
3. Run `HOMEBOY_RUNTIME_RESOLVE_CONTEXT=<resolved-path> HOMEBOY_RUNTIME_SIDECAR_WRITER=<resolved-path> bash tests/phpstan-wordpress-api-stubs-smoke.sh` from `wordpress/`.
4. Run `git diff --check origin/main...HEAD`.

## Verification
- WordPress API/PHPStan regression harness passed.
- `git diff --check` passed.

The broader `phpstan-scoped-smoke.sh` currently fails on its existing non-PHP single-file skip assertion when run against the active runtime helpers; this change does not touch scoped target selection.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode and Homeboy
- **Used for:** Traced the release-only false positive to the shared PHPStan profile, implemented the dynamic-constant contract and regression fixture, and ran deterministic verification. Chris reviewed and owns the change.