### PR TITLE
feat(rust): emit policy-flow fingerprints

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -630,6 +630,28 @@ def matching_delimiter(text, opening, left='{', right='}'):
     return None
 
 
+inline_test_module_ranges = []
+inline_test_module_pattern = re.compile(
+    r'#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]'
+    r'(?:\s*#\s*\[[^]]*\])*'
+    r'\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+\w+\s*\{'
+)
+for test_module_match in inline_test_module_pattern.finditer(masked_content):
+    opening = masked_content.rfind('{', test_module_match.start(), test_module_match.end())
+    closing = matching_delimiter(masked_content, opening)
+    if closing is not None:
+        inline_test_module_ranges.append((test_module_match.start(), closing + 1))
+
+# Keep source offsets stable while excluding test-only declarations from the
+# production aggregate type table and definition scan.
+aggregate_source_chars = list(masked_content)
+for start, end in inline_test_module_ranges:
+    for pos in range(start, end):
+        if aggregate_source_chars[pos] != '\n':
+            aggregate_source_chars[pos] = ' '
+aggregate_source = ''.join(aggregate_source_chars)
+
+
 def split_top_level_spans(text, delimiter=','):
     spans = []
     start = 0
@@ -651,7 +673,7 @@ type_declarations = {}
 struct_fields = {}
 aggregate_definitions = []
 
-for type_match in re.finditer(r'\b(?:pub(?:\([^)]*\))?\s+)?(struct|enum)\s+([A-Z][A-Za-z0-9_]*)\b', masked_content):
+for type_match in re.finditer(r'\b(?:pub(?:\([^)]*\))?\s+)?(struct|enum)\s+([A-Z][A-Za-z0-9_]*)\b', aggregate_source):
     type_declarations[type_match.group(2)] = f'{module_id}::{type_match.group(2)}'
 
 primitive_types = {
@@ -717,13 +739,17 @@ def resolve_type(type_text, impl_type=None):
     return None
 
 
-for struct_match in re.finditer(r'\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Z][A-Za-z0-9_]*)(?:\s*<[^>{;]*>)?\s*\{', masked_content):
+named_struct_pattern = re.compile(
+    r'\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Z][A-Za-z0-9_]*)'
+    r'(?:\s*<[^>{;]*>)?(?:\s+where\b[^{};]*)?\s*\{'
+)
+for struct_match in named_struct_pattern.finditer(aggregate_source):
     name = struct_match.group(1)
-    opening = masked_content.find('{', struct_match.start(), struct_match.end())
-    closing = matching_delimiter(masked_content, opening)
+    opening = aggregate_source.find('{', struct_match.start(), struct_match.end())
+    closing = matching_delimiter(aggregate_source, opening)
     if closing is None:
         continue
-    body = masked_content[opening + 1:closing]
+    body = aggregate_source[opening + 1:closing]
     fields = []
     field_names = set()
     for start, end in split_top_level_spans(body):

--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -654,32 +654,62 @@ aggregate_definitions = []
 for type_match in re.finditer(r'\b(?:pub(?:\([^)]*\))?\s+)?(struct|enum)\s+([A-Z][A-Za-z0-9_]*)\b', masked_content):
     type_declarations[type_match.group(2)] = f'{module_id}::{type_match.group(2)}'
 
-imports_by_name = {}
-for import_match in re.finditer(r'\buse\s+(crate(?:::\w+)+)\s*;', masked_content):
-    imported = import_match.group(1)
-    imports_by_name[imported.rsplit('::', 1)[-1]] = imported
-
 primitive_types = {
     'bool', 'char', 'str', 'String', 'usize', 'isize', 'u8', 'u16', 'u32',
     'u64', 'u128', 'i8', 'i16', 'i32', 'i64', 'i128', 'f32', 'f64',
 }
 
 
+def strip_generic_arguments(type_text):
+    match = re.fullmatch(r'((?:crate|self|super|[A-Za-z_]\w*)(?:::(?:super|self|[A-Za-z_]\w*))*)(?:::)?\s*<.*>', type_text, re.S)
+    return match.group(1) if match else type_text
+
+
+def canonical_type_path(path):
+    path = re.sub(r'\s*::\s*', '::', path.strip())
+    segments = path.split('::')
+    if not segments or any(not re.fullmatch(r'[A-Za-z_]\w*', segment) for segment in segments):
+        return None
+    if segments[0] == 'crate':
+        resolved = ['crate']
+        segments = segments[1:]
+    elif segments[0] == 'self':
+        resolved = module_id.split('::')
+        segments = segments[1:]
+    elif segments[0] == 'super':
+        resolved = module_id.split('::')
+    else:
+        return None
+    for segment in segments:
+        if segment == 'self':
+            continue
+        if segment == 'super':
+            if len(resolved) == 1:
+                return None
+            resolved.pop()
+        else:
+            resolved.append(segment)
+    return '::'.join(resolved)
+
+
+imports_by_name = {}
+for import_match in re.finditer(r'\buse\s+((?:crate|self|super)(?:::\w+)+)\s*;', masked_content):
+    imported = canonical_type_path(import_match.group(1))
+    if imported:
+        imports_by_name[imported.rsplit('::', 1)[-1]] = imported
+
+
 def resolve_type(type_text, impl_type=None):
     value = re.sub(r'\b(?:mut|const|dyn)\b', '', type_text).strip()
-    value = re.sub(r"&\s*'(?:[A-Za-z_]\w*)?\s*", '', value).strip()
-    value = value.lstrip('&').strip()
+    while value.startswith('&'):
+        value = re.sub(r"^&\s*(?:'[A-Za-z_]\w*\s+)?(?:mut\s+)?", '', value).strip()
+    value = strip_generic_arguments(value)
     if value == 'Self' and impl_type:
         return type_declarations.get(impl_type)
     if value in primitive_types:
         return value
-    if value.startswith('crate::'):
-        return value if re.match(r'^crate(?:::\w+)+$', value) else None
-    if value.startswith('self::'):
-        return f"{module_id}::{value[6:]}"
-    if value.startswith('super::'):
-        parent = module_id.rsplit('::', 1)[0] if '::' in module_id else module_id
-        return f"{parent}::{value[7:]}"
+    if value.startswith(('crate::', 'self::', 'super::')):
+        return canonical_type_path(value)
     if value in type_declarations:
         return type_declarations[value]
     if value in imports_by_name:
@@ -687,7 +717,7 @@ def resolve_type(type_text, impl_type=None):
     return None
 
 
-for struct_match in re.finditer(r'\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Z][A-Za-z0-9_]*)\s*\{', masked_content):
+for struct_match in re.finditer(r'\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Z][A-Za-z0-9_]*)(?:\s*<[^>{;]*>)?\s*\{', masked_content):
     name = struct_match.group(1)
     opening = masked_content.find('{', struct_match.start(), struct_match.end())
     closing = matching_delimiter(masked_content, opening)
@@ -749,7 +779,7 @@ def expression_type(expression, variable_types):
         receiver_type = variable_types.get(call_match.group(1))
         if receiver_type:
             return function_returns.get(f"{receiver_type}::{call_match.group(2)}")
-    literal_match = re.match(r'([A-Z][A-Za-z0-9_]*)\s*\{', expression)
+    literal_match = re.match(r'([A-Z][A-Za-z0-9_]*)(?:::)?(?:\s*<[^>{;]*>)?\s*\{', expression)
     if literal_match:
         return resolve_type(literal_match.group(1))
     return None
@@ -824,7 +854,7 @@ for fn in functions:
             'location': location_at(body_offset + access_match.start(2)),
         })
 
-    for literal_match in re.finditer(r'\b([A-Z][A-Za-z0-9_]*)\s*\{', body_masked):
+    for literal_match in re.finditer(r'\b([A-Z][A-Za-z0-9_]*)(?:::)?(?:\s*<[^>{;]*>)?\s*\{', body_masked):
         target_type = resolve_type(literal_match.group(1), fn.impl_type)
         if not target_type or target_type in primitive_types:
             continue
@@ -834,14 +864,21 @@ for fn in functions:
             continue
         literal_body = body_masked[opening + 1:closing]
         mappings_by_source = {}
-        for start, end in split_top_level_spans(literal_body):
-            item = literal_body[start:end].strip()
+        literal_items = [literal_body[start:end].strip() for start, end in split_top_level_spans(literal_body)]
+        initialized_fields = {
+            explicit.group(1)
+            for item in literal_items
+            if not item.startswith('..')
+            for explicit in [re.match(r'([a-z_][A-Za-z0-9_]*)(?:\s*:|\s*$)', item)]
+            if explicit
+        }
+        for item in literal_items:
             update_match = re.fullmatch(r'\.\.\s*([a-z_][A-Za-z0-9_]*)', item)
             if update_match:
                 source = update_match.group(1)
                 source_type = variable_types.get(source)
                 if source_type and source_type in struct_fields:
-                    common = struct_fields[source_type] & struct_fields[target_type]
+                    common = (struct_fields[source_type] & struct_fields[target_type]) - initialized_fields
                     mappings_by_source.setdefault(source_type, set()).update((field, field) for field in common)
                 continue
             explicit = re.match(r'([a-z_][A-Za-z0-9_]*)\s*:\s*([a-z_][A-Za-z0-9_]*|self)\s*\.\s*([a-z_][A-Za-z0-9_]*)\s*$', item)

--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -9,7 +9,10 @@
 #    "registrations": [], "namespace": "...", "imports": [...],
 #    "method_hashes": {...}, "structural_hashes": {...},
 #    "unused_parameters": [...], "dead_code_markers": [...],
-#    "internal_calls": [...], "public_api": [...]}
+#    "internal_calls": [...], "public_api": [...],
+#    "aggregate_definitions": [...], "field_accesses": [...],
+#    "aggregate_projections": [...], "decision_branches": [...],
+#    "method_calls": [...]}
 #
 # Extracts structural information from Rust source files using text matching.
 # Handles methods inside impl blocks and test methods inside #[cfg(test)] modules.
@@ -520,6 +523,442 @@ for line_num, line in enumerate(lines, 1):
                     })
                 break
 
+# ============================================================================
+# Policy-flow facts
+# ============================================================================
+
+def module_id_for_path(path):
+    path = path.replace('\\', '/').removeprefix('./')
+    parts = path.split('/')
+    if parts and parts[0] == 'src':
+        parts = parts[1:]
+    if not parts:
+        return 'crate'
+    leaf = parts[-1]
+    if leaf in {'lib.rs', 'main.rs', 'mod.rs'}:
+        parts = parts[:-1]
+    elif leaf.endswith('.rs'):
+        parts[-1] = leaf[:-3]
+    return 'crate' + (f"::{'::'.join(parts)}" if parts else '')
+
+
+module_id = module_id_for_path(file_path)
+line_offsets = []
+offset = 0
+for source_line in lines:
+    line_offsets.append(offset)
+    offset += len(source_line) + 1
+
+
+def location_at(offset):
+    line = content.count('\n', 0, offset) + 1
+    line_start = content.rfind('\n', 0, offset) + 1
+    return {'line': line, 'column': offset - line_start + 1}
+
+
+def mask_rust(text):
+    """Mask comments and literals while preserving offsets and newlines."""
+    chars = list(text)
+    i = 0
+    block_depth = 0
+    while i < len(chars):
+        if block_depth:
+            if text.startswith('/*', i):
+                chars[i:i + 2] = '  '
+                block_depth += 1
+                i += 2
+            elif text.startswith('*/', i):
+                chars[i:i + 2] = '  '
+                block_depth -= 1
+                i += 2
+            else:
+                if chars[i] != '\n':
+                    chars[i] = ' '
+                i += 1
+            continue
+        if text.startswith('//', i):
+            end = text.find('\n', i)
+            end = len(text) if end < 0 else end
+            chars[i:end] = ' ' * (end - i)
+            i = end
+            continue
+        if text.startswith('/*', i):
+            chars[i:i + 2] = '  '
+            block_depth = 1
+            i += 2
+            continue
+        if chars[i] in {'"', "'"}:
+            # A single quote before an identifier is a lifetime, not a char.
+            if chars[i] == "'" and i + 1 < len(chars) and re.match(r'[A-Za-z_]', chars[i + 1]):
+                lifetime = re.match(r"'[A-Za-z_]\w*", text[i:])
+                if lifetime:
+                    i += len(lifetime.group(0))
+                    continue
+            quote = chars[i]
+            chars[i] = ' '
+            i += 1
+            while i < len(chars):
+                if chars[i] == '\\':
+                    chars[i] = ' '
+                    if i + 1 < len(chars) and chars[i + 1] != '\n':
+                        chars[i + 1] = ' '
+                    i += 2
+                    continue
+                end_quote = chars[i] == quote
+                if chars[i] != '\n':
+                    chars[i] = ' '
+                i += 1
+                if end_quote:
+                    break
+            continue
+        i += 1
+    return ''.join(chars)
+
+
+masked_content = mask_rust(content)
+
+
+def matching_delimiter(text, opening, left='{', right='}'):
+    depth = 0
+    for pos in range(opening, len(text)):
+        if text[pos] == left:
+            depth += 1
+        elif text[pos] == right:
+            depth -= 1
+            if depth == 0:
+                return pos
+    return None
+
+
+def split_top_level_spans(text, delimiter=','):
+    spans = []
+    start = 0
+    depths = {'(': 0, '[': 0, '{': 0, '<': 0}
+    closing = {')': '(', ']': '[', '}': '{', '>': '<'}
+    for pos, ch in enumerate(text):
+        if ch in depths:
+            depths[ch] += 1
+        elif ch in closing and depths[closing[ch]]:
+            depths[closing[ch]] -= 1
+        elif ch == delimiter and not any(depths.values()):
+            spans.append((start, pos))
+            start = pos + 1
+    spans.append((start, len(text)))
+    return spans
+
+
+type_declarations = {}
+struct_fields = {}
+aggregate_definitions = []
+
+for type_match in re.finditer(r'\b(?:pub(?:\([^)]*\))?\s+)?(struct|enum)\s+([A-Z][A-Za-z0-9_]*)\b', masked_content):
+    type_declarations[type_match.group(2)] = f'{module_id}::{type_match.group(2)}'
+
+imports_by_name = {}
+for import_match in re.finditer(r'\buse\s+(crate(?:::\w+)+)\s*;', masked_content):
+    imported = import_match.group(1)
+    imports_by_name[imported.rsplit('::', 1)[-1]] = imported
+
+primitive_types = {
+    'bool', 'char', 'str', 'String', 'usize', 'isize', 'u8', 'u16', 'u32',
+    'u64', 'u128', 'i8', 'i16', 'i32', 'i64', 'i128', 'f32', 'f64',
+}
+
+
+def resolve_type(type_text, impl_type=None):
+    value = re.sub(r'\b(?:mut|const|dyn)\b', '', type_text).strip()
+    value = re.sub(r"&\s*'(?:[A-Za-z_]\w*)?\s*", '', value).strip()
+    value = value.lstrip('&').strip()
+    if value == 'Self' and impl_type:
+        return type_declarations.get(impl_type)
+    if value in primitive_types:
+        return value
+    if value.startswith('crate::'):
+        return value if re.match(r'^crate(?:::\w+)+$', value) else None
+    if value.startswith('self::'):
+        return f"{module_id}::{value[6:]}"
+    if value.startswith('super::'):
+        parent = module_id.rsplit('::', 1)[0] if '::' in module_id else module_id
+        return f"{parent}::{value[7:]}"
+    if value in type_declarations:
+        return type_declarations[value]
+    if value in imports_by_name:
+        return imports_by_name[value]
+    return None
+
+
+for struct_match in re.finditer(r'\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Z][A-Za-z0-9_]*)\s*\{', masked_content):
+    name = struct_match.group(1)
+    opening = masked_content.find('{', struct_match.start(), struct_match.end())
+    closing = matching_delimiter(masked_content, opening)
+    if closing is None:
+        continue
+    body = masked_content[opening + 1:closing]
+    fields = []
+    field_names = set()
+    for start, end in split_top_level_spans(body):
+        chunk = re.sub(r'#\s*\[[^]]*\]', ' ', body[start:end]).strip()
+        field_match = re.match(r'(?:pub(?:\([^)]*\))?\s+)?([a-z_][A-Za-z0-9_]*)\s*:\s*(.+)', chunk, re.S)
+        if not field_match:
+            continue
+        field = {'name': field_match.group(1)}
+        field_type = resolve_type(field_match.group(2).strip())
+        if field_type:
+            field['type_id'] = field_type
+        fields.append(field)
+        field_names.add(field['name'])
+    fields.sort(key=lambda item: (item['name'], item.get('type_id', '')))
+    struct_fields[type_declarations[name]] = field_names
+    aggregate_definitions.append({
+        'type_id': type_declarations[name],
+        'fields': fields,
+        'location': location_at(struct_match.start(1)),
+    })
+
+
+def function_id(fn):
+    if fn.impl_type and fn.impl_type in type_declarations:
+        return f'{type_declarations[fn.impl_type]}::{fn.name}'
+    return f'{module_id}::{fn.name}'
+
+
+def signature_details(fn):
+    signature = '\n'.join(fn.signature_lines)
+    params_start = signature.find('(')
+    params_end = matching_delimiter(signature, params_start, '(', ')') if params_start >= 0 else None
+    params = signature[params_start + 1:params_end] if params_end is not None else ''
+    suffix = signature[params_end + 1:] if params_end is not None else ''
+    return_match = re.search(r'->\s*([^\{;]+)', suffix, re.S)
+    return params, return_match.group(1).strip() if return_match else None
+
+
+function_returns = {}
+for fn in functions:
+    _, return_text = signature_details(fn)
+    resolved_return = resolve_type(return_text, fn.impl_type) if return_text else None
+    function_returns[function_id(fn)] = resolved_return
+
+
+def expression_type(expression, variable_types):
+    expression = expression.strip().lstrip('&').strip()
+    variable_match = re.fullmatch(r'(?:\*\s*)?([a-z_][A-Za-z0-9_]*)', expression)
+    if variable_match:
+        return variable_types.get(variable_match.group(1))
+    call_match = re.fullmatch(r'([a-z_][A-Za-z0-9_]*|self)\s*\.\s*([a-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*\??', expression, re.S)
+    if call_match:
+        receiver_type = variable_types.get(call_match.group(1))
+        if receiver_type:
+            return function_returns.get(f"{receiver_type}::{call_match.group(2)}")
+    literal_match = re.match(r'([A-Z][A-Za-z0-9_]*)\s*\{', expression)
+    if literal_match:
+        return resolve_type(literal_match.group(1))
+    return None
+
+
+def discriminant_id(pattern, domain_type):
+    normalized = re.sub(r'\s+', '', pattern)
+    normalized = re.sub(r'\([^)]*\)|\{[^}]*\}', '', normalized)
+    normalized = normalized.lstrip('&')
+    if '::' in normalized:
+        variant = normalized.rsplit('::', 1)[-1]
+        return f'{domain_type}::{variant}'
+    if re.fullmatch(r'[A-Z][A-Za-z0-9_]*', normalized):
+        return f'{domain_type}::{normalized}'
+    return normalized or '_'
+
+
+field_accesses = []
+aggregate_projections = []
+decision_branches = []
+method_calls = []
+
+for fn in functions:
+    if fn.is_test or fn.is_test_helper or not fn.body_lines:
+        continue
+    callable_id = function_id(fn)
+    body_text = '\n'.join(fn.body_lines)
+    body_masked = mask_rust(body_text)
+    body_offset = line_offsets[fn.line_num - 1]
+    params_text, return_text = signature_details(fn)
+    return_type = resolve_type(return_text, fn.impl_type) if return_text else None
+    variable_types = {}
+    field_origins = {}
+    if fn.impl_type in type_declarations and re.search(r'(?:^|,)\s*&?\s*(?:mut\s+)?self\b', params_text):
+        variable_types['self'] = type_declarations[fn.impl_type]
+    for start, end in split_top_level_spans(params_text):
+        param_match = re.match(r'\s*(?:mut\s+)?([a-z_][A-Za-z0-9_]*)\s*:\s*(.+)', params_text[start:end], re.S)
+        if param_match:
+            param_type = resolve_type(param_match.group(2).strip(), fn.impl_type)
+            if param_type:
+                variable_types[param_match.group(1)] = param_type
+
+    # Resolve explicit locals first, then simple constructor/method assignments.
+    for local_match in re.finditer(r'\blet\s+(?:mut\s+)?([a-z_][A-Za-z0-9_]*)\s*:\s*([^=;]+)', body_masked):
+        local_type = resolve_type(local_match.group(2).strip(), fn.impl_type)
+        if local_type:
+            variable_types[local_match.group(1)] = local_type
+    for _ in range(2):
+        for local_match in re.finditer(r'\blet\s+(?:mut\s+)?([a-z_][A-Za-z0-9_]*)(?:\s*:\s*[^=;]+)?\s*=\s*([^;]+)', body_masked, re.S):
+            name, expression = local_match.group(1), local_match.group(2).strip()
+            inferred = expression_type(expression, variable_types)
+            if inferred:
+                variable_types[name] = inferred
+            origin_match = re.fullmatch(r'([a-z_][A-Za-z0-9_]*|self)\s*\.\s*([a-z_][A-Za-z0-9_]*)', expression)
+            if origin_match and variable_types.get(origin_match.group(1)):
+                field_origins[name] = (origin_match.group(1), origin_match.group(2))
+
+    for access_match in re.finditer(r'\b([a-z_][A-Za-z0-9_]*|self)\s*\.\s*([a-z_][A-Za-z0-9_]*)\b(?!\s*\()', body_masked):
+        receiver, field = access_match.group(1), access_match.group(2)
+        owner_type = variable_types.get(receiver)
+        if not owner_type or owner_type in primitive_types:
+            continue
+        if owner_type in struct_fields and field not in struct_fields[owner_type]:
+            continue
+        following = body_masked[access_match.end():access_match.end() + 12]
+        write = bool(re.match(r'\s*(?:[+\-*/%&|^]?=)(?!=|>)', following))
+        field_accesses.append({
+            'owner_type_id': owner_type,
+            'field': field,
+            'callable_id': callable_id,
+            'access': 'write' if write else 'read',
+            'location': location_at(body_offset + access_match.start(2)),
+        })
+
+    for literal_match in re.finditer(r'\b([A-Z][A-Za-z0-9_]*)\s*\{', body_masked):
+        target_type = resolve_type(literal_match.group(1), fn.impl_type)
+        if not target_type or target_type in primitive_types:
+            continue
+        opening = body_masked.find('{', literal_match.start(), literal_match.end())
+        closing = matching_delimiter(body_masked, opening)
+        if closing is None:
+            continue
+        literal_body = body_masked[opening + 1:closing]
+        mappings_by_source = {}
+        for start, end in split_top_level_spans(literal_body):
+            item = literal_body[start:end].strip()
+            update_match = re.fullmatch(r'\.\.\s*([a-z_][A-Za-z0-9_]*)', item)
+            if update_match:
+                source = update_match.group(1)
+                source_type = variable_types.get(source)
+                if source_type and source_type in struct_fields:
+                    common = struct_fields[source_type] & struct_fields[target_type]
+                    mappings_by_source.setdefault(source_type, set()).update((field, field) for field in common)
+                continue
+            explicit = re.match(r'([a-z_][A-Za-z0-9_]*)\s*:\s*([a-z_][A-Za-z0-9_]*|self)\s*\.\s*([a-z_][A-Za-z0-9_]*)\s*$', item)
+            if explicit:
+                target_field, source, source_field = explicit.groups()
+                source_type = variable_types.get(source)
+                target_valid = target_type not in struct_fields or target_field in struct_fields[target_type]
+                source_valid = source_type not in struct_fields or source_field in struct_fields[source_type]
+                if source_type and source_type not in primitive_types and target_valid and source_valid:
+                    mappings_by_source.setdefault(source_type, set()).add((source_field, target_field))
+                continue
+            shorthand = re.fullmatch(r'([a-z_][A-Za-z0-9_]*)', item)
+            if shorthand and shorthand.group(1) in field_origins:
+                source, source_field = field_origins[shorthand.group(1)]
+                source_type = variable_types.get(source)
+                target_field = shorthand.group(1)
+                target_valid = target_type not in struct_fields or target_field in struct_fields[target_type]
+                source_valid = source_type not in struct_fields or source_field in struct_fields[source_type]
+                if source_type and source_type not in primitive_types and target_valid and source_valid:
+                    mappings_by_source.setdefault(source_type, set()).add((source_field, target_field))
+        for source_type, mappings in mappings_by_source.items():
+            aggregate_projections.append({
+                'source_type_id': source_type,
+                'target_type_id': target_type,
+                'callable_id': callable_id,
+                'field_mappings': [
+                    {'source_field': source, 'target_field': target}
+                    for source, target in sorted(mappings)
+                ],
+                'location': location_at(body_offset + literal_match.start(1)),
+            })
+
+    for call_match in re.finditer(r'\b([a-z_][A-Za-z0-9_]*|self)\s*\.\s*([a-z_][A-Za-z0-9_]*)\s*\([^()]*\)', body_masked):
+        receiver, method = call_match.group(1), call_match.group(2)
+        receiver_type = variable_types.get(receiver)
+        if not receiver_type:
+            continue
+        target_method = f'{receiver_type}::{method}'
+        before = body_masked[:call_match.start()]
+        statement_start = max(before.rfind(';'), before.rfind('{'), before.rfind('}')) + 1
+        prefix = re.sub(r'\s+', ' ', before[statement_start:]).strip()
+        direct_control = bool(re.search(r'(?:^|\b)(?:if|while|match)(?:\s+let\s+.+?=\s*)?$', prefix))
+        direct_return = bool(re.search(r'(?:^|\b)return\s*$', prefix))
+        remainder = body_masked[call_match.end():].strip()
+        tail_return = bool(re.fullmatch(r'\??\s*}', remainder))
+        decision = direct_control or direct_return or tail_return
+        call_return = function_returns.get(target_method)
+        decision_domain = call_return if direct_control else (return_type if direct_return or tail_return else None)
+        fact = {
+            'caller_id': callable_id,
+            'target_method_id': target_method,
+            'receiver_type_id': receiver_type,
+            'result_used_as_decision': decision,
+            'location': location_at(body_offset + call_match.start(2)),
+        }
+        if decision and decision_domain:
+            fact['decision_domain_type_id'] = decision_domain
+        method_calls.append(fact)
+
+    for branch_match in re.finditer(r'\b(?:if|while)\s+let\s+(.+?)\s*=\s*([^\{]+)\{', body_masked, re.S):
+        pattern = branch_match.group(1).strip()
+        domain = expression_type(branch_match.group(2).strip(), variable_types)
+        if domain:
+            pattern_offset = branch_match.start(1) + len(branch_match.group(1)) - len(branch_match.group(1).lstrip())
+            decision_branches.append({
+                'callable_id': callable_id,
+                'domain_type_id': domain,
+                'discriminant_id': discriminant_id(pattern, domain),
+                'location': location_at(body_offset + pattern_offset),
+            })
+
+    for match_match in re.finditer(r'\bmatch\s+([^\{]+)\{', body_masked, re.S):
+        domain = expression_type(match_match.group(1).strip(), variable_types)
+        opening = body_masked.find('{', match_match.start(), match_match.end())
+        closing = matching_delimiter(body_masked, opening)
+        if not domain or closing is None:
+            continue
+        arms = body_masked[opening + 1:closing]
+        for start, end in split_top_level_spans(arms):
+            arm = arms[start:end]
+            arrow = arm.find('=>')
+            if arrow < 0:
+                continue
+            pattern = arm[:arrow].strip()
+            if not pattern:
+                continue
+            pattern_start = start + len(arm[:arrow]) - len(arm[:arrow].lstrip())
+            decision_branches.append({
+                'callable_id': callable_id,
+                'domain_type_id': domain,
+                'discriminant_id': discriminant_id(pattern, domain),
+                'location': location_at(body_offset + opening + 1 + pattern_start),
+            })
+
+
+def stable_unique(items, key):
+    unique = {}
+    for item in items:
+        unique[json.dumps(item, sort_keys=True, separators=(',', ':'))] = item
+    return sorted(unique.values(), key=key)
+
+
+aggregate_definitions = stable_unique(aggregate_definitions, lambda item: (
+    item['type_id'], item['location']['line'], item['location']['column']))
+field_accesses = stable_unique(field_accesses, lambda item: (
+    item['owner_type_id'], item['field'], item['callable_id'], item['access'],
+    item['location']['line'], item['location']['column']))
+aggregate_projections = stable_unique(aggregate_projections, lambda item: (
+    item['source_type_id'], item['target_type_id'], item['callable_id'],
+    item['location']['line'], item['location']['column']))
+decision_branches = stable_unique(decision_branches, lambda item: (
+    item['callable_id'], item['domain_type_id'], item['discriminant_id'],
+    item['location']['line'], item['location']['column']))
+method_calls = stable_unique(method_calls, lambda item: (
+    item['caller_id'], item['target_method_id'], item.get('receiver_type_id', ''),
+    item['location']['line'], item['location']['column']))
+
 # --- Aggregate construction facts ---
 # Rust-specific syntax recognition lives in the Rust extension. Homeboy core
 # consumes these as generic aggregate construction facts.
@@ -604,6 +1043,11 @@ result = {
     'public_api': public_api,
     'aggregate_literals': aggregate_literals,
     'aggregate_construction_seams': aggregate_construction_seams,
+    'aggregate_definitions': aggregate_definitions,
+    'field_accesses': field_accesses,
+    'aggregate_projections': aggregate_projections,
+    'decision_branches': decision_branches,
+    'method_calls': method_calls,
 }
 
 print(json.dumps(result))

--- a/rust/tests/fingerprint-policy-flow-smoke.sh
+++ b/rust/tests/fingerprint-policy-flow-smoke.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FINGERPRINT="${SCRIPT_DIR}/../scripts/fingerprint.sh"
+WORK_DIR="$(mktemp -d -t homeboy-rust-policy-flow.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+cat > "$WORK_DIR/fixture.rs" <<'RS'
+pub enum Decision {
+    Allow,
+    Deny,
+}
+
+pub struct Policy {
+    pub allowed: bool,
+    pub blocked: bool,
+    pub decision: Decision,
+}
+
+pub struct PolicyView {
+    pub allowed: bool,
+}
+
+pub struct DecisionDto {
+    pub decision: Decision,
+}
+
+impl Policy {
+    pub fn authoritative(&self) -> Decision {
+        if self.blocked {
+            Decision::Deny
+        } else if self.allowed {
+            Decision::Allow
+        } else {
+            self.decision
+        }
+    }
+
+    pub fn audit(&self) -> bool {
+        self.allowed
+    }
+
+    pub fn set_allowed(&mut self) {
+        self.allowed = true;
+    }
+
+    pub fn duplicate_branch(&self, decision: Decision) -> bool {
+        if let Decision::Allow = decision {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+pub fn lossy(policy: &Policy) -> PolicyView {
+    PolicyView {
+        allowed: policy.allowed,
+    }
+}
+
+pub fn shorthand(policy: &Policy) -> PolicyView {
+    let allowed: bool = policy.allowed;
+    PolicyView { allowed }
+}
+
+pub fn update(policy: Policy) -> Policy {
+    Policy {
+        blocked: false,
+        ..policy
+    }
+}
+
+pub fn ordinary_dto(policy: &Policy) -> DecisionDto {
+    DecisionDto {
+        decision: policy.decision,
+    }
+}
+
+pub fn downstream(policy: &Policy) -> bool {
+    match policy.authoritative() {
+        Decision::Allow => true,
+        Decision::Deny => false,
+    }
+}
+
+pub fn duplicate_branch(decision: Decision) -> bool {
+    if let Decision::Allow = decision {
+        true
+    } else {
+        false
+    }
+}
+
+pub fn delegate(policy: &Policy) -> Decision {
+    policy.authoritative()
+}
+
+pub fn ordinary_call(policy: &Policy) {
+    policy.audit();
+}
+
+pub fn unresolved(mystery: Mystery, policy: &Policy) {
+    mystery.check();
+    let unknown = mystery.value;
+    UnknownView { unknown };
+    policy.missing().unknown;
+}
+RS
+
+make_input() {
+    python3 - "$WORK_DIR/fixture.rs" <<'PY'
+import json
+import pathlib
+import sys
+
+print(json.dumps({
+    "file_path": "src/policy/flow.rs",
+    "content": pathlib.Path(sys.argv[1]).read_text(),
+}))
+PY
+}
+
+input="$(make_input)"
+first="$(printf '%s' "$input" | "$FINGERPRINT")"
+second="$(printf '%s' "$input" | "$FINGERPRINT")"
+
+if [ "$first" != "$second" ]; then
+    printf 'Fingerprint output changed across identical runs\n' >&2
+    exit 1
+fi
+
+RESULT_JSON="$first" FINGERPRINT="$FINGERPRINT" python3 <<'PY'
+import json
+import os
+import subprocess
+
+result = json.loads(os.environ["RESULT_JSON"])
+module = "crate::policy::flow"
+
+for key in (
+    "aggregate_definitions",
+    "field_accesses",
+    "aggregate_projections",
+    "decision_branches",
+    "method_calls",
+):
+    assert key in result and isinstance(result[key], list), key
+
+definitions = {item["type_id"]: item for item in result["aggregate_definitions"]}
+assert set(definitions) == {
+    f"{module}::Policy",
+    f"{module}::PolicyView",
+    f"{module}::DecisionDto",
+}
+assert [field["name"] for field in definitions[f"{module}::Policy"]["fields"]] == [
+    "allowed",
+    "blocked",
+    "decision",
+]
+assert definitions[f"{module}::Policy"]["fields"][2]["type_id"] == f"{module}::Decision"
+
+accesses = result["field_accesses"]
+authoritative = f"{module}::Policy::authoritative"
+assert {(item["field"], item["access"]) for item in accesses if item["callable_id"] == authoritative} == {
+    ("allowed", "read"),
+    ("blocked", "read"),
+    ("decision", "read"),
+}
+assert all(item["owner_type_id"] == f"{module}::Policy" for item in accesses)
+assert any(
+    item["callable_id"] == f"{module}::Policy::set_allowed"
+    and item["field"] == "allowed"
+    and item["access"] == "write"
+    for item in accesses
+)
+
+projections = result["aggregate_projections"]
+projection_keys = {
+    (item["callable_id"], item["source_type_id"], item["target_type_id"]): {
+        (mapping["source_field"], mapping["target_field"])
+        for mapping in item["field_mappings"]
+    }
+    for item in projections
+}
+assert projection_keys[(f"{module}::lossy", f"{module}::Policy", f"{module}::PolicyView")] == {
+    ("allowed", "allowed")
+}
+assert projection_keys[(f"{module}::shorthand", f"{module}::Policy", f"{module}::PolicyView")] == {
+    ("allowed", "allowed")
+}
+assert projection_keys[(f"{module}::ordinary_dto", f"{module}::Policy", f"{module}::DecisionDto")] == {
+    ("decision", "decision")
+}
+assert projection_keys[(f"{module}::update", f"{module}::Policy", f"{module}::Policy")] == {
+    ("allowed", "allowed"),
+    ("blocked", "blocked"),
+    ("decision", "decision"),
+}
+
+allow_branch_callables = {
+    item["callable_id"]
+    for item in result["decision_branches"]
+    if item["discriminant_id"] == f"{module}::Decision::Allow"
+}
+assert allow_branch_callables == {
+    f"{module}::Policy::duplicate_branch",
+    f"{module}::downstream",
+    f"{module}::duplicate_branch",
+}
+assert all(item["domain_type_id"] == f"{module}::Decision" for item in result["decision_branches"])
+
+calls = {(item["caller_id"], item["target_method_id"]): item for item in result["method_calls"]}
+target = f"{module}::Policy::authoritative"
+assert calls[(f"{module}::downstream", target)]["result_used_as_decision"] is True
+assert calls[(f"{module}::downstream", target)]["decision_domain_type_id"] == f"{module}::Decision"
+assert calls[(f"{module}::delegate", target)]["result_used_as_decision"] is True
+assert calls[(f"{module}::delegate", target)]["decision_domain_type_id"] == f"{module}::Decision"
+audit = calls[(f"{module}::ordinary_call", f"{module}::Policy::audit")]
+assert audit["result_used_as_decision"] is False
+assert "decision_domain_type_id" not in audit
+
+serialized = json.dumps(result, sort_keys=True)
+assert "Mystery" not in serialized
+assert "UnknownView" not in serialized
+for collection in result.values():
+    if isinstance(collection, list) and collection and isinstance(collection[0], dict):
+        for item in collection:
+            location = item.get("location")
+            if location:
+                assert location["line"] >= 1 and location["column"] >= 1
+
+assert result["aggregate_definitions"] == sorted(
+    result["aggregate_definitions"], key=lambda item: (item["type_id"], item["location"]["line"], item["location"]["column"])
+)
+
+def fingerprint(path, content):
+    completed = subprocess.run(
+        [os.environ["FINGERPRINT"]],
+        input=json.dumps({"file_path": path, "content": content}),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+mod_result = fingerprint("src/foo/mod.rs", "struct Local { value: Unknown }\n")
+assert mod_result["aggregate_definitions"] == [{
+    "type_id": "crate::foo::Local",
+    "fields": [{"name": "value"}],
+    "location": {"line": 1, "column": 8},
+}]
+for key in ("field_accesses", "aggregate_projections", "decision_branches", "method_calls"):
+    assert mod_result[key] == []
+
+for root_path in ("src/lib.rs", "src/main.rs"):
+    root_result = fingerprint(root_path, "struct Root { enabled: bool }\n")
+    assert root_result["aggregate_definitions"][0]["type_id"] == "crate::Root"
+
+imported_result = fingerprint("src/adapter.rs", '''
+use crate::domain::Policy;
+use crate::dto::PolicyView;
+
+fn project(policy: &Policy) -> PolicyView {
+    PolicyView { allowed: policy.allowed }
+}
+''')
+assert imported_result["field_accesses"][0]["owner_type_id"] == "crate::domain::Policy"
+assert imported_result["aggregate_projections"][0]["source_type_id"] == "crate::domain::Policy"
+assert imported_result["aggregate_projections"][0]["target_type_id"] == "crate::dto::PolicyView"
+
+print("Rust policy-flow fingerprint smoke passed")
+PY

--- a/rust/tests/fingerprint-policy-flow-smoke.sh
+++ b/rust/tests/fingerprint-policy-flow-smoke.sh
@@ -112,6 +112,12 @@ pub fn unresolved(mystery: Mystery, policy: &Policy) {
 mod tests {
     use super::*;
 
+    struct TestOnlyPolicy {
+        allowed: bool,
+        blocked: bool,
+        decision: Decision,
+    }
+
     fn helper(policy: &Policy) -> PolicyView {
         if let Decision::Allow = policy.authoritative() {
             PolicyView { allowed: policy.allowed }
@@ -176,6 +182,7 @@ assert set(definitions) == {
     f"{module}::PolicyView",
     f"{module}::DecisionDto",
 }
+assert f"{module}::TestOnlyPolicy" not in definitions
 assert [field["name"] for field in definitions[f"{module}::Policy"]["fields"]] == [
     "allowed",
     "blocked",
@@ -310,12 +317,15 @@ assert imported_result["aggregate_projections"][0]["source_type_id"] == "crate::
 assert imported_result["aggregate_projections"][0]["target_type_id"] == "crate::dto::PolicyView"
 
 generic_result = fingerprint("src/generic.rs", '''
-struct Policy<T> {
+struct Policy<T> where T: Copy {
     blocked: bool,
     state: T,
 }
 
-struct PolicyView<T> {
+struct PolicyView<T>
+where
+    T: Copy,
+{
     state: T,
 }
 
@@ -334,7 +344,7 @@ assert generic_result["aggregate_projections"] == [{
     "target_type_id": "crate::generic::PolicyView",
     "callable_id": "crate::generic::project",
     "field_mappings": [{"source_field": "state", "target_field": "state"}],
-    "location": {"line": 12, "column": 5},
+    "location": {"line": 15, "column": 5},
 }]
 
 parent_result = fingerprint("src/domain/nested/adapter.rs", '''

--- a/rust/tests/fingerprint-policy-flow-smoke.sh
+++ b/rust/tests/fingerprint-policy-flow-smoke.sh
@@ -107,6 +107,28 @@ pub fn unresolved(mystery: Mystery, policy: &Policy) {
     UnknownView { unknown };
     policy.missing().unknown;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn helper(policy: &Policy) -> PolicyView {
+        if let Decision::Allow = policy.authoritative() {
+            PolicyView { allowed: policy.allowed }
+        } else {
+            PolicyView { allowed: false }
+        }
+    }
+
+    #[test]
+    fn policy_flow_is_test_only() {
+        let policy = Policy { allowed: true, blocked: false, decision: Decision::Allow };
+        match policy.authoritative() {
+            Decision::Allow => { helper(&policy); }
+            Decision::Deny => {}
+        }
+    }
+}
 RS
 
 make_input() {
@@ -195,9 +217,14 @@ assert projection_keys[(f"{module}::ordinary_dto", f"{module}::Policy", f"{modul
 }
 assert projection_keys[(f"{module}::update", f"{module}::Policy", f"{module}::Policy")] == {
     ("allowed", "allowed"),
-    ("blocked", "blocked"),
     ("decision", "decision"),
 }
+policy_fields = {field["name"] for field in definitions[f"{module}::Policy"]["fields"]}
+update_fields = {
+    target
+    for _, target in projection_keys[(f"{module}::update", f"{module}::Policy", f"{module}::Policy")]
+}
+assert policy_fields - update_fields == {"blocked"}
 
 allow_branch_callables = {
     item["callable_id"]
@@ -224,6 +251,18 @@ assert "decision_domain_type_id" not in audit
 serialized = json.dumps(result, sort_keys=True)
 assert "Mystery" not in serialized
 assert "UnknownView" not in serialized
+policy_flow_serialized = json.dumps({
+    key: result[key]
+    for key in (
+        "aggregate_definitions",
+        "field_accesses",
+        "aggregate_projections",
+        "decision_branches",
+        "method_calls",
+    )
+}, sort_keys=True)
+assert "helper" not in policy_flow_serialized
+assert "policy_flow_is_test_only" not in policy_flow_serialized
 for collection in result.values():
     if isinstance(collection, list) and collection and isinstance(collection[0], dict):
         for item in collection:
@@ -269,6 +308,55 @@ fn project(policy: &Policy) -> PolicyView {
 assert imported_result["field_accesses"][0]["owner_type_id"] == "crate::domain::Policy"
 assert imported_result["aggregate_projections"][0]["source_type_id"] == "crate::domain::Policy"
 assert imported_result["aggregate_projections"][0]["target_type_id"] == "crate::dto::PolicyView"
+
+generic_result = fingerprint("src/generic.rs", '''
+struct Policy<T> {
+    blocked: bool,
+    state: T,
+}
+
+struct PolicyView<T> {
+    state: T,
+}
+
+fn project<T>(policy: &&Policy<T>) -> PolicyView<T> {
+    PolicyView::<T> { state: policy.state }
+}
+''')
+generic_definitions = {item["type_id"]: item for item in generic_result["aggregate_definitions"]}
+assert set(generic_definitions) == {"crate::generic::Policy", "crate::generic::PolicyView"}
+assert generic_definitions["crate::generic::Policy"]["fields"] == [
+    {"name": "blocked", "type_id": "bool"},
+    {"name": "state"},
+]
+assert generic_result["aggregate_projections"] == [{
+    "source_type_id": "crate::generic::Policy",
+    "target_type_id": "crate::generic::PolicyView",
+    "callable_id": "crate::generic::project",
+    "field_mappings": [{"source_field": "state", "target_field": "state"}],
+    "location": {"line": 12, "column": 5},
+}]
+
+parent_result = fingerprint("src/domain/nested/adapter.rs", '''
+struct Local { enabled: bool }
+
+fn inspect(
+    policy: &super::super::Policy,
+    local: &self::Local,
+    root: &crate::domain::Policy,
+) -> bool {
+    policy.blocked || local.enabled || root.allowed
+}
+''')
+parent_owners = {
+    (item["field"], item["owner_type_id"])
+    for item in parent_result["field_accesses"]
+}
+assert parent_owners == {
+    ("blocked", "crate::domain::Policy"),
+    ("enabled", "crate::domain::nested::adapter::Local"),
+    ("allowed", "crate::domain::Policy"),
+}
 
 print("Rust policy-flow fingerprint smoke passed")
 PY


### PR DESCRIPTION
## Summary
- emit deterministic aggregate definitions, field accesses, aggregate projections, typed branches, and method-call facts
- resolve module-qualified identities, generic aggregates, repeated parent paths, struct shorthand, and update syntax
- exclude inline test policy facts and avoid claiming explicitly overridden update fields
- add focused stable-output coverage and bump the Rust extension to `1.28.2`

## Verification
- Rust policy-flow fingerprint smoke passed
- Swift and WordPress fingerprint regression smokes passed
- extension shape lint and JSON validation passed
- real Homeboy positive: run `86699f5b-6af7-496b-8aaf-25fc7689e986` emitted one `lossy_policy_projection`
- real authoritative delegation negative: run `dfe38392-3eab-4c24-9e63-ee289fa6ffd9` emitted no findings

## Dependency
- Homeboy consumer and detector: https://github.com/Extra-Chill/homeboy/pull/9530
- Tracker: https://github.com/Extra-Chill/homeboy/issues/9443