### PR TITLE
fix(wordpress): restore extension readiness check

### DIFF
--- a/tests/extension-shape-lint.mjs
+++ b/tests/extension-shape-lint.mjs
@@ -247,7 +247,7 @@ function validateExtension(extensionId) {
       assertRelativeFile(extensionId, value, keyPath.join('.'));
     }
 
-    if ((key === 'setup_command' || key === 'run_command' || key === 'command') && typeof value === 'string') {
+    if ((key === 'setup_command' || key === 'ready_check' || key === 'run_command' || key === 'command') && typeof value === 'string') {
       for (const relativePath of extractExtensionPathCommands(value)) {
         assertRelativeFile(extensionId, relativePath, keyPath.join('.'));
       }

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -5,11 +5,12 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh",
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh",
       "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs"
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
+      "bash scripts/test/wp-codebox-doctor-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
       "node tests/codebox-client-boundary.test.js",
       "node tests/wp-codebox-fuzz-run-smoke.js",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -118,6 +118,7 @@
     "test:wp-codebox-recipe-helper": "node tests/wp-codebox-recipe-helper-smoke.js",
     "test:wp-codebox-fuzz-plan-recipe-builder": "node tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js",
     "test:wp-codebox-canonical-cli-adapters": "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
+    "test:wp-codebox-doctor": "bash scripts/test/wp-codebox-doctor-smoke.sh",
     "test:wordpress-multisite-e2e-rig": "node rigs/wordpress-multisite-e2e/tests/contract.test.mjs",
     "test:wordpress-multisite-e2e-rig-integration": "node tests/wp-codebox-multisite-network-rig-integration.mjs",
     "test:wp-codebox-artifacts": "node tests/wp-codebox-artifacts-smoke.js",

--- a/wordpress/scripts/test/wp-codebox-doctor-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-doctor-smoke.sh
@@ -155,4 +155,30 @@ if [[ "$runtime_output" != *"runtime wp-codebox doctor"* ]]; then
     exit 1
 fi
 
+MINIMAL_BIN="${TMPDIR}/minimal-bin"
+mkdir -p "$MINIMAL_BIN"
+ln -s "$(command -v dirname)" "${MINIMAL_BIN}/dirname"
+
+set +e
+missing_output=$(HOME="${TMPDIR}/missing-home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMPDIR}/missing-install" \
+    HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/missing-wp-codebox" \
+    HOMEBOY_SETTINGS_JSON='{}' \
+    PATH="$MINIMAL_BIN" \
+    /bin/bash "$DOCTOR" doctor 2>&1)
+missing_status=$?
+set -e
+
+if [ "$missing_status" -eq 0 ]; then
+    echo "Expected doctor to fail when WP Codebox is unavailable" >&2
+    echo "$missing_output" >&2
+    exit 1
+fi
+
+if [[ "$missing_output" != *"wp-codebox not found; set HOMEBOY_WP_CODEBOX_BIN, settings wp_codebox_bin, or install wp-codebox"* ]]; then
+    echo "Expected actionable missing WP Codebox guidance" >&2
+    echo "$missing_output" >&2
+    exit 1
+fi
+
 echo "WP Codebox doctor wrapper smoke passed"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -939,7 +939,7 @@
   "executable": {
     "runtime": {
       "setup_command": "bash {{extension_path}}/scripts/build/setup.sh",
-      "ready_check": "node {{extension_path}}/scripts/build/check-wp-codebox-runtime-core.mjs",
+      "ready_check": "bash {{extension_path}}/scripts/doctor/wp-codebox-doctor.sh doctor",
       "run_command": "bash {{extension_path}}/scripts/test/test-runner.sh"
     }
   },


### PR DESCRIPTION
## Summary
- replace the deleted runtime-core readiness target with the existing WP Codebox doctor command
- validate `ready_check` script targets as part of extension package-shape linting
- cover successful doctor delegation and actionable failure when WP Codebox is unavailable

## Root cause
The WordPress manifest retained a `ready_check` reference to `scripts/build/check-wp-codebox-runtime-core.mjs` after the obsolete recipe-builder/runtime-core checks were removed. Released extension installs therefore failed readiness before validating the current runtime.

## Canonical readiness contract
The extension now uses `scripts/doctor/wp-codebox-doctor.sh doctor`, the existing health primitive for the current WP Codebox CLI architecture. Its resolver verifies that a selected CLI is runnable through the public `commands` surface, then delegates to upstream `wp-codebox doctor`. This validates the actual CLI dependency used by the extension without reintroducing a runtime-core wrapper.

## Package-shape regression coverage
`tests/extension-shape-lint.mjs` now treats `ready_check` like setup and run commands, so every `{{extension_path}}` script target must exist in the shipped extension shape. The doctor behavior smoke is also part of WordPress extension self-checks and has a direct npm entrypoint.

## Verification
- `node tests/extension-shape-lint.mjs` (pass)
- `bash scripts/test/wp-codebox-doctor-smoke.sh` (pass)
- `node tests/wp-codebox-canonical-cli-adapters-smoke.mjs` (pass)
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs` (pass)
- `node tests/codebox-client-boundary.test.js` (pass)
- `node tests/wordpress-manifest-settings-smoke.js` (pass)
- changed-file ESLint, shell syntax, JSON parsing, and `git diff --check` (pass)
- isolated packaged extension install and setup with WP Codebox `0.12.29`; `homeboy extension show wordpress` reported `ready=true` (pass, temporary install removed)
- added-line consumer-specific reference scan (pass)

Repository-wide `npm run lint:js` remains blocked by 54 pre-existing errors in unrelated files. `tests/runtime-helpers-smoke.sh` cannot start because the adjacent Homeboy checkout lacks `src/core/extension/runtime/failure-trap.sh`; the package-shape command it contains passes directly.

Closes #2317