### PR TITLE
Restore WP Codebox PHPUnit runner protocol

### DIFF
--- a/wordpress/scripts/test/playground-db-activation-smoke.sh
+++ b/wordpress/scripts/test/playground-db-activation-smoke.sh
@@ -81,6 +81,7 @@ echo "Dep fixture:  $DEP_FIXTURE_DIR"
 echo ""
 
 source_hash_before=$(tar -C "$(dirname "$HOST_FIXTURE_DIR")" -cf - "$(basename "$HOST_FIXTURE_DIR")" | shasum -a 256)
+set +e
 runner_output=$(HOMEBOY_COMPONENT_ID=test-db-activation-host \
     HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
     HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
@@ -90,7 +91,14 @@ runner_output=$(HOMEBOY_COMPONENT_ID=test-db-activation-host \
     HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
     HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="$ARTIFACTS_DIR" \
     bash "${SCRIPT_DIR}/test-runner.sh" 2>&1)
+runner_status=$?
+set -e
 printf '%s\n' "$runner_output"
+
+if [ "$runner_status" -ne 0 ]; then
+    echo "ERROR: WP Codebox PHPUnit runner exited with status ${runner_status}" >&2
+    exit "$runner_status"
+fi
 
 if [[ "$runner_output" != *"WP Codebox test run complete."* ]]; then
     echo "ERROR: expected WP Codebox PHPUnit runner success classification" >&2

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -21,17 +21,19 @@ const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
 const artifacts = process.env.HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR || path.join(directory, 'artifacts');
 const runArtifacts = path.join(artifacts, `wp-codebox-phpunit.${process.pid}`);
-const dependencies = dependencyPaths(settings).map((source) => ({
-  source,
-  slug: path.basename(source).replace(/@[^/]+$/, ''),
-  activate: true,
-}));
+const dependencies = dependencyPaths(settings).map((source) => {
+  const dependencySlug = path.basename(source).replace(/@[^/]+$/, '');
+  return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug) };
+});
 await requireHarness(harnessSource);
 const options = clean({
   wordpressVersion: settings.wordpress_runtime_version,
   pluginSlug: slug,
-  extra_plugins: [{ source: root, sourceSubpath: subpath, slug, activate: false }, ...dependencies],
-  dependencyMounts: dependencies.map((dependency) => `/wordpress/wp-content/plugins/${dependency.slug}`),
+  extra_plugins: [
+    { source: root, sourceSubpath: subpath, slug, activate: false },
+    ...dependencies.map(({ source, slug: dependencySlug }) => ({ source, slug: dependencySlug, activate: false })),
+  ],
+  dependencyMounts: dependencies.map(({ sandboxDirectory }) => sandboxDirectory),
   testRoot: settings.wp_codebox_phpunit_test_root,
   phpunitXml: settings.wp_codebox_phpunit_config,
   cwd: settings.wp_codebox_phpunit_cwd,
@@ -71,6 +73,9 @@ function dependencyPaths(configuration) {
   const configured = Array.isArray(configuration.validation_dependencies) ? configuration.validation_dependencies : [];
   const canonical = (process.env.HOMEBOY_WORDPRESS_DEPENDENCY_PATHS || '').split('\n');
   return [...new Set([...canonical, ...configured].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
+}
+function sandboxPluginDirectory(pluginSlug) {
+  return `/wordpress/wp-content/plugins/${pluginSlug}`;
 }
 function canonicalMounts(value) {
   return Array.isArray(value) ? value : [];

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -11,6 +11,8 @@ import { spawnSync } from 'node:child_process';
 const settings = json(process.env.HOMEBOY_SETTINGS_JSON, {});
 const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMPONENT_PATH');
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const extensionRoot = path.resolve(scriptDirectory, '../..');
+const harnessSource = path.join(extensionRoot, 'vendor');
 const slug = process.env.COMPONENT_ID || path.basename(componentPath);
 const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
@@ -24,10 +26,12 @@ const dependencies = dependencyPaths(settings).map((source) => ({
   slug: path.basename(source).replace(/@[^/]+$/, ''),
   activate: true,
 }));
+await requireHarness(harnessSource);
 const options = clean({
   wordpressVersion: settings.wordpress_runtime_version,
   pluginSlug: slug,
   extra_plugins: [{ source: root, sourceSubpath: subpath, slug, activate: false }, ...dependencies],
+  dependencyMounts: dependencies.map((dependency) => `/wordpress/wp-content/plugins/${dependency.slug}`),
   testRoot: settings.wp_codebox_phpunit_test_root,
   phpunitXml: settings.wp_codebox_phpunit_config,
   cwd: settings.wp_codebox_phpunit_cwd,
@@ -37,7 +41,7 @@ const options = clean({
   bootstrapMode: settings.wp_codebox_phpunit_bootstrap_mode,
   projectBootstrap: settings.wp_codebox_phpunit_project_bootstrap,
   preloadFiles: settings.wp_codebox_phpunit_preload_files,
-  mounts: settings.wp_codebox_phpunit_mounts,
+  mounts: [...canonicalMounts(settings.wp_codebox_phpunit_mounts), { source: harnessSource, target: '/wp-codebox-vendor', mode: 'readonly' }],
 });
 
 try {
@@ -67,6 +71,19 @@ function dependencyPaths(configuration) {
   const configured = Array.isArray(configuration.validation_dependencies) ? configuration.validation_dependencies : [];
   const canonical = (process.env.HOMEBOY_WORDPRESS_DEPENDENCY_PATHS || '').split('\n');
   return [...new Set([...canonical, ...configured].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
+}
+function canonicalMounts(value) {
+  return Array.isArray(value) ? value : [];
+}
+async function requireHarness(source) {
+  try {
+    await Promise.all([
+      access(path.join(source, 'autoload.php')),
+      access(path.join(source, 'wp-phpunit', 'wp-phpunit')),
+    ]);
+  } catch {
+    throw new Error(`WP Codebox PHPUnit harness is required at ${source}. Run composer install in ${extensionRoot}.`);
+  }
 }
 async function handoffArtifacts(artifactRoot) {
   let pointer;

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+/**
+ * External dependencies
+ */
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
 const settings = json(process.env.HOMEBOY_SETTINGS_JSON, {});
 const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMPONENT_PATH');
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const slug = process.env.COMPONENT_ID || path.basename(componentPath);
 const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
@@ -13,10 +18,16 @@ const directory = await mkdtemp(path.join(tmpdir(), 'homeboy-wp-codebox-phpunit-
 const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
 const artifacts = process.env.HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR || path.join(directory, 'artifacts');
+const runArtifacts = path.join(artifacts, `wp-codebox-phpunit.${process.pid}`);
+const dependencies = dependencyPaths(settings).map((source) => ({
+  source,
+  slug: path.basename(source).replace(/@[^/]+$/, ''),
+  activate: true,
+}));
 const options = clean({
   wordpressVersion: settings.wordpress_runtime_version,
   pluginSlug: slug,
-  extra_plugins: [{ source: root, sourceSubpath: subpath, slug, activate: false }],
+  extra_plugins: [{ source: root, sourceSubpath: subpath, slug, activate: false }, ...dependencies],
   testRoot: settings.wp_codebox_phpunit_test_root,
   phpunitXml: settings.wp_codebox_phpunit_config,
   cwd: settings.wp_codebox_phpunit_cwd,
@@ -32,16 +43,52 @@ const options = clean({
 try {
   await writeFile(optionsPath, `${JSON.stringify(options)}\n`);
   run(['recipe', 'build', 'phpunit', '--options', optionsPath, '--output', recipePath]);
-  run(['recipe-run', '--recipe', recipePath, '--artifacts', artifacts, '--json']);
+  await mkdir(runArtifacts, { recursive: true });
+  run(['recipe-run', '--recipe', recipePath, '--artifacts', runArtifacts, '--json']);
+  await handoffArtifacts(runArtifacts);
+  process.stdout.write('WP Codebox test run complete.\n');
 } finally {
   await rm(directory, { recursive: true, force: true });
 }
 
 function run(args) {
   const result = spawnSync(process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', args, { cwd: componentPath, encoding: 'utf8', stdio: 'inherit' });
-  if (result.error) throw result.error;
-  if (result.status !== 0) process.exit(result.status ?? 1);
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
 }
-function required(value, name) { if (!value) throw new Error(`${name} is required`); return value; }
+function required(value, name) { if (!value) { throw new Error(`${name} is required`); } return value; }
 function json(value, fallback) { try { return value ? JSON.parse(value) : fallback; } catch { return fallback; } }
 function clean(value) { return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== '' && !(Array.isArray(entry) && entry.length === 0))); }
+function dependencyPaths(configuration) {
+  const configured = Array.isArray(configuration.validation_dependencies) ? configuration.validation_dependencies : [];
+  const canonical = (process.env.HOMEBOY_WORDPRESS_DEPENDENCY_PATHS || '').split('\n');
+  return [...new Set([...canonical, ...configured].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
+}
+async function handoffArtifacts(artifactRoot) {
+  let pointer;
+  try { pointer = await readFile(path.join(artifactRoot, 'latest-runtime.json'), 'utf8'); } catch { return; }
+  const runtime = json(pointer, {}).paths?.runtimeDirectory;
+  if (typeof runtime !== 'string' || !/^runtime-[A-Za-z0-9][A-Za-z0-9-]*$/.test(runtime)) {
+    return;
+  }
+  const artifactDirectory = path.join(artifactRoot, runtime);
+  if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
+    runScript('parse-test-results.sh', [artifactDirectory]);
+  }
+  if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
+    runScript('parse-test-failures.sh', [artifactDirectory, componentPath]);
+  }
+}
+function runScript(script, args) {
+  const result = spawnSync('bash', [path.join(scriptDirectory, script), ...args], { cwd: componentPath, encoding: 'utf8', stdio: 'inherit' });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${script} failed with exit code ${result.status ?? 1}`);
+  }
+}

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -6,12 +6,18 @@ import { spawnSync } from 'node:child_process';
 
 const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-canonical-adapter-'));
 const component = path.join(root, 'plugin');
+const dependency = path.join(root, 'db-touching-dependency');
 const observed = path.join(root, 'observed.jsonl');
 const cli = path.join(root, 'wp-codebox');
 const results = path.join(root, 'results', 'bench.json');
+const testResults = path.join(root, 'results', 'test.json');
+const writeResults = path.join(root, 'write-test-results.sh');
 await mkdir(component, { recursive: true });
+await mkdir(dependency, { recursive: true });
+await writeFile(writeResults, `homeboy_write_test_results() { printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$1" "$2" "$3" "$4" > "$HOMEBOY_TEST_RESULTS_FILE"; }
+`);
 await writeFile(cli, `#!/usr/bin/env node
-import { appendFile, readFile, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
 await appendFile(process.env.OBSERVED, JSON.stringify(args) + '\\n');
 if (args[0] === 'recipe' && args[1] === 'build') {
@@ -20,7 +26,13 @@ if (args[0] === 'recipe' && args[1] === 'build') {
   await writeFile(args[args.indexOf('--output') + 1], JSON.stringify({ schema: 'wp-codebox/workspace-recipe/v1' }));
   process.exit(0);
 }
-if (args[0] === 'recipe-run') process.stdout.write(JSON.stringify({ success: true, benchResults: { schema: 'homeboy/bench-results/v1', scenarios: [] } }));
+if (args[0] === 'recipe-run') {
+  const artifacts = args[args.indexOf('--artifacts') + 1];
+  await mkdir(artifacts + '/runtime-fixture/files', { recursive: true });
+  await writeFile(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+  await writeFile(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: 'passed', summary: { total: 1, passed: 1, failed: 0, skipped: 0 } }));
+  process.stdout.write(JSON.stringify({ success: true, benchResults: { schema: 'homeboy/bench-results/v1', scenarios: [] } }));
+}
 `);
 await chmod(cli, 0o755);
 
@@ -33,6 +45,7 @@ try {
     HOMEBOY_SETTINGS_JSON: JSON.stringify({
       wp_codebox_source_root: '/workspace/monorepo',
       wp_codebox_source_subpath: 'plugins/canonical-plugin',
+      validation_dependencies: [dependency],
       wordpress_runtime_workloads: [{ id: 'canonical-workload', run: [] }],
       wordpress_runtime_blueprint: { steps: [] },
     }),
@@ -40,8 +53,9 @@ try {
   const extension = path.resolve(import.meta.dirname, '..');
   const bench = spawnSync(path.join(extension, 'scripts/bench/bench-runner-wp-codebox.sh'), [], { env: { ...process.env, ...base, HOMEBOY_BENCH_RESULTS_FILE: results }, encoding: 'utf8' });
   assert.equal(bench.status, 0, bench.stderr);
-  const phpunit = spawnSync(path.join(extension, 'scripts/test/test-runner-wp-codebox.sh'), [], { env: { ...process.env, ...base }, encoding: 'utf8' });
+  const phpunit = spawnSync(path.join(extension, 'scripts/test/test-runner-wp-codebox.sh'), [], { env: { ...process.env, ...base, HOMEBOY_TEST_RESULTS_FILE: testResults, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: writeResults }, encoding: 'utf8' });
   assert.equal(phpunit.status, 0, phpunit.stderr);
+  assert.match(phpunit.stdout, /WP Codebox test run complete\./);
   const entries = (await readFile(observed, 'utf8')).trim().split('\n').map(JSON.parse);
   assert.deepEqual(entries.filter(Array.isArray).map((args) => args.slice(0, 2)), [
     ['recipe', 'build'], ['recipe-run', '--recipe'], ['recipe', 'build'], ['recipe-run', '--recipe'],
@@ -51,9 +65,11 @@ try {
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
   ]);
+  assert.deepEqual(options[1].extra_plugins[1], { source: dependency, slug: 'db-touching-dependency', activate: true });
   assert.equal(options[0].workloads[0].id, 'canonical-workload');
   assert.equal(Object.hasOwn(options[0], 'wp_codebox_workloads'), false);
   assert.deepEqual(JSON.parse(await readFile(results, 'utf8')).scenarios, []);
+  assert.deepEqual(JSON.parse(await readFile(testResults, 'utf8')), { total: 1, passed: 1, failed: 0, skipped: 0 });
 } finally {
   await rm(root, { recursive: true, force: true });
 }

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -65,7 +65,7 @@ try {
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
   ]);
-  assert.deepEqual(options[1].extra_plugins[1], { source: dependency, slug: 'db-touching-dependency', activate: true });
+  assert.deepEqual(options[1].extra_plugins[1], { source: dependency, slug: 'db-touching-dependency', activate: false });
   assert.deepEqual(options[1].dependencyMounts, ['/wordpress/wp-content/plugins/db-touching-dependency']);
   assert.deepEqual(options[1].mounts, [{ source: path.join(extension, 'vendor'), target: '/wp-codebox-vendor', mode: 'readonly' }]);
   assert.equal(options[0].workloads[0].id, 'canonical-workload');

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -66,6 +66,8 @@ try {
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
   ]);
   assert.deepEqual(options[1].extra_plugins[1], { source: dependency, slug: 'db-touching-dependency', activate: true });
+  assert.deepEqual(options[1].dependencyMounts, ['/wordpress/wp-content/plugins/db-touching-dependency']);
+  assert.deepEqual(options[1].mounts, [{ source: path.join(extension, 'vendor'), target: '/wp-codebox-vendor', mode: 'readonly' }]);
   assert.equal(options[0].workloads[0].id, 'canonical-workload');
   assert.equal(Object.hasOwn(options[0], 'wp_codebox_workloads'), false);
   assert.deepEqual(JSON.parse(await readFile(results, 'utf8')).scenarios, []);


### PR DESCRIPTION
## Summary
- restore validation dependencies through canonical inactive WP Codebox plugin inputs and `dependencyMounts`
- mount the extension-owned PHPUnit harness at `/wp-codebox-vendor`
- restore isolated runtime artifact/result handoff and the Homeboy completion marker
- preserve failed runner diagnostics instead of losing output under `set -e`
- add regression coverage for canonical mounts and dependency projection

## Why
Merged PR https://github.com/Extra-Chill/homeboy-extensions/pull/2294 correctly delegated PHPUnit recipe construction to WP Codebox, but the thin adapter dropped Homeboy-owned context projection. The runtime lacked validation dependencies, the extension PHPUnit harness, result handoff, and completion protocol.

The real canary also exposed an upstream WP Codebox lifecycle gap for dependencies whose activation requires the managed PHPUnit database.

Upstream dependency: https://github.com/Automattic/wp-codebox/pull/1868
Failure evidence: https://github.com/Extra-Chill/homeboy-extensions/actions/runs/29646694037/job/88086037491

## How to test
1. Check out WP Codebox PR #1868 and run `npm install && npm run build`.
2. Set `HOMEBOY_WP_CODEBOX_BIN` to that checkout’s `packages/cli/dist/index.js`.
3. Run `bash wordpress/scripts/test/playground-db-activation-smoke.sh`.
4. Run `cd wordpress && npm run test:wp-codebox-canonical-cli-adapters`.
5. Run `cd wordpress && npx eslint scripts/test/wp-codebox-phpunit-adapter.mjs`.

The end-to-end smoke passes 3 tests and 7 assertions against WP Codebox #1868.

## Compatibility
Validation dependencies now use WP Codebox’s canonical contract: inactive `extra_plugins` plus sandbox `dependencyMounts`. This restores post-install activation and callback behavior without restoring legacy settings, source discovery, local recipe builders, PHPUnit bootstrap logic, or fallback paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.6-sol via OpenCode
- **Used for:** Diagnosed the merged canary regression, implemented Homeboy protocol projection, coordinated the upstream Codebox lifecycle repair, and added regression coverage under Chris Huber's direction.