### PR TITLE
Fix local-shell evidence reference contract

### DIFF
--- a/agent-runtimes/local-shell/scripts/agent/homeboy-local-shell-agent-task-executor.cjs
+++ b/agent-runtimes/local-shell/scripts/agent/homeboy-local-shell-agent-task-executor.cjs
@@ -17,7 +17,7 @@ process.stdout.write(`${JSON.stringify({
   task_id: taskId,
   status: 'no_op',
   summary: 'Local shell runtime accepted the generic agent task request.',
-  evidence_refs: [{ kind: 'preview', url: `https://example.test/${encodeURIComponent(taskId)}/preview` }],
+  evidence_refs: [{ kind: 'preview', uri: `https://example.test/${encodeURIComponent(taskId)}/preview` }],
   metadata: {
     runtime_id: 'local-shell',
     backend: request.executor?.backend || '',

--- a/tests/local-shell-agent-task-executor-boundary.test.mjs
+++ b/tests/local-shell-agent-task-executor-boundary.test.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const executor = path.join(
+  repoRoot,
+  'agent-runtimes',
+  'local-shell',
+  'scripts',
+  'agent',
+  'homeboy-local-shell-agent-task-executor.cjs'
+);
+const request = {
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'local-shell-evidence-uri-boundary',
+  executor: { backend: 'local-shell' },
+  instructions: 'Accept this representative local-shell task request.',
+};
+
+const result = spawnSync(process.execPath, [executor], {
+  encoding: 'utf8',
+  input: JSON.stringify(request),
+});
+
+assert.equal(result.status, 0, result.stderr || result.stdout);
+const outcome = JSON.parse(result.stdout);
+assert.equal(outcome.schema, 'homeboy/agent-task-outcome/v1');
+assert.equal(outcome.task_id, request.task_id);
+assert.equal(outcome.status, 'no_op');
+assert.deepEqual(outcome.evidence_refs, [{
+  kind: 'preview',
+  uri: 'https://example.test/local-shell-evidence-uri-boundary/preview',
+}]);
+assert.equal(outcome.metadata.backend, 'local-shell');
+
+console.log('local-shell agent-task executor boundary passed');


### PR DESCRIPTION
## Summary
- emit the required `evidence_refs[].uri` field from the local-shell agent-task executor
- add a process-boundary regression test that executes the real local-shell adapter and validates its outcome envelope

Tracks https://github.com/Extra-Chill/homeboy/issues/8870

## How to test
1. Check out this branch from a fresh clone.
2. Run `node tests/local-shell-agent-task-executor-boundary.test.mjs`.
3. Run `node --check agent-runtimes/local-shell/scripts/agent/homeboy-local-shell-agent-task-executor.cjs`.
4. Run `node --check tests/local-shell-agent-task-executor-boundary.test.mjs`.

## Verification
- The boundary test passes against the real executor process.
- The repaired runtime unblocked the tracked Homeboy Cook adoption that originally exposed the malformed field.

## Compatibility
This corrects an invalid output field to the existing Homeboy agent-task outcome contract. Consumers expecting the documented `uri` field begin working; the undeclared `url` field was rejected by the controller boundary and is intentionally removed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Control-plane diagnosis, implementation, process-boundary regression coverage, verification, and PR preparation. Chris Huber reviewed and directed the work.