### PR TITLE
fix(wordpress): rebuild extension Composer vendor tree

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -5,12 +5,13 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh",
+      "bash -n scripts/build/install-composer-dependencies.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh",
       "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs"
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
       "bash scripts/test/wp-codebox-doctor-smoke.sh",
+      "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
       "node tests/codebox-client-boundary.test.js",
       "node tests/wp-codebox-fuzz-run-smoke.js",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -119,6 +119,7 @@
     "test:wp-codebox-fuzz-plan-recipe-builder": "node tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js",
     "test:wp-codebox-canonical-cli-adapters": "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
     "test:wp-codebox-doctor": "bash scripts/test/wp-codebox-doctor-smoke.sh",
+    "test:extension-composer-vendor-integrity": "bash tests/extension-composer-vendor-integrity-smoke.sh",
     "test:wordpress-multisite-e2e-rig": "node rigs/wordpress-multisite-e2e/tests/contract.test.mjs",
     "test:wordpress-multisite-e2e-rig-integration": "node tests/wp-codebox-multisite-network-rig-integration.mjs",
     "test:wp-codebox-artifacts": "node tests/wp-codebox-artifacts-smoke.js",

--- a/wordpress/scripts/build/install-composer-dependencies.sh
+++ b/wordpress/scripts/build/install-composer-dependencies.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${EXTENSION_PATH}"
+
+echo "Installing PHP dependencies..."
+
+# Composer trusts installed package metadata and will not restore arbitrary
+# missing or truncated package files. Rebuild from the lockfile so extension
+# updates cannot retain a partially copied vendor tree.
+rm -rf vendor
+composer install --quiet --no-interaction --prefer-dist
+
+php -r '
+$loader = require $argv[1];
+if (! $loader instanceof Composer\Autoload\ClassLoader) {
+    fwrite(STDERR, "Composer autoload did not return a ClassLoader.\n");
+    exit(1);
+}
+' "${EXTENSION_PATH}/vendor/autoload.php"
+
+for binary in phpcs phpstan; do
+    if [[ ! -x "${EXTENSION_PATH}/vendor/bin/${binary}" ]]; then
+        echo "Composer dependency integrity check failed: vendor/bin/${binary} is missing or not executable." >&2
+        exit 1
+    fi
+    "${EXTENSION_PATH}/vendor/bin/${binary}" --version >/dev/null
+done
+
+if [[ ! -f "${EXTENSION_PATH}/vendor/wp-phpunit/wp-phpunit/wp-tests-config.php" ]]; then
+    echo "Composer dependency integrity check failed: the WP Codebox PHPUnit harness is incomplete." >&2
+    exit 1
+fi
+
+echo "PHP dependency integrity checks passed."

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -232,11 +232,10 @@ EOF
 
 echo "Setting up WordPress extension..."
 
-# Install PHP dev dependencies (PHPCS, PHPStan, PHPUnit — used for linting
+# Install PHP dev dependencies (PHPCS, PHPStan, PHPUnit - used for linting
 # and the extension's own self-tests, not for running component tests).
 if [ -f "composer.json" ]; then
-    echo "Installing PHP dependencies..."
-    composer install --quiet --no-interaction --prefer-dist
+    bash "${EXTENSION_PATH}/scripts/build/install-composer-dependencies.sh"
 
     if [ -x "vendor/bin/phpcs" ]; then
         echo "Registering PHPCS standards..."

--- a/wordpress/tests/extension-composer-vendor-integrity-smoke.sh
+++ b/wordpress/tests/extension-composer-vendor-integrity-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_SCRIPT="${ROOT_DIR}/scripts/build/install-composer-dependencies.sh"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-composer-vendor.XXXXXX")"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+EXTENSION_DIR="${WORK_DIR}/wordpress"
+BIN_DIR="${WORK_DIR}/bin"
+mkdir -p "${EXTENSION_DIR}/scripts/build" "${EXTENSION_DIR}/vendor/composer" "${BIN_DIR}"
+cp "${INSTALL_SCRIPT}" "${EXTENSION_DIR}/scripts/build/install-composer-dependencies.sh"
+printf '%s\n' '{}' > "${EXTENSION_DIR}/composer.json"
+printf '%s\n' '{}' > "${EXTENSION_DIR}/composer.lock"
+printf '%s\n' 'stale package metadata' > "${EXTENSION_DIR}/vendor/composer/installed.php"
+printf '%s\n' 'truncated package payload' > "${EXTENSION_DIR}/vendor/.incomplete"
+
+cat > "${BIN_DIR}/composer" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -e vendor/.incomplete || -e vendor/composer/installed.php ]]; then
+    echo "stale vendor tree survived into composer install" >&2
+    exit 91
+fi
+
+printf '%s\n' "$*" > "${FAKE_COMPOSER_ARGS}"
+mkdir -p vendor/composer vendor/bin vendor/wp-phpunit/wp-phpunit
+
+cat > vendor/composer/ClassLoader.php <<'PHP'
+<?php
+namespace Composer\Autoload;
+class ClassLoader {}
+PHP
+
+cat > vendor/autoload.php <<'PHP'
+<?php
+require __DIR__ . '/composer/ClassLoader.php';
+return new Composer\Autoload\ClassLoader();
+PHP
+
+cat > vendor/bin/phpcs <<'SH_BIN'
+#!/usr/bin/env bash
+echo "PHP_CodeSniffer fixture"
+SH_BIN
+
+cat > vendor/bin/phpstan <<'SH_BIN'
+#!/usr/bin/env bash
+if [[ "${FAKE_CORRUPT_PHPSTAN:-0}" == "1" ]]; then
+    echo "corrupted phpstan.phar" >&2
+    exit 2
+fi
+echo "PHPStan fixture"
+SH_BIN
+
+chmod +x vendor/bin/phpcs vendor/bin/phpstan
+printf '%s\n' '<?php' > vendor/wp-phpunit/wp-phpunit/wp-tests-config.php
+SH
+chmod +x "${BIN_DIR}/composer"
+
+FAKE_COMPOSER_ARGS="${WORK_DIR}/composer-args.txt" \
+PATH="${BIN_DIR}:${PATH}" \
+    bash "${EXTENSION_DIR}/scripts/build/install-composer-dependencies.sh"
+
+if [[ -e "${EXTENSION_DIR}/vendor/.incomplete" ]]; then
+    echo "Incomplete vendor payload survived the clean install." >&2
+    exit 1
+fi
+
+if ! grep -q -- 'install --quiet --no-interaction --prefer-dist' "${WORK_DIR}/composer-args.txt"; then
+    echo "Expected a lockfile-backed Composer install." >&2
+    exit 1
+fi
+
+if FAKE_COMPOSER_ARGS="${WORK_DIR}/composer-args.txt" \
+    FAKE_CORRUPT_PHPSTAN=1 \
+    PATH="${BIN_DIR}:${PATH}" \
+        bash "${EXTENSION_DIR}/scripts/build/install-composer-dependencies.sh" >/dev/null 2>&1; then
+    echo "A corrupt PHPStan executable passed the vendor integrity check." >&2
+    exit 1
+fi
+
+echo "WordPress extension Composer vendor integrity smoke passed."


### PR DESCRIPTION
## Summary

- rebuild the WordPress extension's ignored `vendor/` tree from `composer.lock` during setup instead of trusting retained Composer package metadata
- fail setup unless Composer's ClassLoader, PHPCS, PHPStan, and the WP Codebox PHPUnit harness are internally consistent
- add an installed-artifact regression smoke that starts from stale metadata and a truncated payload, then rejects a corrupt PHPStan executable

## Root cause

The extension excludes `wordpress/vendor/` from Git and materializes it during extension setup. Setup previously ran `composer install` over any existing installed tree. Composer trusts `vendor/composer/installed.php`; when package files are missing or truncated but metadata still records the locked package version, it does not reinstall that package. That allowed generated autoload files, a missing ClassLoader, and a corrupt `phpstan.phar` to coexist in an install that setup treated as successful.

The installed artifact reproduced the inconsistency: Composer autoload/PHPCS had subsequently regenerated, while PHPStan still failed with `PharException: manifest cannot be larger than 100 MB`.

## Changes

- `wordpress/scripts/build/install-composer-dependencies.sh`: remove retained `vendor/`, install the locked dependency set, require the generated autoloader, start PHPCS/PHPStan, and require the `wp-phpunit` harness
- `wordpress/scripts/build/setup.sh`: route Composer setup through the integrity-checked installer before registering PHPCS standards
- `wordpress/tests/extension-composer-vendor-integrity-smoke.sh`: prove stale metadata/truncated files are removed and corrupt PHPStan output fails setup
- `wordpress/homeboy.json` and `wordpress/package.json`: register syntax and regression checks in the extension's maintained test surface

## Installed artifact proof

A fresh install from the checked-in lockfile produced:

```text
Composer\Autoload\ClassLoader
PHP_CodeSniffer version 3.13.5 (stable) by Squiz and PHPCSStandards
PHPStan - PHP Static Analysis Tool 2.1.51
```

The setup helper also verified `vendor/wp-phpunit/wp-phpunit/wp-tests-config.php` exists in that same tree.

## Codebox staging

`wp-codebox-phpunit-adapter.mjs` mounts the extension's complete `vendor/` directory at `/wp-codebox-vendor` and points sandbox PHPUnit at `/wp-codebox-vendor/autoload.php`. Rebuilding and validating the tree before setup succeeds means local PHPCS/PHPStan and staged Codebox PHPUnit consume the same coherent dependency artifact. The existing mount-translation smoke passes with the rebuilt tree.

## Verification

Passed:

- `bash scripts/build/install-composer-dependencies.sh`
- `npm run test:extension-composer-vendor-integrity`
- `bash scripts/test/wp-codebox-mount-translation-smoke.sh`
- WordPress extension declared self-check suite from `wordpress/homeboy.json`
- `node tests/extension-shape-lint.mjs`
- `composer validate --strict --no-check-publish`
- changed shell/Node syntax checks and `git diff --check`

Known unrelated baseline failures tracked separately:

- `wordpress/tests/wp-codebox-composer-prepare-smoke.sh` has stale runtime context: #2326
- `npm run lint:js` reports 54 pre-existing errors in unchanged JavaScript files: #2327

Closes #2322