### PR TITLE
Load component during Codebox PHPUnit lifecycle

### DIFF
--- a/wordpress/scripts/test/playground-db-activation-smoke.sh
+++ b/wordpress/scripts/test/playground-db-activation-smoke.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
-CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR}/crates/homeboy-core/src/extension/runtime"
+CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR}/crates/homeboy-extension/src/runtime"
 # The test runner chain (test-runner.sh -> test-runner-wp-codebox.sh) sources the
 # core runtime helpers and hard-requires their HOMEBOY_RUNTIME_* env vars. The
 # shared-core fallbacks were removed in homeboy-extensions e0f604a4, so direct

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -33,7 +33,7 @@ const options = clean({
     { source: root, sourceSubpath: subpath, slug, activate: false },
     ...dependencies.map(({ source, slug: dependencySlug }) => ({ source, slug: dependencySlug, activate: false })),
   ],
-  dependencyMounts: dependencies.map(({ sandboxDirectory }) => sandboxDirectory),
+  dependencyMounts: [...new Set([sandboxPluginDirectory(slug), ...dependencies.map(({ sandboxDirectory }) => sandboxDirectory)])],
   testRoot: settings.wp_codebox_phpunit_test_root,
   phpunitXml: settings.wp_codebox_phpunit_config,
   cwd: settings.wp_codebox_phpunit_cwd,

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-canonical-adapter-'));
-const component = path.join(root, 'plugin');
+const component = path.join(root, 'canonical-plugin');
 const dependency = path.join(root, 'db-touching-dependency');
 const observed = path.join(root, 'observed.jsonl');
 const cli = path.join(root, 'wp-codebox');
@@ -45,7 +45,7 @@ try {
     HOMEBOY_SETTINGS_JSON: JSON.stringify({
       wp_codebox_source_root: '/workspace/monorepo',
       wp_codebox_source_subpath: 'plugins/canonical-plugin',
-      validation_dependencies: [dependency],
+      validation_dependencies: [component, dependency, dependency],
       wordpress_runtime_workloads: [{ id: 'canonical-workload', run: [] }],
       wordpress_runtime_blueprint: { steps: [] },
     }),
@@ -65,8 +65,14 @@ try {
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
   ]);
-  assert.deepEqual(options[1].extra_plugins[1], { source: dependency, slug: 'db-touching-dependency', activate: false });
-  assert.deepEqual(options[1].dependencyMounts, ['/wordpress/wp-content/plugins/db-touching-dependency']);
+  assert.deepEqual(options[1].extra_plugins.slice(1), [
+    { source: component, slug: 'canonical-plugin', activate: false },
+    { source: dependency, slug: 'db-touching-dependency', activate: false },
+  ]);
+  assert.deepEqual(options[1].dependencyMounts, [
+    '/wordpress/wp-content/plugins/canonical-plugin',
+    '/wordpress/wp-content/plugins/db-touching-dependency',
+  ]);
   assert.deepEqual(options[1].mounts, [{ source: path.join(extension, 'vendor'), target: '/wp-codebox-vendor', mode: 'readonly' }]);
   assert.equal(options[0].workloads[0].id, 'canonical-workload');
   assert.equal(Object.hasOwn(options[0], 'wp_codebox_workloads'), false);


### PR DESCRIPTION
## Summary
- load the inactive component plugin through WP Codebox's DB-safe post-install PHPUnit lifecycle
- preserve component-first validation dependency order while deduplicating sandbox mount paths
- update the DB-activation canary to Homeboy's current runtime-helper owner

Closes #2301.

## How to test
1. Run `cd wordpress && node tests/wp-codebox-canonical-cli-adapters-smoke.mjs`; expect `WP Codebox canonical CLI adapters smoke passed.`
2. Run `cd wordpress && node --check scripts/test/wp-codebox-phpunit-adapter.mjs && node --check tests/wp-codebox-canonical-cli-adapters-smoke.mjs`.
3. Run `cd wordpress && npx eslint scripts/test/wp-codebox-phpunit-adapter.mjs`.
4. Run `cd wordpress && bash -n scripts/test/playground-db-activation-smoke.sh`.
5. Confirm the `DB activation PHPUnit smoke` PR check passes against real WP Codebox and Homeboy checkouts.

## Compatibility
Preserves the canonical inactive `extra_plugins` contract and validation dependency ordering. Existing callers gain component loading before PHPUnit; no legacy aliases or fallback paths are restored. The canary path update follows Homeboy's current `homeboy-extension` runtime owner.

## Evidence
- Root cause and downstream failures: https://github.com/Extra-Chill/homeboy-extensions/issues/2301
- SSI PR #651 failure matrix: https://github.com/Automattic/static-site-importer/actions/runs/29667005984
- The same baseline failure on merged SSI PR #650: https://github.com/Automattic/static-site-importer/actions/runs/29649486846

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the cross-repository lifecycle gap, implemented the adapter and canary repairs, added regression coverage, and ran deterministic verification; Chris reviews and owns the change.