### PR TITLE
Accept guild-less discord:v1 route to match the kimaki notification bridge

### DIFF
--- a/discord/discord.json
+++ b/discord/discord.json
@@ -1,7 +1,7 @@
 {
   "name": "Discord Notifications",
   "id": "discord",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "icon": "message.circle",
   "description": "Outbound Discord run-completion notification delivery for Homeboy",
   "author": "Extra Chill",

--- a/discord/scripts/notify.mjs
+++ b/discord/scripts/notify.mjs
@@ -146,9 +146,15 @@ function resolveBotDestination(route, operationsChannelId) {
 }
 
 function parseRoute(route) {
-  const match = /^discord:v1:(channel|thread):(\d{17,20}):(\d{17,20})$/.exec(route);
-  if (!match) return { error: 'route must be discord:v1:<channel|thread>:<guild-id>:<destination-id> with Discord snowflake IDs.' };
-  return { kind: match[1], guildId: match[2], id: match[3] };
+  // Canonical guild-less form emitted by the kimaki notification bridge
+  // (wp-coding-agents #261): discord:v1:<channel|thread>:<destination-id>.
+  const canonical = /^discord:v1:(channel|thread):(\d{17,20})$/.exec(route);
+  if (canonical) return { kind: canonical[1], id: canonical[2] };
+  // Legacy 4-segment form with a guild id. The guild is not used for delivery
+  // (only the destination id is), so accept it for backward compatibility.
+  const legacy = /^discord:v1:(channel|thread):(\d{17,20}):(\d{17,20})$/.exec(route);
+  if (legacy) return { kind: legacy[1], id: legacy[3] };
+  return { error: 'route must be discord:v1:<channel|thread>:<destination-id> with Discord snowflake IDs.' };
 }
 
 function renderContent(args) {

--- a/discord/tests/notify.test.mjs
+++ b/discord/tests/notify.test.mjs
@@ -15,6 +15,8 @@ const threadOneId = '323456789012345678';
 const threadTwoId = '423456789012345678';
 
 await testConcurrentThreadRoutesDoNotCrossDeliver();
+await testGuildlessThreadRoute();
+await testGuildlessChannelRoute();
 await testDynamicChannelRoute();
 await testOperationsChannelDelivery();
 await testRouteLessBotFailsClosed();
@@ -45,6 +47,32 @@ async function testConcurrentThreadRoutesDoNotCrossDeliver() {
         [`/api/v10/channels/${threadTwoId}/messages`, 'run-two'],
       ],
     );
+  });
+}
+
+async function testGuildlessThreadRoute() {
+  // Canonical guild-less form emitted by the kimaki notification bridge
+  // (wp-coding-agents #261): discord:v1:thread:<destination-id>.
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify(
+      { DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` },
+      { route: `discord:v1:thread:${threadOneId}` },
+    );
+    assert.equal(result.delivery.route_kind, 'thread');
+    assert.equal(result.delivery.destination, 'dynamic_thread');
+    assert.equal(requests[0].url, `/api/v10/channels/${threadOneId}/messages`);
+  });
+}
+
+async function testGuildlessChannelRoute() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify(
+      { DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` },
+      { route: `discord:v1:channel:${channelId}` },
+    );
+    assert.equal(result.delivery.route_kind, 'channel');
+    assert.equal(result.delivery.destination, 'dynamic_channel');
+    assert.equal(requests[0].url, `/api/v10/channels/${channelId}/messages`);
   });
 }
 


### PR DESCRIPTION
## Summary
The kimaki notification bridge (wp-coding-agents #261) emits generic Homeboy routes in a **guild-less** 3-segment form (`discord:v1:thread:<id>` / `discord:v1:channel:<id>`), but `notify.mjs` `parseRoute` hard-required a 4-segment form with a guild id and **rejected** them — so run-completion delivery to a kimaki thread would fail end-to-end. The guild id was parsed but never used for delivery (only the destination id is), so the guild-less form is the correct canonical shape.

- `parseRoute` now accepts the canonical guild-less form and still accepts the legacy 4-segment form (guild ignored) for backward compatibility.
- Bump discord extension to 0.5.0.

## Test
- `node discord/tests/notify.test.mjs` passes, including new `testGuildlessThreadRoute` / `testGuildlessChannelRoute` cases; legacy 4-segment tests still pass.

## Notes
Unblocks end-to-end run-completion delivery to Discord threads. Pairs with wp-coding-agents #261 (kimaki→generic-route bridge) and the merged core transport plumbing (homeboy #9699, homeboy-extensions #2353).