### PR TITLE
feat(wordpress): configure multisite runtime inputs

### DIFF
--- a/wordpress/rigs/wordpress-multisite-e2e/README.md
+++ b/wordpress/rigs/wordpress-multisite-e2e/README.md
@@ -47,12 +47,18 @@ settings. Consumers do not edit the rig:
 - `wordpress_runtime_blueprint` adds ordinary WordPress blueprint setup while
   the rig ensures `enableMultisite` remains present.
 - `wp_codebox_extra_plugins` mounts consumer plugins/components.
+- `wp_codebox_extra_themes` mounts immutable local theme checkouts readonly.
+  Entries use `{source,slug,activate?,metadata?}`; sources must be absolute paths
+  to directories with a valid `style.css` `Theme Name` header. At most one theme
+  may be active, and supplied metadata remains in WP Codebox recipe evidence.
 - `wordpress_runtime_prepare_steps` adds seed/setup recipe steps.
 - `wordpress_runtime_workloads` runs consumer workloads through
   `wordpress.bench` after network setup.
 - `wp_codebox_scenario_manifests` adds inline or file-backed browser journeys.
 - `wordpress_runtime_post_steps` adds final assertions or evidence steps.
 - `wordpress_runtime_version` pins the disposable WordPress version.
+- `wordpress_runtime_php_version` pins the rig's WP Codebox PHP runtime using a
+  supported `major.minor` value such as `8.4`.
 
 Example:
 
@@ -61,6 +67,15 @@ HOMEBOY_SETTINGS_JSON='{
   "wp_codebox_extra_plugins": [
     {"source":"/absolute/path/to/plugin","slug":"plugin-under-test","activate":true}
   ],
+  "wp_codebox_extra_themes": [
+    {
+      "source":"/absolute/path/to/theme",
+      "slug":"theme-under-test",
+      "activate":true,
+      "metadata":{"provenance":{"revision":"full-immutable-revision"}}
+    }
+  ],
+  "wordpress_runtime_php_version":"8.4",
   "wordpress_runtime_prepare_steps": [
     {"command":"wordpress.wp-cli","args":["command=option update fixture_ready yes --url=http://localhost/alpha/"]}
   ],
@@ -71,6 +86,11 @@ HOMEBOY_SETTINGS_JSON='{
 Use absolute consumer paths when a package is installed from another checkout.
 WP Codebox validates and executes all supplied recipe steps with its normal
 runtime policy and artifact handling.
+
+The active theme becomes `WP_DEFAULT_THEME` for sites created later in the
+workflow, and the rig switches all sites that exist after its network seed. This
+contract is specific to `wordpress-multisite-e2e`: the canonical WP Codebox bench
+builder does not currently expose PHP runtime selection.
 
 ## Boundary
 

--- a/wordpress/rigs/wordpress-multisite-e2e/README.md
+++ b/wordpress/rigs/wordpress-multisite-e2e/README.md
@@ -49,8 +49,10 @@ settings. Consumers do not edit the rig:
 - `wp_codebox_extra_plugins` mounts consumer plugins/components.
 - `wp_codebox_extra_themes` mounts immutable local theme checkouts readonly.
   Entries use `{source,slug,activate?,metadata?}`; sources must be absolute paths
-  to directories with a valid `style.css` `Theme Name` header. At most one theme
-  may be active, and supplied metadata remains in WP Codebox recipe evidence.
+  to directories with a non-empty `style.css` `Theme Name` header in the first
+  8 KB. Standalone themes need a WordPress-supported index template; child themes
+  need their standalone parent in the same mount list. At most one theme may be
+  active, and supplied metadata remains in WP Codebox recipe evidence.
 - `wordpress_runtime_prepare_steps` adds seed/setup recipe steps.
 - `wordpress_runtime_workloads` runs consumer workloads through
   `wordpress.bench` after network setup.

--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -2,17 +2,21 @@
 /**
  * External dependencies
  */
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const packageRoot = path.dirname(fileURLToPath(import.meta.url));
+const supportedPhpVersions = new Set(['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']);
 
 export async function buildRecipe(settings = {}, cwd = process.cwd()) {
   const fixturePlugin = path.join(packageRoot, 'fixtures/network-fixture');
-  const blueprint = mergeMultisiteBlueprint(settings.wordpress_runtime_blueprint);
+  const phpVersion = runtimePhpVersion(settings);
+  const themes = await extraThemes(settings.wp_codebox_extra_themes);
+  const activeTheme = themes.find((theme) => theme.activate);
+  const blueprint = mergeMultisiteBlueprint(settings.wordpress_runtime_blueprint, activeTheme?.slug);
   const prepareSteps = recipeSteps(settings.wordpress_runtime_prepare_steps);
   const postSteps = recipeSteps(settings.wordpress_runtime_post_steps);
   const scenarioSteps = await browserScenarioSteps(settings.wp_codebox_scenario_manifests, cwd);
@@ -32,6 +36,7 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
     runtime: {
       backend: 'wordpress',
       ...(settings.wordpress_runtime_version ? { wp: settings.wordpress_runtime_version } : {}),
+      ...(phpVersion ? { phpVersion } : {}),
       blueprint,
       preview: { siteUrl: 'http://localhost' },
     },
@@ -45,10 +50,22 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
         },
         ...(settings.wp_codebox_extra_plugins || []),
       ],
+      mounts: themes.map((theme) => ({
+        type: 'directory',
+        source: theme.source,
+        target: `/wordpress/wp-content/themes/${theme.slug}`,
+        mode: 'readonly',
+        metadata: {
+          ...theme.metadata,
+          kind: 'wordpress-theme',
+          slug: theme.slug,
+        },
+      })),
     },
     workflow: {
       steps: [
         phpFileStep('network-seed.php'),
+        ...(activeTheme ? [activateThemeStep(activeTheme.slug)] : []),
         ...prepareSteps,
         ...workloadSteps,
         phpFileStep('network-assert.php'),
@@ -90,12 +107,134 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
   };
 }
 
-function mergeMultisiteBlueprint(value) {
+function mergeMultisiteBlueprint(value, activeThemeSlug) {
   const blueprint = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
-  const steps = Array.isArray(blueprint.steps) ? blueprint.steps : [];
+  const steps = Array.isArray(blueprint.steps) ? [...blueprint.steps] : [];
+  if (activeThemeSlug) {
+    const defineIndex = steps.findIndex((step) => step?.step === 'defineWpConfigConsts');
+    if (defineIndex >= 0) {
+      const existing = steps[defineIndex]?.consts?.WP_DEFAULT_THEME;
+      if (existing !== undefined && existing !== activeThemeSlug) {
+        throw new Error('wordpress_runtime_blueprint WP_DEFAULT_THEME must match the active wp_codebox_extra_themes slug.');
+      }
+      steps[defineIndex] = {
+        ...steps[defineIndex],
+        consts: { ...(steps[defineIndex].consts || {}), WP_DEFAULT_THEME: activeThemeSlug },
+      };
+    } else {
+      steps.push({ step: 'defineWpConfigConsts', consts: { WP_DEFAULT_THEME: activeThemeSlug } });
+    }
+  }
   return {
     ...blueprint,
     steps: steps.some((step) => step?.step === 'enableMultisite') ? steps : [{ step: 'enableMultisite' }, ...steps],
+  };
+}
+
+function runtimePhpVersion(settings) {
+  if (!Object.hasOwn(settings, 'wordpress_runtime_php_version')) {
+    return undefined;
+  }
+  const value = settings.wordpress_runtime_php_version;
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error('wordpress_runtime_php_version must be a non-empty PHP major.minor version.');
+  }
+  const version = value.trim();
+  if (!supportedPhpVersions.has(version)) {
+    throw new Error(`Unsupported wordpress_runtime_php_version: ${version}.`);
+  }
+  return version;
+}
+
+async function extraThemes(value) {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error('wp_codebox_extra_themes must be an array.');
+  }
+
+  const themes = [];
+  const slugs = new Set();
+  for (const [index, entry] of value.entries()) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`wp_codebox_extra_themes[${index}] must be an object.`);
+    }
+    if (typeof entry.source !== 'string' || !path.isAbsolute(entry.source)) {
+      throw new Error(`wp_codebox_extra_themes[${index}].source must be an absolute path.`);
+    }
+    const source = path.resolve(entry.source);
+    let sourceStat;
+    try {
+      sourceStat = await stat(source);
+    } catch {
+      throw new Error(`wp_codebox_extra_themes[${index}].source does not exist: ${source}.`);
+    }
+    if (!sourceStat.isDirectory()) {
+      throw new Error(`wp_codebox_extra_themes[${index}].source must be a directory: ${source}.`);
+    }
+    if (typeof entry.slug !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(entry.slug)) {
+      throw new Error(`wp_codebox_extra_themes[${index}].slug must be a valid WordPress theme directory slug.`);
+    }
+    if (slugs.has(entry.slug)) {
+      throw new Error(`wp_codebox_extra_themes contains duplicate slug: ${entry.slug}.`);
+    }
+    slugs.add(entry.slug);
+    if (entry.activate !== undefined && typeof entry.activate !== 'boolean') {
+      throw new Error(`wp_codebox_extra_themes[${index}].activate must be a boolean.`);
+    }
+    if (entry.metadata !== undefined && (!entry.metadata || typeof entry.metadata !== 'object' || Array.isArray(entry.metadata))) {
+      throw new Error(`wp_codebox_extra_themes[${index}].metadata must be an object.`);
+    }
+
+    let style;
+    try {
+      style = await readFile(path.join(source, 'style.css'), 'utf8');
+    } catch {
+      throw new Error(`wp_codebox_extra_themes[${index}] must contain style.css.`);
+    }
+    if (!/^[ \t*]*Theme Name\s*:/mi.test(style)) {
+      throw new Error(`wp_codebox_extra_themes[${index}].style.css must contain a Theme Name header.`);
+    }
+
+    themes.push({
+      source,
+      slug: entry.slug,
+      activate: entry.activate === true,
+      metadata: entry.metadata || {},
+    });
+  }
+
+  if (themes.filter((theme) => theme.activate).length > 1) {
+    throw new Error('wp_codebox_extra_themes permits at most one active theme.');
+  }
+  return themes;
+}
+
+function activateThemeStep(slug) {
+  const code = `$theme_slug = '${slug}';
+if ( ! is_multisite() ) {
+\tthrow new RuntimeException( 'Expected a multisite runtime.' );
+}
+foreach ( get_sites( array( 'number' => 0, 'fields' => 'ids' ) ) as $site_id ) {
+\tswitch_to_blog( (int) $site_id );
+\ttry {
+\t\t$theme = wp_get_theme( $theme_slug );
+\t\tif ( ! $theme->exists() ) {
+\t\t\tthrow new RuntimeException( 'Mounted theme is unavailable: ' . $theme_slug );
+\t\t}
+\t\tswitch_theme( $theme_slug );
+\t\tif ( get_stylesheet() !== $theme_slug ) {
+\t\t\tthrow new RuntimeException( 'Unable to activate mounted theme: ' . $theme_slug );
+\t\t}
+\t} finally {
+\t\trestore_current_blog();
+\t}
+}`;
+  return {
+    command: 'wordpress.run-php',
+    args: [`code=${code}`],
+    metadata: { kind: 'wordpress-theme-activation', slug },
   };
 }
 

--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -111,12 +111,17 @@ function mergeMultisiteBlueprint(value, activeThemeSlug) {
   const blueprint = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
   const steps = Array.isArray(blueprint.steps) ? [...blueprint.steps] : [];
   if (activeThemeSlug) {
-    const defineIndex = steps.findIndex((step) => step?.step === 'defineWpConfigConsts');
-    if (defineIndex >= 0) {
-      const existing = steps[defineIndex]?.consts?.WP_DEFAULT_THEME;
+    const defineIndexes = steps
+      .map((step, index) => step?.step === 'defineWpConfigConsts' ? index : -1)
+      .filter((index) => index >= 0);
+    for (const index of defineIndexes) {
+      const existing = steps[index]?.consts?.WP_DEFAULT_THEME;
       if (existing !== undefined && existing !== activeThemeSlug) {
         throw new Error('wordpress_runtime_blueprint WP_DEFAULT_THEME must match the active wp_codebox_extra_themes slug.');
       }
+    }
+    const defineIndex = defineIndexes[0] ?? -1;
+    if (defineIndex >= 0) {
       steps[defineIndex] = {
         ...steps[defineIndex],
         consts: { ...(steps[defineIndex].consts || {}), WP_DEFAULT_THEME: activeThemeSlug },
@@ -193,13 +198,15 @@ async function extraThemes(value) {
     } catch {
       throw new Error(`wp_codebox_extra_themes[${index}] must contain style.css.`);
     }
-    if (!/^[ \t*]*Theme Name\s*:/mi.test(style)) {
-      throw new Error(`wp_codebox_extra_themes[${index}].style.css must contain a Theme Name header.`);
+    const name = themeHeader(style, 'Theme Name');
+    if (!name) {
+      throw new Error(`wp_codebox_extra_themes[${index}].style.css must contain a non-empty Theme Name header in its first 8 KB.`);
     }
 
     themes.push({
       source,
       slug: entry.slug,
+      template: themeHeader(style, 'Template'),
       activate: entry.activate === true,
       metadata: entry.metadata || {},
     });
@@ -208,7 +215,49 @@ async function extraThemes(value) {
   if (themes.filter((theme) => theme.activate).length > 1) {
     throw new Error('wp_codebox_extra_themes permits at most one active theme.');
   }
+  const themesBySlug = new Map(themes.map((theme) => [theme.slug, theme]));
+  for (const [index, theme] of themes.entries()) {
+    if (!theme.template) {
+      if (!await hasThemeEntrypoint(theme.source)) {
+        throw new Error(`wp_codebox_extra_themes[${index}] standalone theme must contain index.php, templates/index.html, or block-templates/index.html.`);
+      }
+      continue;
+    }
+    if (theme.template === theme.slug) {
+      throw new Error(`wp_codebox_extra_themes[${index}] child theme cannot name itself as its Template.`);
+    }
+    const parent = themesBySlug.get(theme.template);
+    if (!parent) {
+      throw new Error(`wp_codebox_extra_themes[${index}] child theme requires mounted parent theme: ${theme.template}.`);
+    }
+    if (parent.template) {
+      throw new Error(`wp_codebox_extra_themes[${index}] child theme parent must be a standalone theme: ${theme.template}.`);
+    }
+    if (!await hasThemeEntrypoint(parent.source)) {
+      throw new Error(`wp_codebox_extra_themes[${index}] child theme parent is missing a usable entrypoint: ${theme.template}.`);
+    }
+  }
   return themes;
+}
+
+function themeHeader(style, header) {
+  const contents = style.slice(0, 8 * 1024).replaceAll('\r', '\n');
+  const pattern = new RegExp(`^(?:[ \\t]*<\\?php)?[ \\t\\/*#@]*${header}:(.*)$`, 'im');
+  const match = contents.match(pattern);
+  return match?.[1]?.replace(/\s*(?:\*\/|\?>).*/, '').trim() || '';
+}
+
+async function hasThemeEntrypoint(source) {
+  for (const entrypoint of ['index.php', 'templates/index.html', 'block-templates/index.html']) {
+    try {
+      if ((await stat(path.join(source, entrypoint))).isFile()) {
+        return true;
+      }
+    } catch {
+      // Try the next WordPress-supported entrypoint.
+    }
+  }
+  return false;
 }
 
 function activateThemeStep(slug) {

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { strict as assert } from 'node:assert';
-import { readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 /**
@@ -11,31 +12,106 @@ import { fileURLToPath } from 'node:url';
 import { buildRecipe } from '../run.mjs';
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-const recipe = await buildRecipe({
-  wordpress_runtime_blueprint: { steps: [{ step: 'setSiteOptions', options: { blogname: 'Fixture Network' } }] },
-  wp_codebox_extra_plugins: [{ source: '/tmp/consumer-plugin', slug: 'consumer-plugin', activate: false }],
-  wordpress_runtime_prepare_steps: [{ command: 'wordpress.wp-cli', args: ['command=site list'] }],
-  wordpress_runtime_workloads: [{ id: 'consumer-workload', run: [] }],
-  wp_codebox_scenario_manifests: [{ id: 'consumer-browser-journey', url: '/beta/' }],
-  wordpress_runtime_post_steps: [{ command: 'wordpress.wp-cli', args: ['command=option get home'] }],
-}, root);
+const temporary = await mkdtemp(path.join(os.tmpdir(), 'wordpress-multisite-e2e-contract-'));
+const theme = path.join(temporary, 'consumer-theme');
+const secondTheme = path.join(temporary, 'second-theme');
+const noHeaderTheme = path.join(temporary, 'no-header-theme');
+const noStyleTheme = path.join(temporary, 'no-style-theme');
+const notDirectory = path.join(temporary, 'not-directory');
 
-assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
-assert.equal(recipe.runtime.preview.siteUrl, 'http://localhost');
-assert.equal(recipe.runtime.blueprint.steps[0].step, 'enableMultisite');
-assert.equal(recipe.inputs.extra_plugins[0].pluginFile, 'synthetic-network-fixture/network-fixture.php');
-assert.equal(recipe.inputs.extra_plugins[0].activate, false);
-assert.equal(recipe.inputs.extra_plugins[1].slug, 'consumer-plugin');
-assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.bench'));
-assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'));
-assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-probe'));
-assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-actions'));
-assert.ok(recipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('network-seed.php'))));
-assert.ok(recipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('network-assert.php'))));
+try {
+  await Promise.all([mkdir(theme), mkdir(secondTheme), mkdir(noHeaderTheme), mkdir(noStyleTheme)]);
+  await Promise.all([
+    writeFile(path.join(theme, 'style.css'), '/*\nTheme Name: Consumer Theme\n*/\n'),
+    writeFile(path.join(secondTheme, 'style.css'), '/*\n * Theme Name: Second Theme\n */\n'),
+    writeFile(path.join(noHeaderTheme, 'style.css'), '/* No theme header. */\n'),
+    writeFile(notDirectory, 'not a theme directory\n'),
+  ]);
 
-const rig = JSON.parse(await readFile(path.join(root, 'rig.json'), 'utf8'));
-assert.equal(rig.id, 'wordpress-multisite-e2e');
-assert.ok(rig.pipeline.up.some((step) => step.command?.includes('run.mjs')));
-assert.ok(rig.pipeline.check.some((step) => step.command?.includes('--dry-run')));
+  const prepareStep = { command: 'wordpress.wp-cli', args: ['command=site list'] };
+  const recipe = await buildRecipe({
+    wordpress_runtime_version: 'nightly',
+    wordpress_runtime_php_version: '8.4',
+    wordpress_runtime_blueprint: { steps: [{ step: 'setSiteOptions', options: { blogname: 'Fixture Network' } }] },
+    wp_codebox_extra_plugins: [{ source: '/tmp/consumer-plugin', slug: 'consumer-plugin', activate: false }],
+    wp_codebox_extra_themes: [{
+      source: theme,
+      slug: 'consumer-theme',
+      activate: true,
+      metadata: { provenance: { revision: '0123456789abcdef' } },
+    }],
+    wordpress_runtime_prepare_steps: [prepareStep],
+    wordpress_runtime_workloads: [{ id: 'consumer-workload', run: [] }],
+    wp_codebox_scenario_manifests: [{ id: 'consumer-browser-journey', url: '/beta/' }],
+    wordpress_runtime_post_steps: [{ command: 'wordpress.wp-cli', args: ['command=option get home'] }],
+  }, root);
+
+  assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
+  assert.equal(recipe.runtime.wp, 'nightly');
+  assert.equal(recipe.runtime.phpVersion, '8.4');
+  assert.equal(recipe.runtime.preview.siteUrl, 'http://localhost');
+  assert.equal(recipe.runtime.blueprint.steps[0].step, 'enableMultisite');
+  const defaultThemeStep = recipe.runtime.blueprint.steps.find((step) => step.step === 'defineWpConfigConsts');
+  assert.equal(defaultThemeStep.consts.WP_DEFAULT_THEME, 'consumer-theme');
+  assert.equal(recipe.inputs.extra_plugins[0].pluginFile, 'synthetic-network-fixture/network-fixture.php');
+  assert.equal(recipe.inputs.extra_plugins[0].activate, false);
+  assert.equal(recipe.inputs.extra_plugins[1].slug, 'consumer-plugin');
+  assert.deepEqual(recipe.inputs.mounts, [{
+    type: 'directory',
+    source: theme,
+    target: '/wordpress/wp-content/themes/consumer-theme',
+    mode: 'readonly',
+    metadata: {
+      provenance: { revision: '0123456789abcdef' },
+      kind: 'wordpress-theme',
+      slug: 'consumer-theme',
+    },
+  }]);
+  assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.bench'));
+  assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'));
+  assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-probe'));
+  assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-actions'));
+  const seedIndex = recipe.workflow.steps.findIndex((step) => step.args?.some((arg) => arg.includes('network-seed.php')));
+  const activationIndex = recipe.workflow.steps.findIndex((step) => step.metadata?.kind === 'wordpress-theme-activation');
+  const prepareIndex = recipe.workflow.steps.indexOf(prepareStep);
+  assert.ok(seedIndex >= 0 && seedIndex < activationIndex && activationIndex < prepareIndex);
+  assert.ok(recipe.workflow.steps[activationIndex].args[0].includes("switch_theme( $theme_slug )"));
+  assert.ok(recipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('network-assert.php'))));
+
+  const withoutRuntimeInputs = await buildRecipe({}, root);
+  assert.equal(Object.hasOwn(withoutRuntimeInputs.runtime, 'phpVersion'), false);
+  assert.deepEqual(withoutRuntimeInputs.inputs.mounts, []);
+  assert.equal(withoutRuntimeInputs.workflow.steps.some((step) => step.metadata?.kind === 'wordpress-theme-activation'), false);
+
+  await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '' }, root), /must be a non-empty/);
+  await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '8.4.1' }, root), /Unsupported/);
+  await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '8.6' }, root), /Unsupported/);
+  await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '5.2' }, root), /Unsupported/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: {} }, root), /must be an array/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [null] }, root), /must be an object/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: 'relative/theme', slug: 'theme' }] }, root), /absolute path/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: path.join(temporary, 'missing'), slug: 'theme' }] }, root), /does not exist/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: notDirectory, slug: 'theme' }] }, root), /must be a directory/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: noStyleTheme, slug: 'theme' }] }, root), /must contain style\.css/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: noHeaderTheme, slug: 'theme' }] }, root), /Theme Name header/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: theme, slug: '../theme' }] }, root), /valid WordPress theme directory slug/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: theme, slug: 'theme', metadata: [] }] }, root), /metadata must be an object/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: theme, slug: 'theme', activate: 'yes' }] }, root), /activate must be a boolean/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [
+    { source: theme, slug: 'duplicate' },
+    { source: secondTheme, slug: 'duplicate' },
+  ] }, root), /duplicate slug/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [
+    { source: theme, slug: 'consumer-theme', activate: true },
+    { source: secondTheme, slug: 'second-theme', activate: true },
+  ] }, root), /at most one active theme/);
+
+  const rig = JSON.parse(await readFile(path.join(root, 'rig.json'), 'utf8'));
+  assert.equal(rig.id, 'wordpress-multisite-e2e');
+  assert.ok(rig.pipeline.up.some((step) => step.command?.includes('run.mjs')));
+  assert.ok(rig.pipeline.check.some((step) => step.command?.includes('--dry-run')));
+} finally {
+  await rm(temporary, { recursive: true, force: true });
+}
 
 console.log('WordPress multisite E2E rig contracts passed.');

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -17,14 +17,36 @@ const theme = path.join(temporary, 'consumer-theme');
 const secondTheme = path.join(temporary, 'second-theme');
 const noHeaderTheme = path.join(temporary, 'no-header-theme');
 const noStyleTheme = path.join(temporary, 'no-style-theme');
+const emptyHeaderTheme = path.join(temporary, 'empty-header-theme');
+const lateHeaderTheme = path.join(temporary, 'late-header-theme');
+const noEntrypointTheme = path.join(temporary, 'no-entrypoint-theme');
+const childTheme = path.join(temporary, 'child-theme');
 const notDirectory = path.join(temporary, 'not-directory');
 
 try {
-  await Promise.all([mkdir(theme), mkdir(secondTheme), mkdir(noHeaderTheme), mkdir(noStyleTheme)]);
+  await Promise.all([
+    mkdir(theme),
+    mkdir(path.join(secondTheme, 'templates'), { recursive: true }),
+    mkdir(noHeaderTheme),
+    mkdir(noStyleTheme),
+    mkdir(emptyHeaderTheme),
+    mkdir(lateHeaderTheme),
+    mkdir(noEntrypointTheme),
+    mkdir(childTheme),
+  ]);
   await Promise.all([
     writeFile(path.join(theme, 'style.css'), '/*\nTheme Name: Consumer Theme\n*/\n'),
+    writeFile(path.join(theme, 'index.php'), '<?php\n'),
     writeFile(path.join(secondTheme, 'style.css'), '/*\n * Theme Name: Second Theme\n */\n'),
+    writeFile(path.join(secondTheme, 'templates/index.html'), '<!-- wp:paragraph --><p>Second theme</p><!-- /wp:paragraph -->\n'),
     writeFile(path.join(noHeaderTheme, 'style.css'), '/* No theme header. */\n'),
+    writeFile(path.join(noHeaderTheme, 'index.php'), '<?php\n'),
+    writeFile(path.join(emptyHeaderTheme, 'style.css'), '/*\nTheme Name:   \n*/\n'),
+    writeFile(path.join(emptyHeaderTheme, 'index.php'), '<?php\n'),
+    writeFile(path.join(lateHeaderTheme, 'style.css'), `${'x'.repeat(8192)}\nTheme Name: Too Late\n`),
+    writeFile(path.join(lateHeaderTheme, 'index.php'), '<?php\n'),
+    writeFile(path.join(noEntrypointTheme, 'style.css'), '/*\nTheme Name: No Entrypoint\n*/\n'),
+    writeFile(path.join(childTheme, 'style.css'), '/*\nTheme Name: Child Theme\nTemplate: consumer-theme\n*/\n'),
     writeFile(notDirectory, 'not a theme directory\n'),
   ]);
 
@@ -78,6 +100,23 @@ try {
   assert.ok(recipe.workflow.steps[activationIndex].args[0].includes("switch_theme( $theme_slug )"));
   assert.ok(recipe.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('network-assert.php'))));
 
+  const childRecipe = await buildRecipe({ wp_codebox_extra_themes: [
+    { source: theme, slug: 'consumer-theme' },
+    { source: childTheme, slug: 'child-theme', activate: true },
+  ] }, root);
+  assert.equal(childRecipe.inputs.mounts.length, 2);
+  assert.equal(childRecipe.runtime.blueprint.steps.find((step) => step.step === 'defineWpConfigConsts').consts.WP_DEFAULT_THEME, 'child-theme');
+
+  const repeatedDefinitions = await buildRecipe({
+    wordpress_runtime_blueprint: { steps: [
+      { step: 'defineWpConfigConsts', consts: { WP_DEBUG: true } },
+      { step: 'defineWpConfigConsts', consts: { WP_DEFAULT_THEME: 'consumer-theme' } },
+    ] },
+    wp_codebox_extra_themes: [{ source: theme, slug: 'consumer-theme', activate: true }],
+  }, root);
+  assert.equal(repeatedDefinitions.runtime.blueprint.steps[1].consts.WP_DEFAULT_THEME, 'consumer-theme');
+  assert.equal(repeatedDefinitions.runtime.blueprint.steps[2].consts.WP_DEFAULT_THEME, 'consumer-theme');
+
   const withoutRuntimeInputs = await buildRecipe({}, root);
   assert.equal(Object.hasOwn(withoutRuntimeInputs.runtime, 'phpVersion'), false);
   assert.deepEqual(withoutRuntimeInputs.inputs.mounts, []);
@@ -93,7 +132,10 @@ try {
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: path.join(temporary, 'missing'), slug: 'theme' }] }, root), /does not exist/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: notDirectory, slug: 'theme' }] }, root), /must be a directory/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: noStyleTheme, slug: 'theme' }] }, root), /must contain style\.css/);
-  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: noHeaderTheme, slug: 'theme' }] }, root), /Theme Name header/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: noHeaderTheme, slug: 'theme' }] }, root), /non-empty Theme Name header/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: emptyHeaderTheme, slug: 'theme' }] }, root), /non-empty Theme Name header/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: lateHeaderTheme, slug: 'theme' }] }, root), /first 8 KB/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: noEntrypointTheme, slug: 'theme' }] }, root), /standalone theme must contain/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: theme, slug: '../theme' }] }, root), /valid WordPress theme directory slug/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: theme, slug: 'theme', metadata: [] }] }, root), /metadata must be an object/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: theme, slug: 'theme', activate: 'yes' }] }, root), /activate must be a boolean/);
@@ -105,6 +147,15 @@ try {
     { source: theme, slug: 'consumer-theme', activate: true },
     { source: secondTheme, slug: 'second-theme', activate: true },
   ] }, root), /at most one active theme/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [
+    { source: childTheme, slug: 'child-theme' },
+  ] }, root), /requires mounted parent theme/);
+  await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [
+    { source: theme, slug: 'consumer-theme', activate: true },
+  ], wordpress_runtime_blueprint: { steps: [
+    { step: 'defineWpConfigConsts', consts: { WP_DEFAULT_THEME: 'consumer-theme' } },
+    { step: 'defineWpConfigConsts', consts: { WP_DEFAULT_THEME: 'conflicting-theme' } },
+  ] } }, root), /WP_DEFAULT_THEME must match/);
 
   const rig = JSON.parse(await readFile(path.join(root, 'rig.json'), 'utf8'));
   assert.equal(rig.id, 'wordpress-multisite-e2e');

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -15,7 +15,7 @@ assert.ok(
 	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
 );
 
-for (const settingId of ['package_artifacts', 'package_excludes']) {
+for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wordpress_runtime_php_version']) {
 	assert.ok(settingIds.has(settingId), `wordpress manifest declares ${settingId}`);
 }
 

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1217,6 +1217,13 @@
       "description": "Additional WP Codebox extra plugin entries for bench recipes. Use for runtime prerequisites that must be installed or activated but should not be treated as Homeboy validation dependencies."
     },
     {
+      "id": "wp_codebox_extra_themes",
+      "label": "WP Codebox extra themes",
+      "type": "array",
+      "default": [],
+      "description": "Immutable local theme checkouts for the wordpress-multisite-e2e rig. Each entry is {source,slug,activate?,metadata?}; the rig validates the theme and maps it to a readonly WP Codebox mount. At most one theme may be active."
+    },
+    {
       "id": "wordpress_runtime_workloads",
       "label": "WordPress runtime workloads",
       "type": "array",
@@ -1348,6 +1355,13 @@
       "type": "string",
       "default": "",
       "description": "Optional WordPress core version passed to WordPress test and bench runtime providers. Leave empty for the runner default. Use this when a component needs classes or behavior from a newer WordPress core build."
+    },
+    {
+      "id": "wordpress_runtime_php_version",
+      "label": "WordPress multisite runtime PHP version",
+      "type": "string",
+      "default": "",
+      "description": "Optional PHP major.minor version projected to WP Codebox runtime.phpVersion by the wordpress-multisite-e2e rig. This setting is rig-scoped; the canonical WP Codebox bench builder does not currently expose PHP selection."
     },
     {
       "id": "wp_codebox_php_memory_limit",


### PR DESCRIPTION
## Summary
- add vendor-agnostic `wp_codebox_extra_themes` entries that validate absolute local theme roots, WordPress theme slugs and `style.css` entrypoints, then preserve caller provenance metadata on readonly WP Codebox mounts
- activate the selected theme across the path-based multisite after network creation and before consumer preparation/workloads, while setting `WP_DEFAULT_THEME` for sites created later
- add validated `wordpress_runtime_php_version` selection and project the exact value into `runtime.phpVersion` alongside the requested WordPress runtime for validation, dry-run, execution, and WP Codebox effective-recipe evidence
- reject malformed, missing, duplicate, conflicting, and unsupported runtime inputs through focused generic contracts

## Contracts
Theme mounts use the existing WP Codebox `inputs.mounts` schema rather than adding a substrate-specific theme field. Each mount is readonly at `/wordpress/wp-content/themes/<slug>` and carries generic theme identity plus caller-supplied immutable revision/provenance metadata into effective recipe and failed-run evidence.

PHP selection uses WP Codebox's existing `runtime.phpVersion` field. The same generated recipe is validated and passed to dry-run or real `recipe-run`, preserving the requested WordPress/PHP pair without consumer-owned blueprints or plugin workarounds.

## Tests And Evidence
- `node rigs/wordpress-multisite-e2e/tests/contract.test.mjs` (pass)
- `node tests/wordpress-manifest-settings-smoke.js` (pass)
- `node --check rigs/wordpress-multisite-e2e/run.mjs` (pass)
- `node --check rigs/wordpress-multisite-e2e/tests/contract.test.mjs` (pass)
- `JSON.parse(wordpress.json)` (pass)
- installed `wp-codebox` recipe validation plus `recipe-run --dry-run` through `run.mjs --dry-run` (pass; zero validation or policy issues)
- focused ESLint could not start because this checkout does not have the declared `@wordpress/eslint-plugin` installed; no dependency state was changed
- a full real Playground/browser multisite probe was not rerun in this final shipping pass; evidence is limited truthfully to the focused contracts and installed WP Codebox validation/dry-run above

Closes #2345
Closes #2347