### PR TITLE
fix(opencode): always permit read-only workspace tools for review cooks (#8829)

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -298,7 +298,16 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 			),
 		};
 	}
-	if (workspaceReadPatterns.length > 0) {
+	// The native workspace read/inspection tools (read, glob, grep) correspond to
+	// this executor's declared read-only Homeboy workspace capabilities and are
+	// always permitted within the task cwd, with reads outside it still denied.
+	// This must not be gated on resolving concrete workspace read patterns: a
+	// review-only cook (e.g. `--no-finalize` inspecting an existing candidate)
+	// whose cwd does not resolve to an absolute path would otherwise leave the
+	// inherited `read` policy without a `*: allow` rule, so OpenCode falls back to
+	// its default `ask`, is denied non-interactively, and the cook fails with
+	// `opencode.policy_denied` before it can inspect the candidate (#8829).
+	{
 		content.permission = permissionWithWorkspaceToolAllowances(content.permission);
 		content.agent[primaryAgent] = {
 			...objectValue(content.agent[primaryAgent]),

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -964,6 +964,69 @@ process.exit(0);
 		workspaceRootResult.artifacts.every((artifact) => artifact.path.startsWith(path.join(quietWorkspace, '.homeboy', 'opencode'))),
 		true
 	);
+
+	// #8829: a review-only cook that only inspects an existing candidate can be
+	// dispatched without a workspace path that resolves to an absolute directory.
+	// The read-only inspection tools (read/glob/grep) must still be permitted
+	// within the workspace — otherwise OpenCode falls back to its default `ask`,
+	// is denied non-interactively, and the cook fails with `opencode.policy_denied`
+	// before it can inspect the candidate. Reads outside the workspace stay denied.
+	const reviewCapturePath = path.join(root, 'opencode-review-config.json');
+	const reviewCliPath = path.join(root, 'mock-opencode-review.cjs');
+	fs.writeFileSync(reviewCliPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
+fs.writeFileSync(${JSON.stringify(reviewCapturePath)}, JSON.stringify(config));
+process.stdout.write(JSON.stringify({ type: 'result', result: { summary: 'Reviewed candidate; no changes required.' } }));
+`);
+	// A review-only cook whose workspace is referenced by a *relative* cwd (the
+	// #8829 trigger): it names a real, existing directory but does not resolve to
+	// an absolute path, so no concrete workspace read patterns are generated. The
+	// base permission denies only `*.env` reads with no catch-all allow rule.
+	const reviewWorkspace = path.join(root, 'review-workspace');
+	fs.mkdirSync(reviewWorkspace, { recursive: true });
+	spawnSync('git', ['init'], { cwd: reviewWorkspace, encoding: 'utf8' });
+	spawnSync('git', ['commit', '--allow-empty', '-m', 'candidate'], {
+		cwd: reviewWorkspace,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Homeboy Test',
+			GIT_AUTHOR_EMAIL: 'homeboy@example.test',
+			GIT_COMMITTER_NAME: 'Homeboy Test',
+			GIT_COMMITTER_EMAIL: 'homeboy@example.test',
+		},
+	});
+	const relativeReviewCwd = path.relative(process.cwd(), reviewWorkspace);
+	assert.equal(path.isAbsolute(relativeReviewCwd), false);
+	const reviewResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-review-only',
+		instructions: 'Review the existing candidate and preserve it when correct.',
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				command_args: [reviewCliPath],
+				cwd: relativeReviewCwd,
+				runtime_env: {
+					OPENCODE_CONFIG_CONTENT: JSON.stringify({ permission: { read: { '*.env': 'deny' } } }),
+				},
+			},
+		},
+	}, { env: fixtureEnv });
+
+	assert.equal(reviewResult.status, 'succeeded', JSON.stringify(reviewResult.diagnostics));
+	const reviewConfig = JSON.parse(fs.readFileSync(reviewCapturePath, 'utf8'));
+	// Read-only inspection is permitted within the workspace...
+	assert.equal(reviewConfig.permission.read['*'], 'allow');
+	assert.equal(reviewConfig.agent.build.permission.read['*'], 'allow');
+	assert.equal(nativeToolAction(reviewConfig, 'build', 'glob', 'src/**/*.js'), 'allow');
+	assert.equal(nativeToolAction(reviewConfig, 'build', 'grep', 'TODO'), 'allow');
+	// ...while reads outside the workspace and the pre-existing secret deny remain denied.
+	assert.equal(reviewConfig.permission.read['..'], 'deny');
+	assert.equal(reviewConfig.permission.read['../*'], 'deny');
+	assert.equal(reviewConfig.permission.read['*.env'], 'deny');
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

Fixes Extra-Chill/homeboy#8829. A review-only agent-task cook (e.g. `--no-finalize`, inspecting an existing candidate) failed with `opencode.policy_denied` before it could read any source: OpenCode's permission policy denied the `read` tool, so the run produced no promotable candidate and blocked the immutable-candidate adoption/finalization path.

## Root cause

The OpenCode executor applied its native read-only tool allowance (`read`/`glob`/`grep`) **only when it could resolve concrete absolute workspace read patterns** (`if (workspaceReadPatterns.length > 0)`). A review cook whose cwd does not resolve to an absolute directory yields no patterns, so the inherited `read` policy kept no `*: allow` rule. OpenCode then fell back to its default `ask`, which a non-interactive cook denies → `opencode.policy_denied`.

Verified empirically: with a relative/unresolvable cwd and a base config of `read: { '*.env': 'deny' }`, the generated `permission.read` was `{ '*.env': 'deny' }` (no allow); with an absolute cwd it was `{ '*': 'allow', '..': 'deny', '../*': 'deny', '*.env': 'deny' }`.

## Fix

The read/glob/grep inspection tools correspond to this executor's declared read-only Homeboy workspace capabilities and are now **always** permitted within the task cwd — with reads outside it (`..`, `../*`) and the pre-existing secret denies still denied — independent of whether concrete workspace read patterns were generated. External-directory allowances remain gated as before.

Homeboy-core stays runtime-agnostic; this is entirely within the OpenCode runtime extension.

## Tests

New assertion in `opencode-agent-task-executor-boundary.test.js`: a review-only cook dispatched with a **relative** (non-absolute) cwd and a base `read: { '*.env': 'deny' }` policy now:
- succeeds (no `policy_denied`),
- has `permission.read['*'] === 'allow'` (both top-level and `agent.build`), `glob`/`grep` allowed,
- keeps `..`, `../*`, and `*.env` denied.

Proven to catch the bug via temp-revert (re-gating the allowance fails the new assertions). Full opencode test suite (boundary + progress-events) passes; runtime-manifest check passes.