### PR TITLE
Allow OpenCode access to task attempt roots

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -278,14 +278,14 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 	// Homeboy owns durable task identity, so OpenCode must not create a competing
 	// provider session title from an ambient or run-scoped configuration layer.
 	content.agent.title = { ...objectValue(content.agent.title), disable: true };
-	const workspacePattern = opencodeExternalDirectoryPattern(request, config);
-	if (workspacePattern) {
-		content.permission = permissionWithWorkspaceAllowance(content.permission, workspacePattern);
+	const externalDirectoryPatterns = opencodeExternalDirectoryPatterns(request, config);
+	if (externalDirectoryPatterns.length > 0) {
+		content.permission = permissionWithExternalDirectoryAllowances(content.permission, externalDirectoryPatterns);
 		content.agent[primaryAgent] = {
 			...objectValue(content.agent[primaryAgent]),
-			permission: permissionWithWorkspaceAllowance(
+			permission: permissionWithExternalDirectoryAllowances(
 				objectValue(content.agent[primaryAgent]).permission,
-				workspacePattern
+				externalDirectoryPatterns
 			),
 		};
 	}
@@ -293,26 +293,49 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 	return JSON.stringify(content);
 }
 
-function opencodeExternalDirectoryPattern(request = {}, config = {}) {
+function opencodeExternalDirectoryPatterns(request = {}, config = {}) {
 	const cwd = resolveOpenCodeCwd(request, config);
-	if (typeof cwd !== 'string' || cwd.trim() === '') {
-		return '';
+	if (!isAbsolutePath(cwd)) {
+		return [];
 	}
 
-	const workspace = path.resolve(cwd);
+	const concreteWorkspace = concretePath(cwd);
+	const patterns = [path.join(concreteWorkspace, '**')];
+	const attemptRoot = config.runtime_env?.TMPDIR;
+	if (isAbsolutePath(attemptRoot)) {
+		const concreteAttemptRoot = concretePath(attemptRoot);
+		if (isStrictDescendant(concreteWorkspace, concreteAttemptRoot)) {
+			// OpenCode discovers project metadata from this Homeboy-provided attempt root.
+			patterns.unshift(path.join(concreteAttemptRoot, '*'));
+		}
+	}
+
+	return [...new Set(patterns)];
+}
+
+function concretePath(candidate) {
+	const resolved = path.resolve(candidate);
 	// OpenCode compares tool paths against the process working directory, which
 	// resolves symlinks when the child process starts.
-	let concreteWorkspace = workspace;
 	try {
-		concreteWorkspace = fs.realpathSync.native?.(workspace) || fs.realpathSync(workspace);
+		return fs.realpathSync.native?.(resolved) || fs.realpathSync(resolved);
 	} catch {
 		// Keep the configured request path when the caller materializes it after
 		// constructing the executor environment.
+		return resolved;
 	}
-	return path.join(concreteWorkspace, '**');
 }
 
-function permissionWithWorkspaceAllowance(permission, workspacePattern) {
+function isAbsolutePath(value) {
+	return typeof value === 'string' && value.trim() !== '' && path.isAbsolute(value);
+}
+
+function isStrictDescendant(candidate, parent) {
+	const relative = path.relative(parent, candidate);
+	return relative !== '' && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function permissionWithExternalDirectoryAllowances(permission, patterns) {
 	const rules = typeof permission === 'string'
 		? { '*': permission }
 		: objectValue(permission);
@@ -324,9 +347,9 @@ function permissionWithWorkspaceAllowance(permission, workspacePattern) {
 		...rules,
 		external_directory: {
 			...externalDirectory,
-			// OpenCode resolves matching rules in order, so this narrowly scoped rule
-			// deliberately supersedes an inherited catch-all for this task workspace.
-			[workspacePattern]: 'allow',
+			// OpenCode resolves matching rules in order, so these task-owned paths
+			// deliberately supersede inherited catch-all rules.
+			...Object.fromEntries(patterns.map((pattern) => [pattern, 'allow'])),
 		},
 	};
 }

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -35,6 +35,30 @@ function secretEnvRequirementForProvider(contract, provider) {
 	));
 }
 
+function opencodeWildcardMatch(input, pattern) {
+	let escaped = pattern
+		.replaceAll('\\', '/')
+		.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+		.replace(/\*/g, '.*')
+		.replace(/\?/g, '.');
+	if (escaped.endsWith(' .*')) escaped = `${escaped.slice(0, -3)}( .*)?`;
+	return new RegExp(`^${escaped}$`, process.platform === 'win32' ? 'si' : 's').test(input.replaceAll('\\', '/'));
+}
+
+function externalDirectoryAction(config, agent, requestedPattern) {
+	const permissions = [config.permission, config.agent?.[agent]?.permission];
+	const rules = permissions.flatMap((permission) => Object.entries(permission?.external_directory || {}));
+	return rules.findLast(([pattern]) => opencodeWildcardMatch(requestedPattern, pattern))?.[1] || 'ask';
+}
+
+function concretePath(candidate) {
+	try {
+		return fs.realpathSync(candidate);
+	} catch {
+		return path.resolve(candidate);
+	}
+}
+
 (async () => {
 const provider = providerContract();
 assert.equal(provider.id, 'opencode.agent-task-executor');
@@ -228,8 +252,24 @@ assert.equal(config.agent.title.disable, true);
 	const permissionWorkspaces = [
 		{
 			label: 'controller-scratch',
-			workspace: path.join(root, 'controller-scratch', 'wp-codebox-1825-gate-fix-2c'),
+			attemptRoot: path.join(root, 'controller-scratch', 'wp-codebox-1825-gate-fix-2d'),
+			workspace: path.join(root, 'controller-scratch', 'wp-codebox-1825-gate-fix-2d', 'workspace'),
 			workspaceConfig: 'cwd',
+			allowAttemptRoot: true,
+		},
+		{
+			label: 'unrelated-attempt-root',
+			attemptRoot: path.join(root, 'unrelated-attempt-root'),
+			workspace: path.join(root, 'unrelated-workspace'),
+			workspaceConfig: 'cwd',
+			allowAttemptRoot: false,
+		},
+		{
+			label: 'prefix-collision-attempt-root',
+			attemptRoot: path.join(root, 'controller-scratch', 'wp-codebox-1825-gate-fix-2d'),
+			workspace: path.join(root, 'controller-scratch', 'wp-codebox-1825-gate-fix-2d-sibling', 'workspace'),
+			workspaceConfig: 'cwd',
+			allowAttemptRoot: false,
 		},
 		{
 			label: 'managed-worktree',
@@ -237,6 +277,7 @@ assert.equal(config.agent.title.disable, true);
 			workspaceConfig: 'workspace_path',
 		},
 	];
+	const ambientTmpdir = path.join(root, 'ambient-process-tmpdir');
 	for (const permissionWorkspace of permissionWorkspaces) {
 		fs.mkdirSync(permissionWorkspace.workspace, { recursive: true });
 		spawnSync('git', ['init'], { cwd: permissionWorkspace.workspace, encoding: 'utf8' });
@@ -251,20 +292,32 @@ assert.equal(config.agent.title.disable, true);
 				GIT_COMMITTER_EMAIL: 'homeboy@example.test',
 			},
 		});
-		const concreteWorkspace = fs.realpathSync(permissionWorkspace.workspace);
+		const concreteWorkspace = concretePath(permissionWorkspace.workspace);
 		const workspacePattern = path.join(concreteWorkspace, '**');
+		const concreteAttemptRoot = permissionWorkspace.attemptRoot && concretePath(permissionWorkspace.attemptRoot);
+		const attemptRootPattern = concreteAttemptRoot && path.join(concreteAttemptRoot, '*');
+		const expectedAttemptRootPattern = permissionWorkspace.allowAttemptRoot ? attemptRootPattern : undefined;
+		const configCapturePath = path.join(root, `opencode-permission-${permissionWorkspace.label}.json`);
 		const permissionCliPath = path.join(root, `mock-opencode-permission-${permissionWorkspace.label}.cjs`);
 		fs.writeFileSync(permissionCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 assert.equal(process.cwd(), ${JSON.stringify(concreteWorkspace)});
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
 assert.equal(config.permission.external_directory[${JSON.stringify(workspacePattern)}], 'allow');
+assert.equal(config.permission.external_directory[${JSON.stringify(attemptRootPattern)}], ${JSON.stringify(expectedAttemptRootPattern ? 'allow' : undefined)});
+assert.equal(config.permission.external_directory[${JSON.stringify(path.join(ambientTmpdir, '*'))}], undefined);
 assert.equal(config.permission.external_directory['/unrelated/**'], 'deny');
+assert.equal(config.permission.external_directory['*'], 'deny');
 assert.deepEqual(config.permission.grep, { '*': 'ask' });
 assert.deepEqual(config.permission.glob, { '*': 'ask' });
 assert.deepEqual(config.permission.read, { '*.env': 'deny' });
 assert.deepEqual(config.permission.edit, { '*': 'ask' });
-assert.deepEqual(config.agent.build.permission.external_directory, { ${JSON.stringify(workspacePattern)}: 'allow' });
+assert.deepEqual(config.agent.build.permission.external_directory, ${JSON.stringify(expectedAttemptRootPattern ? {
+			[attemptRootPattern]: 'allow',
+			[workspacePattern]: 'allow',
+		} : { [workspacePattern]: 'allow' })});
+fs.writeFileSync(${JSON.stringify(configCapturePath)}, JSON.stringify(config));
 process.exit(0);
 `);
 		const workspaceRequest = {
@@ -278,7 +331,7 @@ process.exit(0);
 					runtime_env: {
 						OPENCODE_CONFIG_CONTENT: JSON.stringify({
 							permission: {
-								external_directory: { '/unrelated/**': 'deny' },
+								external_directory: { '*': 'deny', '/unrelated/**': 'deny' },
 								grep: { '*': 'ask' }, glob: { '*': 'ask' }, read: { '*.env': 'deny' }, edit: { '*': 'ask' },
 							},
 						}),
@@ -291,8 +344,38 @@ process.exit(0);
 		} else {
 			workspaceRequest.workspace_path = permissionWorkspace.workspace;
 		}
-		const permissionResult = await executeOpenCodeAgentTask(workspaceRequest, { env: fixtureEnv });
+		if (permissionWorkspace.attemptRoot) {
+			workspaceRequest.executor.config.runtime_env.TMPDIR = permissionWorkspace.attemptRoot;
+		}
+		const permissionResult = await executeOpenCodeAgentTask(workspaceRequest, {
+			env: { ...fixtureEnv, TMPDIR: ambientTmpdir },
+		});
 		assert.equal(permissionResult.status, 'succeeded');
+		const generatedConfig = JSON.parse(fs.readFileSync(configCapturePath, 'utf8'));
+		const requestedPatterns = permissionWorkspace.allowAttemptRoot
+			? [
+				path.join(concreteAttemptRoot, '*'),
+				path.join(concreteAttemptRoot, 'workspace', 'packages', 'runtime-playground', 'src', '*'),
+				path.join(concreteAttemptRoot, 'workspace', 'tests', '*'),
+			]
+			: [path.join(concreteWorkspace, 'tests', '*')];
+		for (const requestedPattern of requestedPatterns) {
+			assert.equal(externalDirectoryAction(generatedConfig, 'build', requestedPattern), 'allow');
+		}
+		if (permissionWorkspace.attemptRoot && !permissionWorkspace.allowAttemptRoot) {
+			assert.equal(
+				externalDirectoryAction(generatedConfig, 'build', path.join(concreteAttemptRoot, '*')),
+				'deny'
+			);
+			assert.equal(
+				externalDirectoryAction(generatedConfig, 'build', path.join(concreteAttemptRoot, 'workspace', 'tests', '*')),
+				'deny'
+			);
+		}
+		assert.equal(
+			externalDirectoryAction(generatedConfig, 'build', path.join(root, 'controller-scratch', 'unrelated-attempt', '*')),
+			'deny'
+		);
 	}
 
 	const scratchAttempts = [


### PR DESCRIPTION
## Summary
Extend the exact workspace allowance from #2281 to the containing Homeboy attempt root that OpenCode actually requests, without trusting ambient or unrelated paths.

## What changed
- Allow explicit request runtime\_env.TMPDIR only when the concrete workspace is a strict descendant of that attempt root.
- Model OpenCode wildcard matching against the three patterns observed in a real gate-feedback retry and reject unrelated, ambient, and path-prefix collision roots.

## How to test
1. Run `cd agent-runtimes/opencode && npm install`; expect Dependencies install successfully from a fresh checkout..
2. Run `npm run test:opencode-agent-task-executor-boundary`; expect The boundary suite proves observed attempt-root patterns resolve to allow and unrelated paths resolve to deny..
3. Run `node --check lib/opencode-agent-task-executor.js && node --check tests/opencode-agent-task-executor-boundary.test.js`; expect Both changed JavaScript files pass syntax validation..

## Compatibility
Backwards compatible: the workspace allowance from #2281 remains; attempt-root access is added only for an explicit absolute request TMPDIR that strictly contains the concrete workspace, preserving unrelated denies.

## Evidence
- Base unchanged since verification: main remains at d822d08f44a1666dfc96b90ef4b14363dc44bc9e.
- OpenCode permission matcher boundary: Passed
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2280
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/pull/2281
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/issues/7720
- Verified finalization base: main at d822d08f44a1666dfc96b90ef4b14363dc44bc9e

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Validated PR #2281 against a real Homeboy gate-feedback retry, diagnosed OpenCode attempt-root matching, hardened the permission boundary, and added regression coverage with Chris.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2280
- Relates to Extra-Chill/homeboy#7720
