### PR TITLE
Permit scoped OpenCode workspace reads

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -279,6 +279,7 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 	// provider session title from an ambient or run-scoped configuration layer.
 	content.agent.title = { ...objectValue(content.agent.title), disable: true };
 	const externalDirectoryPatterns = opencodeExternalDirectoryPatterns(request, config);
+	const workspaceReadPatterns = opencodeWorkspaceReadPatterns(request, config);
 	if (externalDirectoryPatterns.length > 0) {
 		content.permission = permissionWithExternalDirectoryAllowances(content.permission, externalDirectoryPatterns);
 		content.agent[primaryAgent] = {
@@ -289,18 +290,29 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 			),
 		};
 	}
+	if (workspaceReadPatterns.length > 0) {
+		content.permission = permissionWithWorkspaceReadAllowances(content.permission, workspaceReadPatterns);
+		content.agent[primaryAgent] = {
+			...objectValue(content.agent[primaryAgent]),
+			permission: permissionWithWorkspaceReadAllowances(
+				objectValue(content.agent[primaryAgent]).permission,
+				workspaceReadPatterns,
+				content.permission
+			),
+		};
+	}
 
 	return JSON.stringify(content);
 }
 
 function opencodeExternalDirectoryPatterns(request = {}, config = {}) {
-	const cwd = resolveOpenCodeCwd(request, config);
-	if (!isAbsolutePath(cwd)) {
+	const workspacePatterns = opencodeWorkspaceReadPatterns(request, config);
+	if (workspacePatterns.length === 0) {
 		return [];
 	}
 
-	const concreteWorkspace = concretePath(cwd);
-	const patterns = [path.join(concreteWorkspace, '**')];
+	const concreteWorkspace = concretePath(resolveOpenCodeCwd(request, config));
+	const patterns = [...workspacePatterns];
 	const attemptRoot = config.runtime_env?.TMPDIR;
 	if (isAbsolutePath(attemptRoot)) {
 		const concreteAttemptRoot = concretePath(attemptRoot);
@@ -311,6 +323,11 @@ function opencodeExternalDirectoryPatterns(request = {}, config = {}) {
 	}
 
 	return [...new Set(patterns)];
+}
+
+function opencodeWorkspaceReadPatterns(request = {}, config = {}) {
+	const cwd = resolveOpenCodeCwd(request, config);
+	return isAbsolutePath(cwd) ? [path.join(concretePath(cwd), '**')] : [];
 }
 
 function concretePath(candidate) {
@@ -350,6 +367,32 @@ function permissionWithExternalDirectoryAllowances(permission, patterns) {
 			// OpenCode resolves matching rules in order, so these task-owned paths
 			// deliberately supersede inherited catch-all rules.
 			...Object.fromEntries(patterns.map((pattern) => [pattern, 'allow'])),
+		},
+	};
+}
+
+function permissionWithWorkspaceReadAllowances(permission, patterns, inheritedPermission = {}) {
+	const rules = typeof permission === 'string'
+		? { '*': permission }
+		: objectValue(permission);
+	const inheritedRead = typeof inheritedPermission.read === 'string'
+		? { '*': inheritedPermission.read }
+		: objectValue(inheritedPermission.read);
+	const read = {
+		...inheritedRead,
+		...(typeof rules.read === 'string' ? { '*': rules.read } : objectValue(rules.read)),
+	};
+	const deniedReadRules = Object.fromEntries(
+		Object.entries(read).filter(([pattern, action]) => pattern !== '*' && action === 'deny')
+	);
+
+	return {
+		...rules,
+		read: {
+			// Permit source inspection only under the concrete task workspace.
+			'*': 'deny',
+			...Object.fromEntries(patterns.map((pattern) => [pattern, 'allow'])),
+			...deniedReadRules,
 		},
 	};
 }

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,7 +9,7 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.2.1',
+		version: '1.2.2',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
 		contract_producers: [
 			{

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "contract_producers": [
     {
@@ -51,15 +51,17 @@
         "unable_to_remediate",
         "provider_error",
         "timeout",
+        "candidate_recoverable",
         "failed",
         "follow_up_issue",
         "cancelled"
       ],
       "failure_classifications": [
         "provider",
-        "provider_quota",
         "transient",
         "timeout",
+        "stalled",
+        "rate_limited",
         "policy_denied",
         "capability_missing",
         "invalid_input",

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -51,6 +51,12 @@ function externalDirectoryAction(config, agent, requestedPattern) {
 	return rules.findLast(([pattern]) => opencodeWildcardMatch(requestedPattern, pattern))?.[1] || 'ask';
 }
 
+function readAction(config, agent, requestedPath) {
+	const permissions = [config.permission, config.agent?.[agent]?.permission];
+	const rules = permissions.flatMap((permission) => Object.entries(permission?.read || {}));
+	return rules.findLast(([pattern]) => opencodeWildcardMatch(requestedPath, pattern))?.[1] || 'allow';
+}
+
 function concretePath(candidate) {
 	try {
 		return fs.realpathSync(candidate);
@@ -201,7 +207,11 @@ assert.equal(config.agent.title.disable, true);
 	assert.deepEqual(config.mcp, { example: { type: 'local' } });
 	assert.equal(Object.hasOwn(config, 'agents'), false);
 	assert.deepEqual(config.permission, {
-	  read: { '*.env': 'deny' },
+	  read: {
+	    '*': 'deny',
+	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow',
+	    '*.env': 'deny'
+	  },
 	  glob: { '*': 'ask' },
 	  grep: { '*': 'ask', 'secret': 'deny' },
 	  edit: { '*': 'ask' },
@@ -212,6 +222,11 @@ assert.equal(config.agent.title.disable, true);
 	  }
 	});
 	assert.deepEqual(config.agent.build.permission, {
+	  read: {
+	    '*': 'deny',
+	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow',
+	    '*.env': 'deny'
+	  },
 	  external_directory: {
 	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
 	  }
@@ -311,12 +326,22 @@ assert.equal(config.permission.external_directory['/unrelated/**'], 'deny');
 assert.equal(config.permission.external_directory['*'], 'deny');
 assert.deepEqual(config.permission.grep, { '*': 'ask' });
 assert.deepEqual(config.permission.glob, { '*': 'ask' });
-assert.deepEqual(config.permission.read, { '*.env': 'deny' });
-assert.deepEqual(config.permission.edit, { '*': 'ask' });
-assert.deepEqual(config.agent.build.permission.external_directory, ${JSON.stringify(expectedAttemptRootPattern ? {
+		assert.deepEqual(config.permission.read, {
+			'*': 'deny',
+			${JSON.stringify(workspacePattern)}: 'allow',
+			'*.env': 'deny',
+		});
+		assert.deepEqual(config.permission.edit, { '*': 'ask' });
+		assert.deepEqual(config.agent.build.permission, ${JSON.stringify(expectedAttemptRootPattern ? {
+			read: { '*': 'deny', [workspacePattern]: 'allow', '*.env': 'deny' },
+			external_directory: {
 			[attemptRootPattern]: 'allow',
 			[workspacePattern]: 'allow',
-		} : { [workspacePattern]: 'allow' })});
+			},
+		} : {
+			read: { '*': 'deny', [workspacePattern]: 'allow', '*.env': 'deny' },
+			external_directory: { [workspacePattern]: 'allow' },
+		})});
 fs.writeFileSync(${JSON.stringify(configCapturePath)}, JSON.stringify(config));
 process.exit(0);
 `);
@@ -362,6 +387,14 @@ process.exit(0);
 		for (const requestedPattern of requestedPatterns) {
 			assert.equal(externalDirectoryAction(generatedConfig, 'build', requestedPattern), 'allow');
 		}
+		assert.equal(
+			readAction(generatedConfig, 'build', path.join(concreteWorkspace, 'src', 'index.js')),
+			'allow'
+		);
+		assert.equal(
+			readAction(generatedConfig, 'build', path.join(root, 'outside-workspace', 'index.js')),
+			'deny'
+		);
 		if (permissionWorkspace.attemptRoot && !permissionWorkspace.allowAttemptRoot) {
 			assert.equal(
 				externalDirectoryAction(generatedConfig, 'build', path.join(concreteAttemptRoot, '*')),


### PR DESCRIPTION
Closes #2283

## Source relationship
This follows the runtime-local OpenCode permission composition introduced by #2281 and narrowed for task attempt roots in #2282. The candidate adds only OpenCode `read` policy composition; it does not add runtime-specific behavior to Homeboy core.

## Change kind
Bug fix and generated-manifest freshness update. The generated OpenCode runtime manifest now reflects the current shared outcome contract and receives an independent patch version bump to `1.2.2`.

## Scope and safety
Generated OpenCode configuration now denies reads by default, permits reads only under the concrete resolved task workspace, and reapplies inherited specific read denials such as `*.env` after the workspace allow rule. Per-agent composition receives the same policy, so an agent override cannot discard the inherited environment-file denial. Existing non-read permissions are not broadened, attempt-root external-directory behavior remains unchanged, and unrelated workspace reads remain denied.

## Verification capability
The focused boundary test captures generated `OPENCODE_CONFIG_CONTENT` using a mock CLI and deterministically validates concrete/symlink-resolved workspace permissions, environment-file denial retention, out-of-workspace denial, unrelated attempt-root denial, and unchanged external-directory behavior.

## Testing
1. `cd agent-runtimes/opencode && npm run test:opencode-agent-task-executor-boundary`
2. `cd agent-runtimes/opencode && npm run check:runtime-manifest`
3. `git diff --check origin/main...HEAD`
4. `git diff --exit-code origin/main...HEAD -- CHANGELOG.md`

## Compatibility impact
OpenCode agent-task runs are now intentionally limited to read inspection within their declared concrete workspace. Existing specific read denials remain effective. No Homeboy core contract or behavior changes.

## AI assistance disclosure
AI assistance was used to inspect the candidate, run deterministic validation, regenerate the stale runtime manifest, and draft this PR description; the resulting changes and checks were reviewed locally.