### PR TITLE
feat(rust): add find_definition refactor command for struct discovery

### DIFF
--- a/rust/scripts/refactor/__main__.py
+++ b/rust/scripts/refactor/__main__.py
@@ -14,6 +14,7 @@ from .imports import resolve_imports
 from .visibility import adjust_visibility
 from .rewrite import rewrite_caller_imports
 from .struct_fields import collapse_struct_defaults, propagate_struct_fields
+from .definition import find_definition
 from .module_index import generate_module_index
 
 
@@ -64,6 +65,10 @@ def handle_collapse_struct_defaults(data: dict) -> dict:
     return collapse_struct_defaults(data)
 
 
+def handle_find_definition(data: dict) -> dict:
+    return find_definition(data)
+
+
 def handle_generate_module_index(data: dict) -> dict:
     return generate_module_index(
         data.get("submodules", []),
@@ -79,6 +84,7 @@ COMMANDS = {
     "rewrite_caller_imports": handle_rewrite_caller_imports,
     "propagate_struct_fields": handle_propagate_struct_fields,
     "collapse_struct_defaults": handle_collapse_struct_defaults,
+    "find_definition": handle_find_definition,
     "generate_module_index": handle_generate_module_index,
 }
 

--- a/rust/scripts/refactor/definition.py
+++ b/rust/scripts/refactor/definition.py
@@ -1,0 +1,116 @@
+"""Rust struct-definition discovery.
+
+Language-specific analysis for locating a struct definition and extracting its
+full source block (attributes + doc comments + braced body) from Rust source.
+
+This lives in the Rust refactor extension — not in `homeboy-refactor` — so the
+core refactor engine stays language-agnostic. The engine walks candidate files
+(by extension) and asks each language extension, via the `find_definition`
+command, whether a given file defines the named item and what its source block
+is. A PHP/Go/Swift extension answers the same command with its own class/struct
+syntax; nothing about `pub struct` leaks into the generic dispatch.
+"""
+
+
+def defines_struct(content: str, struct_name: str) -> bool:
+    """Whether `content` contains a definition of `struct_name`.
+
+    Matches `pub struct Name`, `pub(crate) struct Name`, and the immediate
+    brace form (`... struct Name {`). Mirrors the historical core behavior.
+    """
+    patterns = (
+        f"pub struct {struct_name} ",
+        f"pub struct {struct_name} {{",
+        f"pub(crate) struct {struct_name} ",
+        f"pub(crate) struct {struct_name} {{",
+    )
+    return any(p in content for p in patterns)
+
+
+def extract_struct_source(content: str, struct_name: str):
+    """Extract the full struct source block from `content`.
+
+    Walks backwards from the `struct Name` line to include leading attributes
+    (`#[...]`) and doc comments (`///`, `//!`), then forwards to the
+    brace-balanced end of the struct body. Returns the source string, or `None`
+    if the struct is not found.
+    """
+    lines = content.split("\n")
+
+    struct_pattern = f"struct {struct_name} "
+    struct_pattern_brace = f"struct {struct_name} {{"
+    start_line = None
+
+    for i, line in enumerate(lines):
+        if struct_pattern in line or struct_pattern_brace in line:
+            # Walk backwards to include attributes and doc comments.
+            actual_start = i
+            for j in range(i - 1, -1, -1):
+                trimmed = lines[j].strip()
+                if (
+                    trimmed.startswith("#")
+                    or trimmed.startswith("///")
+                    or trimmed.startswith("//!")
+                ):
+                    actual_start = j
+                elif trimmed == "":
+                    prev = lines[j - 1].strip() if j > 0 else ""
+                    if j > 0 and (prev.startswith("#") or prev.startswith("///")):
+                        actual_start = j
+                    else:
+                        break
+                else:
+                    break
+            start_line = actual_start
+            break
+
+    if start_line is None:
+        return None
+
+    # Find the brace-balanced end of the struct body.
+    depth = 0
+    found_open = False
+    end_line = start_line
+    for i in range(start_line, len(lines)):
+        for ch in lines[i]:
+            if ch == "{":
+                depth += 1
+                found_open = True
+            elif ch == "}":
+                depth -= 1
+        if found_open and depth == 0:
+            end_line = i
+            break
+
+    return "\n".join(lines[start_line : end_line + 1])
+
+
+def find_definition(data: dict) -> dict:
+    """Answer whether a single file defines the named struct.
+
+    Input:
+        struct_name: str
+        file_content: str
+        file_path: str (opaque; echoed back for the caller's convenience)
+
+    Output:
+        defines: bool
+        struct_source: str | None  — the full source block when `defines`
+        file_path: str
+    """
+    struct_name = data["struct_name"]
+    content = data.get("file_content", "")
+    file_path = data.get("file_path", "")
+
+    if not defines_struct(content, struct_name):
+        return {"defines": False, "struct_source": None, "file_path": file_path}
+
+    source = extract_struct_source(content, struct_name)
+    # `defines_struct` uses `pub`-qualified patterns; `extract_struct_source`
+    # matches the bare `struct Name` line. They agree in practice, but guard
+    # against a mismatch by reporting `defines` only when we actually extracted.
+    return {
+        "defines": source is not None,
+        "struct_source": source,
+        "file_path": file_path,
+    }

--- a/rust/scripts/refactor/test_definition.py
+++ b/rust/scripts/refactor/test_definition.py
@@ -1,0 +1,94 @@
+"""Tests for the `find_definition` refactor command (Rust struct discovery)."""
+
+import unittest
+
+from .definition import defines_struct, extract_struct_source, find_definition
+
+
+PUB_STRUCT = """\
+use std::collections::HashMap;
+
+/// A widget.
+#[derive(Debug, Default, Clone)]
+pub struct Widget {
+    pub id: u64,
+    pub label: String,
+    pub tags: Vec<String>,
+}
+
+impl Widget {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+"""
+
+PUB_CRATE_STRUCT = """\
+pub(crate) struct Internal {
+    count: usize,
+}
+"""
+
+
+class TestDefinesStruct(unittest.TestCase):
+    def test_matches_pub_struct(self):
+        self.assertTrue(defines_struct(PUB_STRUCT, "Widget"))
+
+    def test_matches_pub_crate_struct(self):
+        self.assertTrue(defines_struct(PUB_CRATE_STRUCT, "Internal"))
+
+    def test_no_match_for_absent_struct(self):
+        self.assertFalse(defines_struct(PUB_STRUCT, "Gadget"))
+
+    def test_no_match_for_mere_usage(self):
+        usage = "let w = Widget { id: 1, ..Default::default() };"
+        self.assertFalse(defines_struct(usage, "Widget"))
+
+
+class TestExtractStructSource(unittest.TestCase):
+    def test_extracts_block_with_attrs_and_docs(self):
+        source = extract_struct_source(PUB_STRUCT, "Widget")
+        self.assertIsNotNone(source)
+        # Leading doc comment and derive attribute are included.
+        self.assertIn("/// A widget.", source)
+        self.assertIn("#[derive(Debug, Default, Clone)]", source)
+        self.assertIn("pub struct Widget {", source)
+        # Body fields included, brace-balanced end.
+        self.assertIn("pub tags: Vec<String>,", source)
+        self.assertTrue(source.rstrip().endswith("}"))
+        self.assertEqual(source.count("{"), source.count("}"))
+        # The impl block after the struct must NOT be swept in.
+        self.assertNotIn("fn new()", source)
+
+    def test_returns_none_when_absent(self):
+        self.assertIsNone(extract_struct_source(PUB_STRUCT, "Gadget"))
+
+
+class TestFindDefinitionCommand(unittest.TestCase):
+    def test_reports_definition_and_source(self):
+        result = find_definition(
+            {
+                "struct_name": "Widget",
+                "file_content": PUB_STRUCT,
+                "file_path": "src/widget.rs",
+            }
+        )
+        self.assertTrue(result["defines"])
+        self.assertIn("pub struct Widget {", result["struct_source"])
+        self.assertEqual(result["file_path"], "src/widget.rs")
+
+    def test_reports_absence(self):
+        result = find_definition(
+            {
+                "struct_name": "Gadget",
+                "file_content": PUB_STRUCT,
+                "file_path": "src/widget.rs",
+            }
+        )
+        self.assertFalse(result["defines"])
+        self.assertIsNone(result["struct_source"])
+        self.assertEqual(result["file_path"], "src/widget.rs")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a `find_definition` command to the **Rust refactor extension** that locates a struct definition and extracts its full source block (attributes + doc comments + brace-balanced body) from Rust source.

This is the **language-specific half** of removing Rust struct-syntax parsing from the core `homeboy-refactor` crate (core-side PR: `refactor/push-definition-finding-to-extensions`). Previously `homeboy-refactor` hardcoded `format!("pub struct {} ", name)` and a brace-walker — Rust analysis living inside the supposedly language-generic refactor engine. Moving it here (next to `parse_items`, `collapse_struct_defaults`, `propagate_struct_fields`) keeps the engine language-agnostic: it walks candidate files and asks each language extension, via `find_definition`, whether a file defines the item and what its source block is. A PHP/Go/Swift extension answers the same command with its own class/type syntax.

## Changes
- **New `refactor/definition.py`**: `defines_struct` (pub / pub(crate) struct matching), `extract_struct_source` (attribute/doc backward-walk + brace-balanced forward scan), `find_definition` (per-file command handler).
- **`refactor/__main__.py`**: wired `find_definition` into `COMMANDS`.
- **New `refactor/test_definition.py`**: 8 golden tests.

## Verification
- All **17 refactor unit tests pass** (8 new + 9 existing collapse tests).
- **End-to-end** against a real homeboy struct (`ReleaseStepResult`): correctly locates it and extracts the 17-line source block starting at the `#[derive(...)]` attribute — behaviorally identical to the old core-side Rust extractor.

## Merge order
Merge **this first**, then the core PR that depends on the `find_definition` command.