### PR TITLE
Map OpenCode workspace tool permissions

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -128,6 +128,11 @@ const OPENCODE_WORKSPACE_TOOLS = {
 	],
 };
 
+const OPENCODE_NATIVE_WORKSPACE_PERMISSIONS = {
+	readonly: ['read', 'glob', 'grep'],
+	readwrite: ['edit', 'bash'],
+};
+
 const OPENCODE_WORKSPACE_MATERIALIZATION = {
 	cwd: 'git_checkout',
 	requires_git: true,
@@ -290,12 +295,11 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 		};
 	}
 	if (workspaceReadPatterns.length > 0) {
-		content.permission = permissionWithWorkspaceReadAllowances(content.permission, workspaceReadPatterns);
+		content.permission = permissionWithWorkspaceToolAllowances(content.permission);
 		content.agent[primaryAgent] = {
 			...objectValue(content.agent[primaryAgent]),
-			permission: permissionWithWorkspaceReadAllowances(
+			permission: permissionWithWorkspaceToolAllowances(
 				objectValue(content.agent[primaryAgent]).permission,
-				workspaceReadPatterns,
 				content.permission
 			),
 		};
@@ -370,29 +374,33 @@ function permissionWithExternalDirectoryAllowances(permission, patterns) {
 	};
 }
 
-function permissionWithWorkspaceReadAllowances(permission, patterns, inheritedPermission = {}) {
+function permissionWithWorkspaceToolAllowances(permission, inheritedPermission = {}) {
 	const rules = typeof permission === 'string'
 		? { '*': permission }
 		: objectValue(permission);
-	const inheritedRead = typeof inheritedPermission.read === 'string'
-		? { '*': inheritedPermission.read }
-		: objectValue(inheritedPermission.read);
-	const read = {
-		...inheritedRead,
-		...(typeof rules.read === 'string' ? { '*': rules.read } : objectValue(rules.read)),
-	};
-	const deniedReadRules = Object.fromEntries(
-		Object.entries(read).filter(([pattern, action]) => pattern !== '*' && action === 'deny')
-	);
+	const permissionTools = Object.values(OPENCODE_NATIVE_WORKSPACE_PERMISSIONS).flat();
+	return permissionTools.reduce((nextRules, tool) => ({
+		...nextRules,
+		[tool]: workspaceToolPermissionRules(rules[tool], inheritedPermission[tool], tool),
+	}), rules);
+}
 
+function workspaceToolPermissionRules(permission, inheritedPermission, tool) {
+	const inheritedRules = typeof inheritedPermission === 'string'
+		? { '*': inheritedPermission }
+		: objectValue(inheritedPermission);
+	const rules = typeof permission === 'string'
+		? { '*': permission }
+		: objectValue(permission);
+	const deniedRules = Object.fromEntries(
+		Object.entries({ ...inheritedRules, ...rules }).filter(([pattern, action]) => pattern !== '*' && action === 'deny')
+	);
 	return {
-		...rules,
-		read: {
-			// Permit source inspection only under the concrete task workspace.
-			'*': 'deny',
-			...Object.fromEntries(patterns.map((pattern) => [pattern, 'allow'])),
-			...deniedReadRules,
-		},
+		// These surfaces correspond to the executor's declared Homeboy workspace
+		// capabilities. OpenCode evaluates their paths from the task cwd.
+		'*': 'allow',
+		...(tool === 'read' ? { '..': 'deny', '../*': 'deny', '..\\*': 'deny' } : {}),
+		...deniedRules,
 	};
 }
 

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -51,10 +51,19 @@ function externalDirectoryAction(config, agent, requestedPattern) {
 	return rules.findLast(([pattern]) => opencodeWildcardMatch(requestedPattern, pattern))?.[1] || 'ask';
 }
 
-function readAction(config, agent, requestedPath) {
+function readAction(config, agent, worktree, filepath) {
+	// OpenCode evaluates ReadTool rules after resolving the target against its
+	// workspace, so absolute workspace rules cannot match nested source files.
+	const requestedPath = path.relative(worktree, filepath);
 	const permissions = [config.permission, config.agent?.[agent]?.permission];
 	const rules = permissions.flatMap((permission) => Object.entries(permission?.read || {}));
 	return rules.findLast(([pattern]) => opencodeWildcardMatch(requestedPath, pattern))?.[1] || 'allow';
+}
+
+function nativeToolAction(config, agent, tool, requestedValue) {
+	const permissions = [config.permission, config.agent?.[agent]?.permission];
+	const rules = permissions.flatMap((permission) => Object.entries(permission?.[tool] || {}));
+	return rules.findLast(([pattern]) => opencodeWildcardMatch(requestedValue, pattern))?.[1] || 'allow';
 }
 
 function concretePath(candidate) {
@@ -208,14 +217,16 @@ assert.equal(config.agent.title.disable, true);
 	assert.equal(Object.hasOwn(config, 'agents'), false);
 	assert.deepEqual(config.permission, {
 	  read: {
-	    '*': 'deny',
-	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow',
+	    '*': 'allow',
+	    '..': 'deny',
+	    '../*': 'deny',
+	    '..\\\\*': 'deny',
 	    '*.env': 'deny'
 	  },
-	  glob: { '*': 'ask' },
-	  grep: { '*': 'ask', 'secret': 'deny' },
-	  edit: { '*': 'ask' },
-	  bash: { '*': 'ask' },
+	  glob: { '*': 'allow' },
+	  grep: { '*': 'allow', 'secret': 'deny' },
+	  edit: { '*': 'allow' },
+	  bash: { '*': 'allow', 'git push *': 'deny' },
 	  external_directory: {
 	    '/unrelated/**': 'deny',
 	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
@@ -223,10 +234,16 @@ assert.equal(config.agent.title.disable, true);
 	});
 	assert.deepEqual(config.agent.build.permission, {
 	  read: {
-	    '*': 'deny',
-	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow',
+	    '*': 'allow',
+	    '..': 'deny',
+	    '../*': 'deny',
+	    '..\\\\*': 'deny',
 	    '*.env': 'deny'
 	  },
+	  glob: { '*': 'allow' },
+	  grep: { '*': 'allow', 'secret': 'deny' },
+	  edit: { '*': 'allow' },
+	  bash: { '*': 'allow', 'git push *': 'deny' },
 	  external_directory: {
 	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
 	  }
@@ -251,7 +268,7 @@ assert.equal(config.agent.title.disable, true);
 							glob: { '*': 'ask' },
 							grep: { '*': 'ask', secret: 'deny' },
 							edit: { '*': 'ask' },
-							bash: { '*': 'ask' },
+							bash: { '*': 'ask', 'git push *': 'deny' },
 							external_directory: { '/unrelated/**': 'deny' },
 						},
 						agents: { build: { model: 'invalid-plural-key/must-not-survive' } },
@@ -262,7 +279,7 @@ assert.equal(config.agent.title.disable, true);
 			},
 		},
 	}, { env: fixtureEnv });
-	assert.equal(modelResult.status, 'succeeded');
+	assert.equal(modelResult.status, 'succeeded', JSON.stringify(modelResult.diagnostics));
 
 	const permissionWorkspaces = [
 		{
@@ -324,22 +341,33 @@ assert.equal(config.permission.external_directory[${JSON.stringify(attemptRootPa
 assert.equal(config.permission.external_directory[${JSON.stringify(path.join(ambientTmpdir, '*'))}], undefined);
 assert.equal(config.permission.external_directory['/unrelated/**'], 'deny');
 assert.equal(config.permission.external_directory['*'], 'deny');
-assert.deepEqual(config.permission.grep, { '*': 'ask' });
-assert.deepEqual(config.permission.glob, { '*': 'ask' });
+assert.deepEqual(config.permission.grep, { '*': 'allow', secret: 'deny' });
+assert.deepEqual(config.permission.glob, { '*': 'allow' });
 		assert.deepEqual(config.permission.read, {
-			'*': 'deny',
-			${JSON.stringify(workspacePattern)}: 'allow',
+			'*': 'allow',
+			'..': 'deny',
+			'../*': 'deny',
+			'..\\\\*': 'deny',
 			'*.env': 'deny',
 		});
-		assert.deepEqual(config.permission.edit, { '*': 'ask' });
+		assert.deepEqual(config.permission.edit, { '*': 'allow' });
+		assert.deepEqual(config.permission.bash, { '*': 'allow', 'git push *': 'deny' });
 		assert.deepEqual(config.agent.build.permission, ${JSON.stringify(expectedAttemptRootPattern ? {
-			read: { '*': 'deny', [workspacePattern]: 'allow', '*.env': 'deny' },
+			read: { '*': 'allow', '..': 'deny', '../*': 'deny', '..\\*': 'deny', '*.env': 'deny' },
+			glob: { '*': 'allow' },
+			grep: { '*': 'allow', secret: 'deny' },
+			edit: { '*': 'allow' },
+			bash: { '*': 'allow', 'git push *': 'deny' },
 			external_directory: {
 			[attemptRootPattern]: 'allow',
 			[workspacePattern]: 'allow',
 			},
 		} : {
-			read: { '*': 'deny', [workspacePattern]: 'allow', '*.env': 'deny' },
+			read: { '*': 'allow', '..': 'deny', '../*': 'deny', '..\\*': 'deny', '*.env': 'deny' },
+			glob: { '*': 'allow' },
+			grep: { '*': 'allow', secret: 'deny' },
+			edit: { '*': 'allow' },
+			bash: { '*': 'allow', 'git push *': 'deny' },
 			external_directory: { [workspacePattern]: 'allow' },
 		})});
 fs.writeFileSync(${JSON.stringify(configCapturePath)}, JSON.stringify(config));
@@ -357,7 +385,7 @@ process.exit(0);
 						OPENCODE_CONFIG_CONTENT: JSON.stringify({
 							permission: {
 								external_directory: { '*': 'deny', '/unrelated/**': 'deny' },
-								grep: { '*': 'ask' }, glob: { '*': 'ask' }, read: { '*.env': 'deny' }, edit: { '*': 'ask' },
+								grep: { '*': 'ask', secret: 'deny' }, glob: { '*': 'ask' }, read: { '*.env': 'deny' }, edit: { '*': 'ask' }, bash: { '*': 'ask', 'git push *': 'deny' },
 							},
 						}),
 					},
@@ -375,7 +403,7 @@ process.exit(0);
 		const permissionResult = await executeOpenCodeAgentTask(workspaceRequest, {
 			env: { ...fixtureEnv, TMPDIR: ambientTmpdir },
 		});
-		assert.equal(permissionResult.status, 'succeeded');
+		assert.equal(permissionResult.status, 'succeeded', JSON.stringify(permissionResult.diagnostics));
 		const generatedConfig = JSON.parse(fs.readFileSync(configCapturePath, 'utf8'));
 		const requestedPatterns = permissionWorkspace.allowAttemptRoot
 			? [
@@ -388,11 +416,17 @@ process.exit(0);
 			assert.equal(externalDirectoryAction(generatedConfig, 'build', requestedPattern), 'allow');
 		}
 		assert.equal(
-			readAction(generatedConfig, 'build', path.join(concreteWorkspace, 'src', 'index.js')),
+			readAction(generatedConfig, 'build', concreteWorkspace, path.join(concreteWorkspace, 'src', 'index.js')),
 			'allow'
 		);
+		assert.equal(nativeToolAction(generatedConfig, 'build', 'glob', 'src/**/*.js'), 'allow');
+		assert.equal(nativeToolAction(generatedConfig, 'build', 'grep', 'TODO'), 'allow');
+		assert.equal(nativeToolAction(generatedConfig, 'build', 'grep', 'secret'), 'deny');
+		assert.equal(nativeToolAction(generatedConfig, 'build', 'edit', 'src/index.js'), 'allow');
+		assert.equal(nativeToolAction(generatedConfig, 'build', 'bash', 'git status --short'), 'allow');
+		assert.equal(nativeToolAction(generatedConfig, 'build', 'bash', 'git push origin trunk'), 'deny');
 		assert.equal(
-			readAction(generatedConfig, 'build', path.join(root, 'outside-workspace', 'index.js')),
+			readAction(generatedConfig, 'build', concreteWorkspace, path.join(root, 'outside-workspace', 'index.js')),
 			'deny'
 		);
 		if (permissionWorkspace.attemptRoot && !permissionWorkspace.allowAttemptRoot) {


### PR DESCRIPTION
## Summary
- translate the OpenCode executor's declared read/write workspace capabilities into native non-interactive tool permissions
- allow workspace inspection, search, edits, and verification commands instead of inheriting terminal `ask` rules
- preserve explicit sensitive-file, command, external-directory, and parent-traversal denials

Closes #2296.

## Root cause

The executor advertised `workspace_read` and `workspace_run`, but only generated an explicit native `read` override. OpenCode inherited `ask` rules for tools such as `glob`, `grep`, `edit`, and `bash`; because agent-task runs are non-interactive, those calls terminated otherwise valid coding tasks as `policy_denied`.

## How to test
1. Run `cd agent-runtimes/opencode`.
2. Run `npm run test:opencode-agent-task-executor`.
3. Run `npm run check:runtime-manifest`.
4. Confirm the boundary test permits workspace-relative read, glob, grep, edit, and verification commands.
5. Confirm the same test denies sensitive-file reads, parent traversal, external directories, and `git push` commands.

## Compatibility
- Existing declared OpenCode workspace capabilities now match runtime behavior.
- Explicit non-wildcard deny rules remain authoritative.
- Native command permissions are policy controls rather than an OS sandbox; the executor still relies on sanitized environment and publication separation for defense in depth.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.6 Sol via OpenCode
- **Used for:** Diagnosed the executor permission mismatch, implemented and tested the capability mapping, and drafted this PR with Chris reviewing and owning the change.