### PR TITLE
Allow OpenCode access to assigned workspaces

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -259,6 +259,7 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 	const config = request.executor?.config || {};
 	const model = config.model || request.executor?.model || request.model;
 	const smallModel = config.small_model || config.smallModel;
+	const primaryAgent = config.agent || 'build';
 
 	const content = parseOpenCodeConfigContent(existingContent);
 	content.$schema = content.$schema || 'https://opencode.ai/config.json';
@@ -267,7 +268,6 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 
 	if (model) {
 		content.model = model;
-		const primaryAgent = config.agent || 'build';
 		content.agent[primaryAgent] = { ...objectValue(content.agent[primaryAgent]), model };
 	}
 
@@ -278,8 +278,57 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 	// Homeboy owns durable task identity, so OpenCode must not create a competing
 	// provider session title from an ambient or run-scoped configuration layer.
 	content.agent.title = { ...objectValue(content.agent.title), disable: true };
+	const workspacePattern = opencodeExternalDirectoryPattern(request, config);
+	if (workspacePattern) {
+		content.permission = permissionWithWorkspaceAllowance(content.permission, workspacePattern);
+		content.agent[primaryAgent] = {
+			...objectValue(content.agent[primaryAgent]),
+			permission: permissionWithWorkspaceAllowance(
+				objectValue(content.agent[primaryAgent]).permission,
+				workspacePattern
+			),
+		};
+	}
 
 	return JSON.stringify(content);
+}
+
+function opencodeExternalDirectoryPattern(request = {}, config = {}) {
+	const cwd = resolveOpenCodeCwd(request, config);
+	if (typeof cwd !== 'string' || cwd.trim() === '') {
+		return '';
+	}
+
+	const workspace = path.resolve(cwd);
+	// OpenCode compares tool paths against the process working directory, which
+	// resolves symlinks when the child process starts.
+	let concreteWorkspace = workspace;
+	try {
+		concreteWorkspace = fs.realpathSync.native?.(workspace) || fs.realpathSync(workspace);
+	} catch {
+		// Keep the configured request path when the caller materializes it after
+		// constructing the executor environment.
+	}
+	return path.join(concreteWorkspace, '**');
+}
+
+function permissionWithWorkspaceAllowance(permission, workspacePattern) {
+	const rules = typeof permission === 'string'
+		? { '*': permission }
+		: objectValue(permission);
+	const externalDirectory = typeof rules.external_directory === 'string'
+		? { '*': rules.external_directory }
+		: objectValue(rules.external_directory);
+
+	return {
+		...rules,
+		external_directory: {
+			...externalDirectory,
+			// OpenCode resolves matching rules in order, so this narrowly scoped rule
+			// deliberately supersedes an inherited catch-all for this task workspace.
+			[workspacePattern]: 'allow',
+		},
+	};
 }
 
 function parseOpenCodeConfigContent(content) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -173,10 +173,26 @@ assert.equal(config.model, 'opencode-go/kimi-k2.7-code');
 assert.equal(config.agent.build.model, 'opencode-go/kimi-k2.7-code');
 assert.equal(config.small_model, 'zai-coding-plan/glm-5.2');
 assert.equal(config.agent.title.disable, true);
-assert.equal(config.agent.title.model, 'ambient-title-model-must-not-change');
-assert.deepEqual(config.mcp, { example: { type: 'local' } });
-assert.equal(Object.hasOwn(config, 'agents'), false);
-process.exit(0);
+	assert.equal(config.agent.title.model, 'ambient-title-model-must-not-change');
+	assert.deepEqual(config.mcp, { example: { type: 'local' } });
+	assert.equal(Object.hasOwn(config, 'agents'), false);
+	assert.deepEqual(config.permission, {
+	  read: { '*.env': 'deny' },
+	  glob: { '*': 'ask' },
+	  grep: { '*': 'ask', 'secret': 'deny' },
+	  edit: { '*': 'ask' },
+	  bash: { '*': 'ask' },
+	  external_directory: {
+	    '/unrelated/**': 'deny',
+	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
+	  }
+	});
+	assert.deepEqual(config.agent.build.permission, {
+	  external_directory: {
+	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
+	  }
+	});
+	process.exit(0);
 `);
 	const modelResult = await executeOpenCodeAgentTask({
 		...request,
@@ -191,6 +207,14 @@ process.exit(0);
 				runtime_env: {
 					OPENCODE_CONFIG_CONTENT: JSON.stringify({
 						mcp: { example: { type: 'local' } },
+						permission: {
+							read: { '*.env': 'deny' },
+							glob: { '*': 'ask' },
+							grep: { '*': 'ask', secret: 'deny' },
+							edit: { '*': 'ask' },
+							bash: { '*': 'ask' },
+							external_directory: { '/unrelated/**': 'deny' },
+						},
 						agents: { build: { model: 'invalid-plural-key/must-not-survive' } },
 						agent: { title: { disable: false, model: 'ambient-title-model-must-not-change' } },
 					}),
@@ -200,6 +224,76 @@ process.exit(0);
 		},
 	}, { env: fixtureEnv });
 	assert.equal(modelResult.status, 'succeeded');
+
+	const permissionWorkspaces = [
+		{
+			label: 'controller-scratch',
+			workspace: path.join(root, 'controller-scratch', 'wp-codebox-1825-gate-fix-2c'),
+			workspaceConfig: 'cwd',
+		},
+		{
+			label: 'managed-worktree',
+			workspace: path.join(root, 'managed-worktrees', 'homeboy-extensions@attempt'),
+			workspaceConfig: 'workspace_path',
+		},
+	];
+	for (const permissionWorkspace of permissionWorkspaces) {
+		fs.mkdirSync(permissionWorkspace.workspace, { recursive: true });
+		spawnSync('git', ['init'], { cwd: permissionWorkspace.workspace, encoding: 'utf8' });
+		spawnSync('git', ['commit', '--allow-empty', '-m', 'initial'], {
+			cwd: permissionWorkspace.workspace,
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				GIT_AUTHOR_NAME: 'Homeboy Test',
+				GIT_AUTHOR_EMAIL: 'homeboy@example.test',
+				GIT_COMMITTER_NAME: 'Homeboy Test',
+				GIT_COMMITTER_EMAIL: 'homeboy@example.test',
+			},
+		});
+		const concreteWorkspace = fs.realpathSync(permissionWorkspace.workspace);
+		const workspacePattern = path.join(concreteWorkspace, '**');
+		const permissionCliPath = path.join(root, `mock-opencode-permission-${permissionWorkspace.label}.cjs`);
+		fs.writeFileSync(permissionCliPath, `#!/usr/bin/env node
+const assert = require('node:assert/strict');
+assert.equal(process.cwd(), ${JSON.stringify(concreteWorkspace)});
+const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
+assert.equal(config.permission.external_directory[${JSON.stringify(workspacePattern)}], 'allow');
+assert.equal(config.permission.external_directory['/unrelated/**'], 'deny');
+assert.deepEqual(config.permission.grep, { '*': 'ask' });
+assert.deepEqual(config.permission.glob, { '*': 'ask' });
+assert.deepEqual(config.permission.read, { '*.env': 'deny' });
+assert.deepEqual(config.permission.edit, { '*': 'ask' });
+assert.deepEqual(config.agent.build.permission.external_directory, { ${JSON.stringify(workspacePattern)}: 'allow' });
+process.exit(0);
+`);
+		const workspaceRequest = {
+			...request,
+			task_id: `opencode-permission-${permissionWorkspace.label}`,
+			executor: {
+				...request.executor,
+				config: {
+					...request.executor.config,
+					command_args: [permissionCliPath],
+					runtime_env: {
+						OPENCODE_CONFIG_CONTENT: JSON.stringify({
+							permission: {
+								external_directory: { '/unrelated/**': 'deny' },
+								grep: { '*': 'ask' }, glob: { '*': 'ask' }, read: { '*.env': 'deny' }, edit: { '*': 'ask' },
+							},
+						}),
+					},
+				},
+			},
+		};
+		if (permissionWorkspace.workspaceConfig === 'cwd') {
+			workspaceRequest.executor.config.cwd = permissionWorkspace.workspace;
+		} else {
+			workspaceRequest.workspace_path = permissionWorkspace.workspace;
+		}
+		const permissionResult = await executeOpenCodeAgentTask(workspaceRequest, { env: fixtureEnv });
+		assert.equal(permissionResult.status, 'succeeded');
+	}
 
 	const scratchAttempts = [
 		{ id: 'run-2250-attempt-1', status: 0 },


### PR DESCRIPTION
## Summary
Allow the OpenCode executor to access the concrete workspace Homeboy assigns to each task without broadening access to unrelated external directories.

## What changed
- Derive an exact realpath-based \<workspace\>/\*\* external-directory allow rule and merge it into global and selected-agent OpenCode permission config while preserving existing rules.
- Cover controller-scratch and managed-worktree workspace resolution plus preservation of existing read, glob, grep, edit, and unrelated-directory policies.

## How to test
1. Run `cd agent-runtimes/opencode && npm install`; expect Dependencies install successfully from a fresh checkout..
2. Run `npm run test:opencode-agent-task-executor-boundary`; expect The boundary suite prints OpenCode agent task executor boundary passed..
3. Run `node --check lib/opencode-agent-task-executor.js && node --check tests/opencode-agent-task-executor-boundary.test.js`; expect Both runtime and test files pass syntax validation..

## Compatibility
Backwards compatible: requests without a resolvable workspace keep their prior config; existing permission rules remain intact, and only the concrete assigned workspace gains access.

## Evidence
- Base unchanged since verification: main remains at 97366e92503c7e86c3e1904eb9923f81dc8f1803.
- OpenCode executor boundary: Passed
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2280
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/7720
- Verified finalization base: main at 97366e92503c7e86c3e1904eb9923f81dc8f1803

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the cross-layer permission failure, implemented the adapter fix and deterministic tests, and reviewed the final diff with Chris.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2280
- Relates to Extra-Chill/homeboy#7720
