### PR TITLE
Remove provider-owned concurrency defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Homeboy Extensions
 
+Agent runtime providers describe invocation and process lifecycle behavior. They do not own
+execution capacity. Configure the global runner ceiling with Homeboy's
+`runner.settings.concurrency_limit`; per-plan concurrency requests remain bounded by that limit.
+
 Official extension directory for [Homeboy](https://github.com/Extra-Chill/homeboy). Each extension is a project-type primitive — it teaches Homeboy how to discover, audit, lint, test, and release a particular kind of codebase.
 
 This is a **monorepo** — each subdirectory is a standalone extension. Install individual extensions, not the whole repo.

--- a/agent-runtimes/claude-code/claude-code.json
+++ b/agent-runtimes/claude-code/claude-code.json
@@ -133,8 +133,7 @@
       },
       "lifecycle": {
         "completion": "synchronous_process",
-        "cancellation": "provider_signal",
-        "max_concurrency_default": 1
+        "cancellation": "provider_signal"
       },
       "artifact_contract": {
         "patch": ["git-diff", "patch"],

--- a/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
+++ b/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
@@ -80,7 +80,6 @@ function providerContract(options = {}) {
 		lifecycle: {
 			completion: 'synchronous_process',
 			cancellation: 'provider_signal',
-			max_concurrency_default: 1,
 		},
 		artifact_contract: {
 			patch: ['git-diff', 'patch'],

--- a/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
@@ -34,7 +34,7 @@ assert.equal(provider.backend, 'claude-code');
 assert.equal(provider.runtime, 'claude-code');
 assert.equal(provider.status, 'available');
 assert.equal(provider.integration_contract, 'homeboy-claude-code-agent-task/v1');
-assert.equal(provider.lifecycle.max_concurrency_default, 1);
+assert.equal(Object.hasOwn(provider.lifecycle, 'max_concurrency_default'), false);
 assert.equal(provider.lifecycle.cancellation, 'provider_signal');
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'claude-code').env, CLAUDE_CODE_REQUIRED_SECRET_ENV);
 assert.deepEqual(provider.provider_defaults['claude-code'].secret_env, CLAUDE_CODE_SECRET_ENV);

--- a/agent-runtimes/codex/codex.json
+++ b/agent-runtimes/codex/codex.json
@@ -121,8 +121,7 @@
       },
       "lifecycle": {
         "completion": "synchronous_process",
-        "cancellation": "provider_signal",
-        "max_concurrency_default": 1
+        "cancellation": "provider_signal"
       },
       "artifact_contract": {
         "patch": ["git-diff", "patch"],

--- a/agent-runtimes/codex/lib/codex-agent-task-executor.js
+++ b/agent-runtimes/codex/lib/codex-agent-task-executor.js
@@ -71,7 +71,6 @@ function providerContract(options = {}) {
 		lifecycle: {
 			completion: 'synchronous_process',
 			cancellation: 'provider_signal',
-			max_concurrency_default: 1,
 		},
 		artifact_contract: {
 			patch: ['git-diff', 'patch'],

--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -39,7 +39,7 @@ assert.equal(provider.backend, 'codex');
 assert.equal(provider.runtime, 'codex');
 assert.equal(provider.status, 'available');
 assert.equal(provider.integration_contract, 'homeboy-codex-agent-task/v1');
-assert.equal(provider.lifecycle.max_concurrency_default, 1);
+assert.equal(Object.hasOwn(provider.lifecycle, 'max_concurrency_default'), false);
 assert.equal(provider.lifecycle.cancellation, 'provider_signal');
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, CODEX_SECRET_ENV);
 assert.deepEqual(provider.provider_defaults.codex.secret_env, CODEX_SECRET_ENV);

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -230,7 +230,6 @@ function providerContract(options = {}) {
 		lifecycle: {
 			completion: 'synchronous_process',
 			cancellation: 'provider_signal',
-			max_concurrency_default: 1,
 		},
 		artifact_contract: {
 			patch: ['git-diff', 'patch'],

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -222,8 +222,7 @@
       },
       "lifecycle": {
         "completion": "synchronous_process",
-        "cancellation": "provider_signal",
-        "max_concurrency_default": 1
+        "cancellation": "provider_signal"
       },
       "artifact_contract": {
         "patch": [

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -73,7 +73,7 @@ assert.equal(provider.runtime_id, 'opencode');
 assert.equal(provider.status, 'active');
 assert.equal(provider.integration_contract, 'homeboy-opencode-agent-task/v1');
 assert.deepEqual(provider.invocation, OPENCODE_INVOCATION);
-assert.equal(provider.lifecycle.max_concurrency_default, 1);
+assert.equal(Object.hasOwn(provider.lifecycle, 'max_concurrency_default'), false);
 assert.equal(provider.lifecycle.cancellation, 'provider_signal');
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, OPENCODE_SECRET_ENV);
 assert.deepEqual(provider.provider_defaults.codex.secret_env, OPENCODE_SECRET_ENV);

--- a/agent-runtimes/pi/lib/pi-agent-task-executor.js
+++ b/agent-runtimes/pi/lib/pi-agent-task-executor.js
@@ -45,7 +45,6 @@ function providerContract(options = {}) {
 		lifecycle: {
 			completion: 'synchronous_process',
 			cancellation: 'process_signal',
-			max_concurrency_default: 1,
 		},
 		status: 'experimental',
 		integration_contract: 'homeboy-pi-agent-task/v1',

--- a/agent-runtimes/pi/pi.json
+++ b/agent-runtimes/pi/pi.json
@@ -84,8 +84,7 @@
       "provider_defaults": {},
       "lifecycle": {
         "completion": "synchronous_process",
-        "cancellation": "process_signal",
-        "max_concurrency_default": 1
+        "cancellation": "process_signal"
       },
       "status": "experimental",
       "integration_contract": "homeboy-pi-agent-task/v1"

--- a/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
@@ -25,7 +25,7 @@ assert.equal(provider.backend, 'pi');
 assert.equal(provider.runtime, 'pi');
 assert.equal(provider.status, 'experimental');
 assert.equal(provider.integration_contract, 'homeboy-pi-agent-task/v1');
-assert.equal(provider.lifecycle.max_concurrency_default, 1);
+assert.equal(Object.hasOwn(provider.lifecycle, 'max_concurrency_default'), false);
 assert.equal(provider.lifecycle.cancellation, 'process_signal');
 assert.deepEqual(provider.secret_env_requirements, []);
 assert.deepEqual(provider.provider_defaults, {});


### PR DESCRIPTION
## Summary
Make Homeboy runner concurrency\_limit the sole capacity owner by removing per-provider concurrency defaults.

## What changed
- OpenCode, Codex, Claude Code, and Pi contracts and manifests no longer declare max\_concurrency\_default; boundary tests enforce absence.

## How to test
1. Run `npm run test:opencode-agent-task-executor-boundary`; expect OpenCode boundary passes.
2. Run `npm run check:runtime-manifest`; expect OpenCode generated manifest is current.
3. Run `npm run test:codex-agent-task-executor-boundary`; expect Codex boundary passes.
4. Run `npm run test:claude-code-agent-task-executor-boundary`; expect Claude Code boundary passes.
5. Run `npm run test:pi-agent-task-executor-boundary`; expect Pi boundary passes.
6. Run `git diff --check`; expect patch has no whitespace errors.

## Compatibility
Provider manifests lose a redundant scheduling hint; capacity remains controlled by Homeboy runner.settings.concurrency\_limit.

## Evidence
- Base unchanged since verification: main remains at e5eea604d1d36a9fb70883c260f8f230012a4f9b.
- CI expected: tests
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2291
- Verified finalization base: main at e5eea604d1d36a9fb70883c260f8f230012a4f9b
- claude-boundary: Passed
- codex-boundary: Passed
- diff-check: Passed
- opencode-boundary: Passed
- pi-boundary: Passed
- runtime-manifest: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced concurrency ownership, removed duplicated provider declarations, updated boundary coverage, and ran deterministic verification.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2291
