### PR TITLE
fix(nodejs): share Playwright browser cache with runtimes

### DIFF
--- a/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
+++ b/agent-runtimes/wp-codebox/lib/runtime-setup.cjs
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { normalizeProviderPlugin } = require('../../../runtime-agent-ci/lib/full-run-inputs.cjs');
 const { resolveDependencyTarget, runtimeDependencyEntries } = require('../../../runtime-agent-ci/lib/materialize-dependencies.cjs');
 
@@ -14,6 +15,9 @@ function setupRuntime({ phase, workspace, env = process.env, run }) {
   // for the wp-codebox runtime regardless of the WordPress-dependency gate.
   if (phase === 'after_commands') {
     exportRuntimeBin(workspace, env);
+    if (fs.existsSync(extensionPlaywrightUtility(workspace))) {
+      setupExtensionBrowserCache({ workspace, env });
+    }
   }
   if (!requiresWordPressDependencies(env)) {
     return;
@@ -26,6 +30,42 @@ function setupRuntime({ phase, workspace, env = process.env, run }) {
   if (phase === 'after_commands') {
     installCheckedOutPhpDependencies({ workspace, env, run });
   }
+}
+
+function setupExtensionBrowserCache({ workspace, env = process.env, spawn = spawnSync }) {
+  const utility = extensionPlaywrightUtility(workspace);
+  if (!fs.existsSync(utility)) {
+    throw new Error(`Node.js extension Playwright utility is missing: ${utility}`);
+  }
+  const setup = spawn('bash', [utility, 'setup'], { encoding: 'utf8', env });
+  if (setup.error || setup.status !== 0) {
+    throw new Error(`Extension Playwright setup failed. Run \`homeboy extension action nodejs browser.playwright.setup\`. ${setup.stderr || setup.error?.message || ''}`.trim());
+  }
+  const status = spawn('bash', [utility, 'status', '--json'], { encoding: 'utf8', env });
+  if (status.error || status.status !== 0) {
+    throw new Error(`Extension Playwright readiness check failed. Run \`homeboy extension action nodejs browser.playwright.setup\`. ${status.stderr || status.error?.message || ''}`.trim());
+  }
+  let readiness;
+  try {
+    readiness = JSON.parse(status.stdout);
+  } catch {
+    throw new Error('Extension Playwright readiness check returned invalid JSON. Run `homeboy extension action nodejs browser.playwright.setup`.');
+  }
+  if (readiness.package?.state !== 'ready' || readiness.chromium?.state !== 'ready' || typeof readiness.browser_cache_dir !== 'string' || /[\r\n]/.test(readiness.browser_cache_dir)) {
+    throw new Error('Extension Playwright package or Chromium is not ready. Run `homeboy extension action nodejs browser.playwright.setup`.');
+  }
+  appendRuntimeEnvironment(env, 'HOMEBOY_RUNTIME_ENV_PLAYWRIGHT_BROWSERS_PATH', readiness.browser_cache_dir);
+}
+
+function extensionPlaywrightUtility(workspace) {
+  return path.join(workspace, '.ci', 'homeboy-extensions', 'nodejs', 'scripts', 'browser', 'playwright.sh');
+}
+
+function appendRuntimeEnvironment(env, name, value) {
+  if (!env.GITHUB_ENV) {
+    return;
+  }
+  fs.appendFileSync(env.GITHUB_ENV, `${name}=${value}\n`);
 }
 
 function installCheckedOutPhpDependencies({ workspace, env = process.env, run }) {
@@ -154,5 +194,6 @@ module.exports = {
   installCheckedOutPhpDependencies,
   requiresWordPressDependencies,
   safeDependencySubdir,
+  setupExtensionBrowserCache,
   setupRuntime,
 };

--- a/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
+++ b/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
@@ -5,6 +5,7 @@ require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixt
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
 
 process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(__dirname, '..', '..', '..', 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 
@@ -16,6 +17,8 @@ const {
 	wpCodeboxResolveCommand,
 	wpCodeboxSupportsRunAgentTaskCommand,
 } = require('..');
+const { setupExtensionBrowserCache } = require('../lib/runtime-setup.cjs');
+const { runtimeEnvFromHost } = require('../../../runtime-agent-ci/lib/full-run-config.cjs');
 
 const runtimeRoot = path.join(__dirname, '..');
 const descriptorSource = fs.readFileSync(path.join(runtimeRoot, 'lib', 'wp-codebox-adapter-descriptor.js'), 'utf8');
@@ -77,5 +80,26 @@ assert.equal(wpCodeboxSupportsRunAgentTaskCommand({
 		};
 	},
 }), true);
+
+const setupWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-playwright-cache-contract-'));
+const setupUtility = path.join(setupWorkspace, '.ci', 'homeboy-extensions', 'nodejs', 'scripts', 'browser');
+fs.mkdirSync(setupUtility, { recursive: true });
+fs.writeFileSync(path.join(setupUtility, 'playwright.sh'), '#!/usr/bin/env bash\n');
+const runtimeEnvFile = path.join(setupWorkspace, 'runtime.env');
+const invokedActions = [];
+setupExtensionBrowserCache({
+  workspace: setupWorkspace,
+  env: { GITHUB_ENV: runtimeEnvFile },
+  spawn(_command, args) {
+    invokedActions.push(args.slice(1));
+    return args[1] === 'setup'
+      ? { status: 0, stdout: '', stderr: '' }
+      : { status: 0, stdout: JSON.stringify({ package: { state: 'ready' }, chromium: { state: 'ready' }, browser_cache_dir: '/runner/cache/homeboy/nodejs-playwright/browsers' }), stderr: '' };
+  },
+});
+assert.deepEqual(invokedActions, [['setup'], ['status', '--json']]);
+assert.equal(fs.readFileSync(runtimeEnvFile, 'utf8'), 'HOMEBOY_RUNTIME_ENV_PLAYWRIGHT_BROWSERS_PATH=/runner/cache/homeboy/nodejs-playwright/browsers\n');
+assert.deepEqual(runtimeEnvFromHost({ HOMEBOY_RUNTIME_ENV_PLAYWRIGHT_BROWSERS_PATH: '/runner/cache/homeboy/nodejs-playwright/browsers', HOMEBOY_RUNTIME_ENV_TOKEN: 'secret-value' }), { PLAYWRIGHT_BROWSERS_PATH: '/runner/cache/homeboy/nodejs-playwright/browsers' });
+fs.rmSync(setupWorkspace, { recursive: true, force: true });
 
 process.stdout.write('WP Codebox adapter boundary passed\n');

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "wp-codebox",
   "name": "WP Codebox",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
   "contract_producers": [
     {

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -237,6 +237,17 @@ outcomes and diagnostics. If a runtime adds a secret-bearing metadata key, it
 must add that key to `redacted_metadata_keys`, preferably with
 `extendRedactedMetadataKeys()` from the adapter.
 
+### Persistent Runtime Environment
+
+An extension setup adapter can expose a persistent, non-secret runner resource
+to job-private execution by writing `HOMEBOY_RUNTIME_ENV_<NAME>=<value>` to
+`GITHUB_ENV`. The full-run configuration projects `<NAME>` into `runtime_env`.
+This is for stable paths and similar runner mechanics, not credentials; names
+ending in `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, or `KEY`, and values
+containing line breaks, are rejected. Setup-projected values override matching
+workflow input values because they describe the resource materialized for that
+specific runner job.
+
 ## Capability Declarations
 
 ### Run-scoped scratch

--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -1,6 +1,6 @@
 {
   "name": "Node.js",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "icon": "server.rack",
   "description": "Node.js project type — discovery, audit grammar, and npm release lifecycle",
   "author": "Extra Chill",

--- a/nodejs/scripts/browser/playwright.sh
+++ b/nodejs/scripts/browser/playwright.sh
@@ -6,6 +6,7 @@ EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 SOURCE_DIR="${EXTENSION_PATH}/runtime/playwright"
 RUNTIME_DIR="${HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/homeboy/nodejs-playwright}"
 PACKAGE_DIR="${RUNTIME_DIR}/package"
+BROWSER_CACHE_DIR="${RUNTIME_DIR}/browsers"
 NODE_BIN="${HOMEBOY_NODEJS_PLAYWRIGHT_NODE:-node}"
 NPM_BIN="${HOMEBOY_NODEJS_PLAYWRIGHT_NPM:-npm}"
 STAT_BIN="${HOMEBOY_NODEJS_PLAYWRIGHT_STAT:-stat}"
@@ -83,7 +84,7 @@ NODE
 
 browser_state() {
     [ "$1" = ready ] || { printf 'missing'; return; }
-    if "$NODE_BIN" - "$PACKAGE_DIR" <<'NODE' >/dev/null 2>&1
+    if assert_runtime_tree "$BROWSER_CACHE_DIR" && PLAYWRIGHT_BROWSERS_PATH="$BROWSER_CACHE_DIR" "$NODE_BIN" - "$PACKAGE_DIR" <<'NODE' >/dev/null 2>&1
 const { createRequire } = require('node:module'); const { lstatSync } = require('node:fs'); const { spawnSync } = require('node:child_process'); const path = require('node:path');
 try { const p = createRequire(path.join(process.argv[2], 'package.json'))('playwright'); const bin = p.chromium.executablePath(); if (lstatSync(bin).isSymbolicLink()) throw 0; const result = spawnSync(bin, ['--version'], { encoding: 'utf8' }); process.exit(result.status === 0 ? 0 : 1); } catch { process.exit(1); }
 NODE
@@ -95,10 +96,10 @@ status() {
     local hash package browser
     hash="$(hash_sources)"; package="$(package_state "$hash")"; browser="$(browser_state "$package")"
     if [ "${2:-}" = --json ]; then
-        "$NODE_BIN" - "$package" "$browser" "$PACKAGE_DIR" "$(setup_command)" <<'NODE'
-const [packageState, chromiumState, runtimePackageDir, setupCommand] = process.argv.slice(2);
+        "$NODE_BIN" - "$package" "$browser" "$PACKAGE_DIR" "$BROWSER_CACHE_DIR" "$(setup_command)" <<'NODE'
+const [packageState, chromiumState, runtimePackageDir, browserCacheDir, setupCommand] = process.argv.slice(2);
 const reason = (state, kind) => state === 'ready' ? null : state === 'missing' ? `${kind} missing` : `${kind} invalid, corrupt, or version-mismatched`;
-console.log(JSON.stringify({ package: { state: packageState, reason: reason(packageState, 'package') }, chromium: { state: chromiumState, reason: reason(chromiumState, 'Chromium') }, runtime_package_dir: runtimePackageDir, setup_command: setupCommand }));
+console.log(JSON.stringify({ package: { state: packageState, reason: reason(packageState, 'package') }, chromium: { state: chromiumState, reason: reason(chromiumState, 'Chromium') }, runtime_package_dir: runtimePackageDir, browser_cache_dir: browserCacheDir, setup_command: setupCommand }));
 NODE
     else
         printf 'Playwright package: %s\nChromium: %s\n' "$package" "$browser"
@@ -108,6 +109,7 @@ NODE
 
 setup() {
     require_node; assert_safe_path "$RUNTIME_DIR"; mkdir -p "$RUNTIME_DIR"; chmod 700 "$RUNTIME_DIR"; assert_safe_path "$RUNTIME_DIR"
+    mkdir -p "$BROWSER_CACHE_DIR"; chmod 700 "$BROWSER_CACHE_DIR"; assert_runtime_tree "$BROWSER_CACHE_DIR"
     local hash state tmp
     hash="$(hash_sources)"; state="$(package_state "$hash")"
     if [ "$state" != ready ]; then
@@ -119,7 +121,7 @@ setup() {
         PACKAGE_DIR="$installed_package_dir"; rm -rf "${RUNTIME_DIR}/.package.previous"; [ ! -e "$PACKAGE_DIR" ] || mv "$PACKAGE_DIR" "${RUNTIME_DIR}/.package.previous"; mv "$tmp" "$PACKAGE_DIR"; rm -rf "${RUNTIME_DIR}/.package.previous"
     fi
     local package browser; package="$(package_state "$hash")"; browser="$(browser_state "$package")"
-    if [ "$browser" != ready ]; then "$NODE_BIN" "$PACKAGE_DIR/node_modules/playwright/cli.js" install chromium; fi
+    if [ "$browser" != ready ]; then PLAYWRIGHT_BROWSERS_PATH="$BROWSER_CACHE_DIR" "$NODE_BIN" "$PACKAGE_DIR/node_modules/playwright/cli.js" install chromium; fi
     status status
 }
 
@@ -127,7 +129,7 @@ execute() {
     require_node; local module="${1:-}"; shift || true; [ -n "$module" ] || { echo 'usage: playwright.sh execute <module> [args...]' >&2; exit 64; }
     local hash package browser; hash="$(hash_sources)"; package="$(package_state "$hash")"; browser="$(browser_state "$package")"
     [ "$package" = ready ] && [ "$browser" = ready ] || { echo "Playwright utility is not ready. Run: $(setup_command)" >&2; exit 69; }
-    HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR="$PACKAGE_DIR" "$NODE_BIN" --require "$SCRIPT_DIR/playwright-require.cjs" --import "$SCRIPT_DIR/register-playwright-loader.mjs" "$SCRIPT_DIR/execute-playwright-module.mjs" "$module" "$@"
+    PLAYWRIGHT_BROWSERS_PATH="$BROWSER_CACHE_DIR" HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_PACKAGE_DIR="$PACKAGE_DIR" "$NODE_BIN" --require "$SCRIPT_DIR/playwright-require.cjs" --import "$SCRIPT_DIR/register-playwright-loader.mjs" "$SCRIPT_DIR/execute-playwright-module.mjs" "$module" "$@"
 }
 
 action_execute() {

--- a/nodejs/tests/playwright-utility-smoke.sh
+++ b/nodejs/tests/playwright-utility-smoke.sh
@@ -26,15 +26,18 @@ cat > "$prefix/node_modules/playwright/package.json" <<'PKG'
 PKG
 cat > "$prefix/node_modules/playwright/index.js" <<'JS'
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const browserPath = () => path.join(process.env.PLAYWRIGHT_BROWSERS_PATH || path.join(process.env.HOME, '.cache', 'ms-playwright'), 'chromium-1223', 'chrome-linux', 'chrome');
 exports.chromium = {
-  executablePath: () => path.join(__dirname, 'chromium-ready'),
-  launch: async () => ({ close: async () => {} }),
+  executablePath: browserPath,
+  launch: async () => { const result = spawnSync(browserPath(), ['--version']); if (result.status !== 0) throw new Error('Chromium executable is missing'); return { close: async () => {} }; },
 };
 JS
 cat > "$prefix/node_modules/playwright/cli.js" <<'JS'
 const fs = require('node:fs');
 const path = require('node:path');
-const browser = path.join(__dirname, 'chromium-ready');
+const browser = path.join(process.env.PLAYWRIGHT_BROWSERS_PATH, 'chromium-1223', 'chrome-linux', 'chrome');
+fs.mkdirSync(path.dirname(browser), { recursive: true });
 fs.writeFileSync(browser, '#!/bin/sh\necho Chromium fake\n');
 fs.chmodSync(browser, 0o700);
 fs.appendFileSync(process.env.HOMEBOY_TEST_CLI_LOG, 'install chromium\n');
@@ -97,7 +100,7 @@ PROJECT_DIR="$TMP_DIR/fresh-project"
 mkdir -p "$PROJECT_DIR"
 cat > "$PROJECT_DIR/extension-runtime.mjs" <<'EOF'
 import { chromium } from 'playwright';
-if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('extension Playwright was not resolved');
+if (!chromium.executablePath().endsWith('chrome')) throw new Error('extension Playwright was not resolved');
 EOF
 HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$PROJECT_DIR/extension-runtime.mjs"
 
@@ -112,7 +115,7 @@ HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$P
 
 cat > "$PROJECT_DIR/action-runtime.mjs" <<'EOF'
 import { chromium } from 'playwright';
-if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('action did not use extension runtime');
+if (!chromium.executablePath().endsWith('chrome')) throw new Error('action did not use extension runtime');
 if (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(['--literal', 'a b', 'line one\nline two'])) throw new Error(`action args changed: ${JSON.stringify(process.argv)}`);
 EOF
 
@@ -125,9 +128,25 @@ export const chromium = { executablePath: () => 'project-local' };
 EOF
 cat > "$PROJECT_DIR/project-local.mjs" <<'EOF'
 import { chromium } from 'playwright';
-if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('utility did not force its pinned Playwright runtime');
+if (!chromium.executablePath().endsWith('chrome')) throw new Error('utility did not force its pinned Playwright runtime');
 EOF
 HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$PROJECT_DIR/project-local.mjs"
+
+CONSUMER_DIR="$TMP_DIR/composed-consumer"
+mkdir -p "$CONSUMER_DIR/node_modules/playwright"
+cp "$RUNTIME_DIR/package/node_modules/playwright/package.json" "$CONSUMER_DIR/node_modules/playwright/package.json"
+cp "$RUNTIME_DIR/package/node_modules/playwright/index.js" "$CONSUMER_DIR/node_modules/playwright/index.js"
+cat > "$CONSUMER_DIR/launch.mjs" <<'EOF'
+import { chromium } from 'playwright';
+const browser = await chromium.launch();
+await browser.close();
+EOF
+FRESH_HOME="$TMP_DIR/job-private-home"
+if HOME="$FRESH_HOME" node "$CONSUMER_DIR/launch.mjs" >/dev/null 2>&1; then
+    echo 'composed consumer unexpectedly found Chromium in a fresh HOME' >&2
+    exit 1
+fi
+HOME="$FRESH_HOME" PLAYWRIGHT_BROWSERS_PATH="$RUNTIME_DIR/browsers" node "$CONSUMER_DIR/launch.mjs"
 
 HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" \
 HOMEBOY_SETTINGS_JSON="{\"selected\":[{\"module\":\"$PROJECT_DIR/action-runtime.mjs\",\"args\":[\"--literal\",\"a b\",\"line one\\nline two\"]}]}" \
@@ -155,8 +174,8 @@ printf '{"name":"playwright","version":"1.61.1"}\n' > "$MISSING_RUNTIME/package/
 PACKAGE_ONLY_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$MISSING_RUNTIME" bash "$UTILITY" status --json)"
 node -e 'const status = JSON.parse(process.argv[1]); if (status.package.state !== "invalid" || status.chromium.state !== "missing") process.exit(1)' "$PACKAGE_ONLY_STATUS"
 
-printf 'not executable\n' > "$RUNTIME_DIR/package/node_modules/playwright/chromium-ready"
-chmod 600 "$RUNTIME_DIR/package/node_modules/playwright/chromium-ready"
+printf 'not executable\n' > "$RUNTIME_DIR/browsers/chromium-1223/chrome-linux/chrome"
+chmod 600 "$RUNTIME_DIR/browsers/chromium-1223/chrome-linux/chrome"
 INVALID_BROWSER_STATUS="$(HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" status --json)"
 node -e 'const status = JSON.parse(process.argv[1]); if (status.chromium.state !== "invalid" || !status.chromium.reason) process.exit(1)' "$INVALID_BROWSER_STATUS"
 HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" HOMEBOY_NODEJS_PLAYWRIGHT_NPM="$FAKE_NPM" HOMEBOY_TEST_NPM_LOG="$NPM_LOG" HOMEBOY_TEST_CLI_LOG="$CLI_LOG" bash "$UTILITY" setup >/dev/null
@@ -179,7 +198,7 @@ mv "$RUNTIME_DIR/package/node_modules/playwright-real" "$RUNTIME_DIR/package/nod
 
 cat > "$PROJECT_DIR/commonjs-runtime.cjs" <<'EOF'
 const { chromium } = require('playwright');
-if (!chromium.executablePath().endsWith('chromium-ready')) throw new Error('CommonJS did not use extension runtime');
+if (!chromium.executablePath().endsWith('chrome')) throw new Error('CommonJS did not use extension runtime');
 EOF
 HOMEBOY_NODEJS_PLAYWRIGHT_RUNTIME_DIR="$RUNTIME_DIR" bash "$UTILITY" execute "$PROJECT_DIR/commonjs-runtime.cjs"
 

--- a/runtime-agent-ci/lib/full-run-config.cjs
+++ b/runtime-agent-ci/lib/full-run-config.cjs
@@ -103,7 +103,10 @@ function buildConfig(env) {
   const runtimeOverlays = normalizePathSources(parseJsonInput('runtime_overlays', env.RUNTIME_OVERLAYS || '[]', 'array', []), workspace);
   const runtimeMounts = normalizePathSources(parseJsonInput('runtime_mounts', env.RUNTIME_MOUNTS || '[]', 'array', []), workspace);
   const componentContracts = parseJsonInput('component_contracts', env.COMPONENT_CONTRACTS || '[]', 'array', []);
-  const runtimeEnv = parseJsonInput('runtime_env', env.RUNTIME_ENV || '{}', 'object', {});
+  const runtimeEnv = {
+    ...parseJsonInput('runtime_env', env.RUNTIME_ENV || '{}', 'object', {}),
+    ...runtimeEnvFromHost(env),
+  };
   const runtimeConfig = parseJsonInput('runtime_config', env.RUNTIME_CONFIG || '{}', 'object', {});
   const pathMaterializationPlan = parsePathMaterializationPlan(env.PATH_MATERIALIZATION_PLAN || '', { workspace });
   const loopPolicy = loopPolicyFromEnv(env, workloadProfile.loop_policy);
@@ -512,6 +515,17 @@ function runtimeFieldsFromProjection(fields, env) {
   }).filter(([, value]) => value !== undefined && value !== ''));
 }
 
+function runtimeEnvFromHost(env = {}) {
+  const prefix = 'HOMEBOY_RUNTIME_ENV_';
+  return Object.fromEntries(Object.entries(env).flatMap(([name, value]) => {
+    if (!name.startsWith(prefix) || typeof value !== 'string' || /[\r\n]/.test(value)) {
+      return [];
+    }
+    const target = name.slice(prefix.length);
+    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(target) && !/(?:TOKEN|SECRET|PASSWORD|CREDENTIAL|KEY)$/i.test(target) ? [[target, value]] : [];
+  }));
+}
+
 function mergeProjection(base, override) {
   if (!plainObject(override)) {
     return base;
@@ -561,4 +575,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, parseRuntimeWorkloadProfile, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired, withoutInternalKeys, writeFullRunConfig };
+module.exports = { buildConfig, buildSecretEnvFallbacks, buildSecretEnvPlan, loopPolicyFromEnv, parseRuntimeWorkloadProfile, projectRuntimeConfig, providerBenchEnvFromManifest, runtimeEnvFromHost, runtimePathRequired, withoutInternalKeys, writeFullRunConfig };


### PR DESCRIPTION
## Summary
Expose the extension-owned Chromium cache to composed runtimes so browser workloads work from fresh project workspaces without repository-local Playwright installation.

## What changed
- Move Chromium into the Node extension runtime cache and report its stable cache path.
- Project non-secret HOMEBOY\_RUNTIME\_ENV\_\* setup values into runtime\_env, with credential-shaped names rejected.
- Have WP Codebox prepare the extension browser utility and export PLAYWRIGHT\_BROWSERS\_PATH to its job runtime.

## How to test
1. Run `bash nodejs/tests/playwright-utility-smoke.sh`; expect The extension utility installs, reuses, validates, and launches Chromium from its private browser cache..
2. Run `node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js`; expect WP Codebox setup exports the extension browser cache into runtime\_env..
3. Run `node --test runtime-agent-ci/tests/build-runner-config.test.js`; expect The full-run runtime environment projection tests pass..
4. Run `bash -n nodejs/scripts/browser/playwright.sh nodejs/tests/playwright-utility-smoke.sh`; expect Both modified shell scripts pass syntax validation..

## Compatibility
Backward-compatible for existing project-local Playwright workflows. The Node.js extension-owned browser location moves to its private runtime cache, while consumers use the newly projected PLAYWRIGHT\_BROWSERS\_PATH contract rather than relying on job-private HOME defaults.

## Evidence
- Base unchanged since verification: main remains at 615fe3632d0cd30e9a70d5aea82be80460d733d5.
- Durable run execution: Succeeded
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/2254
- Verified finalization base: main at 615fe3632d0cd30e9a70d5aea82be80460d733d5
- gate-1: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-terra
- **Used for:** Implemented and tested the runtime integration; Chris reviews and owns the change.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2254
