### PR TITLE
Preserve WP Codebox source identity

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -62,12 +62,17 @@ cat > "${FAKE_BIN}/git" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 
+SOURCE_SHA="0123456789abcdef0123456789abcdef01234567"
+
 case "$1" in
     clone)
         dest="${@: -1}"
         mkdir -p "${dest}/.git"
         ;;
     -C)
+        if [ "${3:-}" = "rev-parse" ] && [ "${4:-}" = "HEAD" ]; then
+            printf '%s\n' "${SOURCE_SHA}"
+        fi
         exit 0
         ;;
     *)
@@ -173,6 +178,18 @@ fi
 
 if [ ! -f "${source_wp_codebox_core_module}" ]; then
     echo "Expected source fallback to export built runtime core module" >&2
+    exit 1
+fi
+
+if ! grep -q '^WP_CODEBOX_SOURCE_REF=main$' "${SOURCE_GITHUB_ENV_FILE}"; then
+    echo "Expected source fallback to export the requested WP Codebox ref" >&2
+    cat "${SOURCE_GITHUB_ENV_FILE}" >&2
+    exit 1
+fi
+
+if ! grep -q '^WP_CODEBOX_SOURCE_SHA=0123456789abcdef0123456789abcdef01234567$' "${SOURCE_GITHUB_ENV_FILE}"; then
+    echo "Expected source fallback to export the resolved WP Codebox SHA" >&2
+    cat "${SOURCE_GITHUB_ENV_FILE}" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -207,6 +207,13 @@ EOF
     git -C "${repo_dir}" fetch --quiet origin "${ref}"
     git -C "${repo_dir}" checkout --quiet FETCH_HEAD
 
+    local source_sha
+    source_sha="$(git -C "${repo_dir}" rev-parse HEAD)"
+    export WP_CODEBOX_SOURCE_REF="${ref}"
+    export WP_CODEBOX_SOURCE_SHA="${source_sha}"
+    write_github_env "WP_CODEBOX_SOURCE_REF" "${ref}"
+    write_github_env "WP_CODEBOX_SOURCE_SHA" "${source_sha}"
+
     npm --prefix "${repo_dir}" install --quiet --no-fund --no-audit --omit=optional
     npm --prefix "${repo_dir}" run build --silent
 


### PR DESCRIPTION
## Summary

- resolve the exact SHA after a source-mode WP Codebox checkout
- persist the requested ref and resolved SHA through `GITHUB_ENV`
- prevent downstream WP Codebox provenance from borrowing consumer workflow coordinates

## Verification

- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `git diff --check`

Closes #2338