### PR TITLE
Allow OpenCode to recover from denied tool calls

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -493,6 +493,9 @@ function opencodeFailureOutcome(context) {
 }
 
 function withPolicyDeniedOutcome(context = {}, terminal = {}) {
+	if (terminal.status === 'succeeded') {
+		return terminal;
+	}
 	const denial = detectOpenCodePolicyDenial(context);
 	if (!denial) {
 		return terminal;
@@ -658,7 +661,7 @@ function collectOpenCodeArtifacts(context = {}) {
 		captureErrors.push({ artifact: 'patch', message: patchCapture.error });
 	}
 	const patch = patchCapture.content;
-	const policyDenial = detectOpenCodePolicyDenial(context);
+	const policyDenial = spawnResult.status === 0 ? null : detectOpenCodePolicyDenial(context);
 	const resultStatus = policyDenial ? 'failed' : (spawnResult.status === 0 ? 'succeeded' : 'failed');
 	const resultEnvelope = JSON.stringify({
 		schema: 'homeboy/opencode-agent-result/v1',

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -732,6 +732,45 @@ process.exit(0);
 			GIT_COMMITTER_EMAIL: 'homeboy@example.test',
 		},
 	});
+	const recoveredCliPath = path.join(root, 'mock-opencode-policy-denied-then-completed.cjs');
+	fs.writeFileSync(recoveredCliPath, `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: 'message',
+  timestamp: '2026-07-03T15:12:00.000Z',
+  parts: [{
+    type: 'tool',
+    tool: 'bash',
+    input: { command: 'cd /tmp && git clone https://example.invalid/private.git' },
+    state: { error: 'The user rejected permission to use this specific tool call.' }
+  }]
+}) + '\\n');
+process.stdout.write(JSON.stringify({ type: 'message', text: 'Completed after the denied tool call.' }) + '\\n');
+process.exit(0);
+`);
+	const recoveredResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-policy-denied-then-completed',
+		workspace_path: deniedWorkspace,
+		artifacts_path: deniedArtifactDir,
+		expected_artifacts: ['patch', 'transcript', 'agent_result'],
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				command_args: [recoveredCliPath],
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(recoveredResult.status, 'succeeded');
+	assert.equal(recoveredResult.failure_classification, undefined);
+	assert.equal(recoveredResult.failure_code, undefined);
+	assert.equal(recoveredResult.metadata.denied_tool_call, undefined);
+	assert.deepEqual(recoveredResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stdout', 'patch', 'transcript']);
+	assert.equal(recoveredResult.diagnostics.some((diagnostic) => diagnostic.class === 'opencode.policy_denied'), false);
+	const recoveredAgentResult = JSON.parse(fs.readFileSync(recoveredResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
+	assert.equal(recoveredAgentResult.status, 'succeeded');
+	assert.equal(recoveredAgentResult.failure_classification, undefined);
+
 	const deniedCliPath = path.join(root, 'mock-opencode-policy-denied.cjs');
 	fs.writeFileSync(deniedCliPath, `#!/usr/bin/env node
 process.stdout.write(JSON.stringify({
@@ -744,7 +783,7 @@ process.stdout.write(JSON.stringify({
     state: { error: 'The user rejected permission to use this specific tool call.' }
   }]
 }) + '\\n');
-process.exit(0);
+process.exit(1);
 `);
 	const deniedResult = await executeOpenCodeAgentTask({
 		...request,


### PR DESCRIPTION
## Summary
- preserve successful OpenCode outcomes when the transcript contains an individually denied tool call
- retain `policy_denied` classification for nonzero terminal failures caused by permission policy
- cover recoverable and terminal denial paths in the adapter boundary test

Relates to Extra-Chill/homeboy#7720.

## How to test
1. Run `cd agent-runtimes/opencode && npm run test:opencode-agent-task-executor`.
2. Run `npm run check:runtime-manifest`.
3. Run `node --check lib/opencode-agent-task-executor.js && node --check tests/opencode-agent-task-executor-boundary.test.js`.

## Compatibility
The adapter outcome schema is unchanged. Successful status-0 executions are no longer reclassified from incidental denied tool events; genuine nonzero permission failures retain the existing failure code and classification.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.6-sol), Homeboy
- **Used for:** Diagnosed the false-terminal classification, drafted the focused implementation and tests, and ran deterministic verification.