### PR TITLE
Route declared standalone PHP smoke tests directly

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -142,10 +142,22 @@ Available factories from the WordPress test framework: `user`, `post`,
 ### Real-WordPress host smokes
 
 Standalone smoke files matching `tests/**/*-smoke.php` are diagnostic/operator
-targets, not default release gates. Run one explicitly through the same selected
-real WordPress runtime harness when you need it. The selected file is
-mounted with the component and executed via `wordpress.run-php`, so WordPress
-functions and runtime dependencies are available.
+targets, not default release gates. A component can declare each file's required
+environment in a root `homeboy-test-manifest.json`:
+
+```json
+{
+  "schema": "homeboy/test-manifest/v1",
+  "tests": {
+    "tests/contract-smoke.php": { "environment": "standalone-php" },
+    "tests/runtime-smoke.php": { "environment": "wordpress" }
+  }
+}
+```
+
+`standalone-php` files run directly with PHP, while `wordpress` files are
+mounted with the component and executed via `wordpress.run-php`. Undeclared
+PHP smokes default to `wordpress`, preserving the existing runtime behavior.
 
 To rerun one existing smoke on demand before pushing:
 
@@ -153,7 +165,8 @@ To rerun one existing smoke on demand before pushing:
 homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```
 
-The focused command does not change default test discovery or add smokes to CI.
+Use `--file` for a manifest-declared standalone PHP smoke. The focused command
+does not change default test discovery or add smokes to CI.
 Output preserves the machine-readable `HOST_SMOKE_BEGIN`,
 `HOST_SMOKE_PROGRESS`, `HOST_SMOKE_OK`, `HOST_SMOKE_FAIL`, and
 `HOST_SMOKE_SUMMARY` markers.

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -68,16 +68,29 @@ rejected with a clear error.
 ## Real-WordPress host smokes
 
 Standalone PHP smoke files can live under `tests/**/*-smoke.php`. They are
-diagnostic/operator targets, not default release gates. Run one explicitly
-through the selected runtime backend against real WordPress when you need the
-same component mounts, dependency mounts, drop-in handling, WordPress version
-selection, and `wordpress.run-php` recipe execution path CI uses:
+diagnostic/operator targets, not default release gates. Declare each smoke's
+environment in a root `homeboy-test-manifest.json` using schema
+`homeboy/test-manifest/v1`. Its `tests` object maps exact test paths to an
+`environment` of `standalone-php` or `wordpress`. Undeclared PHP smokes default
+to `wordpress`. `standalone-php` scripts run directly with PHP; `wordpress`
+scripts use the selected runtime backend with component mounts, dependency
+mounts, drop-in handling, WordPress version selection, and `wordpress.run-php`:
+
+```json
+{
+  "schema": "homeboy/test-manifest/v1",
+  "tests": {
+    "tests/contract-smoke.php": { "environment": "standalone-php" }
+  }
+}
+```
 
 ```bash
 homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```
 
-This focused path preserves the machine-readable `HOST_SMOKE_BEGIN`,
+Use `--file tests/contract-smoke.php` to run a declared standalone PHP smoke.
+The real-WordPress focused path preserves the machine-readable `HOST_SMOKE_BEGIN`,
 `HOST_SMOKE_PROGRESS`, `HOST_SMOKE_OK`, `HOST_SMOKE_FAIL`, and
 `HOST_SMOKE_SUMMARY` markers, and fails fast with the selected script name.
 

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -244,6 +244,20 @@ assert_contains "${TMPDIR}/smoke-file.out" "HOST_SMOKE_BEGIN:tests/import-agent-
 assert_contains "${TMPDIR}/smoke-file.out" "standalone smoke ran"
 assert_not_contains "${TMPDIR}/smoke-file.out" "WP_CODEBOX_STUB"
 
+cat > "${component}/homeboy-test-manifest.json" <<'JSON'
+{
+  "schema": "homeboy/test-manifest/v1",
+  "tests": {
+    "tests/import-agent-ability-smoke.php": {
+      "environment": "standalone-php"
+    },
+    "tests/queue-routing-smoke.php": {
+      "environment": "wordpress"
+    }
+  }
+}
+JSON
+
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
@@ -255,10 +269,34 @@ HOMEBOY_TEST_SCOPE_ENV_NAME="HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" \
 HOMEBOY_TEST_SCOPE_ENV_VALUE=$'tests/import-agent-ability-smoke.php\ntests/queue-routing-smoke.php' \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-smoke-files.out"
 
-assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
+assert_contains "${TMPDIR}/changed-smoke-files.out" "PHP_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
+assert_contains "${TMPDIR}/changed-smoke-files.out" "PHP_SMOKE_OK:tests/import-agent-ability-smoke.php"
+assert_contains "${TMPDIR}/changed-smoke-files.out" "PHP_SMOKE_SUMMARY:passed=1 failed=0"
 assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/queue-routing-smoke.php"
-assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_SUMMARY:passed=2 failed=0"
+assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_SUMMARY:passed=1 failed=0"
+assert_not_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
 assert_not_contains "${TMPDIR}/changed-smoke-files.out" "WP_CODEBOX_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE_WP="${TMPDIR}/stubs/host-smoke-wp.sh" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/import-agent-ability-smoke.php > "${TMPDIR}/declared-standalone-smoke-file.out"
+
+assert_contains "${TMPDIR}/declared-standalone-smoke-file.out" "PHP_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
+assert_contains "${TMPDIR}/declared-standalone-smoke-file.out" "PHP_SMOKE_OK:tests/import-agent-ability-smoke.php"
+assert_not_contains "${TMPDIR}/declared-standalone-smoke-file.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE_WP="${TMPDIR}/stubs/host-smoke-wp.sh" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/queue-routing-smoke.php > "${TMPDIR}/declared-wordpress-smoke-file.out"
+
+assert_contains "${TMPDIR}/declared-wordpress-smoke-file.out" "HOST_SMOKE_BEGIN:tests/queue-routing-smoke.php"
+assert_not_contains "${TMPDIR}/declared-wordpress-smoke-file.out" "PHP_SMOKE_BEGIN:tests/queue-routing-smoke.php"
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Test runner router for WordPress Homeboy extension.
 #
 # Plugin/theme PHPUnit tests and core-dev checkouts run through the selected
-# WordPress runtime backend. Pure host-PHP smoke suites can explicitly use the
-# host-smoke backend.
+# WordPress runtime backend. PHP smoke scripts can declare a standalone PHP
+# environment in the component's test manifest.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
@@ -32,6 +32,69 @@ fi
 # WordPress. The default suite is PHPUnit. Standalone smoke scripts are
 # diagnostic/operator targets and run only when selected explicitly with --file,
 # --host-smoke-file, or the HOMEBOY_WORDPRESS_HOST_SMOKE_FILES scope environment.
+
+homeboy_wordpress_test_environment() {
+    local test_file="$1"
+    local manifest_path="${HOMEBOY_WORDPRESS_TEST_MANIFEST:-${PLUGIN_PATH}/homeboy-test-manifest.json}"
+
+    if [ ! -e "$manifest_path" ]; then
+        printf '%s\n' "wordpress"
+        return 0
+    fi
+
+    jq -er --arg testFile "$test_file" '
+        if type != "object" or .schema != "homeboy/test-manifest/v1" then
+            error("expected schema homeboy/test-manifest/v1")
+        elif (.tests | type) != "object" then
+            error("expected tests object")
+        else
+            (.tests[$testFile].environment // "wordpress") as $environment
+            | if $environment == "wordpress" or $environment == "standalone-php" then
+                $environment
+            else
+                error("unsupported environment " + ($environment | tostring))
+              end
+        end
+    ' "$manifest_path" 2>/dev/null || {
+        echo "ERROR: invalid WordPress test manifest: ${manifest_path}" >&2
+        return 2
+    }
+}
+
+homeboy_wordpress_run_standalone_php_smoke_files() {
+    local smoke_files_raw="$1"
+    local php_bin="${HOMEBOY_PHP_BIN:-php}"
+    local smoke_file smoke_abs rel_path exit_code
+    local passed=0
+    local failed=0
+    local last_failure_exit=0
+
+    echo "Running standalone PHP smoke tests..."
+    echo "  Component: ${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
+    echo "  Backend: standalone-php"
+
+    while IFS= read -r smoke_file; do
+        [ -n "$smoke_file" ] || continue
+        if ! smoke_abs="$(homeboy_wordpress_rel_test_file "$smoke_file")"; then
+            echo "ERROR: requested standalone PHP smoke file not found or outside the component: ${smoke_file}" >&2
+            return 2
+        fi
+        rel_path="$smoke_abs"
+        echo "PHP_SMOKE_BEGIN:${rel_path}"
+        if "$php_bin" "${PLUGIN_PATH}/${rel_path}"; then
+            echo "PHP_SMOKE_OK:${rel_path}"
+            passed=$((passed + 1))
+        else
+            exit_code=$?
+            echo "PHP_SMOKE_FAIL:${rel_path}:exit=${exit_code}"
+            failed=$((failed + 1))
+            last_failure_exit="$exit_code"
+        fi
+    done <<< "$smoke_files_raw"
+
+    echo "PHP_SMOKE_SUMMARY:passed=${passed} failed=${failed}"
+    [ "$failed" -eq 0 ] || return "$last_failure_exit"
+}
 
 show_usage() {
     cat <<'EOF'
@@ -368,7 +431,30 @@ fi
 
 if [ -z "$TARGET_FILE" ] && [ "${HOMEBOY_TEST_SCOPE_KIND:-}" = "exclusive_env" ]; then
     if [ "${HOMEBOY_TEST_SCOPE_ENV_NAME:-}" = "HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" ] && [ -n "${HOMEBOY_TEST_SCOPE_ENV_VALUE:-}" ]; then
-        HOMEBOY_WORDPRESS_HOST_SMOKE_FILES="$HOMEBOY_TEST_SCOPE_ENV_VALUE" exec bash "$SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+        standalone_php_smoke_files=""
+        wordpress_smoke_files=""
+        while IFS= read -r scoped_smoke_file; do
+            [ -n "$scoped_smoke_file" ] || continue
+            if ! scoped_smoke_rel="$(homeboy_wordpress_rel_test_file "$scoped_smoke_file")"; then
+                echo "ERROR: requested PHP smoke file not found or outside the component: ${scoped_smoke_file}" >&2
+                exit 2
+            fi
+            scoped_environment="$(homeboy_wordpress_test_environment "$scoped_smoke_rel")" || exit $?
+            if [ "$scoped_environment" = "standalone-php" ]; then
+                standalone_php_smoke_files+="${standalone_php_smoke_files:+$'\n'}${scoped_smoke_rel}"
+            else
+                wordpress_smoke_files+="${wordpress_smoke_files:+$'\n'}${scoped_smoke_rel}"
+            fi
+        done <<< "$HOMEBOY_TEST_SCOPE_ENV_VALUE"
+
+        scope_status=0
+        if [ -n "$standalone_php_smoke_files" ]; then
+            homeboy_wordpress_run_standalone_php_smoke_files "$standalone_php_smoke_files" || scope_status=$?
+        fi
+        if [ -n "$wordpress_smoke_files" ]; then
+            HOMEBOY_WORDPRESS_HOST_SMOKE_FILES="$wordpress_smoke_files" bash "$SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}" || scope_status=$?
+        fi
+        exit "$scope_status"
     fi
 fi
 
@@ -449,7 +535,12 @@ if [ -n "$TARGET_FILE" ]; then
         tests/*.php|tests/*/*.php|tests/*/*/*.php|tests/*/*/*/*.php)
             case "$target_base" in
                 *-smoke.php)
-                    HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="$target_rel" exec bash "$SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+                    target_environment="$(homeboy_wordpress_test_environment "$target_rel")" || exit $?
+                    if [ "$target_environment" = "standalone-php" ]; then
+                        homeboy_wordpress_run_standalone_php_smoke_files "$target_rel"
+                    else
+                        HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="$target_rel" exec bash "$SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+                    fi
                     ;;
                 *Test.php|test-*.php)
                     WORDPRESS_RUNTIME_RUNNER="$(homeboy_wordpress_runtime_runner)" || exit $?

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.26.1",
+  "version": "3.26.2",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
@@ -1058,7 +1058,7 @@
   },
   "testing": {
     "backend": "wp-codebox",
-      "description": "WordPress tests always run through WP Codebox against real WordPress, routed by file type: tests/**/*Test.php and tests/**/test-*.php run as PHPUnit; tests/**/*-smoke.php standalone scripts run via wordpress.run-php with WordPress booted. There is no bare-host/no-WordPress backend."
+      "description": "WordPress PHPUnit tests run through WP Codebox against real WordPress. PHP smoke files selected by changed-file routing use the component's homeboy-test-manifest.json environment declaration: standalone-php files run directly with PHP and wordpress files run through wordpress.run-php. Undeclared PHP smokes default to WordPress."
   },
   "ci": {
     "profiles": {


### PR DESCRIPTION
## Summary
- add a generic component-owned `homeboy-test-manifest.json` contract for exact PHP test environment declarations
- route `standalone-php` smoke tests through direct PHP and retain `wordpress` tests in the real WordPress runtime
- preserve WordPress as the default for undeclared PHP smoke tests
- apply classification consistently to changed-file and direct-file scopes
- document the contract and add routing assertions

Closes #2285

## How to test
1. Run `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh`.
2. Run `jq empty wordpress/wordpress.json`.
3. Run `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh` with the repository's declared matching WP Codebox fixture/runtime.
4. Confirm a manifest-declared `standalone-php` file runs directly and a declared or default `wordpress` file routes through `wordpress.run-php`.

## Verification
- shell syntax checks passed
- extension manifest JSON validation passed
- changed/direct-file routing assertions reached and passed
- `git diff --check` passed

The full local routing-smoke script later encountered the pre-existing fixture precedence mismatch tracked separately; the changed route assertions themselves passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the runtime classification mismatch, designed the generic test manifest contract, implemented routing, documentation, and deterministic assertions; Chris reviews and owns the change.
