### PR TITLE
fix(nodejs): do not run TypeScript tests with bare node --test

### DIFF
--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -83,6 +83,37 @@ homeboy_node_targeted_test_script() {
     return 1
 }
 
+# True when any selected runner arg is a TypeScript test file. Bare `node
+# --test` cannot execute `.ts`/`.tsx` sources — they resolve `.js` specifiers and
+# need a TypeScript loader (e.g. tsx) — so it fails with ERR_MODULE_NOT_FOUND
+# before any test runs, which must not be classified as a product test failure.
+homeboy_runner_args_include_typescript() {
+    local arg
+    for arg in "${RUNNER_ARGS[@]}"; do
+        case "$arg" in
+            *.ts | *.tsx | *.mts | *.cts) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+# Resolve a Node built-in test-runner command that can execute TypeScript when
+# the selected files require it. Prefers a resolvable `tsx` loader
+# (`node --import tsx --test`); returns non-zero when TypeScript files are
+# selected but no loader is available so the caller can fail with actionable
+# guidance instead of running bare `node --test`.
+homeboy_node_builtin_test_command() {
+    if ! homeboy_runner_args_include_typescript; then
+        printf 'node --test'
+        return 0
+    fi
+    if node --import tsx --eval '' >/dev/null 2>&1; then
+        printf 'node --import tsx --test'
+        return 0
+    fi
+    return 1
+}
+
 WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
 if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
     # shellcheck source=/dev/null
@@ -96,10 +127,19 @@ elif [ ${#RUNNER_ARGS[@]} -gt 0 ] && TARGETED_TEST_SCRIPT="$(homeboy_node_target
     TEST_CMD="$(homeboy_node_script_command "$TARGETED_TEST_SCRIPT")"
 elif homeboy_has_npm_script "test"; then
     TEST_CMD="$(homeboy_project_run_script_command test)"
+elif TEST_CMD="$(homeboy_node_builtin_test_command)"; then
+    # Node 18+ ships a built-in test runner (with a tsx loader for TypeScript).
+    # This is the right default for projects without an explicit script.
+    :
 else
-    # Node 18+ ships a built-in test runner. This is the right default
-    # for tiny projects without an explicit script.
-    TEST_CMD="node --test"
+    # TypeScript test files were selected but no runner can execute them: no
+    # `test`/targeted package script and no resolvable `tsx` loader. Fail with
+    # actionable guidance rather than invoking bare `node --test`, whose
+    # module-resolution error is not a product test failure. (#8324)
+    echo "Error: selected TypeScript test file(s) require a declared test runner or a 'tsx' loader, but neither was found." >&2
+    echo "  - Add a package.json \"test\" script (or configure node_targeted_test_script) that runs the TypeScript tests (e.g. via tsx), or" >&2
+    echo "  - Add 'tsx' as a dependency so 'node --import tsx --test' can execute them." >&2
+    exit 1
 fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then

--- a/nodejs/scripts/test/typescript-test-loader-smoke.sh
+++ b/nodejs/scripts/test/typescript-test-loader-smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke: the Node.js test runner must not invoke bare `node --test` on
+# TypeScript test files. Bare Node cannot resolve the `.js` specifiers TS
+# sources import and fails with ERR_MODULE_NOT_FOUND before any test runs, which
+# must not be reported as a product test failure. (#8324)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+for helper in "$SIDECAR_WRITER_HELPER" "$RUNNER_PRELUDE_HELPER" "$COMMAND_CAPTURE_HELPER"; do
+    if [ ! -f "$helper" ]; then
+        echo "Missing runtime helper: $helper" >&2
+        exit 1
+    fi
+done
+
+# A project with a TypeScript test and no `test`/targeted package script, so the
+# runner reaches its built-in fallback.
+PROJECT="${TMPDIR}/project"
+mkdir -p "${PROJECT}/tests" "${PROJECT}/src"
+cat > "${PROJECT}/package.json" <<'JSON'
+{
+  "name": "ts-test-fallback-smoke",
+  "private": true,
+  "scripts": {
+    "build": "node -e \"process.exit(0)\""
+  }
+}
+JSON
+echo 'export const value = 1;' > "${PROJECT}/src/index.ts"
+cat > "${PROJECT}/tests/example.test.ts" <<'TS'
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { value } from '../src/index.js';
+test('value is one', () => assert.equal(value, 1));
+TS
+
+set +e
+OUTPUT="$(
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT" \
+    HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+    HOMEBOY_CHANGED_TEST_FILES="tests/example.test.ts" \
+        bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" 2>&1
+)"
+STATUS=$?
+set -e
+
+# The runner must never resolve bare `node --test` for a TypeScript file.
+if printf '%s\n' "$OUTPUT" | grep -Eq "Command:[[:space:]]+node --test( |$)"; then
+    echo "Runner invoked bare 'node --test' on a TypeScript test file" >&2
+    printf '%s\n' "$OUTPUT" | sed 's/^/  /' >&2
+    exit 1
+fi
+
+# Acceptable outcomes: a tsx-backed built-in command, or a clear actionable
+# refusal. Both keep bare Node from misclassifying a loader error as a failure.
+if printf '%s\n' "$OUTPUT" | grep -Fq "Command:   node --import tsx --test"; then
+    echo "PASS: TypeScript tests routed through the tsx loader"
+elif [ "$STATUS" -ne 0 ] && printf '%s\n' "$OUTPUT" | grep -Fq "require a declared test runner or a 'tsx' loader"; then
+    echo "PASS: TypeScript tests without a loader fail with actionable guidance"
+else
+    echo "Unexpected TypeScript test resolution (status $STATUS):" >&2
+    printf '%s\n' "$OUTPUT" | sed 's/^/  /' >&2
+    exit 1
+fi


### PR DESCRIPTION
Fixes Extra-Chill/homeboy#8324.

## Problem

`homeboy review --path <wp-codebox-worktree> --changed-since origin/main` selects changed `.test.ts` files and, when the project has no top-level `test`/targeted package script, the Node.js test runner fell through to bare `node --test`. Node's built-in runner cannot execute TypeScript — the tests import `.js` specifiers and rely on a `tsx` loader — so it failed with `ERR_MODULE_NOT_FOUND` before any test ran, and Homeboy classified that module-resolution error as a **product test failure**.

(WP Codebox declares per-file `tsx tests/*.ts` scripts and no single `npm test`, so the changed-scope selection reached the bare-node fallback.)

## Fix

In `scripts/test/test-runner.sh`, when the selected runner args include TypeScript test files (`.ts`/`.tsx`/`.mts`/`.cts`):

- Resolve the built-in command to `node --import tsx --test` when a `tsx` loader is available.
- Otherwise fail with actionable guidance (declare a `test`/targeted script, or add `tsx`) instead of invoking bare `node --test`.

JavaScript selections keep using `node --test` unchanged, and the existing `test`-script / targeted-script resolution paths are untouched.

This matches the issue's required outcome: respect the repo's TypeScript runner/loader or fail with actionable unsupported-runner guidance; never misclassify a bare-Node module-resolution error as a product test failure.

## Testing

- New `scripts/test/typescript-test-loader-smoke.sh`: a TypeScript changed-test selection (no `test` script) must never resolve `Command: node --test` — it either routes through `node --import tsx --test` or fails with the actionable guidance.
- Verified the reproduction locally: bare `node --test tests/foo.test.ts` fails with the exact `ERR_MODULE_NOT_FOUND: Cannot find module '.../src/index.js'`; the TS-detection helper and command resolution behave correctly (TS→loader/guidance, JS→`node --test`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (chubes-bot)
- **Used for:** Reproduced the bare-Node TypeScript resolution failure, traced it to the runner's built-in `node --test` fallback lacking TS-awareness, and added tsx-loader routing / actionable refusal with a smoke. Chris reviews and owns the change.