### PR TITLE
fix(wordpress): skip absent PHPUnit suites

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -13,6 +13,7 @@
       "bash scripts/test/wp-codebox-doctor-smoke.sh",
       "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
+      "bash scripts/test/full-suite-no-phpunit-smoke.sh",
       "node tests/codebox-client-boundary.test.js",
       "node tests/wp-codebox-fuzz-run-smoke.js",
       "node tests/wordpress-fuzz-runner-smoke.js",

--- a/wordpress/scripts/test/full-suite-no-phpunit-smoke.sh
+++ b/wordpress/scripts/test/full-suite-no-phpunit-smoke.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+component="${TMPDIR}/component"
+runtime_stub="${TMPDIR}/runtime.sh"
+mkdir -p "${component}/tests"
+printf '%s\n' '<?php // Standalone smoke, not PHPUnit.' > "${component}/tests/contract-smoke.php"
+
+cat > "$runtime_stub" <<'SH'
+#!/usr/bin/env bash
+echo "PHPUNIT_RUNTIME_INVOKED"
+SH
+chmod +x "$runtime_stub"
+
+run_router() {
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_ID="component" \
+    HOMEBOY_COMPONENT_PATH="$component" \
+    HOMEBOY_COMPONENT_SHAPE="plugin" \
+    HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="$runtime_stub" \
+        bash "${EXTENSION_PATH}/scripts/test/test-runner.sh"
+}
+
+HOMEBOY_SETTINGS_JSON='{"phpunit_no_tests":"skip"}' run_router > "${TMPDIR}/skip.out"
+grep -Fq "Skipping PHPUnit: no canonical test files were discovered." "${TMPDIR}/skip.out"
+if grep -Fq "PHPUNIT_RUNTIME_INVOKED" "${TMPDIR}/skip.out"; then
+    echo "Skip policy must not invoke PHPUnit for a smoke-only component." >&2
+    exit 1
+fi
+
+set +e
+HOMEBOY_SETTINGS_JSON='{"phpunit_no_tests":"fail"}' run_router > "${TMPDIR}/fail.out" 2>&1
+status=$?
+set -e
+if [ "$status" -ne 1 ]; then
+    echo "Expected fail policy to exit 1, got ${status}." >&2
+    exit 1
+fi
+grep -Fq "ERROR: no canonical PHPUnit test files were discovered." "${TMPDIR}/fail.out"
+
+HOMEBOY_SETTINGS_JSON='{"phpunit_no_tests":"skip","wp_codebox_phpunit_test_root":"/unresolved/tests"}' run_router > "${TMPDIR}/explicit.out"
+grep -Fq "PHPUNIT_RUNTIME_INVOKED" "${TMPDIR}/explicit.out"
+
+printf '%s\n' '<?php // Canonical PHPUnit test.' > "${component}/tests/ContractTest.php"
+HOMEBOY_SETTINGS_JSON='{"phpunit_no_tests":"skip"}' run_router > "${TMPDIR}/phpunit.out"
+grep -Fq "PHPUNIT_RUNTIME_INVOKED" "${TMPDIR}/phpunit.out"
+
+echo "Full-suite no-PHPUnit routing smoke passed"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -295,6 +295,52 @@ homeboy_wordpress_is_configured_phpunit_file() {
     esac
 }
 
+homeboy_wordpress_full_suite_phpunit_root() {
+    local configured_root
+    local resolved_root
+
+    configured_root="$(homeboy_setting wp_codebox_phpunit_test_root '.wp_codebox_phpunit_test_root' '')"
+    if [ -z "$configured_root" ]; then
+        printf '%s\n' "${PLUGIN_PATH}/tests"
+        return 0
+    fi
+
+    resolved_root="$(homeboy_wordpress_resolve_wp_codebox_sandbox_path "$configured_root" || true)"
+    [ -n "$resolved_root" ] || return 1
+    printf '%s\n' "$resolved_root"
+}
+
+homeboy_wordpress_has_phpunit_tests() {
+    local test_root="$1"
+    local test_file
+
+    [ -d "$test_root" ] || return 1
+    if ! test_file="$(find "$test_root" -type f \( -name '*Test.php' -o -name 'test-*.php' \) -print -quit)"; then
+        return 2
+    fi
+    [ -n "$test_file" ]
+}
+
+homeboy_wordpress_handle_no_phpunit_tests() {
+    local policy
+    policy="$(homeboy_setting phpunit_no_tests '.phpunit_no_tests' 'skipped')"
+
+    case "$policy" in
+        skip|skipped)
+            echo "Skipping PHPUnit: no canonical test files were discovered."
+            return 0
+            ;;
+        fail)
+            echo "ERROR: no canonical PHPUnit test files were discovered." >&2
+            return 1
+            ;;
+        *)
+            echo "ERROR: unsupported phpunit_no_tests policy: ${policy}" >&2
+            return 2
+            ;;
+    esac
+}
+
 homeboy_wordpress_run_js_smoke_files() {
     local smoke_files_raw="$1"
     local node_bin="${HOMEBOY_NODE_BIN:-node}"
@@ -564,5 +610,17 @@ fi
 # Full-suite run (no --file, no changed-file scope): run the canonical PHPUnit
 # backend only. Ad hoc PHP smoke scripts are intentionally not release gates;
 # rerun one explicitly with --host-smoke-file or --file when diagnosing it.
+full_suite_phpunit_root="$(homeboy_wordpress_full_suite_phpunit_root || true)"
+if [ -n "$full_suite_phpunit_root" ]; then
+    full_suite_phpunit_status=0
+    homeboy_wordpress_has_phpunit_tests "$full_suite_phpunit_root" || full_suite_phpunit_status=$?
+    if [ "$full_suite_phpunit_status" -eq 1 ]; then
+        homeboy_wordpress_handle_no_phpunit_tests
+        exit $?
+    elif [ "$full_suite_phpunit_status" -ne 0 ]; then
+        echo "ERROR: unable to inspect PHPUnit test root: ${full_suite_phpunit_root}" >&2
+        exit "$full_suite_phpunit_status"
+    fi
+fi
 WORDPRESS_RUNTIME_RUNNER="$(homeboy_wordpress_runtime_runner)" || exit $?
 exec bash "$WORDPRESS_RUNTIME_RUNNER" "${PASSTHROUGH_ARGS[@]}"


### PR DESCRIPTION
## Summary
- inspect the configured or default test root before unscoped PHPUnit runs
- honor `phpunit_no_tests` when no canonical PHPUnit files exist
- keep unresolved explicit test roots and inspection errors fail-closed
- cover skip, fail, explicit-root, and real-PHPUnit routing

Fixes #2348.

## Verification
- `HOMEBOY_RUNTIME_RUNNER_PRELUDE=/Users/chubes/Developer/homeboy/crates/homeboy-extension/src/runtime/runner-prelude.sh bash wordpress/scripts/test/full-suite-no-phpunit-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/full-suite-no-phpunit-smoke.sh`
- `jq empty wordpress/homeboy.json`
- `git diff --check`