### PR TITLE
feat(wordpress): unblock consumer multisite E2E composition

### DIFF
--- a/wordpress/rigs/wordpress-multisite-e2e/README.md
+++ b/wordpress/rigs/wordpress-multisite-e2e/README.md
@@ -56,6 +56,9 @@ settings. Consumers do not edit the rig:
 - `wp_codebox_dependency_overlays` forwards existing WP Codebox Composer package
   overlays for replacing a consumer plugin's bundled dependency from an
   immutable checkout.
+- `wordpress_multisite_synthetic_fixture` defaults to `true` for the rig's
+  alpha/beta self-test. Set it to `false` when consumer prepare, scenario, and
+  post steps own the complete network topology and journey.
 - `wordpress_runtime_prepare_steps` adds seed/setup recipe steps.
 - `wordpress_runtime_workloads` runs consumer workloads through
   `wordpress.bench` after network setup.

--- a/wordpress/rigs/wordpress-multisite-e2e/README.md
+++ b/wordpress/rigs/wordpress-multisite-e2e/README.md
@@ -53,6 +53,9 @@ settings. Consumers do not edit the rig:
   8 KB. Standalone themes need a WordPress-supported index template; child themes
   need their standalone parent in the same mount list. At most one theme may be
   active, and supplied metadata remains in WP Codebox recipe evidence.
+- `wp_codebox_dependency_overlays` forwards existing WP Codebox Composer package
+  overlays for replacing a consumer plugin's bundled dependency from an
+  immutable checkout.
 - `wordpress_runtime_prepare_steps` adds seed/setup recipe steps.
 - `wordpress_runtime_workloads` runs consumer workloads through
   `wordpress.bench` after network setup.

--- a/wordpress/rigs/wordpress-multisite-e2e/README.md
+++ b/wordpress/rigs/wordpress-multisite-e2e/README.md
@@ -62,6 +62,9 @@ settings. Consumers do not edit the rig:
 - `wordpress_runtime_prepare_steps` adds seed/setup recipe steps.
 - `wordpress_runtime_workloads` runs consumer workloads through
   `wordpress.bench` after network setup.
+- `wordpress_runtime_workload_plugin_slug` selects the mounted plugin that owns
+  configured workloads. It defaults to the synthetic fixture only while that
+  fixture is enabled and is required for consumer-owned topology workloads.
 - `wp_codebox_scenario_manifests` adds inline or file-backed browser journeys.
 - `wordpress_runtime_post_steps` adds final assertions or evidence steps.
 - `wordpress_runtime_version` pins the disposable WordPress version.

--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -13,6 +13,7 @@ const supportedPhpVersions = new Set(['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', 
 
 export async function buildRecipe(settings = {}, cwd = process.cwd()) {
   const fixturePlugin = path.join(packageRoot, 'fixtures/network-fixture');
+  const syntheticFixture = settings.wordpress_multisite_synthetic_fixture !== false;
   const phpVersion = runtimePhpVersion(settings);
   const themes = await extraThemes(settings.wp_codebox_extra_themes);
   const activeTheme = themes.find((theme) => theme.activate);
@@ -43,12 +44,12 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
     },
     inputs: {
       extra_plugins: [
-        {
+        ...(syntheticFixture ? [{
           source: fixturePlugin,
           slug: 'synthetic-network-fixture',
           pluginFile: 'synthetic-network-fixture/network-fixture.php',
           activate: false,
-        },
+        }] : []),
         ...(settings.wp_codebox_extra_plugins || []),
       ],
       mounts: themes.map((theme) => ({
@@ -66,39 +67,41 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
     },
     workflow: {
       steps: [
-        phpFileStep('network-seed.php'),
+        ...(syntheticFixture ? [phpFileStep('network-seed.php')] : []),
         ...(activeTheme ? [activateThemeStep(activeTheme.slug)] : []),
         ...prepareSteps,
         ...workloadSteps,
-        phpFileStep('network-assert.php'),
-        {
-          command: 'wordpress.browser-probe',
-          args: [
-            'url=http://localhost/alpha/fixture-check/',
-            'route-host=localhost',
-            'assert=exists:#synthetic-site-alpha',
-            'assert=exists:#synthetic-auth-anonymous',
-            'assert=no-console-errors',
-            'assert=no-page-errors',
-            'capture=console,errors,html,network,screenshot',
-          ],
-        },
-        {
-          command: 'wordpress.browser-actions',
-          args: [
-            'auth=wordpress-admin',
-            'auth-user-id=1',
-            `steps-json=${JSON.stringify([
-              { kind: 'navigate', url: '/alpha/fixture-check/', waitFor: 'load' },
-              { kind: 'expect', selector: '#synthetic-site-alpha', state: 'visible' },
-              { kind: 'expect', selector: '#synthetic-auth-authenticated', state: 'visible' },
-              { kind: 'navigate', url: '/beta/fixture-check/', waitFor: 'load' },
-              { kind: 'expect', selector: '#synthetic-site-beta', state: 'visible' },
-              { kind: 'expect', selector: '#synthetic-auth-authenticated', state: 'visible' },
-            ])}`,
-            'capture=steps,console,errors,html,network,screenshot,dom-snapshot',
-          ],
-        },
+        ...(syntheticFixture ? [
+          phpFileStep('network-assert.php'),
+          {
+            command: 'wordpress.browser-probe',
+            args: [
+              'url=http://localhost/alpha/fixture-check/',
+              'route-host=localhost',
+              'assert=exists:#synthetic-site-alpha',
+              'assert=exists:#synthetic-auth-anonymous',
+              'assert=no-console-errors',
+              'assert=no-page-errors',
+              'capture=console,errors,html,network,screenshot',
+            ],
+          },
+          {
+            command: 'wordpress.browser-actions',
+            args: [
+              'auth=wordpress-admin',
+              'auth-user-id=1',
+              `steps-json=${JSON.stringify([
+                { kind: 'navigate', url: '/alpha/fixture-check/', waitFor: 'load' },
+                { kind: 'expect', selector: '#synthetic-site-alpha', state: 'visible' },
+                { kind: 'expect', selector: '#synthetic-auth-authenticated', state: 'visible' },
+                { kind: 'navigate', url: '/beta/fixture-check/', waitFor: 'load' },
+                { kind: 'expect', selector: '#synthetic-site-beta', state: 'visible' },
+                { kind: 'expect', selector: '#synthetic-auth-authenticated', state: 'visible' },
+              ])}`,
+              'capture=steps,console,errors,html,network,screenshot,dom-snapshot',
+            ],
+          },
+        ] : []),
         ...scenarioSteps,
         ...postSteps,
       ],

--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -8,7 +8,7 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-const WP_CODEBOX_MAX_BUFFER_BYTES = 20 * 1024 * 1024;
+const WP_CODEBOX_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
 
 const packageRoot = path.dirname(fileURLToPath(import.meta.url));
 const supportedPhpVersions = new Set(['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']);
@@ -20,18 +20,29 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
   const themes = await extraThemes(settings.wp_codebox_extra_themes);
   const activeTheme = themes.find((theme) => theme.activate);
   const dependencyOverlays = recipeArray(settings.wp_codebox_dependency_overlays, 'wp_codebox_dependency_overlays');
+  const extraPlugins = [
+    ...(syntheticFixture ? [{
+      source: fixturePlugin,
+      slug: 'synthetic-network-fixture',
+      pluginFile: 'synthetic-network-fixture/network-fixture.php',
+      activate: false,
+    }] : []),
+    ...recipeArray(settings.wp_codebox_extra_plugins, 'wp_codebox_extra_plugins'),
+  ];
+  const workloads = recipeArray(settings.wordpress_runtime_workloads, 'wordpress_runtime_workloads');
+  const workloadPlugin = workloadPluginSlug(settings.wordpress_runtime_workload_plugin_slug, workloads, extraPlugins, syntheticFixture);
   const blueprint = mergeMultisiteBlueprint(settings.wordpress_runtime_blueprint, activeTheme?.slug);
   const prepareSteps = recipeSteps(settings.wordpress_runtime_prepare_steps);
   const postSteps = recipeSteps(settings.wordpress_runtime_post_steps);
   const scenarioSteps = await browserScenarioSteps(settings.wp_codebox_scenario_manifests, cwd);
-  const workloadSteps = settings.wordpress_runtime_workloads?.length ? [{
+  const workloadSteps = workloads.length ? [{
     command: 'wordpress.bench',
     args: [
       'component-id=wordpress-multisite-e2e',
-      'plugin-slug=synthetic-network-fixture',
+      `plugin-slug=${workloadPlugin}`,
       'iterations=1',
       'warmup=0',
-      `workloads-json=${JSON.stringify(settings.wordpress_runtime_workloads)}`,
+      `workloads-json=${JSON.stringify(workloads)}`,
     ],
   }] : [];
 
@@ -45,15 +56,7 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
       preview: { siteUrl: 'http://localhost' },
     },
     inputs: {
-      extra_plugins: [
-        ...(syntheticFixture ? [{
-          source: fixturePlugin,
-          slug: 'synthetic-network-fixture',
-          pluginFile: 'synthetic-network-fixture/network-fixture.php',
-          activate: false,
-        }] : []),
-        ...(settings.wp_codebox_extra_plugins || []),
-      ],
+      extra_plugins: extraPlugins,
       mounts: themes.map((theme) => ({
         type: 'directory',
         source: theme.source,
@@ -315,6 +318,24 @@ function recipeArray(value, label) {
   return value;
 }
 
+function workloadPluginSlug(value, workloads, extraPlugins, syntheticFixture) {
+  const configured = value === undefined || value === '' ? undefined : value;
+  if (configured !== undefined && (typeof configured !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(configured))) {
+    throw new Error('wordpress_runtime_workload_plugin_slug must be a valid WordPress plugin directory slug.');
+  }
+  if (workloads.length === 0) {
+    return undefined;
+  }
+  const slug = configured || (syntheticFixture ? 'synthetic-network-fixture' : '');
+  if (!slug) {
+    throw new Error('wordpress_runtime_workload_plugin_slug is required when workloads run without the synthetic fixture.');
+  }
+  if (!extraPlugins.some((plugin) => plugin?.slug === slug || plugin?.mountSlug === slug)) {
+    throw new Error(`wordpress_runtime_workload_plugin_slug must match a declared wp_codebox_extra_plugins entry: ${slug}.`);
+  }
+  return slug;
+}
+
 async function browserScenarioSteps(value, cwd) {
   if (value === undefined) {
     return [];
@@ -365,21 +386,41 @@ async function main() {
 
 export function runCodebox(args, capture = false) {
   const executable = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox';
+  const maxBuffer = codeboxMaxBuffer();
   const result = spawnSync(executable, args, {
     encoding: 'utf8',
     stdio: capture ? 'pipe' : 'inherit',
-    maxBuffer: WP_CODEBOX_MAX_BUFFER_BYTES,
+    maxBuffer,
   });
   if (result.error) {
+    result.error.stdout = result.stdout || '';
+    result.error.stderr = result.stderr || '';
+    result.error.maxBuffer = maxBuffer;
     throw result.error;
   }
   if (capture && result.stderr) {
     process.stderr.write(result.stderr);
   }
   if (result.status !== 0) {
-    throw new Error(`WP Codebox exited with status ${result.status}.`);
+    const error = new Error(`WP Codebox exited with status ${result.status}.`);
+    error.stdout = result.stdout || '';
+    error.stderr = result.stderr || '';
+    error.status = result.status;
+    throw error;
   }
   return result;
+}
+
+function codeboxMaxBuffer() {
+  const raw = process.env.HOMEBOY_WP_CODEBOX_MAX_BUFFER_BYTES;
+  if (raw === undefined || raw === '') {
+    return WP_CODEBOX_MAX_BUFFER_BYTES;
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('HOMEBOY_WP_CODEBOX_MAX_BUFFER_BYTES must be a positive integer.');
+  }
+  return value;
 }
 
 function parseSettings(raw) {

--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -16,6 +16,7 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
   const phpVersion = runtimePhpVersion(settings);
   const themes = await extraThemes(settings.wp_codebox_extra_themes);
   const activeTheme = themes.find((theme) => theme.activate);
+  const dependencyOverlays = recipeArray(settings.wp_codebox_dependency_overlays, 'wp_codebox_dependency_overlays');
   const blueprint = mergeMultisiteBlueprint(settings.wordpress_runtime_blueprint, activeTheme?.slug);
   const prepareSteps = recipeSteps(settings.wordpress_runtime_prepare_steps);
   const postSteps = recipeSteps(settings.wordpress_runtime_post_steps);
@@ -61,6 +62,7 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
           slug: theme.slug,
         },
       })),
+      dependency_overlays: dependencyOverlays,
     },
     workflow: {
       steps: [
@@ -295,11 +297,15 @@ function phpFileStep(file) {
 }
 
 function recipeSteps(value) {
+  return recipeArray(value, 'WordPress runtime recipe steps');
+}
+
+function recipeArray(value, label) {
   if (value === undefined) {
     return [];
   }
   if (!Array.isArray(value)) {
-    throw new Error('WordPress runtime recipe steps must be arrays.');
+    throw new Error(`${label} must be an array.`);
   }
   return value;
 }

--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -325,7 +325,10 @@ async function browserScenarioSteps(value, cwd) {
     const scenario = typeof entry === 'string'
       ? JSON.parse(await readFile(path.resolve(cwd, entry), 'utf8'))
       : entry;
-    scenarios.push({ command: 'wordpress.browser-scenario', args: [`scenario-json=${JSON.stringify(scenario)}`] });
+    scenarios.push({
+      command: 'wordpress.browser-scenario',
+      args: [`scenario-json=${JSON.stringify(scenario)}`, 'route-host=localhost'],
+    });
   }
   return scenarios;
 }

--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -8,6 +8,8 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
+const WP_CODEBOX_MAX_BUFFER_BYTES = 20 * 1024 * 1024;
+
 const packageRoot = path.dirname(fileURLToPath(import.meta.url));
 const supportedPhpVersions = new Set(['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']);
 
@@ -361,9 +363,13 @@ async function main() {
   }
 }
 
-function runCodebox(args, capture = false) {
+export function runCodebox(args, capture = false) {
   const executable = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox';
-  const result = spawnSync(executable, args, { encoding: 'utf8', stdio: capture ? 'pipe' : 'inherit' });
+  const result = spawnSync(executable, args, {
+    encoding: 'utf8',
+    stdio: capture ? 'pipe' : 'inherit',
+    maxBuffer: WP_CODEBOX_MAX_BUFFER_BYTES,
+  });
   if (result.error) {
     throw result.error;
   }

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -62,6 +62,13 @@ try {
       activate: true,
       metadata: { provenance: { revision: '0123456789abcdef' } },
     }],
+    wp_codebox_dependency_overlays: [{
+      kind: 'composer-package',
+      package: 'example/runtime-package',
+      source: '/tmp/runtime-package',
+      consumer: 'consumer-plugin',
+      metadata: { provenance: { revision: 'fedcba9876543210' } },
+    }],
     wordpress_runtime_prepare_steps: [prepareStep],
     wordpress_runtime_workloads: [{ id: 'consumer-workload', run: [] }],
     wp_codebox_scenario_manifests: [{ id: 'consumer-browser-journey', url: '/beta/' }],
@@ -88,6 +95,13 @@ try {
       kind: 'wordpress-theme',
       slug: 'consumer-theme',
     },
+  }]);
+  assert.deepEqual(recipe.inputs.dependency_overlays, [{
+    kind: 'composer-package',
+    package: 'example/runtime-package',
+    source: '/tmp/runtime-package',
+    consumer: 'consumer-plugin',
+    metadata: { provenance: { revision: 'fedcba9876543210' } },
   }]);
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.bench'));
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'));
@@ -120,6 +134,7 @@ try {
   const withoutRuntimeInputs = await buildRecipe({}, root);
   assert.equal(Object.hasOwn(withoutRuntimeInputs.runtime, 'phpVersion'), false);
   assert.deepEqual(withoutRuntimeInputs.inputs.mounts, []);
+  assert.deepEqual(withoutRuntimeInputs.inputs.dependency_overlays, []);
   assert.equal(withoutRuntimeInputs.workflow.steps.some((step) => step.metadata?.kind === 'wordpress-theme-activation'), false);
 
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '' }, root), /must be a non-empty/);
@@ -127,6 +142,7 @@ try {
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '8.6' }, root), /Unsupported/);
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '5.2' }, root), /Unsupported/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: {} }, root), /must be an array/);
+  await assert.rejects(buildRecipe({ wp_codebox_dependency_overlays: {} }, root), /wp_codebox_dependency_overlays must be an array/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [null] }, root), /must be an object/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: 'relative/theme', slug: 'theme' }] }, root), /absolute path/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: path.join(temporary, 'missing'), slug: 'theme' }] }, root), /does not exist/);

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -137,6 +137,19 @@ try {
   assert.deepEqual(withoutRuntimeInputs.inputs.dependency_overlays, []);
   assert.equal(withoutRuntimeInputs.workflow.steps.some((step) => step.metadata?.kind === 'wordpress-theme-activation'), false);
 
+  const consumerTopology = await buildRecipe({
+    wordpress_multisite_synthetic_fixture: false,
+    wp_codebox_extra_plugins: [{ source: '/tmp/consumer-plugin', slug: 'consumer-plugin', activate: false }],
+    wordpress_runtime_prepare_steps: [prepareStep],
+    wp_codebox_scenario_manifests: [{ id: 'consumer-owned-topology', url: '/' }],
+  }, root);
+  assert.equal(consumerTopology.inputs.extra_plugins.some((plugin) => plugin.slug === 'synthetic-network-fixture'), false);
+  assert.equal(consumerTopology.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('network-seed.php'))), false);
+  assert.equal(consumerTopology.workflow.steps.some((step) => step.args?.some((arg) => arg.includes('network-assert.php'))), false);
+  assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-probe'), false);
+  assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-actions'), false);
+  assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'), true);
+
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '' }, root), /must be a non-empty/);
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '8.4.1' }, root), /Unsupported/);
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '8.6' }, root), /Unsupported/);

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -141,6 +141,8 @@ try {
   const consumerTopology = await buildRecipe({
     wordpress_multisite_synthetic_fixture: false,
     wp_codebox_extra_plugins: [{ source: '/tmp/consumer-plugin', slug: 'consumer-plugin', activate: false }],
+    wordpress_runtime_workload_plugin_slug: 'consumer-plugin',
+    wordpress_runtime_workloads: [{ id: 'file-workload', run: [{ type: 'php', file: '/tmp/workload.php' }] }],
     wordpress_runtime_prepare_steps: [prepareStep],
     wp_codebox_scenario_manifests: [{ id: 'consumer-owned-topology', url: '/' }],
   }, root);
@@ -150,17 +152,36 @@ try {
   assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-probe'), false);
   assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-actions'), false);
   assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'), true);
+  const consumerBench = consumerTopology.workflow.steps.find((step) => step.command === 'wordpress.bench');
+  assert.ok(consumerBench.args.includes('plugin-slug=consumer-plugin'));
+  assert.equal(consumerBench.args.some((arg) => arg.includes('synthetic-network-fixture')), false);
 
   const previousCodeboxBin = process.env.HOMEBOY_WP_CODEBOX_BIN;
+  const previousMaxBuffer = process.env.HOMEBOY_WP_CODEBOX_MAX_BUFFER_BYTES;
   process.env.HOMEBOY_WP_CODEBOX_BIN = process.execPath;
   try {
     const largeOutput = runCodebox(['-e', "process.stdout.write('x'.repeat(2 * 1024 * 1024))"], true);
     assert.equal(largeOutput.stdout.length, 2 * 1024 * 1024);
+    process.env.HOMEBOY_WP_CODEBOX_MAX_BUFFER_BYTES = '1024';
+    assert.throws(
+      () => runCodebox(['-e', "process.stderr.write('overflow diagnostic'); process.stdout.write('x'.repeat(2048))"], true),
+      (error) => error.code === 'ENOBUFS'
+        && error.maxBuffer === 1024
+        && error.stderr.includes('overflow diagnostic')
+        && error.stdout.length > 0,
+    );
+    process.env.HOMEBOY_WP_CODEBOX_MAX_BUFFER_BYTES = 'invalid';
+    assert.throws(() => runCodebox(['--version'], true), /must be a positive integer/);
   } finally {
     if (previousCodeboxBin === undefined) {
       delete process.env.HOMEBOY_WP_CODEBOX_BIN;
     } else {
       process.env.HOMEBOY_WP_CODEBOX_BIN = previousCodeboxBin;
+    }
+    if (previousMaxBuffer === undefined) {
+      delete process.env.HOMEBOY_WP_CODEBOX_MAX_BUFFER_BYTES;
+    } else {
+      process.env.HOMEBOY_WP_CODEBOX_MAX_BUFFER_BYTES = previousMaxBuffer;
     }
   }
 
@@ -170,6 +191,9 @@ try {
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '5.2' }, root), /Unsupported/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: {} }, root), /must be an array/);
   await assert.rejects(buildRecipe({ wp_codebox_dependency_overlays: {} }, root), /wp_codebox_dependency_overlays must be an array/);
+  await assert.rejects(buildRecipe({ wordpress_multisite_synthetic_fixture: false, wordpress_runtime_workloads: [{ id: 'missing-owner', run: [] }] }, root), /workload_plugin_slug is required/);
+  await assert.rejects(buildRecipe({ wordpress_multisite_synthetic_fixture: false, wordpress_runtime_workload_plugin_slug: '../plugin', wordpress_runtime_workloads: [{ id: 'invalid-owner', run: [] }] }, root), /valid WordPress plugin directory slug/);
+  await assert.rejects(buildRecipe({ wordpress_multisite_synthetic_fixture: false, wordpress_runtime_workload_plugin_slug: 'missing-plugin', wordpress_runtime_workloads: [{ id: 'unknown-owner', run: [] }] }, root), /must match a declared/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [null] }, root), /must be an object/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: 'relative/theme', slug: 'theme' }] }, root), /absolute path/);
   await assert.rejects(buildRecipe({ wp_codebox_extra_themes: [{ source: path.join(temporary, 'missing'), slug: 'theme' }] }, root), /does not exist/);

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -105,6 +105,7 @@ try {
   }]);
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.bench'));
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'));
+  assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario' && step.args.includes('route-host=localhost')));
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-probe'));
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-actions'));
   const seedIndex = recipe.workflow.steps.findIndex((step) => step.args?.some((arg) => arg.includes('network-seed.php')));

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 /**
  * Internal dependencies
  */
-import { buildRecipe } from '../run.mjs';
+import { buildRecipe, runCodebox } from '../run.mjs';
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const temporary = await mkdtemp(path.join(os.tmpdir(), 'wordpress-multisite-e2e-contract-'));
@@ -150,6 +150,19 @@ try {
   assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-probe'), false);
   assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-actions'), false);
   assert.equal(consumerTopology.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'), true);
+
+  const previousCodeboxBin = process.env.HOMEBOY_WP_CODEBOX_BIN;
+  process.env.HOMEBOY_WP_CODEBOX_BIN = process.execPath;
+  try {
+    const largeOutput = runCodebox(['-e', "process.stdout.write('x'.repeat(2 * 1024 * 1024))"], true);
+    assert.equal(largeOutput.stdout.length, 2 * 1024 * 1024);
+  } finally {
+    if (previousCodeboxBin === undefined) {
+      delete process.env.HOMEBOY_WP_CODEBOX_BIN;
+    } else {
+      process.env.HOMEBOY_WP_CODEBOX_BIN = previousCodeboxBin;
+    }
+  }
 
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '' }, root), /must be a non-empty/);
   await assert.rejects(buildRecipe({ wordpress_runtime_php_version: '8.4.1' }, root), /Unsupported/);

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -15,7 +15,7 @@ assert.ok(
 	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
 );
 
-for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wordpress_runtime_php_version']) {
+for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wordpress_runtime_php_version']) {
 	assert.ok(settingIds.has(settingId), `wordpress manifest declares ${settingId}`);
 }
 

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -15,7 +15,7 @@ assert.ok(
 	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
 );
 
-for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version']) {
+for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version', 'wordpress_runtime_workload_plugin_slug']) {
 	assert.ok(settingIds.has(settingId), `wordpress manifest declares ${settingId}`);
 }
 

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -15,7 +15,7 @@ assert.ok(
 	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
 );
 
-for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wordpress_runtime_php_version']) {
+for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version']) {
 	assert.ok(settingIds.has(settingId), `wordpress manifest declares ${settingId}`);
 }
 

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1231,6 +1231,13 @@
       "description": "Existing WP Codebox dependency overlay entries forwarded by the wordpress-multisite-e2e rig for immutable Composer package replacement."
     },
     {
+      "id": "wordpress_multisite_synthetic_fixture",
+      "label": "WordPress multisite synthetic fixture",
+      "type": "boolean",
+      "default": true,
+      "description": "Run the wordpress-multisite-e2e rig's built-in alpha/beta self-test. Set false when consumer prepare/scenario/post steps own the complete network topology and journey."
+    },
+    {
       "id": "wordpress_runtime_workloads",
       "label": "WordPress runtime workloads",
       "type": "array",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1224,6 +1224,13 @@
       "description": "Immutable local theme checkouts for the wordpress-multisite-e2e rig. Each entry is {source,slug,activate?,metadata?}; the rig validates the theme and maps it to a readonly WP Codebox mount. At most one theme may be active."
     },
     {
+      "id": "wp_codebox_dependency_overlays",
+      "label": "WP Codebox dependency overlays",
+      "type": "array",
+      "default": [],
+      "description": "Existing WP Codebox dependency overlay entries forwarded by the wordpress-multisite-e2e rig for immutable Composer package replacement."
+    },
+    {
       "id": "wordpress_runtime_workloads",
       "label": "WordPress runtime workloads",
       "type": "array",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1245,6 +1245,13 @@
       "description": "Backend-neutral WordPress workload declarations passed to the selected runtime adapter after dependency mounts and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file}, {type: 'ability', ability|name, input}, or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata."
     },
     {
+      "id": "wordpress_runtime_workload_plugin_slug",
+      "label": "WordPress runtime workload plugin slug",
+      "type": "string",
+      "default": "",
+      "description": "Mounted plugin slug that owns wordpress-multisite-e2e workloads. Defaults to the synthetic fixture only while that fixture is enabled; consumer-owned topology workloads must name a declared wp_codebox_extra_plugins entry."
+    },
+    {
       "id": "wordpress_runtime_prepare_steps",
       "label": "WordPress runtime prepare steps",
       "type": "array",


### PR DESCRIPTION
## Summary
- forward generic WP Codebox Composer dependency overlays through `wordpress-multisite-e2e`
- let consumers disable the rig's synthetic alpha/beta fixture and own the complete multisite topology and journey
- route consumer browser scenarios through the canonical local multisite host

## Roadie E2E Blockers
- `0aa5db6d` fixes the immutable dependency-composition blocker: Roadie's real plugin graph needs a local Composer package checkout overlaid into a mounted consumer plugin, but the rig previously dropped WP Codebox `dependency_overlays`. The generic setting now preserves overlay source, consumer, package, and provenance in the effective recipe.
- `5aae6d6f` fixes the topology collision: Roadie's E2E prepares its own network sites and assertions, while the rig always injected and executed the unrelated synthetic alpha/beta plugin, seed, assertions, and browser journey. `wordpress_multisite_synthetic_fixture=false` removes only that built-in self-test so consumer-owned setup/scenarios remain authoritative.
- `58821397` fixes browser reachability after consumer topology setup: scenario URLs must be routed to the disposable Playground origin even when the virtual multisite request host differs. Adding `route-host=localhost` keeps the browser request inside WP Codebox instead of relying on external DNS.

These are vendor-agnostic contracts; no Roadie or Extra Chill names are present in the runtime implementation.

## Tests
- `node rigs/wordpress-multisite-e2e/tests/contract.test.mjs` (pass)
- `node tests/wordpress-manifest-settings-smoke.js` (pass)
- Node syntax checks for the rig and contracts (pass)
- `wordpress.json` parse (pass)
- `git diff --check origin/main...HEAD` (pass)
- installed WP Codebox recipe validation and `recipe-run --dry-run` through the rig (pass, zero validation or policy issues)

## Commit Range
This follow-up contains only:
- `0aa5db6d` feat(wordpress): forward multisite dependency overlays
- `5aae6d6f` feat(wordpress): allow consumer-owned multisite topology
- `58821397` fix(wordpress): route multisite browser host

Follow-up to #2358.