### PR TITLE
Align discord notification transport with core notification-transport/v1 contract

### DIFF
--- a/discord/discord.json
+++ b/discord/discord.json
@@ -1,7 +1,7 @@
 {
   "name": "Discord Notifications",
   "id": "discord",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "icon": "message.circle",
   "description": "Outbound Discord run-completion notification delivery for Homeboy",
   "author": "Extra Chill",
@@ -15,14 +15,9 @@
   },
   "notification_transports": [
     {
-      "schema": "homeboy/notification-transport-command/v1",
+      "schema": "homeboy/notification-transport/v1",
       "id": "discord.run-completion",
-      "command": "node {{extension_path}}/scripts/notify.mjs --run-id {run_id} --status {status} --title {title} --body {body} --route={route}",
-      "contract": {
-        "event": "homeboy/run-completion/v1",
-        "outbound_only": true,
-        "owns_orchestration_lifecycle": false
-      }
+      "command": ["node", "{extension_path}/scripts/notify.mjs"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The `discord` extension declared `notification_transports` with schema `homeboy/notification-transport-command/v1` and a template-string command (`node {{extension_path}}/scripts/notify.mjs --run-id {run_id} ...`). Current homeboy core only implements `homeboy/notification-transport/v1`, which takes a **literal argv array** and appends the typed event flags (`--run-id/--status/--title/--body/--route`) itself — so the old manifest was unrecognized/unusable on shipped homeboy.
- Switch to the literal-argv contract: `command: ["node", "{extension_path}/scripts/notify.mjs"]`. Homeboy resolves `{extension_path}` and appends the event flags; `notify.mjs` already parses both `--flag value` and `--flag=value`.
- Bump discord extension to 0.4.0.

## Why
Unblocks the report-back loop — this transport is what lets a homeboy cook/run post its completion to a Discord thread. Pairs with homeboy core PR that resolves `{extension_path}` in the transport argv.

## Test
- `node tests/notify.test.mjs` passes (tests `notify.mjs` behavior directly; unaffected by the manifest format change).
- `discord.json` validated as JSON.