### PR TITLE
fix(wordpress): hydrate Codebox fuzz readiness

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -26,6 +26,7 @@ const {
 	requiredWpCodeboxContractsForFuzzCase,
 	requiredWpCodeboxContractsForFuzzPlan,
 } = require('./wordpress-fuzz-command-manifest');
+const { createCodeboxClient } = require('./codebox-client');
 
 const WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA = 'homeboy/wordpress-fuzz-runner-result/v1';
 const HOMEBOY_FUZZ_CAMPAIGN_SCHEMA = 'homeboy/fuzz-campaign/v1';
@@ -192,8 +193,10 @@ function buildWordPressFuzzRunnerSummary({
 
 async function resolveCodeboxResult(context, options = {}) {
 	const runner = options.runFuzzSuite || options.runRuntimeTask || options.runTask;
+	const runtimeDescriptor = typeof runner === 'function' ? {} : await readWpCodeboxFuzzRuntimeDescriptor({ ...options, env: context.env });
 	return runWpCodeboxFuzzSuite({
 		...options,
+		...runtimeDescriptor,
 		env: context.env,
 		taskId: context.runId,
 		input: context.wpCodeboxInput,
@@ -203,6 +206,78 @@ async function resolveCodeboxResult(context, options = {}) {
 		instructions: context.taskRequest.instructions,
 		...(typeof runner === 'function' ? { runFuzzSuite: runner } : {}),
 	});
+}
+
+async function readWpCodeboxFuzzRuntimeDescriptor(options = {}) {
+	if (hasExplicitWpCodeboxFuzzRuntimeContract(options)) {
+		return {};
+	}
+
+	const client = createCodeboxClient(options);
+	let result;
+	try {
+		result = await client.runPublicCliCommand(['runtime', 'descriptor', '--json'], options);
+	} catch (error) {
+		return blockedWpCodeboxFuzzRuntimeDescriptor(client, error.message);
+	}
+	if (result.status !== 0) {
+		return blockedWpCodeboxFuzzRuntimeDescriptor(client, `exited with status ${result.status}.`, result);
+	}
+
+	let descriptor;
+	try {
+		descriptor = JSON.parse(result.stdout);
+	} catch {
+		return blockedWpCodeboxFuzzRuntimeDescriptor(client, 'did not return valid JSON.', result);
+	}
+	if (!objectOrUndefined(descriptor) || descriptor.schema !== 'wp-codebox/runtime-descriptor/v1') {
+		return blockedWpCodeboxFuzzRuntimeDescriptor(client, 'did not return a wp-codebox/runtime-descriptor/v1 document.', result);
+	}
+
+	const runtimeContractManifest = objectOrUndefined(descriptor.contractManifest);
+	const publicCliReadiness = objectOrUndefined(runtimeContractManifest?.readiness?.wordpressRuntime);
+	if (!runtimeContractManifest || !publicCliReadiness) {
+		return blockedWpCodeboxFuzzRuntimeDescriptor(client, 'did not declare contractManifest.readiness.wordpressRuntime.', result, descriptor);
+	}
+
+	return { runtimeDescriptor: descriptor, runtimeContractManifest, publicCliReadiness };
+}
+
+function hasExplicitWpCodeboxFuzzRuntimeContract(options = {}) {
+	return Boolean(
+		options.runtimeContractManifest
+		|| options.runtime_contract_manifest
+		|| options.publicCliReadiness
+		|| options.public_cli_readiness
+	);
+}
+
+function blockedWpCodeboxFuzzRuntimeDescriptor(client, detail, result = {}, descriptor) {
+	return {
+		runtimeDescriptor: descriptor,
+		runtimeContractManifest: {},
+		publicCliReadiness: {
+			schema: 'wp-codebox/fuzz-runner-readiness/v1',
+			status: 'blocked',
+			mode: 'runtime-backed',
+			command_available: false,
+			diagnostics: [{
+				severity: 'error',
+				code: 'wp_codebox_runtime_descriptor_unavailable',
+				message: `WP Codebox runtime descriptor from ${wpCodeboxRuntimeDescriptorBin(client)} ${detail}`,
+				stderr: result.stderr || undefined,
+				stdout: result.stdout || undefined,
+			}],
+		},
+	};
+}
+
+function wpCodeboxRuntimeDescriptorBin(client) {
+	try {
+		return client.publicCliBin();
+	} catch {
+		return 'the configured WP Codebox binary';
+	}
 }
 
 function fuzzSuiteInstructions({ workload, workloadId, runId }) {
@@ -297,7 +372,6 @@ function wpCodeboxRuntimeRequirementsFromWorkload(workload = {}, options = {}) {
 
 function buildWpCodeboxFuzzRuntimeRequirements({ workload = {}, env = {} } = {}) {
 	const context = objectOrUndefined(workload.metadata?.homeboy_runtime_context || workload.metadata?.homeboyRuntimeContext);
-	const components = objectOrUndefined(context?.components);
 	const workloadRoot = nonEmptyString(env?.wpCodeboxFuzzWorkloadRoot || env?.WP_CODEBOX_FUZZ_WORKLOAD_ROOT);
 	const target = objectOrUndefined(workload.target) || {};
 	if (target.type === 'wordpress-core') {
@@ -311,6 +385,7 @@ function buildWpCodeboxFuzzRuntimeRequirements({ workload = {}, env = {} } = {})
 			}),
 		});
 	}
+	const components = objectOrUndefined(context?.components);
 	const componentId = workload.target?.component
 		|| workload.metadata?.fixture?.component
 		|| workload.metadata?.fixture?.plugin

--- a/wordpress/tests/wordpress-fuzz-destructive-codebox-readiness-gate.test.js
+++ b/wordpress/tests/wordpress-fuzz-destructive-codebox-readiness-gate.test.js
@@ -229,6 +229,55 @@ assert.deepEqual(normalizeWpCodeboxDestructiveReadiness(completeReadiness, {
 }).missing_primitives, undefined);
 
 (async () => {
+	for (const [label, descriptor, expectedPreflight, expectedFuzzCalls] of [
+		['complete', {
+			schema: 'wp-codebox/runtime-descriptor/v1',
+			version: 1,
+			contractManifest: {
+				...runtimeContractManifest,
+				capabilities: { wordpressRuntime: { commands: ['run-fuzz-suite', 'run-wordpress-workload'], capabilities: completeReadiness.capabilities.capabilities, runner_modes: { 'runtime-backed': true } } },
+				readiness: { wordpressRuntime: completeReadiness },
+			},
+		}, true, 1],
+		['incomplete', {
+			schema: 'wp-codebox/runtime-descriptor/v1',
+			version: 1,
+			contractManifest: {
+				...runtimeContractManifest,
+				capabilities: { wordpressRuntime: { commands: ['run-fuzz-suite', 'run-wordpress-workload'], capabilities: incompleteReadiness.capabilities.capabilities, runner_modes: { 'runtime-backed': true } } },
+				readiness: { wordpressRuntime: incompleteReadiness },
+			},
+		}, false, 0],
+	]) {
+		const cliCalls = [];
+		const result = await runWordPressFuzzRunnerResult({
+			env: {
+				workloadPath: `/unused/${label}-descriptor-workload.json`,
+				workloadId: `${label}-descriptor-workload`,
+				runId: `${label}-descriptor-run`,
+				HOMEBOY_WP_CODEBOX_BIN: '/selected/wp-codebox-0.13.1',
+			},
+			workload: { id: `${label}-descriptor-workload`, plan: destructivePlan },
+			runPublicCli: ({ command, args }) => {
+				cliCalls.push({ command, args });
+				if (args.join(' ') === 'runtime descriptor --json') {
+					return { status: 0, stdout: JSON.stringify(descriptor) };
+				}
+				return { status: 0, stdout: JSON.stringify({ schema: 'wp-codebox/fuzz-suite-result/v1', request_id: `${label}-descriptor-run`, status: 'succeeded' }) };
+			},
+		});
+
+		assert.equal(cliCalls[0].command, '/selected/wp-codebox-0.13.1');
+		assert.deepEqual(cliCalls[0].args, ['runtime', 'descriptor', '--json']);
+		assert.equal(cliCalls.filter(({ args }) => args[0] === 'run-fuzz-suite').length, expectedFuzzCalls);
+		if (expectedPreflight) {
+			assert.equal(result.wp_codebox_result.failures.some((failure) => failure.code === 'wp_codebox_fuzz_missing_destructive_readiness'), false);
+		} else {
+			assert.equal(result.wp_codebox_result.metadata.preflight.ok, false);
+			assert.equal(result.wp_codebox_result.metadata.preflight.diagnostics.some((diagnostic) => diagnostic.code === 'wp_codebox_fuzz_missing_destructive_readiness'), true);
+		}
+	}
+
 	const result = await runWordPressFuzzRunnerResult({
 		env: {
 			workloadPath: '/unused/destructive-workload.json',

--- a/wordpress/tests/wordpress-fuzz-runtime-task.test.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-task.test.js
@@ -150,6 +150,7 @@ Promise.all([
 	runWpCodeboxFuzzSuite({
 		taskId: 'unavailable-runtime',
 		input: { id: 'unavailable-runtime', cases: [{ id: 'case-1' }] },
+		runtimeContractManifest: {},
 		publicCliCapabilities: { commands: { 'run-fuzz-suite': false, 'run-wordpress-workload': false } },
 	}).then((summary) => {
 		assert.equal(summary.schema, WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA);


### PR DESCRIPTION
## Summary

- hydrate production fuzz preflight from the selected WP Codebox public runtime descriptor
- fail closed when the descriptor is unavailable, malformed, or missing WordPress readiness
- preserve explicit runtime contracts and injected runners used by deterministic callers

Closes #2364.

Downstream validation: chubes4/homeboy-rigs#693. The repaired Jetpack workload passed on `homeboy-lab` as `jetpack-owner-drift-gh-693-v8` with job-scoped WP Codebox 0.13.1.

## Testing

- `npm run lint:js -- lib/wordpress-fuzz-runner.js`
- `node tests/wordpress-fuzz-destructive-codebox-readiness-gate.test.js`
- `node tests/wordpress-fuzz-runtime-task.test.js`
- `node tests/wordpress-fuzz-runner-codebox-contract-canary.js`
- `git diff --check`

## AI Assistance

OpenAI `gpt-5.6-sol` through OpenCode implemented the runtime descriptor hydration, tests, and PR draft. Chris Huber reviewed the diff and remains responsible for the change.