### PR TITLE
Fix Homeboy runtime helper path in WP Codebox canary

### DIFF
--- a/wordpress/scripts/test/playground-db-activation-smoke.sh
+++ b/wordpress/scripts/test/playground-db-activation-smoke.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
-CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR}/src/core/extension/runtime"
+CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR}/crates/homeboy-core/src/extension/runtime"
 # The test runner chain (test-runner.sh -> test-runner-wp-codebox.sh) sources the
 # core runtime helpers and hard-requires their HOMEBOY_RUNTIME_* env vars. The
 # shared-core fallbacks were removed in homeboy-extensions e0f604a4, so direct


### PR DESCRIPTION
## Summary
- point the direct WP Codebox DB activation canary at Homeboy's current core runtime helper directory
- restore resolution of runner prelude, context, and runner-step helpers before the canary invokes the extension test chain

Closes #2288

## How to test
1. Run `bash -n wordpress/scripts/test/playground-db-activation-smoke.sh`.
2. Check out Homeboy main beside the extension checkout or set `HOMEBOY_CORE_DIR` to it.
3. Confirm `runner-prelude.sh`, `resolve-context.sh`, and `runner-steps.sh` resolve below `crates/homeboy-core/src/extension/runtime`.
4. Run `bash wordpress/scripts/test/playground-db-activation-smoke.sh` with the workflow's WP Codebox environment.

## Verification
- shell syntax passed
- all three helpers exist at the corrected path in current Homeboy main
- `git diff --check` passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the failed canary log, traced the Homeboy runtime layout, and applied the focused integration-path repair; Chris reviews and owns the change.
