### PR TITLE
Preflight effective WP Codebox runtime settings

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -195,6 +195,7 @@ function providerContract(options = {}) {
     backend: WP_CODEBOX_BACKEND,
     runtime_id: options.runtimeId || options.runtime_id || runtimeManifest().id || 'wp-codebox',
     invocation: runtimeCommandInvocation(options),
+    readiness_invocation: runtimeReadinessInvocation(options),
     ...agentTaskProviderContractFields(),
     secret_env_requirements: options.secretEnvRequirements || runtimeSecretEnvRequirements(),
     capabilities: normalizeArray(options.capabilities || PROVIDER_CAPABILITIES),
@@ -231,6 +232,10 @@ function runtimeExecutorManifest() {
 
 function runtimeCommandInvocation(options = {}) {
   return firstObject(options.invocation, runtimeExecutorManifest().invocation);
+}
+
+function runtimeReadinessInvocation(options = {}) {
+  return firstObject(options.readinessInvocation, options.readiness_invocation, runtimeExecutorManifest().readiness_invocation);
 }
 
 function runtimeProviderCapabilities() {

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -157,15 +157,15 @@ function validateCanonicalRuntimeContractManifest(manifest) {
 
 function coreModuleCandidates(options = {}) {
   const explicit = options.wpCodeboxCoreModule || options.coreModule || process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE;
-  if (explicit) {
-    return [normalizeCoreModuleSpecifier(explicit)];
-  }
-
+  const installDir = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.join(process.env.HOME || '', '.cache', 'homeboy', 'wp-codebox');
   const candidates = [
+    explicit,
+    path.join(installDir, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js'),
+    path.join(installDir, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js'),
     DEFAULT_CODEBOX_CONTRACTS_MODULE,
     'wp-codebox-workspace/contracts',
-  ];
-  return candidates.map(normalizeCoreModuleSpecifier);
+  ].filter(Boolean);
+  return [...new Set(candidates.map(normalizeCoreModuleSpecifier))];
 }
 
 function normalizeCoreModuleSpecifier(specifier) {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -67,11 +67,21 @@ function requireWpCodeboxCoreLoader() {
 
   return {
     async loadWpCodeboxCore(options = {}) {
-      const moduleCandidates = [
+      const explicitCandidates = [
         process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE,
         process.env.WP_CODEBOX_CORE_MODULE,
-        ...(options.packageCandidates || []),
       ].filter(Boolean);
+      const installDir = process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.join(process.env.HOME || '', '.cache', 'homeboy', 'wp-codebox');
+      const managedDistDirs = [
+        ...explicitCandidates.filter(isPathLike).map((candidate) => path.dirname(path.resolve(candidate))),
+        path.join(installDir, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist'),
+        path.join(installDir, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist'),
+      ];
+      const moduleCandidates = [
+        ...managedDistDirs.flatMap((directory) => (options.packageDistEntries || []).map((entry) => path.join(directory, entry))),
+        ...explicitCandidates,
+        ...(options.packageCandidates || []),
+      ].filter(Boolean).filter((candidate, index, all) => all.indexOf(candidate) === index);
       const errors = [];
       for (const candidate of moduleCandidates) {
         try {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-provider-readiness.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-provider-readiness.cjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const {
+  wpCodeboxRuntimeReadinessDiagnostics,
+} = require('../../lib/wp-codebox-runtime-readiness');
+
+const REQUEST_SCHEMA = 'homeboy/agent-task-provider-readiness-request/v1';
+const RESULT_SCHEMA = 'homeboy/agent-task-provider-readiness-result/v1';
+
+function main() {
+  const request = JSON.parse(fs.readFileSync(0, 'utf8'));
+  if (request?.schema !== REQUEST_SCHEMA || !request.effective_config || typeof request.effective_config !== 'object') {
+    throw new Error(`WP Codebox provider readiness requires ${REQUEST_SCHEMA} with effective_config.`);
+  }
+
+  const config = request.effective_config;
+  const diagnostics = wpCodeboxRuntimeReadinessDiagnostics({
+    runtime_overlays: config.runtime_overlays || config.wp_codebox_runtime_overlays || [],
+    runtime_overlay_profiles: config.runtime_overlay_profiles || [],
+  }, {
+    wpCodeboxCoreModule: config.wp_codebox_core_module || config.wpCodeboxCoreModule,
+  });
+  process.stdout.write(JSON.stringify({
+    schema: RESULT_SCHEMA,
+    ready: diagnostics.length === 0,
+    message: diagnostics[0]?.message || 'WP Codebox provider runtime is ready.',
+    diagnostics,
+  }));
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+}

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -227,6 +227,18 @@
         ],
         "display": "node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs"
       },
+      "readiness_invocation": {
+        "schema": "homeboy/command-invocation/v1",
+        "argv": [
+          "node",
+          "{{runtime_path}}/scripts/agent/homeboy-codebox-provider-readiness.cjs"
+        ],
+        "env_allowlist": [
+          "HOMEBOY_WP_CODEBOX_CORE_MODULE",
+          "WP_CODEBOX_CORE_MODULE"
+        ],
+        "display": "node {{runtime_path}}/scripts/agent/homeboy-codebox-provider-readiness.cjs"
+      },
       "cli": {
         "reserved_selector_hints": ["opencode", "codex", "claude-code"],
         "profiles": [

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -195,8 +195,10 @@ assert.deepEqual(loaded.manifest, canonicalManifest);
 
 delete process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
 const contractCandidates = coreModuleCandidates({ wpCodeboxInstallDir: path.join(tempRoot, 'wp-codebox-install') });
-assert.equal(contractCandidates[0], '@automattic/wp-codebox-core/contracts');
-assert.equal(contractCandidates[1], 'wp-codebox-workspace/contracts');
-assert.equal(contractCandidates.length, 2);
+assert.equal(contractCandidates[0], pathToFileURL(path.join(tempRoot, 'wp-codebox-install/source/node_modules/@automattic/wp-codebox-core/dist/contracts.js')).href);
+assert.equal(contractCandidates[1], pathToFileURL(path.join(tempRoot, 'wp-codebox-install/release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/contracts.js')).href);
+assert.equal(contractCandidates[2], '@automattic/wp-codebox-core/contracts');
+assert.equal(contractCandidates[3], 'wp-codebox-workspace/contracts');
+assert.equal(contractCandidates.length, 4);
 
 console.log('wp-codebox runtime contract source smoke passed');

--- a/tests/wp-codebox-runtime-readiness-controller-smoke.mjs
+++ b/tests/wp-codebox-runtime-readiness-controller-smoke.mjs
@@ -10,6 +10,7 @@ const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-read
 const executor = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs');
 const providerReadiness = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-codebox-provider-readiness.cjs');
 const coreModule = path.join(rootDir, 'wordpress', 'tests', 'fixtures', 'wp-codebox-core-agent-task-normalizer.mjs');
+const runtimeContractFixture = path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 
 try {
   const overlayRoot = path.join(tempRoot, 'php-ai-client');
@@ -85,6 +86,26 @@ process.stdout.write(JSON.stringify({ success: true, status: 'completed' }));
   assert.equal(diagnostic.data.setup_command, `composer install --working-dir=${overlayRoot}`);
   assert.equal(diagnostic.data.owner_surface, 'wp-codebox-runtime-integration');
   assert.equal(fs.existsSync(capture), false, 'task runner is not spawned when runtime readiness fails');
+
+  const managedInstall = path.join(tempRoot, 'managed-wp-codebox');
+  const managedCoreDist = path.join(managedInstall, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist');
+  fs.mkdirSync(managedCoreDist, { recursive: true });
+  fs.writeFileSync(path.join(managedCoreDist, 'contracts.js'), `module.exports = require(${JSON.stringify(runtimeContractFixture)});\n`);
+  fs.writeFileSync(path.join(managedCoreDist, 'run-results.js'), 'module.exports = {};\n');
+  const managedResult = spawnSync(process.execPath, [executor, '--task-runner', runner], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: {
+      ...process.env,
+      HOMEBOY_WP_CODEBOX_INSTALL_DIR: managedInstall,
+      HOMEBOY_WP_CODEBOX_CORE_MODULE: '',
+      WP_CODEBOX_CORE_MODULE: '',
+    },
+  });
+  assert.equal(managedResult.status, 1, managedResult.stderr || managedResult.stdout);
+  const managedOutcome = JSON.parse(managedResult.stdout);
+  assert.ok(managedOutcome.diagnostics.some((entry) => entry.class === 'codebox.preflight.runtime_overlay_dependency_unprepared'));
+  assert.equal(fs.existsSync(capture), false, 'managed run-results resolution still stops before task runner spawn');
 
   const injectionRequest = {
     schema: 'homeboy/agent-task-request/v1',

--- a/tests/wp-codebox-runtime-readiness-controller-smoke.mjs
+++ b/tests/wp-codebox-runtime-readiness-controller-smoke.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-readiness-controller-'));
 const executor = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs');
+const providerReadiness = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-codebox-provider-readiness.cjs');
 const coreModule = path.join(rootDir, 'wordpress', 'tests', 'fixtures', 'wp-codebox-core-agent-task-normalizer.mjs');
 
 try {
@@ -45,6 +46,25 @@ process.stdout.write(JSON.stringify({ success: true, status: 'completed' }));
     workspace: { mode: 'ephemeral' },
     limits: { timeout_ms: 120000 },
   };
+
+  const configuredReadiness = spawnSync(process.execPath, [providerReadiness], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      schema: 'homeboy/agent-task-provider-readiness-request/v1',
+      provider_id: 'wordpress.codebox-agent-task-executor',
+      backend: 'wp-codebox',
+      effective_config: request.executor.config,
+    }),
+    env: {
+      ...process.env,
+      HOMEBOY_WP_CODEBOX_CORE_MODULE: coreModule,
+    },
+  });
+  assert.equal(configuredReadiness.status, 0, configuredReadiness.stderr);
+  const readinessResult = JSON.parse(configuredReadiness.stdout);
+  assert.equal(readinessResult.schema, 'homeboy/agent-task-provider-readiness-result/v1');
+  assert.equal(readinessResult.ready, false);
+  assert.match(readinessResult.message, /vendor\/autoload\.php is missing/);
 
   const result = spawnSync(process.execPath, [executor, '--task-runner', runner], {
     encoding: 'utf8',

--- a/tests/wp-codebox-runtime-readiness-smoke.mjs
+++ b/tests/wp-codebox-runtime-readiness-smoke.mjs
@@ -26,7 +26,7 @@ const {
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-readiness-'));
 try {
   const missingContract = path.join(tempRoot, 'missing-contract.cjs');
-  const contractDiagnostics = runtimeContractReadinessDiagnostics({ wpCodeboxCoreModule: missingContract });
+  const contractDiagnostics = runtimeContractReadinessDiagnostics({ wpCodeboxCoreModule: missingContract, wpCodeboxInstallDir: tempRoot });
   assert.equal(contractDiagnostics.length, 1);
   assert.equal(contractDiagnostics[0].class, RUNTIME_CONTRACT_FAILURE_CLASS);
   assert.match(contractDiagnostics[0].message, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);

--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -29,7 +29,8 @@ set -euo pipefail
 printf '%s\n' 'wp-codebox release stub'
 SH
 chmod +x "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox"
-printf '%s\n' 'export const fixture = true;' > "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"
+printf '%s\n' 'module.exports = { fixture: true };' > "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"
+printf '%s\n' 'module.exports = { runtimeContractManifest() { return {}; } };' > "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/contracts.js"
 tar -czf "${ARTIFACT_PATH}" -C "${ARTIFACT_ROOT}" wp-codebox-cli
 
 cat > "${FAKE_BIN}/curl" <<SH
@@ -104,7 +105,8 @@ while [ "$#" -gt 0 ]; do
         run)
             mkdir -p "${prefix}/node_modules/@automattic/wp-codebox-core/dist"
             mkdir -p "${prefix}/packages/cli/dist"
-            printf '%s\n' 'export const fixture = true;' > "${prefix}/node_modules/@automattic/wp-codebox-core/dist/index.js"
+            printf '%s\n' 'module.exports = { fixture: true };' > "${prefix}/node_modules/@automattic/wp-codebox-core/dist/index.js"
+            printf '%s\n' 'module.exports = { runtimeContractManifest() { return {}; } };' > "${prefix}/node_modules/@automattic/wp-codebox-core/dist/contracts.js"
             cat > "${prefix}/packages/cli/dist/index.js" <<'NODE'
 #!/usr/bin/env node
 console.log('wp-codebox source stub');
@@ -214,7 +216,8 @@ cat > "${COLD_BIN}" <<'SH'
 printf '%s\n' 'wp-codebox cached stub'
 SH
 chmod +x "${COLD_BIN}"
-printf '%s\n' 'export const fixture = true;' > "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/index.js"
+printf '%s\n' 'module.exports = { fixture: true };' > "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/index.js"
+printf '%s\n' 'module.exports = { runtimeContractManifest() { return {}; } };' > "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/contracts.js"
 
 # A network would be a hard failure here: the bin already exists, so no curl/git
 # install should run. Point curl/git at stubs that fail loudly if invoked.
@@ -242,7 +245,7 @@ if ! grep -q '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${COLD_GITHUB_ENV_FILE}"; then
 fi
 
 cold_core_module="$(grep '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${COLD_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
-if [ "${cold_core_module}" != "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/index.js" ]; then
+if [ "${cold_core_module}" != "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/contracts.js" ]; then
     echo "Expected cold-cache setup to resolve the on-disk core package module, got: ${cold_core_module}" >&2
     exit 1
 fi
@@ -266,14 +269,14 @@ cat > "${STALE_ROOT}/packages/cli/dist/index.js" <<'NODE'
 console.log('stale wp-codebox');
 NODE
 chmod +x "${STALE_ROOT}/packages/cli/dist/index.js"
-printf '%s\n' 'export const fixture = "stale";' > "${STALE_ROOT}/packages/runtime-core/dist/index.js"
+printf '%s\n' 'module.exports = { runtimeContractManifest() { return { fixture: "stale" }; } };' > "${STALE_ROOT}/packages/runtime-core/dist/index.js"
 
 cat > "${CURRENT_ROOT}/packages/cli/dist/index.js" <<'NODE'
 #!/usr/bin/env node
 console.log('current wp-codebox');
 NODE
 chmod +x "${CURRENT_ROOT}/packages/cli/dist/index.js"
-printf '%s\n' 'export const fixture = "current";' > "${CURRENT_ROOT}/packages/runtime-core/dist/index.js"
+printf '%s\n' 'module.exports = { runtimeContractManifest() { return { fixture: "current" }; } };' > "${CURRENT_ROOT}/packages/runtime-core/dist/index.js"
 
 (
     cd "${EXTENSION_DIR}"

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -28,6 +28,9 @@ install_wp_codebox() {
         if [ ! -f "${module_path}" ]; then
             return 1
         fi
+        if ! node -e 'const value=require(process.argv[1]); const module=value?.default && typeof value.default === "object" ? {...value.default,...value} : value; if (typeof module?.runtimeContractManifest !== "function") process.exit(1);' "${module_path}" >/dev/null 2>&1; then
+            return 1
+        fi
 
         export HOMEBOY_WP_CODEBOX_CORE_MODULE="${module_path}"
         write_github_env "HOMEBOY_WP_CODEBOX_CORE_MODULE" "${module_path}"
@@ -94,7 +97,9 @@ install_wp_codebox() {
         for candidate in \
             "${WP_CODEBOX_CORE_MODULE:-}" \
             "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" \
+            "${probe_root}/source/node_modules/@automattic/wp-codebox-core/dist/contracts.js" \
             "${probe_root}/source/node_modules/@automattic/wp-codebox-core/dist/index.js" \
+            "${probe_root}/release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/contracts.js" \
             "${probe_root}/release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"; do
             if [ -n "${candidate}" ] && configure_core_module "${candidate}"; then
                 return 0
@@ -179,7 +184,7 @@ EOF
             write_github_env "PATH" "${bin_dir}:${PATH}"
 
             echo "WP Codebox installed: ${bin_path}"
-            if configure_core_module "${extract_dir}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"; then
+            if resolve_core_module_from_known_locations; then
                 return 0
             fi
 
@@ -217,7 +222,7 @@ EOF
     npm --prefix "${repo_dir}" install --quiet --no-fund --no-audit --omit=optional
     npm --prefix "${repo_dir}" run build --silent
 
-    configure_core_module "${repo_dir}/node_modules/@automattic/wp-codebox-core/dist/index.js" || {
+    resolve_core_module_from_known_locations || {
         echo "Built WP Codebox source did not contain the @automattic/wp-codebox-core package entrypoint" >&2
         exit 1
     }


### PR DESCRIPTION
## Summary

- Declare a WP Codebox provider-owned readiness invocation.
- Evaluate canonical contract loading and configured runtime overlays against Homeboy effective settings.
- Surface the existing actionable runtime diagnostics before executor startup.

Closes #2352.
Depends on Extra-Chill/homeboy#9696.

## Tests

- `node tests/wp-codebox-runtime-readiness-smoke.mjs`
- `node tests/wp-codebox-runtime-readiness-controller-smoke.mjs`
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `git diff --check`

## AI assistance

- **AI assistance:** Yes
- **Tool:** OpenCode
- **Model:** OpenAI GPT-5.6 Sol
- **Used for:** Reproduced the closed-readiness regression, added the configured readiness entrypoint and declaration, and verified the controller and provider boundaries. Chris reviewed and owns every line.