### PR TITLE
feat(refactor): add collapse_struct_defaults — inverse of propagate

### DIFF
--- a/rust/scripts/refactor/__main__.py
+++ b/rust/scripts/refactor/__main__.py
@@ -13,7 +13,7 @@ from .tests import find_related_tests
 from .imports import resolve_imports
 from .visibility import adjust_visibility
 from .rewrite import rewrite_caller_imports
-from .struct_fields import propagate_struct_fields
+from .struct_fields import collapse_struct_defaults, propagate_struct_fields
 from .module_index import generate_module_index
 
 
@@ -60,6 +60,10 @@ def handle_propagate_struct_fields(data: dict) -> dict:
     return propagate_struct_fields(data)
 
 
+def handle_collapse_struct_defaults(data: dict) -> dict:
+    return collapse_struct_defaults(data)
+
+
 def handle_generate_module_index(data: dict) -> dict:
     return generate_module_index(
         data.get("submodules", []),
@@ -74,6 +78,7 @@ COMMANDS = {
     "adjust_visibility": handle_adjust_visibility,
     "rewrite_caller_imports": handle_rewrite_caller_imports,
     "propagate_struct_fields": handle_propagate_struct_fields,
+    "collapse_struct_defaults": handle_collapse_struct_defaults,
     "generate_module_index": handle_generate_module_index,
 }
 

--- a/rust/scripts/refactor/struct_fields.py
+++ b/rust/scripts/refactor/struct_fields.py
@@ -238,3 +238,267 @@ def propagate_struct_fields(data: dict) -> dict:
                                             if any(f['name'] not in i['fields_present']
                                                    for f in struct_fields)]),
     }
+
+
+# ============================================================================
+# collapse_struct_defaults — the inverse of propagate_struct_fields.
+#
+# Given a struct definition and a file, find each struct instantiation and
+# collapse fields whose value equals the type's default into a single trailing
+# `..Default::default()`. Reuses parse_struct_fields (field defaults) and the
+# brace-aware literal-finding approach. Conservative by construction: it only
+# removes a field when its literal value textually matches a known default
+# expression for that field's type, never touches a literal that already
+# contains `..`, and leaves the whole literal untouched if no field is
+# removable.
+# ============================================================================
+
+# Per-type set of literal expressions that are semantically the default value.
+# The comparison is intentionally textual (no eval) and matches the forms that
+# actually appear in hand-written Rust. `_default_exprs_for_type` returns the
+# accepted spellings for a field's declared type.
+def _normalize_expr(expr: str) -> str:
+    """Collapse whitespace so multi-line/oddly-spaced values compare cleanly."""
+    return ' '.join(expr.split()).strip().rstrip(',').strip()
+
+
+def _default_exprs_for_type(rust_type: str) -> set:
+    """Return the set of literal expressions that equal the default for a type.
+
+    Only returns spellings we can prove are the default. Types we can't reason
+    about return an empty set, so their fields are never collapsed.
+    """
+    t = rust_type.strip()
+
+    if t.startswith('Option<'):
+        return {'None'}
+
+    if t.startswith('Vec<') or t == 'Vec':
+        return {'Vec::new()', 'vec![]', 'Vec::default()', 'Default::default()'}
+
+    if 'HashMap' in t:
+        return {'HashMap::new()', 'std::collections::HashMap::new()',
+                'HashMap::default()', 'Default::default()'}
+    if 'BTreeMap' in t:
+        return {'BTreeMap::new()', 'std::collections::BTreeMap::new()',
+                'BTreeMap::default()', 'Default::default()'}
+    if 'HashSet' in t:
+        return {'HashSet::new()', 'std::collections::HashSet::new()',
+                'HashSet::default()', 'Default::default()'}
+    if 'BTreeSet' in t:
+        return {'BTreeSet::new()', 'std::collections::BTreeSet::new()',
+                'BTreeSet::default()', 'Default::default()'}
+
+    if t == 'String':
+        return {'String::new()', 'String::default()', '"".to_string()',
+                '"".to_owned()', 'String::from("")', 'Default::default()'}
+
+    if t == 'bool':
+        return {'false', 'bool::default()', 'Default::default()'}
+
+    if t in ('u8', 'u16', 'u32', 'u64', 'u128', 'usize',
+             'i8', 'i16', 'i32', 'i64', 'i128', 'isize'):
+        return {'0', f'{t}::default()', 'Default::default()'}
+    if t in ('f32', 'f64'):
+        return {'0.0', '0.', f'{t}::default()', 'Default::default()'}
+
+    if t == 'serde_json::Value' or t == 'Value':
+        return {'serde_json::Value::Null', 'Value::Null', 'Default::default()'}
+
+    # Unknown type: no provable default spelling.
+    return set()
+
+
+def _split_top_level_fields(inner_lines: list, start_index: int) -> list:
+    """Split a struct literal body into top-level `name: value` field entries.
+
+    `inner_lines` are the raw source lines strictly between the opening and
+    closing brace of the literal. Returns a list of dicts:
+      {name, value, first_line, last_line, is_spread, is_shorthand}
+    where line numbers are ABSOLUTE (1-indexed), offset by start_index (the
+    0-indexed line number of the first inner line).
+
+    Brace/paren/bracket depth is tracked so multi-line values (e.g.
+    `metadata: json!({ ... })`) are captured as a single field. Returns None
+    if the body cannot be cleanly parsed (bail — never guess).
+    """
+    fields = []
+    depth = 0
+    buf = []
+    buf_first = None
+
+    for offset, raw in enumerate(inner_lines):
+        abs_line = start_index + offset + 1  # 1-indexed absolute
+        if buf_first is None and raw.strip():
+            buf_first = abs_line
+        buf.append((abs_line, raw))
+
+        for ch in raw:
+            if ch in '([{':
+                depth += 1
+            elif ch in ')]}':
+                depth -= 1
+
+        # A field entry terminates at a top-level trailing comma.
+        stripped = raw.rstrip()
+        if depth == 0 and stripped.endswith(','):
+            entry = _classify_field_entry(buf, buf_first, abs_line)
+            if entry is None:
+                return None
+            fields.append(entry)
+            buf = []
+            buf_first = None
+
+    # Trailing entry without a comma (last field before closing brace).
+    if any(raw.strip() for _, raw in buf):
+        if depth != 0:
+            return None
+        entry = _classify_field_entry(buf, buf_first, buf[-1][0])
+        if entry is None:
+            return None
+        fields.append(entry)
+
+    return fields
+
+
+def _classify_field_entry(buf, first_line, last_line) -> dict:
+    """Turn a buffered set of (line, text) tuples into a field entry dict."""
+    text = '\n'.join(t for _, t in buf).strip()
+    if not text:
+        return None
+
+    # Skip comment-only buffers by ignoring leading comment lines.
+    non_comment = [t for _, t in buf if t.strip() and not t.strip().startswith('//')]
+    if not non_comment:
+        # Comment-only region between fields — represent as a passthrough.
+        return {'name': None, 'value': None, 'first_line': first_line,
+                'last_line': last_line, 'is_spread': False, 'is_shorthand': False,
+                'passthrough': True}
+
+    joined = _normalize_expr(text)
+
+    # Spread base: `..expr`
+    if joined.startswith('..'):
+        return {'name': None, 'value': joined, 'first_line': first_line,
+                'last_line': last_line, 'is_spread': True, 'is_shorthand': False,
+                'passthrough': False}
+
+    # `name: value`
+    m = re.match(r'^(\w+)\s*:\s*(.*)$', joined, re.DOTALL)
+    if m:
+        return {'name': m.group(1), 'value': _normalize_expr(m.group(2)),
+                'first_line': first_line, 'last_line': last_line,
+                'is_spread': False, 'is_shorthand': False, 'passthrough': False}
+
+    # Shorthand: bare `name`
+    m = re.match(r'^(\w+)$', joined)
+    if m:
+        return {'name': m.group(1), 'value': m.group(1),
+                'first_line': first_line, 'last_line': last_line,
+                'is_spread': False, 'is_shorthand': True, 'passthrough': False}
+
+    # Anything else we don't understand — bail.
+    return None
+
+
+def collapse_struct_defaults(data: dict) -> dict:
+    """Collapse default-valued fields in struct instantiations into
+    `..Default::default()`.
+
+    Input:
+      struct_name: str
+      struct_source: str — the struct definition block (for field types/defaults)
+      file_content: str
+      file_path: str
+
+    Output:
+      edits: list[{file, start_line, end_line, replacement, description}]
+        (replace-range edits: lines [start_line, end_line] inclusive, 1-indexed,
+         become `replacement`)
+      instantiations_found, instantiations_collapsed
+    """
+    struct_name = data['struct_name']
+    file_content = data['file_content']
+    file_path = data.get('file_path', '')
+    struct_fields = data.get('struct_fields', [])
+    if not struct_fields and 'struct_source' in data:
+        struct_fields = parse_struct_fields(data['struct_source'])
+
+    field_types = {f['name']: f['type'] for f in struct_fields}
+
+    lines = file_content.split('\n')
+    instantiations = find_struct_instantiations(file_content, struct_name)
+
+    edits = []
+    collapsed = 0
+
+    for inst in instantiations:
+        open_line = inst['start_line'] - 1        # 0-indexed line with `Struct {`
+        close_line = inst['closing_brace_line'] - 1  # 0-indexed line with `}`
+
+        # Single-line literals are left alone (rare, low value, higher risk).
+        if close_line <= open_line:
+            continue
+
+        inner = lines[open_line + 1:close_line]
+        parsed = _split_top_level_fields(inner, open_line + 1)
+        if parsed is None:
+            continue
+
+        # Never touch a literal that already spreads (`..base`).
+        if any(f['is_spread'] for f in parsed):
+            continue
+
+        removable = []   # field entries safe to drop
+        for f in parsed:
+            if f.get('passthrough'):
+                # A comment between fields blocks a clean collapse — bail on
+                # this literal to avoid orphaning comments.
+                removable = []
+                break
+            if f['is_shorthand']:
+                continue
+            ftype = field_types.get(f['name'])
+            if ftype is None:
+                continue
+            accepted = _default_exprs_for_type(ftype)
+            if f['value'] in accepted:
+                removable.append(f)
+
+        if not removable:
+            continue
+
+        # Keep the fields that are NOT removable, in original order, then append
+        # `..Default::default()`. Rebuild the whole literal body deterministically.
+        kept = [f for f in parsed if f not in removable and not f.get('passthrough')]
+
+        # Indentation from the first inner field line.
+        indent = inst['indent']
+
+        new_body_lines = []
+        for f in kept:
+            # Re-emit the field's ORIGINAL source lines verbatim to preserve
+            # exact formatting/values (multi-line json!, etc.).
+            for ln in range(f['first_line'] - 1, f['last_line']):
+                new_body_lines.append(lines[ln])
+        new_body_lines.append(f"{indent}..Default::default()")
+
+        # Replace the inner region (between braces) with the rebuilt body.
+        # start/end are 1-indexed inclusive lines to replace.
+        edits.append({
+            'file': file_path,
+            'start_line': open_line + 2,   # first inner line (1-indexed)
+            'end_line': close_line,        # last inner line (1-indexed)
+            'replacement': '\n'.join(new_body_lines),
+            'description': (
+                f"Collapse {len(removable)} default-valued field(s) "
+                f"into ..Default::default() in {struct_name} instantiation"
+            ),
+        })
+        collapsed += 1
+
+    return {
+        'edits': edits,
+        'instantiations_found': len(instantiations),
+        'instantiations_collapsed': collapsed,
+    }

--- a/rust/scripts/refactor/test_collapse_defaults.py
+++ b/rust/scripts/refactor/test_collapse_defaults.py
@@ -1,0 +1,200 @@
+"""Tests for collapse_struct_defaults — the inverse of propagate_struct_fields.
+
+Verifies that default-valued fields in struct instantiations are collapsed into
+`..Default::default()`, and — critically — that non-default values are preserved
+and risky literals are left untouched.
+"""
+
+import unittest
+
+from .struct_fields import collapse_struct_defaults
+
+
+STRUCT_SOURCE = """
+pub struct AgentTaskOutcome {
+    pub schema: String,
+    pub task_id: String,
+    pub status: AgentTaskOutcomeStatus,
+    pub summary: Option<String>,
+    pub artifacts: Vec<AgentTaskArtifact>,
+    pub outputs: serde_json::Value,
+    pub metadata: serde_json::Value,
+}
+"""
+
+
+def _apply_edits(content: str, edits: list) -> str:
+    """Apply replace-range edits to content (1-indexed inclusive lines).
+
+    Mirrors what the Rust EditOp apply engine does, so tests assert on the
+    resulting source, not just the edit objects.
+    """
+    lines = content.split('\n')
+    # Apply from the bottom up so earlier line numbers stay valid.
+    for edit in sorted(edits, key=lambda e: e['start_line'], reverse=True):
+        start = edit['start_line'] - 1
+        end = edit['end_line']  # exclusive slice end == inclusive last line
+        replacement = edit['replacement'].split('\n')
+        lines[start:end] = replacement
+    return '\n'.join(lines)
+
+
+class TestCollapseStructDefaults(unittest.TestCase):
+    def _run(self, file_content, struct_source=STRUCT_SOURCE, name='AgentTaskOutcome'):
+        return collapse_struct_defaults({
+            'struct_name': name,
+            'struct_source': struct_source,
+            'file_content': file_content,
+            'file_path': 'test.rs',
+        })
+
+    def test_collapses_trailing_default_fields(self):
+        content = '''fn make() -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        schema: schema(),
+        task_id: "cook".to_string(),
+        status: AgentTaskOutcomeStatus::Succeeded,
+        summary: None,
+        artifacts: Vec::new(),
+        outputs: serde_json::Value::Null,
+        metadata: serde_json::Value::Null,
+    }
+}'''
+        result = self._run(content)
+        self.assertEqual(result['instantiations_collapsed'], 1)
+        applied = _apply_edits(content, result['edits'])
+        self.assertIn('..Default::default()', applied)
+        self.assertIn('task_id: "cook".to_string()', applied)
+        self.assertIn('status: AgentTaskOutcomeStatus::Succeeded', applied)
+        # The default-valued fields are gone.
+        self.assertNotIn('summary: None', applied)
+        self.assertNotIn('artifacts: Vec::new()', applied)
+        self.assertNotIn('metadata: serde_json::Value::Null', applied)
+
+    def test_preserves_interleaved_non_default_values(self):
+        content = '''fn make() -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        schema: schema(),
+        task_id: "cook".to_string(),
+        status: AgentTaskOutcomeStatus::Succeeded,
+        summary: Some("done".to_string()),
+        artifacts: Vec::new(),
+        outputs: serde_json::json!({"k": "v"}),
+        metadata: serde_json::Value::Null,
+    }
+}'''
+        result = self._run(content)
+        applied = _apply_edits(content, result['edits'])
+        # Non-default values must survive.
+        self.assertIn('summary: Some("done".to_string())', applied)
+        self.assertIn('outputs: serde_json::json!({"k": "v"})', applied)
+        # Defaults collapsed.
+        self.assertNotIn('artifacts: Vec::new()', applied)
+        self.assertNotIn('metadata: serde_json::Value::Null', applied)
+        self.assertIn('..Default::default()', applied)
+
+    def test_preserves_multiline_macro_value(self):
+        content = '''fn make() -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        task_id: "cook".to_string(),
+        status: AgentTaskOutcomeStatus::Succeeded,
+        summary: None,
+        metadata: serde_json::json!({
+            "run_id": "run-1",
+            "nested": { "a": 1 }
+        }),
+    }
+}'''
+        result = self._run(content)
+        applied = _apply_edits(content, result['edits'])
+        # The multi-line json! must be preserved verbatim.
+        self.assertIn('"run_id": "run-1"', applied)
+        self.assertIn('"nested": { "a": 1 }', applied)
+        self.assertNotIn('summary: None', applied)
+        self.assertIn('..Default::default()', applied)
+
+    def test_no_op_when_no_default_fields(self):
+        content = '''fn make() -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        task_id: "cook".to_string(),
+        status: AgentTaskOutcomeStatus::Succeeded,
+        summary: Some("x".to_string()),
+        metadata: serde_json::json!({"k": 1}),
+    }
+}'''
+        result = self._run(content)
+        self.assertEqual(result['instantiations_collapsed'], 0)
+        self.assertEqual(result['edits'], [])
+
+    def test_skips_literal_that_already_spreads(self):
+        content = '''fn make() -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        task_id: "cook".to_string(),
+        summary: None,
+        ..Default::default()
+    }
+}'''
+        result = self._run(content)
+        self.assertEqual(result['instantiations_collapsed'], 0)
+
+    def test_skips_literal_with_interspersed_comment(self):
+        content = '''fn make() -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        task_id: "cook".to_string(),
+        // an explanatory comment
+        summary: None,
+        metadata: serde_json::Value::Null,
+    }
+}'''
+        result = self._run(content)
+        # Bail rather than orphan the comment.
+        self.assertEqual(result['instantiations_collapsed'], 0)
+
+    def test_accepts_alternate_default_spellings(self):
+        content = '''fn make() -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        schema: "".to_string(),
+        task_id: "cook".to_string(),
+        status: AgentTaskOutcomeStatus::Succeeded,
+        artifacts: vec![],
+    }
+}'''
+        result = self._run(content)
+        applied = _apply_edits(content, result['edits'])
+        # `"".to_string()` (String default) and `vec![]` (Vec default) collapse.
+        self.assertNotIn('schema: ""', applied)
+        self.assertNotIn('artifacts: vec![]', applied)
+        self.assertIn('..Default::default()', applied)
+
+    def test_does_not_collapse_unknown_type_fields(self):
+        # `status` is an enum — no provable default spelling — so a value that
+        # happens to look empty must never be collapsed.
+        content = '''fn make() -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        task_id: "cook".to_string(),
+        status: AgentTaskOutcomeStatus::Succeeded,
+        summary: None,
+    }
+}'''
+        result = self._run(content)
+        applied = _apply_edits(content, result['edits'])
+        # status stays explicit; only summary collapses.
+        self.assertIn('status: AgentTaskOutcomeStatus::Succeeded', applied)
+        self.assertNotIn('summary: None', applied)
+
+    def test_preserves_shorthand_fields(self):
+        content = '''fn make(task_id: String) -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        task_id,
+        status: AgentTaskOutcomeStatus::Succeeded,
+        summary: None,
+    }
+}'''
+        result = self._run(content)
+        applied = _apply_edits(content, result['edits'])
+        self.assertIn('task_id,', applied)
+        self.assertNotIn('summary: None', applied)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements the Python side of homeboy/#9102. Adds a `collapse_struct_defaults` command to the Rust refactor extension — the **inverse** of `propagate_struct_fields`. Given a struct definition and a file, it finds each struct instantiation and collapses fields whose value equals the type's default into a single trailing `..Default::default()`.

This is the automation for the struct-construction simplification campaign (homeboy #9081/#9086/#9087/#9092/#9096), where the per-struct `Default` primitive is added by hand but the ~45–100 site migrations are mechanical.

## How it works
Reuses `parse_struct_fields` (field name/type) and the brace-aware literal-scanning approach from propagate. New logic:
- A **top-level field splitter** that tracks brace/paren/bracket depth, so multi-line values like `json!({...})` are captured as one field.
- **Per-type default-spelling recognition** (`_default_exprs_for_type`) that only collapses a field when its value textually matches a known default: `None`, `Vec::new()`/`vec![]`, `Value::Null`, `String::new()`/`"".to_string()`, `false`, `0`, map/set `::new()`, `Default::default()`.

## Conservative by construction
- Only collapses when ≥1 field is provably default
- Never touches a literal that already contains `..`
- Bails on a literal with an interspersed comment (won't orphan comments)
- Never collapses unknown-type fields (e.g. enums) — no provable default
- Preserves non-default and shorthand fields **verbatim**, re-emitting their original source lines (exact formatting, multi-line macros intact)

## Output
Emits replace-range edits (`start_line`/`end_line`/`replacement`) for the shared EditOp apply engine — the Rust `homeboy refactor collapse-defaults` subcommand (separate PR) consumes these.

## Tests
9 golden tests: trailing defaults, interleaved non-defaults, multi-line macros, no-op, already-spread, interspersed comment, alternate default spellings, unknown-type, shorthand. Verified end-to-end via `python3 -m refactor` stdin dispatch. Existing 39 refactor tests unaffected.

## Validation plan
The Rust subcommand PR will dry-run this against `AgentTaskOutcome`/`ArtifactRecord` (structs already migrated by hand with equivalence tests) and confirm the generated diffs match the hand-migration before `--write` is trusted.

Closes part of Extra-Chill/homeboy#9102.