### PR TITLE
Emit structured live OpenCode progress

### DIFF
--- a/agent-runtimes/opencode/README.md
+++ b/agent-runtimes/opencode/README.md
@@ -62,3 +62,23 @@ command args may be supplied with
 
 The outcome includes status, diagnostics, and bounded metadata. It intentionally
 does not include raw child stdout, stderr, argv, or secret environment values.
+
+## Live Progress
+
+While OpenCode runs, the executor translates its JSONL tool frames into
+`homeboy/agent-task-progress/v1` envelopes. Each envelope has a stable per-run
+`sequence` and `cursor`, a runtime-neutral activity type, and structured bounded
+data. The executor writes them to `progress_events_path` (or its run artifact
+directory) and also delivers them through the optional `onProgress` callback.
+
+The adapter exposes tool, command, file, retry, and provider activity only. It
+omits model messages and reasoning, redacts declared secret values and secret-like
+command assignments, converts workspace paths to relative paths, and replaces all
+other absolute paths with `<private-path>`. Repeated frames are coalesced and the
+stream is capped at `max_progress_events` (default 200). The terminal result records
+the same event summary and exposes `progress_events` when events were emitted.
+
+This is the runtime-side producer for Homeboy #8282. Homeboy must ingest the JSONL
+file or callback as its single canonical structured event stream, preserving the
+cursor rather than serializing frames into log messages; that adoption is tracked by
+Homeboy #9162.

--- a/agent-runtimes/opencode/index.js
+++ b/agent-runtimes/opencode/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
 	...require('./lib/opencode-agent-task-executor'),
+	...require('./lib/opencode-progress-events'),
 	...require('./lib/opencode-runtime-manifest'),
 };

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -14,6 +14,9 @@ const {
 	createCliAgentTaskExecutor,
 	timeoutSecondsFromLimits,
 } = require('../../lib/cli-agent-task-executor');
+const {
+	createOpenCodeProgressAdapter,
+} = require('./opencode-progress-events');
 
 const { spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
@@ -70,6 +73,7 @@ const OPENCODE_CAPABILITIES = [
 	'provider_owned_auth',
 	'provider_owned_session',
 	'provider_owned_cancellation',
+	'live_progress_events',
 	'nested_orchestrator',
 	'run_scoped_scratch',
 ];
@@ -471,6 +475,7 @@ function opencodeSuccessOutcome(context) {
 		metadata: {
 			exit_code: 0,
 			opencode_session: sessionMetadata(context),
+			opencode_progress: progressMetadata(context),
 		},
 		...collectOpenCodeArtifacts(context),
 	});
@@ -487,6 +492,7 @@ function opencodeFailureOutcome(context) {
 			exit_code: context.spawnResult.status,
 			...(context.spawnResult.signal ? { signal: context.spawnResult.signal } : {}),
 			opencode_session: sessionMetadata(context),
+			opencode_progress: progressMetadata(context),
 		},
 		...collectOpenCodeArtifacts(context),
 	});
@@ -680,6 +686,7 @@ function collectOpenCodeArtifacts(context = {}) {
 			transcript: transcript !== '',
 		},
 		opencode_session: sessionMetadata(context),
+		opencode_progress: progressMetadata(context),
 	}, null, 2);
 
 	for (const requirement of requirements) {
@@ -689,6 +696,12 @@ function collectOpenCodeArtifacts(context = {}) {
 			addArtifact(requirement, `${safeFileSegment(request.task_id)}-opencode-transcript.txt`, transcript, 'agent-runtime-transcript');
 		} else if (requirement.name === 'agent_result') {
 			addArtifact(requirement, `${safeFileSegment(request.task_id)}-opencode-result.json`, `${resultEnvelope}\n`, 'json');
+		} else if (requirement.name === 'progress_events') {
+			const progressPath = context.progressEventPath;
+			if (progressPath && fs.existsSync(progressPath) && fs.statSync(progressPath).size > 0) {
+				const progress = fs.readFileSync(progressPath, 'utf8');
+				addArtifact(requirement, `${safeFileSegment(request.task_id)}-opencode-progress.jsonl`, progress, 'agent-task-progress');
+			}
 		}
 	}
 
@@ -732,6 +745,18 @@ function collectOpenCodeRuntimeLogs(context = {}) {
 	return { artifacts, evidence_refs };
 }
 
+function collectOpenCodeProgressEvents(context = {}) {
+	const filePath = context.progressEventPath;
+	if (!filePath || !fs.existsSync(filePath) || fs.statSync(filePath).size === 0) {
+		return {};
+	}
+	const bytes = fs.statSync(filePath).size;
+	return {
+		artifacts: [{ id: 'progress_events', name: 'progress_events', kind: 'agent-task-progress', path: filePath, bytes }],
+		evidence_refs: [{ kind: 'agent-task-progress', label: 'OpenCode progress events', uri: fileUri(filePath) }],
+	};
+}
+
 function fileUri(filePath) {
 	return `file://${filePath}`;
 }
@@ -746,6 +771,10 @@ function mergeEvidence(primary = {}, secondary = {}) {
 function sessionMetadata(context = {}) {
 	const explicit = context.spawnResult?.opencode_session || context.spawnResult?.opencodeSession;
 	return explicit && typeof explicit === 'object' && !Array.isArray(explicit) ? explicit : OPENCODE_SESSION_METADATA_ABSENT;
+}
+
+function progressMetadata(context = {}) {
+	return context.spawnResult?.progress || { emitted: 0, coalesced_or_dropped: 0, last_type: '' };
 }
 
 function gitRevision(cwd) {
@@ -790,6 +819,7 @@ function canonicalArtifactRequirements(request = {}) {
 		{ name: 'patch', kind: 'git-diff', required: true },
 		{ name: 'transcript', kind: 'agent-runtime-transcript', required: true },
 		{ name: 'agent_result', kind: 'json', required: true },
+		{ name: 'progress_events', kind: 'agent-task-progress', required: false },
 	];
 	const declared = uniqueDeclaredArtifactRequirements(request);
 	return [...canonical, ...declared].filter((requirement, index, all) => (
@@ -909,6 +939,7 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 	const spawnExtra = { env: { ...opencodeSpawnEnv(request, options), PWD: cwd } };
 	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
 	const runtimeLogPaths = openCodeRuntimeLogPaths(request, config);
+	const progressEventPath = openCodeProgressEventPath(request, config);
 	const initialRevision = gitRevision(cwd);
 	const spawnResult = await spawnOpenCodeStreaming(commandSpec.command, args, {
 		cwd,
@@ -916,9 +947,18 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 		timeoutMs: timeoutSeconds > 0 ? timeoutSeconds * 1000 : 0,
 		runtimeLogPaths,
 		diagnosticLogPath: openCodeDiagnosticLogPath(config, spawnExtra.env),
+		progress: createOpenCodeProgressAdapter({
+			taskId: request.task_id,
+			cwd,
+			env: spawnExtra.env,
+			filePath: progressEventPath,
+			maxEvents: config.max_progress_events || config.maxProgressEvents,
+			onProgress: options.onProgress || options.on_progress,
+		}),
 	});
-	const context = { request, config, commandSpec, cwd, initialRevision, spawnResult, spawnExtra, runtimeLogPaths };
+	const context = { request, config, commandSpec, cwd, initialRevision, spawnResult, spawnExtra, runtimeLogPaths, progressEventPath };
 	const runtimeLogs = collectOpenCodeRuntimeLogs(context);
+	const progressEvidence = collectOpenCodeProgressEvents(context);
 
 	if (spawnResult.error?.code === 'ENOENT') {
 		return outcome(request, {
@@ -927,7 +967,8 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 			failure_code: 'agent_task.opencode_command_not_found',
 			summary: 'OpenCode command was not found.',
 			diagnostics: [{ classification: 'provider_setup', message: 'Install opencode or configure executor.config.command.' }],
-			...runtimeLogs,
+			metadata: { opencode_progress: progressMetadata(context) },
+			...mergeEvidence(runtimeLogs, progressEvidence),
 		});
 	}
 
@@ -944,8 +985,8 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 				classification: fatalRuntimeError?.classification || (timedOut ? 'timeout' : 'provider_setup'),
 				message: spawnResult.error.message,
 			}],
-			metadata: { opencode_session: sessionMetadata(context) },
-			...runtimeLogs,
+			metadata: { opencode_session: sessionMetadata(context), opencode_progress: progressMetadata(context) },
+			...mergeEvidence(runtimeLogs, progressEvidence),
 		});
 	}
 
@@ -987,6 +1028,15 @@ function openCodeRuntimeLogPaths(request = {}, config = {}) {
 		stdout: path.join(artifactDir, `${safeFileSegment(request.task_id)}-opencode-runtime-stdout.log`),
 		stderr: path.join(artifactDir, `${safeFileSegment(request.task_id)}-opencode-runtime-stderr.log`),
 	};
+}
+
+function openCodeProgressEventPath(request = {}, config = {}) {
+	const configured = config.progress_events_path || config.progressEventsPath || request.progress_events_path || request.progressEventsPath || process.env.HOMEBOY_AGENT_TASK_PROGRESS_EVENTS_FILE || '';
+	if (configured) {
+		return configured;
+	}
+	const artifactDir = resolveArtifactDir({ request, config });
+	return artifactDir ? path.join(artifactDir, `${safeFileSegment(request.task_id)}-opencode-progress.jsonl`) : '';
 }
 
 function openCodeDiagnosticLogPath(config = {}, env = process.env) {
@@ -1047,6 +1097,7 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			if (filePath) {
 				fs.appendFileSync(filePath, content);
 			}
+			options.progress?.consume(stream, content);
 			fatalStreamBuffers[stream] = `${fatalStreamBuffers[stream]}${content}`.slice(-1200);
 			const matched = findOpenCodeFatalRuntimeError(fatalStreamBuffers[stream]);
 			if (matched) {
@@ -1071,6 +1122,7 @@ function spawnOpenCodeStreaming(command, args, options = {}) {
 			resolve({
 				stdout: stdoutChunks.join(''),
 				stderr: stderrChunks.join(''),
+				progress: options.progress?.finish() || { emitted: 0, coalesced_or_dropped: 0, last_type: '' },
 				...(fatalRuntimeError ? { fatalRuntimeError } : {}),
 				...result,
 			});

--- a/agent-runtimes/opencode/lib/opencode-progress-events.js
+++ b/agent-runtimes/opencode/lib/opencode-progress-events.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const OPENCODE_PROGRESS_EVENT_SCHEMA = 'homeboy/agent-task-progress/v1';
+const DEFAULT_MAX_PROGRESS_EVENTS = 200;
+const MAX_SUMMARY_LENGTH = 240;
+
+function createOpenCodeProgressAdapter(options = {}) {
+	const state = { sequence: 0, emitted: [], dropped: 0, lastSignature: '', buffers: { stdout: '', stderr: '' } };
+	const maxEvents = positiveInteger(options.maxEvents, DEFAULT_MAX_PROGRESS_EVENTS);
+	const workspace = options.cwd && path.isAbsolute(options.cwd) ? path.resolve(options.cwd) : '';
+	if (options.filePath) {
+		fs.mkdirSync(path.dirname(options.filePath), { recursive: true });
+		fs.writeFileSync(options.filePath, '');
+	}
+	const emit = (event) => {
+		const signature = JSON.stringify({ type: event.type, data: event.data });
+		if (signature === state.lastSignature || state.emitted.length >= maxEvents) {
+			state.dropped += 1;
+			return false;
+		}
+		state.lastSignature = signature;
+		state.sequence += 1;
+		event.sequence = state.sequence;
+		event.cursor = `opencode:${state.sequence}`;
+		state.emitted.push(event);
+		if (options.filePath) {
+			fs.appendFileSync(options.filePath, `${JSON.stringify(event)}\n`);
+		}
+		try {
+			options.onProgress?.(event);
+		} catch {
+			// Progress delivery is advisory and must not terminate provider execution.
+		}
+		return true;
+	};
+	const consume = (stream, chunk) => {
+		state.buffers[stream] = `${state.buffers[stream] || ''}${String(chunk || '')}`;
+		const lines = state.buffers[stream].split(/\r?\n/);
+		state.buffers[stream] = lines.pop();
+		for (const line of lines) consumeLine(line, stream, emit, options, workspace, state);
+	};
+	const finish = () => {
+		for (const [stream, line] of Object.entries(state.buffers)) {
+			if (line) consumeLine(line, stream, emit, options, workspace, state);
+		}
+		state.buffers = { stdout: '', stderr: '' };
+		return summary(state);
+	};
+	return { consume, finish, events: () => [...state.emitted], summary: () => summary(state) };
+}
+
+function consumeLine(line, stream, emit, options, workspace, state) {
+	let frame;
+	try {
+		frame = JSON.parse(line);
+	} catch {
+		return;
+	}
+	const event = translateOpenCodeEvent(frame, { stream, taskId: options.taskId, workspace, env: options.env, now: options.now });
+	if (!event) return;
+	emit(event);
+}
+
+function translateOpenCodeEvent(frame = {}, context = {}) {
+	const parts = Array.isArray(frame.parts) ? frame.parts : [frame];
+	for (const part of parts) {
+		const tool = stringValue(part.tool || part.name || frame.tool || frame.name);
+		const input = objectValue(part.input || part.args || frame.input || frame.args);
+		if (!tool) continue;
+		const status = stringValue(part.state?.status || part.status || frame.status).toLowerCase();
+		const failed = Boolean(part.state?.error || part.error || frame.error) || ['error', 'failed'].includes(status);
+		const completed = ['completed', 'complete', 'done', 'success', 'succeeded'].includes(status);
+		const type = progressType(tool, failed ? 'failed' : completed ? 'completed' : 'started');
+		return progressEnvelope(type, tool, input, frame, context, failed ? part.state?.error || part.error || frame.error : '');
+	}
+	const error = stringValue(frame.error || frame.message);
+	if (error && /(retry|rate limit|quota|backoff)/i.test(error)) {
+		return progressEnvelope('provider.retrying', '', {}, frame, context, error);
+	}
+	return null;
+}
+
+function progressType(tool, state) {
+	const normalized = tool.toLowerCase();
+	if (['bash', 'command', 'shell', 'execute'].includes(normalized)) return `command.${state}`;
+	if (['read', 'cat'].includes(normalized)) return `file.read.${state}`;
+	if (['glob', 'grep', 'search', 'find'].includes(normalized)) return `file.search.${state}`;
+	if (['edit', 'write', 'apply_patch', 'patch', 'delete'].includes(normalized)) return `file.edit.${state}`;
+	return `tool.${state}`;
+}
+
+function progressEnvelope(type, tool, input, frame, context, error) {
+	const data = {};
+	if (tool) data.tool = bounded(sanitize(tool, context), 80);
+	const candidatePath = stringValue(input.path || input.filePath || input.filepath || input.file || input.pattern);
+	if (candidatePath) data.path = workspaceRelativePath(candidatePath, context.workspace);
+	const command = stringValue(input.command || input.cmd);
+	if (command) data.command = bounded(sanitizeCommand(command, context), MAX_SUMMARY_LENGTH);
+	if (input.query) data.query = bounded(sanitize(String(input.query), context), 120);
+	if (error) data.message = bounded(sanitize(String(error), context), MAX_SUMMARY_LENGTH);
+	const exitCode = Number(input.exit_code ?? input.exitCode ?? frame.exit_code ?? frame.exitCode);
+	if (Number.isInteger(exitCode)) data.exit_code = exitCode;
+	return {
+		schema: OPENCODE_PROGRESS_EVENT_SCHEMA,
+		task_id: context.taskId || 'unknown-task',
+		source: 'provider',
+		type,
+		timestamp: validTimestamp(frame.timestamp || frame.time?.created || frame.created_at) || timestamp(context.now),
+		data,
+	};
+}
+
+function workspaceRelativePath(value, workspace) {
+	const sanitized = sanitize(value, {});
+	if (!path.isAbsolute(sanitized)) return bounded(sanitized.replaceAll('\\', '/'), MAX_SUMMARY_LENGTH);
+	if (workspace && (sanitized === workspace || sanitized.startsWith(`${workspace}${path.sep}`))) {
+		return path.relative(workspace, sanitized).replaceAll('\\', '/') || '.';
+	}
+	return '<private-path>';
+}
+
+function sanitizeCommand(value, context) {
+	return sanitize(value, context)
+		.replace(/\b[A-Za-z_][A-Za-z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|AUTH)=[^\s]+/gi, (match) => `${match.split('=')[0]}=[redacted]`)
+		.replace(/\/[A-Za-z0-9_./~-]+/g, (candidate) => workspaceRelativePath(candidate, context.workspace));
+}
+
+function sanitize(value, context) {
+	let result = String(value || '');
+	for (const secret of Object.values(context.env || {})) {
+		if (typeof secret === 'string' && secret.length >= 4) result = result.split(secret).join('[redacted]');
+	}
+	return result.replace(/([?&](?:token|key|secret|password|authorization)=)[^&#\s]*/gi, '$1[redacted]');
+}
+
+function summary(state) {
+	return { emitted: state.emitted.length, coalesced_or_dropped: state.dropped, last_type: state.emitted.at(-1)?.type || '' };
+}
+
+function validTimestamp(value) { return typeof value === 'string' && !Number.isNaN(Date.parse(value)) ? value : ''; }
+function timestamp(value) { return typeof value === 'function' ? value() : typeof value === 'string' ? value : new Date().toISOString(); }
+function bounded(value, max) { return String(value || '').slice(0, max); }
+function stringValue(value) { return typeof value === 'string' && value.trim() ? value.trim() : ''; }
+function objectValue(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
+function positiveInteger(value, fallback) { return Number.isInteger(Number(value)) && Number(value) > 0 ? Number(value) : fallback; }
+
+module.exports = { OPENCODE_PROGRESS_EVENT_SCHEMA, createOpenCodeProgressAdapter, translateOpenCodeEvent };

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -114,6 +114,7 @@
         "provider_owned_auth",
         "provider_owned_session",
         "provider_owned_cancellation",
+        "live_progress_events",
         "nested_orchestrator",
         "run_scoped_scratch"
       ],

--- a/agent-runtimes/opencode/package.json
+++ b/agent-runtimes/opencode/package.json
@@ -18,7 +18,8 @@
     "generate:runtime-manifest": "node scripts/agent/homeboy-opencode-runtime-manifest.cjs --write",
     "check:runtime-manifest": "node scripts/agent/homeboy-opencode-runtime-manifest.cjs --check",
     "test:opencode-agent-task-executor": "node tests/opencode-agent-task-executor-boundary.test.js",
-    "test:opencode-agent-task-executor-boundary": "node tests/opencode-agent-task-executor-boundary.test.js"
+    "test:opencode-agent-task-executor-boundary": "node tests/opencode-agent-task-executor-boundary.test.js",
+    "test:opencode-progress-events": "node tests/opencode-progress-events.test.js"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -97,6 +97,7 @@ assert.equal(provider.redacted_metadata_keys.includes('opencode_auth'), true);
 assert.equal(provider.capabilities.includes('repo_workspace'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('run_scoped_scratch'), true);
+assert.equal(provider.capabilities.includes('live_progress_events'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'opencode.json'), 'utf8'));
@@ -765,8 +766,12 @@ process.exit(0);
 	assert.equal(recoveredResult.failure_classification, undefined);
 	assert.equal(recoveredResult.failure_code, undefined);
 	assert.equal(recoveredResult.metadata.denied_tool_call, undefined);
-	assert.deepEqual(recoveredResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stdout', 'patch', 'transcript']);
+	assert.deepEqual(recoveredResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stdout', 'patch', 'progress_events', 'transcript']);
 	assert.equal(recoveredResult.diagnostics.some((diagnostic) => diagnostic.class === 'opencode.policy_denied'), false);
+	assert.deepEqual(recoveredResult.metadata.opencode_progress, { emitted: 1, coalesced_or_dropped: 0, last_type: 'command.failed' });
+	const recoveredProgress = fs.readFileSync(recoveredResult.artifacts.find((artifact) => artifact.name === 'progress_events').path, 'utf8');
+	assert.match(recoveredProgress, /"type":"command.failed"/);
+	assert.equal(recoveredProgress.includes('/tmp'), false);
 	const recoveredAgentResult = JSON.parse(fs.readFileSync(recoveredResult.artifacts.find((artifact) => artifact.name === 'agent_result').path, 'utf8'));
 	assert.equal(recoveredAgentResult.status, 'succeeded');
 	assert.equal(recoveredAgentResult.failure_classification, undefined);
@@ -805,7 +810,7 @@ process.exit(1);
 	assert.equal(deniedResult.failure_category, 'task.policy_denied');
 	assert.equal(deniedResult.retryable, false);
 	assert.equal(deniedResult.metadata.missing_declared_artifacts, undefined);
-	assert.deepEqual(deniedResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stdout', 'patch', 'transcript']);
+	assert.deepEqual(deniedResult.artifacts.map((artifact) => artifact.name).sort(), ['agent_result', 'opencode-runtime-stdout', 'patch', 'progress_events', 'transcript']);
 	assert.deepEqual(deniedResult.metadata.denied_tool_call, {
 		tool: 'bash',
 		command: 'cd /tmp && git clone https://example.invalid/private.git',

--- a/agent-runtimes/opencode/tests/opencode-progress-events.test.js
+++ b/agent-runtimes/opencode/tests/opencode-progress-events.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createOpenCodeProgressAdapter } = require('../lib/opencode-progress-events');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-opencode-progress-'));
+try {
+	const workspace = path.join(root, 'workspace');
+	const eventPath = path.join(root, 'progress.jsonl');
+	fs.mkdirSync(workspace);
+	const live = [];
+	const adapter = createOpenCodeProgressAdapter({
+		taskId: 'task-2311', cwd: workspace, filePath: eventPath,
+		env: { ACCESS_TOKEN: 'top-secret-token' }, now: '2026-07-20T12:00:00.000Z', onProgress: (event) => live.push(event),
+	});
+	adapter.consume('stdout', `${JSON.stringify({ timestamp: '2026-07-20T12:00:01.000Z', parts: [{ tool: 'read', input: { path: path.join(workspace, 'src/index.js') }, state: { status: 'completed' } }] })}\n`);
+	adapter.consume('stdout', `${JSON.stringify({ parts: [{ tool: 'bash', input: { command: `ACCESS_TOKEN=top-secret-token npm test ${path.join(workspace, 'package.json')}` }, state: { status: 'completed', exit_code: 0 } }] })}\n`);
+	adapter.consume('stderr', `${JSON.stringify({ error: 'Rate limit reached; retrying with token top-secret-token.' })}\n`);
+	const summary = adapter.finish();
+	assert.deepEqual(live, JSON.parse(`[${fs.readFileSync(eventPath, 'utf8').trim().split('\n').join(',')}]`));
+	assert.deepEqual(live.map((event) => event.type), ['file.read.completed', 'command.completed', 'provider.retrying']);
+	assert.deepEqual(live.map((event) => event.sequence), [1, 2, 3]);
+	assert.deepEqual(live.map((event) => event.cursor), ['opencode:1', 'opencode:2', 'opencode:3']);
+	assert.equal(live[0].data.path, 'src/index.js');
+	assert.equal(live[1].data.command.includes('top-secret-token'), false);
+	assert.equal(live[1].data.command.includes('ACCESS_TOKEN=[redacted]'), true);
+	assert.equal(live[1].data.command.includes('workspace/package.json'), false);
+	assert.equal(live[1].data.command.includes('package.json'), true);
+	assert.equal(JSON.stringify(live).includes(root), false);
+	assert.equal(JSON.stringify(live).includes('top-secret-token'), false);
+	assert.deepEqual(summary, { emitted: 3, coalesced_or_dropped: 0, last_type: 'provider.retrying' });
+
+	const bounded = createOpenCodeProgressAdapter({ taskId: 'task-2311', cwd: workspace, maxEvents: 2, now: '2026-07-20T12:00:00.000Z' });
+	for (const pathname of ['a.js', 'a.js', 'b.js', 'c.js']) {
+		bounded.consume('stdout', `${JSON.stringify({ parts: [{ tool: 'read', input: { path: pathname } }] })}\n`);
+	}
+	assert.deepEqual(bounded.events().map((event) => event.data.path), ['a.js', 'b.js']);
+	assert.deepEqual(bounded.finish(), { emitted: 2, coalesced_or_dropped: 2, last_type: 'file.read.started' });
+} finally {
+	fs.rmSync(root, { recursive: true, force: true });
+}
+
+process.stdout.write('OpenCode progress event replay passed\n');


### PR DESCRIPTION
## Summary
Translate OpenCode runtime output into structured live progress events while retaining the final executor result contract.

## What changed
- Adds a reusable progress-event adapter with deterministic replay behavior.
- Streams structured progress from the OpenCode executor and documents the event contract.

## How to test
1. Run `node --test agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js agent-runtimes/opencode/tests/opencode-progress-events.test.js`; expect Both OpenCode executor and progress replay tests pass..

## Compatibility
Additive runtime event capability; the existing final executor result remains available to consumers.

## Evidence
- Base unchanged since verification: main remains at a72f27159c6b257c1653c83bd49c20833e5b84ff.
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2311
- Verified finalization base: main at a72f27159c6b257c1653c83bd49c20833e5b84ff
- focused: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Drafted implementation, event adapter, tests, documentation, rebase verification, and PR evidence; Chris reviews and owns the change.

## Source relationships
- Closes #2311
