### PR TITLE
feat(wordpress): add reusable multisite E2E rig

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -118,6 +118,8 @@
     "test:wp-codebox-recipe-helper": "node tests/wp-codebox-recipe-helper-smoke.js",
     "test:wp-codebox-fuzz-plan-recipe-builder": "node tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js",
     "test:wp-codebox-canonical-cli-adapters": "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
+    "test:wordpress-multisite-e2e-rig": "node rigs/wordpress-multisite-e2e/tests/contract.test.mjs",
+    "test:wordpress-multisite-e2e-rig-integration": "node tests/wp-codebox-multisite-network-rig-integration.mjs",
     "test:wp-codebox-artifacts": "node tests/wp-codebox-artifacts-smoke.js",
     "test:wordpress-workload-profile": "node tests/wordpress-workload-profile-smoke.js",
     "test:wordpress-workload-scale-profile": "node tests/wordpress-workload-scale-profile-smoke.js",

--- a/wordpress/rigs/wordpress-multisite-e2e/README.md
+++ b/wordpress/rigs/wordpress-multisite-e2e/README.md
@@ -1,0 +1,80 @@
+# WordPress Multisite E2E Rig
+
+This portable Homeboy rig boots a disposable path-based WordPress multisite in
+WP Codebox. Its synthetic fixture creates a main site plus `/alpha/` and
+`/beta/`, network-activates a network-only plugin, and verifies shared user
+identity, isolated site options/content, shared network state, anonymous browser
+access, authenticated cross-site navigation, console/page errors, assertions,
+screenshots, and browser evidence artifacts.
+
+The rig composes existing ownership boundaries: Homeboy installs and runs the
+package, the WordPress extension supplies WordPress-specific fixture composition,
+and WP Codebox owns Playground, browser automation, runtime policy, and evidence.
+
+## Install And Validate
+
+From a homeboy-extensions checkout:
+
+```bash
+homeboy rig install ./wordpress/rigs/wordpress-multisite-e2e
+homeboy rig materialize ./wordpress/rigs/wordpress-multisite-e2e/rig.json
+homeboy rig lint ./wordpress/rigs/wordpress-multisite-e2e
+homeboy rig package lint ./wordpress/rigs/wordpress-multisite-e2e
+homeboy rig check wordpress-multisite-e2e
+```
+
+Run the real disposable network integration:
+
+```bash
+HOMEBOY_ARTIFACT_ROOT="$PWD/artifacts/wordpress-multisite-e2e" \
+  homeboy rig up wordpress-multisite-e2e
+```
+
+To verify against an unreleased WP Codebox checkout, use an explicit executable
+override without changing committed config:
+
+```bash
+HOMEBOY_WP_CODEBOX_BIN=/path/to/wp-codebox/packages/cli/dist/index.js \
+HOMEBOY_ARTIFACT_ROOT="$PWD/artifacts/wordpress-multisite-e2e" \
+  homeboy rig up wordpress-multisite-e2e
+```
+
+## Consumer Configuration
+
+The runner reads the WordPress extension's existing `HOMEBOY_SETTINGS_JSON`
+settings. Consumers do not edit the rig:
+
+- `wordpress_runtime_blueprint` adds ordinary WordPress blueprint setup while
+  the rig ensures `enableMultisite` remains present.
+- `wp_codebox_extra_plugins` mounts consumer plugins/components.
+- `wordpress_runtime_prepare_steps` adds seed/setup recipe steps.
+- `wordpress_runtime_workloads` runs consumer workloads through
+  `wordpress.bench` after network setup.
+- `wp_codebox_scenario_manifests` adds inline or file-backed browser journeys.
+- `wordpress_runtime_post_steps` adds final assertions or evidence steps.
+- `wordpress_runtime_version` pins the disposable WordPress version.
+
+Example:
+
+```bash
+HOMEBOY_SETTINGS_JSON='{
+  "wp_codebox_extra_plugins": [
+    {"source":"/absolute/path/to/plugin","slug":"plugin-under-test","activate":true}
+  ],
+  "wordpress_runtime_prepare_steps": [
+    {"command":"wordpress.wp-cli","args":["command=option update fixture_ready yes --url=http://localhost/alpha/"]}
+  ],
+  "wp_codebox_scenario_manifests": ["/absolute/path/to/browser-journey.json"]
+}' homeboy rig up wordpress-multisite-e2e
+```
+
+Use absolute consumer paths when a package is installed from another checkout.
+WP Codebox validates and executes all supplied recipe steps with its normal
+runtime policy and artifact handling.
+
+## Boundary
+
+This rig covers native path-based Playground multisite at the canonical
+`http://localhost` origin. It does not claim mapped-subdomain, mapped-domain, or
+cross-domain-cookie parity. Those topologies require a separate runtime that can
+faithfully model DNS, origins, TLS, and browser cookie boundaries.

--- a/wordpress/rigs/wordpress-multisite-e2e/fixtures/network-assert.php
+++ b/wordpress/rigs/wordpress-multisite-e2e/fixtures/network-assert.php
@@ -1,0 +1,53 @@
+<?php
+
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+if ( ! defined( 'SYNTHETIC_NETWORK_FIXTURE_LOADED' ) || ! is_plugin_active_for_network( 'synthetic-network-fixture/network-fixture.php' ) ) {
+	throw new RuntimeException( 'The network-only fixture plugin is not loaded and network active.' );
+}
+
+$host = wp_parse_url( network_home_url( '/' ), PHP_URL_HOST );
+$user = get_user_by( 'login', 'network_fixture_user' );
+if ( ! $user ) {
+	throw new RuntimeException( 'The shared network user is missing.' );
+}
+
+$observed = array();
+foreach ( array( 'alpha', 'beta' ) as $site_key ) {
+	$sites = get_sites(
+		array(
+			'domain' => $host,
+			'path'   => '/' . $site_key . '/',
+			'number' => 1,
+		)
+	);
+	if ( 1 !== count( $sites ) ) {
+		throw new RuntimeException( 'Fixture site lookup was not deterministic for ' . $site_key . '.' );
+	}
+
+	$site_id = (int) $sites[0]->blog_id;
+	if ( ! is_user_member_of_blog( (int) $user->ID, $site_id ) ) {
+		throw new RuntimeException( 'The shared network user is not a member of ' . $site_key . '.' );
+	}
+
+	switch_to_blog( $site_id );
+	$current_user = get_user_by( 'login', 'network_fixture_user' );
+	$page         = get_page_by_path( 'fixture-check', OBJECT, 'page' );
+	$observed[]   = array(
+		'user_id' => $current_user ? (int) $current_user->ID : 0,
+		'option'  => get_option( 'synthetic_site_state' ),
+		'page'    => $page ? $page->post_content : '',
+		'network' => get_site_option( 'synthetic_network_state' ),
+	);
+	restore_current_blog();
+}
+
+if ( $observed[0]['user_id'] !== $observed[1]['user_id'] || (int) $user->ID !== $observed[0]['user_id'] ) {
+	throw new RuntimeException( 'User identity is not shared across sites.' );
+}
+if ( 'isolated-alpha' !== $observed[0]['option'] || 'isolated-beta' !== $observed[1]['option'] || $observed[0]['page'] === $observed[1]['page'] ) {
+	throw new RuntimeException( 'Site-scoped option or content isolation failed.' );
+}
+if ( 'shared-network-value' !== $observed[0]['network'] || $observed[0]['network'] !== $observed[1]['network'] ) {
+	throw new RuntimeException( 'Network-scoped state is not shared.' );
+}

--- a/wordpress/rigs/wordpress-multisite-e2e/fixtures/network-fixture/network-fixture.php
+++ b/wordpress/rigs/wordpress-multisite-e2e/fixtures/network-fixture/network-fixture.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Plugin Name: Synthetic Network Fixture
+ * Description: Generic path-based multisite fixture markers.
+ * Network: true
+ */
+
+define( 'SYNTHETIC_NETWORK_FIXTURE_LOADED', true );
+
+add_action(
+	'wp_footer',
+	static function () {
+		$site = get_option( 'synthetic_site_key', 'main' );
+		printf(
+			'<div id="synthetic-network-fixture" data-site="%1$s" data-user="%2$d"><span id="synthetic-site-%1$s">%1$s</span><span id="synthetic-auth-%3$s">%3$s</span></div>',
+			esc_attr( $site ),
+			get_current_user_id(),
+			is_user_logged_in() ? 'authenticated' : 'anonymous'
+		);
+	}
+);

--- a/wordpress/rigs/wordpress-multisite-e2e/fixtures/network-seed.php
+++ b/wordpress/rigs/wordpress-multisite-e2e/fixtures/network-seed.php
@@ -1,0 +1,79 @@
+<?php
+
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+if ( ! is_multisite() ) {
+	throw new RuntimeException( 'Expected a multisite runtime.' );
+}
+
+$_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+
+$plugin = 'synthetic-network-fixture/network-fixture.php';
+if ( ! is_plugin_active_for_network( $plugin ) ) {
+	$result = activate_plugin( $plugin, '', true );
+	if ( is_wp_error( $result ) ) {
+		throw new RuntimeException( $result->get_error_message() );
+	}
+}
+
+$host = wp_parse_url( network_home_url( '/' ), PHP_URL_HOST );
+if ( ! is_string( $host ) || '' === $host ) {
+	throw new RuntimeException( 'Unable to resolve the network host.' );
+}
+
+$user = get_user_by( 'login', 'network_fixture_user' );
+if ( ! $user ) {
+	$user_id = wp_create_user( 'network_fixture_user', 'fixture-password', 'network-fixture@example.test' );
+	if ( is_wp_error( $user_id ) ) {
+		throw new RuntimeException( $user_id->get_error_message() );
+	}
+	$user = get_user_by( 'id', $user_id );
+}
+
+update_site_option( 'synthetic_network_state', 'shared-network-value' );
+
+$sites = array( 'alpha', 'beta' );
+foreach ( $sites as $site_key ) {
+	$path     = '/' . $site_key . '/';
+	$existing = get_sites(
+		array(
+			'domain' => $host,
+			'path'   => $path,
+			'number' => 1,
+		)
+	);
+	$site_id  = $existing ? (int) $existing[0]->blog_id : wpmu_create_blog( $host, $path, ucfirst( $site_key ) . ' Fixture Site', (int) $user->ID );
+
+	if ( is_wp_error( $site_id ) || ! $site_id ) {
+		throw new RuntimeException( 'Unable to create fixture site ' . $site_key . '.' );
+	}
+
+	add_user_to_blog( $site_id, (int) $user->ID, 'administrator' );
+	switch_to_blog( $site_id );
+	update_option( 'synthetic_site_key', $site_key );
+	update_option( 'synthetic_site_state', 'isolated-' . $site_key );
+	update_option( 'permalink_structure', '/%postname%/' );
+	$page = get_page_by_path( 'fixture-check', OBJECT, 'page' );
+	if ( ! $page ) {
+		$page_id = wp_insert_post(
+			array(
+				'post_title'   => ucfirst( $site_key ) . ' Fixture Check',
+				'post_name'    => 'fixture-check',
+				'post_content' => 'Synthetic content for ' . $site_key . '.',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+				'post_author'  => (int) $user->ID,
+			),
+			true
+		);
+		if ( is_wp_error( $page_id ) ) {
+			restore_current_blog();
+			throw new RuntimeException( $page_id->get_error_message() );
+		}
+	}
+	flush_rewrite_rules();
+	restore_current_blog();
+}
+
+update_option( 'synthetic_site_key', 'main' );
+update_option( 'synthetic_site_state', 'isolated-main' );

--- a/wordpress/rigs/wordpress-multisite-e2e/rig.json
+++ b/wordpress/rigs/wordpress-multisite-e2e/rig.json
@@ -1,0 +1,42 @@
+{
+  "id": "wordpress-multisite-e2e",
+  "description": "Disposable path-based WordPress multisite E2E network fixture",
+  "resources": {
+    "exclusive": ["wordpress-multisite-e2e:${env.HOMEBOY_ARTIFACT_ROOT}"]
+  },
+  "pipeline": {
+    "up": [
+      {
+        "kind": "requirement",
+        "executable": "node",
+        "remediation": "Install Node.js 18 or newer"
+      },
+      {
+        "kind": "requirement",
+        "executable": "wp-codebox",
+        "executable_env": "HOMEBOY_WP_CODEBOX_BIN",
+        "remediation": "Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN"
+      },
+      {
+        "kind": "command",
+        "label": "run disposable multisite E2E network",
+        "command": "node ${package.root}/run.mjs",
+        "cwd": "${env.PWD}"
+      }
+    ],
+    "check": [
+      {
+        "kind": "check",
+        "label": "validate multisite rig contracts",
+        "command": "node ${package.root}/tests/contract.test.mjs",
+        "cwd": "${package.root}"
+      },
+      {
+        "kind": "check",
+        "label": "validate generated WP Codebox recipe",
+        "command": "node ${package.root}/run.mjs --dry-run",
+        "cwd": "${env.PWD}"
+      }
+    ]
+  }
+}

--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * External dependencies
+ */
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.dirname(fileURLToPath(import.meta.url));
+
+export async function buildRecipe(settings = {}, cwd = process.cwd()) {
+  const fixturePlugin = path.join(packageRoot, 'fixtures/network-fixture');
+  const blueprint = mergeMultisiteBlueprint(settings.wordpress_runtime_blueprint);
+  const prepareSteps = recipeSteps(settings.wordpress_runtime_prepare_steps);
+  const postSteps = recipeSteps(settings.wordpress_runtime_post_steps);
+  const scenarioSteps = await browserScenarioSteps(settings.wp_codebox_scenario_manifests, cwd);
+  const workloadSteps = settings.wordpress_runtime_workloads?.length ? [{
+    command: 'wordpress.bench',
+    args: [
+      'component-id=wordpress-multisite-e2e',
+      'plugin-slug=synthetic-network-fixture',
+      'iterations=1',
+      'warmup=0',
+      `workloads-json=${JSON.stringify(settings.wordpress_runtime_workloads)}`,
+    ],
+  }] : [];
+
+  return {
+    schema: 'wp-codebox/workspace-recipe/v1',
+    runtime: {
+      backend: 'wordpress',
+      ...(settings.wordpress_runtime_version ? { wp: settings.wordpress_runtime_version } : {}),
+      blueprint,
+      preview: { siteUrl: 'http://localhost' },
+    },
+    inputs: {
+      extra_plugins: [
+        {
+          source: fixturePlugin,
+          slug: 'synthetic-network-fixture',
+          pluginFile: 'synthetic-network-fixture/network-fixture.php',
+          activate: false,
+        },
+        ...(settings.wp_codebox_extra_plugins || []),
+      ],
+    },
+    workflow: {
+      steps: [
+        phpFileStep('network-seed.php'),
+        ...prepareSteps,
+        ...workloadSteps,
+        phpFileStep('network-assert.php'),
+        {
+          command: 'wordpress.browser-probe',
+          args: [
+            'url=http://localhost/alpha/fixture-check/',
+            'route-host=localhost',
+            'assert=exists:#synthetic-site-alpha',
+            'assert=exists:#synthetic-auth-anonymous',
+            'assert=no-console-errors',
+            'assert=no-page-errors',
+            'capture=console,errors,html,network,screenshot',
+          ],
+        },
+        {
+          command: 'wordpress.browser-actions',
+          args: [
+            'auth=wordpress-admin',
+            'auth-user-id=1',
+            `steps-json=${JSON.stringify([
+              { kind: 'navigate', url: '/alpha/fixture-check/', waitFor: 'load' },
+              { kind: 'expect', selector: '#synthetic-site-alpha', state: 'visible' },
+              { kind: 'expect', selector: '#synthetic-auth-authenticated', state: 'visible' },
+              { kind: 'navigate', url: '/beta/fixture-check/', waitFor: 'load' },
+              { kind: 'expect', selector: '#synthetic-site-beta', state: 'visible' },
+              { kind: 'expect', selector: '#synthetic-auth-authenticated', state: 'visible' },
+            ])}`,
+            'capture=steps,console,errors,html,network,screenshot,dom-snapshot',
+          ],
+        },
+        ...scenarioSteps,
+        ...postSteps,
+      ],
+    },
+    artifacts: {
+      directory: process.env.HOMEBOY_ARTIFACT_ROOT || path.join(cwd, 'artifacts/wordpress-multisite-e2e'),
+    },
+  };
+}
+
+function mergeMultisiteBlueprint(value) {
+  const blueprint = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  const steps = Array.isArray(blueprint.steps) ? blueprint.steps : [];
+  return {
+    ...blueprint,
+    steps: steps.some((step) => step?.step === 'enableMultisite') ? steps : [{ step: 'enableMultisite' }, ...steps],
+  };
+}
+
+function phpFileStep(file) {
+  return {
+    command: 'wordpress.run-php',
+    args: [`code-file=${path.join(packageRoot, 'fixtures', file)}`],
+  };
+}
+
+function recipeSteps(value) {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error('WordPress runtime recipe steps must be arrays.');
+  }
+  return value;
+}
+
+async function browserScenarioSteps(value, cwd) {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error('wp_codebox_scenario_manifests must be an array.');
+  }
+  const scenarios = [];
+  for (const entry of value) {
+    const scenario = typeof entry === 'string'
+      ? JSON.parse(await readFile(path.resolve(cwd, entry), 'utf8'))
+      : entry;
+    scenarios.push({ command: 'wordpress.browser-scenario', args: [`scenario-json=${JSON.stringify(scenario)}`] });
+  }
+  return scenarios;
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const settings = parseSettings(process.env.HOMEBOY_SETTINGS_JSON);
+  const recipe = await buildRecipe(settings);
+  const temporary = await mkdtemp(path.join(os.tmpdir(), 'wordpress-multisite-e2e-'));
+  const recipePath = path.join(temporary, 'recipe.json');
+  const resultPath = process.env.HOMEBOY_NETWORK_E2E_RESULT_FILE || path.join(temporary, 'result.json');
+  await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`);
+
+  try {
+    runCodebox(['recipe', 'validate', '--recipe', recipePath, '--json']);
+    const args = ['recipe-run', '--recipe', recipePath, '--artifacts', recipe.artifacts.directory, '--json'];
+    if (dryRun) {
+      args.push('--dry-run');
+    }
+    const result = runCodebox(args, true);
+    await mkdir(path.dirname(resultPath), { recursive: true });
+    await writeFile(resultPath, result.stdout);
+    const envelope = JSON.parse(result.stdout);
+    if (!dryRun && envelope.success !== true) {
+      throw new Error('WP Codebox multisite recipe did not succeed.');
+    }
+    process.stdout.write(result.stdout);
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+function runCodebox(args, capture = false) {
+  const executable = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox';
+  const result = spawnSync(executable, args, { encoding: 'utf8', stdio: capture ? 'pipe' : 'inherit' });
+  if (result.error) {
+    throw result.error;
+  }
+  if (capture && result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  if (result.status !== 0) {
+    throw new Error(`WP Codebox exited with status ${result.status}.`);
+  }
+  return result;
+}
+
+function parseSettings(raw) {
+  if (!raw) {
+    return {};
+  }
+  const value = JSON.parse(raw);
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('HOMEBOY_SETTINGS_JSON must contain a JSON object.');
+  }
+  return value;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+/**
+ * Internal dependencies
+ */
+import { buildRecipe } from '../run.mjs';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const recipe = await buildRecipe({
+  wordpress_runtime_blueprint: { steps: [{ step: 'setSiteOptions', options: { blogname: 'Fixture Network' } }] },
+  wp_codebox_extra_plugins: [{ source: '/tmp/consumer-plugin', slug: 'consumer-plugin', activate: false }],
+  wordpress_runtime_prepare_steps: [{ command: 'wordpress.wp-cli', args: ['command=site list'] }],
+  wordpress_runtime_workloads: [{ id: 'consumer-workload', run: [] }],
+  wp_codebox_scenario_manifests: [{ id: 'consumer-browser-journey', url: '/beta/' }],
+  wordpress_runtime_post_steps: [{ command: 'wordpress.wp-cli', args: ['command=option get home'] }],
+}, root);
+
+assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
+assert.equal(recipe.runtime.preview.siteUrl, 'http://localhost');
+assert.equal(recipe.runtime.blueprint.steps[0].step, 'enableMultisite');
+assert.equal(recipe.inputs.extra_plugins[0].pluginFile, 'synthetic-network-fixture/network-fixture.php');
+assert.equal(recipe.inputs.extra_plugins[0].activate, false);
+assert.equal(recipe.inputs.extra_plugins[1].slug, 'consumer-plugin');
+assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.bench'));
+assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'));
+assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-probe'));
+assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-actions'));
+assert.ok(recipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('network-seed.php'))));
+assert.ok(recipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('network-assert.php'))));
+
+const rig = JSON.parse(await readFile(path.join(root, 'rig.json'), 'utf8'));
+assert.equal(rig.id, 'wordpress-multisite-e2e');
+assert.ok(rig.pipeline.up.some((step) => step.command?.includes('run.mjs')));
+assert.ok(rig.pipeline.check.some((step) => step.command?.includes('--dry-run')));
+
+console.log('WordPress multisite E2E rig contracts passed.');

--- a/wordpress/scripts/bench/wp-codebox-bench-adapter.mjs
+++ b/wordpress/scripts/bench/wp-codebox-bench-adapter.mjs
@@ -25,6 +25,8 @@ const options = clean({
   env: settings.bench_env,
   wpConfigDefines: settings.wp_config_defines,
   workloads: settings.wordpress_runtime_workloads,
+  prepareSteps: settings.wordpress_runtime_prepare_steps,
+  postSteps: settings.wordpress_runtime_post_steps,
 });
 
 try {

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -48,6 +48,8 @@ try {
       validation_dependencies: [component, dependency, dependency],
       wordpress_runtime_workloads: [{ id: 'canonical-workload', run: [] }],
       wordpress_runtime_blueprint: { steps: [] },
+      wordpress_runtime_prepare_steps: [{ command: 'wordpress.wp-cli', args: ['command=option get home'] }],
+      wordpress_runtime_post_steps: [{ command: 'wordpress.browser-probe', args: ['url=/'] }],
     }),
   };
   const extension = path.resolve(import.meta.dirname, '..');
@@ -76,6 +78,8 @@ try {
   assert.deepEqual(options[1].mounts, [{ source: path.join(extension, 'vendor'), target: '/wp-codebox-vendor', mode: 'readonly' }]);
   assert.equal(options[1].multisite, false, 'phpunit recipe defaults to single-site when nothing requests multisite');
   assert.equal(options[0].workloads[0].id, 'canonical-workload');
+  assert.deepEqual(options[0].prepareSteps, [{ command: 'wordpress.wp-cli', args: ['command=option get home'] }]);
+  assert.deepEqual(options[0].postSteps, [{ command: 'wordpress.browser-probe', args: ['url=/'] }]);
   assert.equal(Object.hasOwn(options[0], 'wp_codebox_workloads'), false);
   assert.deepEqual(JSON.parse(await readFile(results, 'utf8')).scenarios, []);
   assert.deepEqual(JSON.parse(await readFile(testResults, 'utf8')), { total: 1, passed: 1, failed: 0, skipped: 0 });

--- a/wordpress/tests/wp-codebox-multisite-network-rig-integration.mjs
+++ b/wordpress/tests/wp-codebox-multisite-network-rig-integration.mjs
@@ -1,0 +1,55 @@
+import { strict as assert } from 'node:assert';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'wordpress-multisite-rig-integration-'));
+const resultFile = path.join(root, 'result.json');
+const artifacts = path.join(root, 'artifacts');
+const runner = path.resolve(import.meta.dirname, '../rigs/wordpress-multisite-e2e/run.mjs');
+
+try {
+  const result = spawnSync(process.execPath, [runner], {
+    cwd: root,
+    env: {
+      ...process.env,
+      HOMEBOY_ARTIFACT_ROOT: artifacts,
+      HOMEBOY_NETWORK_E2E_RESULT_FILE: resultFile,
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const envelope = JSON.parse(await readFile(resultFile, 'utf8'));
+  assert.equal(envelope.success, true);
+  assert.deepEqual(
+    envelope.result.commands.map((command) => [command.command, command.status]),
+    [
+      ['wordpress.run-php', 'succeeded'],
+      ['wordpress.run-php', 'succeeded'],
+      ['wordpress.run-php', 'succeeded'],
+      ['wordpress.browser-probe', 'succeeded'],
+      ['wordpress.browser-actions', 'succeeded'],
+    ],
+  );
+
+  const pointer = JSON.parse(await readFile(path.join(artifacts, 'latest-runtime.json'), 'utf8'));
+  const browser = path.join(artifacts, pointer.runtimeId, 'files/browser');
+  const anonymous = JSON.parse(await readFile(path.join(browser, 'summary.json'), 'utf8'));
+  const authenticated = JSON.parse(await readFile(path.join(browser, 'action-summary.json'), 'utf8'));
+  assert.equal(anonymous.assertions.failed, 0);
+  assert.equal(anonymous.assertions.results.find((assertion) => assertion.id === 'no-console-errors').passed, true);
+  assert.equal(authenticated.summary.auth.mode, 'wordpress-admin');
+  assert.equal(authenticated.summary.assertions.failed, 0);
+  assert.deepEqual(
+    authenticated.steps.filter((step) => step.kind === 'navigate').map((step) => new URL(step.finalUrl).pathname),
+    ['/alpha/fixture-check/', '/beta/fixture-check/'],
+  );
+  await readFile(path.join(browser, 'console.jsonl'));
+  await readFile(path.join(browser, 'errors.jsonl'));
+  assert.ok((await readFile(path.join(browser, 'screenshot.png'))).byteLength > 0);
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox multisite network rig integration passed.');


### PR DESCRIPTION
## Summary

- add a portable Homeboy rig package for disposable path-based WordPress multisite E2E testing
- prove network activation, deterministic sites, shared users, scoped state, anonymous access, and authenticated cross-site navigation with synthetic fixtures
- expose consumer plugins, seeds, workloads, scenarios, blueprints, and final probes through existing WordPress extension settings
- forward the already-declared runtime prepare/post settings through the canonical WP Codebox bench adapter

## Ownership And Reuse

The package keeps ownership at existing boundaries: Homeboy owns rig install/materialize/lint/up lifecycle, the WordPress extension owns the WordPress-specific network composition, and WP Codebox owns Playground startup, recipe policy, browser actions/assertions, diagnostics, screenshots, and evidence bundles.

No Homeboy core behavior, WP Codebox primitive, generic schema, or new extension setting was added. The implementation composes `enableMultisite`, `inputs.extra_plugins`, ordinary recipe steps, `wordpress.run-php`, `wordpress.bench`, `wordpress.browser-probe`, `wordpress.browser-actions`, and WP Codebox's existing failure artifact path.

## Configuration Contract

Consumers configure the rig without editing it through existing settings:

- `wordpress_runtime_blueprint`
- `wordpress_runtime_version`
- `wp_codebox_extra_plugins`
- `wordpress_runtime_prepare_steps`
- `wordpress_runtime_workloads`
- `wp_codebox_scenario_manifests`
- `wordpress_runtime_post_steps`

## Synthetic Journey

The fixture creates `/alpha/` and `/beta/` under a canonical `http://localhost` network. PHP assertions verify a network-only plugin is loaded and network active, site lookup is deterministic, one user ID is shared across both sites, options/content remain site scoped, and a site option remains network scoped. Browser evidence verifies anonymous rendering with zero console/page errors, then uses one authenticated browser session to navigate from the alpha fixture page to the beta fixture page while retaining authentication and passing DOM assertions. WP Codebox captures console, runtime, network, HTML, DOM snapshot, and screenshot evidence, including on browser-command failure.

## Verification

- `homeboy rig lint ./wordpress/rigs/wordpress-multisite-e2e` passed
- `homeboy rig package lint ./wordpress/rigs/wordpress-multisite-e2e` passed
- `homeboy rig materialize ./wordpress/rigs/wordpress-multisite-e2e/rig.json` passed
- `node wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs` passed
- `node wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs` passed
- `npm run test:wordpress-multisite-e2e-rig-integration` passed against the WP Codebox #1900 review build
- PHP syntax checks passed for all synthetic fixture files
- authored rig, fixture, test, and documentation scans found no product references

## Upstream Dependencies

- https://github.com/Automattic/wp-codebox/pull/1900 provides the native path-based Playground multisite rewrite behavior used by the real integration run.
- https://github.com/Automattic/wp-codebox/pull/1897 is the related local read-only mount materialization fix used by portable fixture mounts.
- Committed configuration contains no machine-specific checkout path; unreleased builds are selected only through `HOMEBOY_WP_CODEBOX_BIN` at verification time.

## Topology Boundary

This covers native path-based multisite at one canonical origin. It does not claim mapped-subdomain, mapped-domain, or cross-domain-cookie parity; those require a runtime that faithfully models their DNS, TLS, origin, and cookie boundaries.

Closes #2318
Closes #2319