### PR TITLE
fix(wordpress): boot multisite runtime for network-only plugin PHPUnit

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -608,10 +608,16 @@ if (result.status === 'process_exited') {
 - **WP version defaults to 6.9.** Override `wordpress_runtime_version` to pass
   a different WordPress version to WP Codebox. Mismatched versions produce
   missing-class errors.
-- **Multisite is opt-in.** Set `HOMEBOY_WORDPRESS_MULTISITE=1` or
-  `wp_codebox_multisite: true` in settings.
-  Plugin tests also auto-enable multisite when the plugin header declares
-  `Network: true`.
+- **Multisite runtime.** Plugin PHPUnit recipes provision a multisite runtime
+  when any of the following request it, in precedence order:
+  1. `HOMEBOY_WORDPRESS_MULTISITE=1` (env)
+  2. `wp_codebox_multisite: true` in settings (set `false` to force single-site
+     even for a network plugin)
+  3. the plugin's own `Network: true` header (auto-detected, zero config)
+
+  The selected runtime is reported to WP Codebox via the `multisite` recipe
+  argument (`0` single-site, `1` multisite), so network-only plugins that
+  `wp_die()` outside multisite boot correctly.
 - **Partial phpunit.xml consumption.** The runner reads `<testsuite>` and
   `<exclude>` entries from `phpunit.xml.dist` only; other elements are
   ignored.

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,6 +10,7 @@
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
+      "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
       "node tests/codebox-client-boundary.test.js",
       "node tests/wp-codebox-fuzz-run-smoke.js",
       "node tests/wordpress-fuzz-runner-smoke.js",

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -16,6 +16,8 @@ const harnessSource = path.join(extensionRoot, 'vendor');
 const slug = process.env.COMPONENT_ID || path.basename(componentPath);
 const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
+const pluginSourceDirectory = subpath ? path.join(root, subpath) : root;
+const multisite = await resolveMultisite(settings, pluginSourceDirectory);
 const directory = await mkdtemp(path.join(tmpdir(), 'homeboy-wp-codebox-phpunit-'));
 const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
@@ -42,6 +44,7 @@ const options = clean({
   wpConfigDefines: settings.wp_config_defines,
   bootstrapMode: settings.wp_codebox_phpunit_bootstrap_mode,
   projectBootstrap: settings.wp_codebox_phpunit_project_bootstrap,
+  multisite,
   preloadFiles: settings.wp_codebox_phpunit_preload_files,
   mounts: [...canonicalMounts(settings.wp_codebox_phpunit_mounts), { source: harnessSource, target: '/wp-codebox-vendor', mode: 'readonly' }],
 });
@@ -67,6 +70,50 @@ function run(args) {
   }
 }
 function required(value, name) { if (!value) { throw new Error(`${name} is required`); } return value; }
+async function resolveMultisite(configuration, pluginDirectory) {
+  const fromEnv = process.env.HOMEBOY_WORDPRESS_MULTISITE;
+  if (fromEnv !== undefined && fromEnv !== '') {
+    return truthy(fromEnv);
+  }
+  if (configuration.wp_codebox_multisite !== undefined) {
+    return truthy(configuration.wp_codebox_multisite);
+  }
+  return pluginRequiresNetwork(pluginDirectory);
+}
+async function pluginRequiresNetwork(pluginDirectory) {
+  if (typeof pluginDirectory !== 'string' || pluginDirectory === '') {
+    return false;
+  }
+  let entries;
+  try {
+    entries = await readdir(pluginDirectory, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  const candidates = entries
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.php'))
+    .map((entry) => entry.name);
+  for (const candidate of candidates) {
+    let header;
+    try {
+      header = await readFile(path.join(pluginDirectory, candidate), 'utf8');
+    } catch {
+      continue;
+    }
+    const block = header.slice(0, 8192);
+    if (!/^[\s*#\/]*Plugin Name\s*:/im.test(block)) {
+      continue;
+    }
+    return /^[\s*#\/]*Network\s*:\s*(true|1|yes|on)\b/im.test(block);
+  }
+  return false;
+}
+function truthy(value) {
+  if (typeof value === 'boolean') { return value; }
+  if (typeof value === 'number') { return value === 1; }
+  if (typeof value !== 'string') { return false; }
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
 function json(value, fallback) { try { return value ? JSON.parse(value) : fallback; } catch { return fallback; } }
 function clean(value) { return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== '' && !(Array.isArray(entry) && entry.length === 0))); }
 function dependencyPaths(configuration) {

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -74,6 +74,7 @@ try {
     '/wordpress/wp-content/plugins/db-touching-dependency',
   ]);
   assert.deepEqual(options[1].mounts, [{ source: path.join(extension, 'vendor'), target: '/wp-codebox-vendor', mode: 'readonly' }]);
+  assert.equal(options[1].multisite, false, 'phpunit recipe defaults to single-site when nothing requests multisite');
   assert.equal(options[0].workloads[0].id, 'canonical-workload');
   assert.equal(Object.hasOwn(options[0], 'wp_codebox_workloads'), false);
   assert.deepEqual(JSON.parse(await readFile(results, 'utf8')).scenarios, []);

--- a/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
@@ -1,0 +1,110 @@
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+// Exercises the plugin PHPUnit adapter's multisite resolution so that
+// network-only plugins (Network: true) boot a multisite runtime instead of
+// crashing in wp_die(). Covers the three supported sources, in precedence
+// order: HOMEBOY_WORDPRESS_MULTISITE env, wp_codebox_multisite setting, and
+// the plugin's own `Network: true` header.
+
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-multisite-'));
+
+// Minimal fake wp-codebox CLI: capture the phpunit options JSON, then satisfy
+// the recipe-run handoff the adapter expects.
+const cli = path.join(root, 'wp-codebox');
+await writeFile(cli, `#!/usr/bin/env node
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+const args = process.argv.slice(2);
+if (args[0] === 'recipe' && args[1] === 'build') {
+  const options = JSON.parse(await readFile(args[args.indexOf('--options') + 1], 'utf8'));
+  await appendFile(process.env.OBSERVED, JSON.stringify({ options }) + '\\n');
+  await writeFile(args[args.indexOf('--output') + 1], JSON.stringify({ schema: 'wp-codebox/workspace-recipe/v1' }));
+  process.exit(0);
+}
+if (args[0] === 'recipe-run') {
+  const artifacts = args[args.indexOf('--artifacts') + 1];
+  await mkdir(artifacts + '/runtime-fixture/files', { recursive: true });
+  await writeFile(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+  process.stdout.write(JSON.stringify({ success: true }));
+}
+`);
+await chmod(cli, 0o755);
+
+let scenario = 0;
+async function resolvedMultisite({ pluginPhp, settings = {}, env = {} }) {
+  scenario += 1;
+  const component = path.join(root, `plugin-${scenario}`);
+  const observed = path.join(root, `observed-${scenario}.jsonl`);
+  await mkdir(component, { recursive: true });
+  if (pluginPhp !== undefined) {
+    await writeFile(path.join(component, 'plugin.php'), pluginPhp);
+  }
+  const result = spawnSync(runner, [], {
+    env: {
+      ...process.env,
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: `plugin-${scenario}`,
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      OBSERVED: observed,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify(settings),
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const captured = (await readFile(observed, 'utf8')).trim().split('\n').map(JSON.parse);
+  return captured[0].options.multisite;
+}
+
+try {
+  const singleSitePlugin = '<?php\n/**\n * Plugin Name: Single Site\n */\n';
+  const networkPlugin = '<?php\n/**\n * Plugin Name: Network Only\n * Network: true\n */\n';
+
+  // Default: no signal anywhere -> single-site.
+  assert.equal(
+    await resolvedMultisite({ pluginPhp: singleSitePlugin }),
+    false,
+    'no signal defaults to single-site',
+  );
+
+  // Plugin header Network: true auto-enables multisite with zero config.
+  assert.equal(
+    await resolvedMultisite({ pluginPhp: networkPlugin }),
+    true,
+    'Network: true plugin header auto-enables multisite',
+  );
+
+  // wp_codebox_multisite setting enables multisite for a single-site plugin.
+  assert.equal(
+    await resolvedMultisite({ pluginPhp: singleSitePlugin, settings: { wp_codebox_multisite: true } }),
+    true,
+    'wp_codebox_multisite setting enables multisite',
+  );
+
+  // Setting can also explicitly force single-site even for a Network plugin.
+  assert.equal(
+    await resolvedMultisite({ pluginPhp: networkPlugin, settings: { wp_codebox_multisite: false } }),
+    false,
+    'explicit wp_codebox_multisite=false overrides Network header',
+  );
+
+  // Env var takes precedence over everything.
+  assert.equal(
+    await resolvedMultisite({
+      pluginPhp: singleSitePlugin,
+      settings: { wp_codebox_multisite: false },
+      env: { HOMEBOY_WORDPRESS_MULTISITE: '1' },
+    }),
+    true,
+    'HOMEBOY_WORDPRESS_MULTISITE env overrides settings',
+  );
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox PHPUnit multisite smoke passed.');


### PR DESCRIPTION
## Summary
- Plugin PHPUnit recipes always booted a single-site runtime, so network-only plugins that `wp_die()` when `! is_multisite()` (e.g. `Network: true` Extra Chill Users) crashed before PHPUnit could produce a structured response.
- The existing `wp_codebox_multisite` setting only affected the core-dev PHPUnit path (`test-runner-core-dev-wp-codebox.sh`), never the normal plugin PHPUnit path (`wp-codebox-phpunit-adapter.mjs`).

## Fix
The plugin PHPUnit adapter now resolves a multisite runtime option and passes it through to the WP Codebox `phpunit` recipe, which already provisions a multisite runtime and emits the `multisite=0/1` command arg. Resolution precedence:
1. `HOMEBOY_WORDPRESS_MULTISITE` env
2. `wp_codebox_multisite` setting (set `false` to force single-site even for a network plugin)
3. the plugin's own `Network: true` header — auto-detected, zero config

This delivers the behavior `docs/TESTING.md` already promised (Network-header auto-enable) but that was never implemented.

## Acceptance criteria
- [x] `wordpress.phpunit` accepts and applies a multisite runtime option for plugin tests.
- [x] The existing `wp_codebox_multisite` setting affects plugin PHPUnit recipes.
- [x] A `Network: true` fixture plugin boots multisite (covered by new smoke test).
- [x] Recipe artifacts report single-site vs multisite via the `multisite` recipe arg.

## Tests
- New `tests/wp-codebox-phpunit-multisite-smoke.mjs` (wired into `homeboy.json` test recipe) covers all five resolution scenarios (default, Network header, setting on/off, env override).
- Extended `wp-codebox-canonical-cli-adapters-smoke.mjs` to assert the single-site default.
- Both smoke tests pass locally; adapter passes `node --check`.

Closes #2310