### PR TITLE
Isolate the WP Codebox routing smoke fixture

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -29,6 +29,37 @@ assert_not_contains() {
 component="${TMPDIR}/component"
 mkdir -p "${component}/tests/Unit" "${component}/wordpress/tests" "${component}/bin/tests/i18n-tools" "${TMPDIR}/stubs"
 
+# Simulate a caller with a managed Codebox installation whose CLI and core module
+# are incompatible with this fixture. The smoke owns its runtime inputs below.
+ambient_install_dir="${TMPDIR}/ambient-codebox-install"
+ambient_wp_codebox_bin="${ambient_install_dir}/source/packages/cli/dist/index.js"
+ambient_core_module="${TMPDIR}/stubs/ambient-wp-codebox-core.mjs"
+mkdir -p "$(dirname "${ambient_wp_codebox_bin}")"
+cat > "${ambient_wp_codebox_bin}" <<'NODE'
+#!/usr/bin/env node
+process.stderr.write('AMBIENT_WP_CODEBOX_CLI_SELECTED\n');
+process.exit(1);
+NODE
+chmod +x "${ambient_wp_codebox_bin}"
+cat > "${ambient_core_module}" <<'NODE'
+export const incompatibleAmbientCodeboxModule = true;
+NODE
+
+HOMEBOY_WP_CODEBOX_INSTALL_DIR="${ambient_install_dir}"
+HOMEBOY_SETTINGS_WP_CODEBOX_BIN="${ambient_wp_codebox_bin}"
+HOMEBOY_WP_CODEBOX_BIN="${ambient_wp_codebox_bin}"
+HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE="${ambient_core_module}"
+HOMEBOY_WP_CODEBOX_CORE_MODULE="${ambient_core_module}"
+WP_CODEBOX_CORE_MODULE="${ambient_core_module}"
+HOMEBOY_SETTINGS_JSON='{"wp_codebox_bin":"'"${ambient_wp_codebox_bin}"'","wp_codebox_core_module":"'"${ambient_core_module}"'"}'
+
+unset HOMEBOY_SETTINGS_WP_CODEBOX_BIN HOMEBOY_WP_CODEBOX_BIN
+unset HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE HOMEBOY_WP_CODEBOX_CORE_MODULE WP_CODEBOX_CORE_MODULE
+unset HOMEBOY_SETTINGS_JSON
+HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMPDIR}/fixture-codebox-install"
+HOMEBOY_WP_CODEBOX_CORE_MODULE="${EXTENSION_PATH}/tests/fixtures/wp-codebox-core-recipe-builder.mjs"
+export HOMEBOY_WP_CODEBOX_INSTALL_DIR HOMEBOY_WP_CODEBOX_CORE_MODULE
+
 cat > "${component}/tests/import-agent-ability-smoke.php" <<'PHP'
 <?php
 fwrite( STDOUT, "standalone smoke ran\n" );
@@ -74,6 +105,7 @@ cat > "${TMPDIR}/stubs/wp-codebox.sh" <<'SH'
 set -euo pipefail
 echo "WP_CODEBOX_STUB"
 echo "SELECTED=${HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE:-}"
+echo "CORE_MODULE=${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}"
 printf 'CHANGED=%s\n' "${HOMEBOY_CHANGED_TEST_FILES:-}"
 printf 'NODE_OPTIONS=%s\n' "${NODE_OPTIONS:-}"
 printf 'ARGS=%s\n' "$*"
@@ -153,33 +185,6 @@ fi
 printf '{"success":true,"executions":[{"stdout":"OK (1 test, 1 assertion)\n","stderr":""}]}\n'
 SH
 chmod +x "${TMPDIR}/stubs/wp-codebox.sh"
-
-cat > "${TMPDIR}/stubs/phpunit-recipe-builder.mjs" <<'NODE'
-#!/usr/bin/env node
-import fs from 'node:fs';
-
-const input = JSON.parse(fs.readFileSync(0, 'utf8'));
-const options = input.options || input;
-const recipe = {
-  schema: 'wp-codebox/workspace-recipe/v1',
-  runtime: { wp: options.wordpressVersion, blueprint: { steps: [] } },
-  inputs: { mounts: options.mounts || [] },
-  workflow: { steps: [{ command: 'wordpress.phpunit', args: [
-    `plugin-slug=${options.pluginSlug}`,
-    `test-file=${options.selectedTestFile || ''}`,
-    `changed-tests-json=${JSON.stringify(options.changedTestFiles || [])}`,
-    `env-json=${JSON.stringify(options.env || {})}`,
-    `wp-config-defines-json=${JSON.stringify(options.wpConfigDefines || {})}`,
-    `autoload-file=${options.autoloadFile}`,
-    `tests-dir=${options.testsDir}`,
-    `test-root=${options.testRoot || ''}`,
-    `dependency-mounts=${(options.dependencyMounts || []).filter(Boolean).join(',')}`,
-    `multisite=${options.multisite ? '1' : '0'}`,
-  ] }] },
-};
-process.stdout.write(`${JSON.stringify(recipe, null, 2)}\n`);
-NODE
-chmod +x "${TMPDIR}/stubs/phpunit-recipe-builder.mjs"
 
 # Stub for the real-WordPress smoke runner. The real runner boots WordPress via
 # WP Codebox; for routing assertions we only need to confirm smoke files reach it
@@ -367,7 +372,6 @@ HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_WORDPRESS_TEST_RUNTIME_BACKEND="wp-codebox" \
 HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
-HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php --filter ImportAgent > "${TMPDIR}/phpunit-file.out"
 
 assert_contains "${TMPDIR}/phpunit-file.out" "WP_CODEBOX_STUB"
@@ -400,7 +404,6 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
-HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
 HOMEBOY_CHANGED_TEST_FILES=$'tests/import-agent-ability-smoke.php\ntests/Unit/ImportAgentAbilityTest.php' \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-mixed-files.out"
 
@@ -414,18 +417,21 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
-HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php --filter ImportAgent > "${TMPDIR}/wp-codebox-file.out"
 
 assert_contains "${TMPDIR}/wp-codebox-file.out" "WP_CODEBOX_STUB"
 assert_contains "${TMPDIR}/wp-codebox-file.out" "Backend: wp-codebox"
 assert_contains "${TMPDIR}/wp-codebox-file.out" "NODE_OPTIONS=--max-old-space-size=8192"
+assert_contains "${TMPDIR}/wp-codebox-file.out" "CORE_MODULE=${EXTENSION_PATH}/tests/fixtures/wp-codebox-core-recipe-builder.mjs"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "recipe-run"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "--recipe"
-assert_contains "${TMPDIR}/wp-codebox-args.txt" "wordpress.phpunit"
+assert_contains "${TMPDIR}/wp-codebox-args.txt" "fixture.wordpress.phpunit"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "autoload-file=/wp-codebox-vendor/autoload.php"
 assert_not_contains "${TMPDIR}/wp-codebox-args.txt" "6.9"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" '"target": "/wordpress/wp-content/plugins/component"'
+assert_not_contains "${TMPDIR}/wp-codebox-file.out" "AMBIENT_WP_CODEBOX_CLI_SELECTED"
+assert_not_contains "${TMPDIR}/wp-codebox-file.out" "${ambient_core_module}"
+assert_not_contains "${TMPDIR}/wp-codebox-args.txt" "AMBIENT_WP_CODEBOX_CLI_SELECTED"
 if [ -e "${component}/.phpunit.result.cache" ]; then
     echo "Expected WP Codebox runner to clean PHPUnit result cache" >&2
     exit 1
@@ -438,7 +444,6 @@ HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_SETTINGS_JSON='{"wp_codebox_phpunit_mounts":[{"source":"'"${component}"'","target":"/home/example/public_html","mode":"readwrite"}],"wp_codebox_phpunit_test_root":"/home/example/public_html/bin/tests/i18n-tools"}' \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
-HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file /home/example/public_html/bin/tests/i18n-tools/ExtractTest.php > "${TMPDIR}/wp-codebox-configured-root-file.out"
 
 assert_contains "${TMPDIR}/wp-codebox-configured-root-file.out" "WP_CODEBOX_STUB"
@@ -450,7 +455,6 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_SETTINGS_JSON='{"wp_codebox_bin":"'"${TMPDIR}/stubs/wp-codebox.sh"'","wordpress_runtime_version":"latest"}' \
-HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
 WP_CODEBOX_ARGS_FILE="${TMPDIR}/wp-codebox-settings-args.txt" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php > "${TMPDIR}/wp-codebox-settings.out"
 
@@ -465,7 +469,6 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
-HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/registration-drift.out" 2>&1
 status=$?
 set -e
@@ -492,7 +495,6 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$no_phpunit_component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
-HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/no-phpunit-composer.out" 2>&1
 
 assert_contains "${TMPDIR}/no-phpunit-composer.out" "Running Composer test script"
@@ -514,7 +516,6 @@ HOMEBOY_COMPONENT_PATH="$no_phpunit_npm_component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_SETTINGS_JSON='{"npm_test_script":"headless-preview-boot-smoke"}' \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
-HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/no-phpunit-npm.out" 2>&1
 
 assert_contains "${TMPDIR}/no-phpunit-npm.out" "Running npm test script"


### PR DESCRIPTION
## Summary
- isolate the WordPress routing smoke from ambient managed WP Codebox installations
- pin the smoke's fixture CLI and core module while using an empty managed-install root
- remove the custom recipe-builder bypass so the real loader validates the fixture export
- assert that conflicting ambient CLI/module values cannot shadow fixture selection

Closes #2286

## How to test
1. Run `bash -n wordpress/scripts/test/test-runner-file-routing-smoke.sh`.
2. Export the current Homeboy runtime helper paths for `HOMEBOY_RUNTIME_RUNNER_PRELUDE`, `HOMEBOY_RUNTIME_RESOLVE_CONTEXT`, and `HOMEBOY_RUNTIME_RUNNER_STEPS`.
3. Run `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh` while ambient managed WP Codebox paths are configured.
4. Confirm the test selects its fixture CLI/core module, emits the fixture recipe command, and never selects the conflicting ambient paths.

## Verification
- full routing smoke passed
- shell syntax passed
- `git diff --check` passed
- committed-tree `git show --check` passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Traced WP Codebox selection precedence, isolated the deterministic fixture, added anti-shadowing assertions, and reran the complete smoke; Chris reviews and owns the change.
