### PR TITLE
Remove concrete AI model fallbacks

### DIFF
--- a/agent-runtimes/codex/codex.json
+++ b/agent-runtimes/codex/codex.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "codex",
   "name": "Codex",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Standalone Codex agent runtime for repository-scoped agent tasks.",
   "contract_producers": [
     {
@@ -107,7 +107,6 @@
       },
       "provider_defaults": {
         "codex": {
-          "model": "gpt-5.5",
           "command": "codex",
           "command_args": ["exec"],
           "secret_env": [

--- a/agent-runtimes/codex/lib/codex-agent-task-executor.js
+++ b/agent-runtimes/codex/lib/codex-agent-task-executor.js
@@ -62,7 +62,6 @@ function providerContract(options = {}) {
 		},
 		provider_defaults: {
 			codex: {
-				model: 'gpt-5.5',
 				command: CODEX_DEFAULT_COMMAND,
 				command_args: [...CODEX_DEFAULT_COMMAND_ARGS],
 				secret_env: [...CODEX_SECRET_ENV],
@@ -115,11 +114,14 @@ const { execute: executeCodexAgentTask, outcome, validationFailure } = createCli
 	artifactProvider: 'codex',
 	collectArtifacts: true,
 	resolveCommandSpec,
-	buildArgs: (request, config, commandSpec) => [
-		...commandSpec.args,
-		...(config.model ? ['--model', config.model] : []),
-		request.instructions,
-	],
+	buildArgs: (request, config, commandSpec) => {
+		const model = config.model || request.executor?.model || request.model;
+		return [
+			...commandSpec.args,
+			...(model ? ['--model', model] : []),
+			request.instructions,
+		];
+	},
 	buildSpawn: (request, config, options) => ({
 		env: cliAgentTaskSpawnEnv(request, options, {
 			allowlist: ['HOMEBOY_CODEX_COMMAND', 'HOMEBOY_CODEX_COMMAND_ARGS'],

--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -43,7 +43,7 @@ assert.equal(Object.hasOwn(provider.lifecycle, 'max_concurrency_default'), false
 assert.equal(provider.lifecycle.cancellation, 'provider_signal');
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, CODEX_SECRET_ENV);
 assert.deepEqual(provider.provider_defaults.codex.secret_env, CODEX_SECRET_ENV);
-assert.equal(provider.provider_defaults.codex.model, 'gpt-5.5');
+assert.equal(Object.hasOwn(provider.provider_defaults.codex, 'model'), false);
 assert.equal(provider.provider_defaults.codex.command, CODEX_DEFAULT_COMMAND);
 assert.deepEqual(provider.provider_defaults.codex.command_args, CODEX_DEFAULT_COMMAND_ARGS);
 assert.equal(provider.redacted_metadata_keys.includes('codex_auth'), true);
@@ -56,6 +56,7 @@ const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'codex.json')
 assert.equal(manifest.id, 'codex');
 assert.equal(manifest.name, 'Codex');
 assert.equal(manifest.agent_task_executors.length, 1);
+assert.equal(Object.hasOwn(manifest.agent_task_executors[0].provider_defaults.codex, 'model'), false);
 
 const registry = runtimeRegistry({ repoRoot });
 assert.equal(registry.codex.id, 'codex');
@@ -84,6 +85,12 @@ try {
 	assert.equal(fs.existsSync(scriptPath), true, `provider command target should exist: ${scriptPath}`);
 
 	const mockCliPath = path.join(root, 'mock-codex.cjs');
+	const omittedModelCliPath = path.join(root, 'mock-codex-without-model.cjs');
+	fs.writeFileSync(omittedModelCliPath, `#!/usr/bin/env node
+const assert = require('node:assert/strict');
+assert.deepEqual(process.argv.slice(2), ['exec', 'Run without selecting a model.']);
+process.exit(0);
+`);
 	fs.writeFileSync(mockCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
 assert.equal(process.argv[2], 'exec');
@@ -116,6 +123,21 @@ process.exit(0);
 		},
 		instructions: 'Prove the Codex runtime boundary without leaking secrets.',
 	};
+	const omittedModelResult = executeCodexAgentTask({
+		...request,
+		task_id: 'codex-without-model',
+		executor: {
+			...request.executor,
+			config: {
+				provider: 'codex',
+				command: process.execPath,
+				command_args: [omittedModelCliPath, 'exec'],
+				artifacts_path: path.join(root, 'omitted-model-artifacts'),
+			},
+		},
+		instructions: 'Run without selecting a model.',
+	});
+	assert.equal(omittedModelResult.status, 'succeeded', JSON.stringify(omittedModelResult.diagnostics));
 	const runResult = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
 		env: {

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -161,7 +161,6 @@ const OPENCODE_ROLE_ALIASES = {
 
 const OPENCODE_PROVIDER_DEFAULTS = {
 	codex: {
-		model: 'gpt-5.5',
 		secret_env: [...OPENCODE_SECRET_ENV],
 		secret_env_sources: {
 			AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: {

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,7 +9,7 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.2.2',
+		version: '1.2.3',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
 		contract_producers: [
 			{

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "contract_producers": [
     {
@@ -159,7 +159,6 @@
       },
       "provider_defaults": {
         "codex": {
-          "model": "gpt-5.5",
           "secret_env": [
             "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
             "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -86,7 +86,7 @@ assert.equal(Object.hasOwn(provider.lifecycle, 'max_concurrency_default'), false
 assert.equal(provider.lifecycle.cancellation, 'provider_signal');
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, OPENCODE_SECRET_ENV);
 assert.deepEqual(provider.provider_defaults.codex.secret_env, OPENCODE_SECRET_ENV);
-assert.equal(provider.provider_defaults.codex.model, 'gpt-5.5');
+assert.equal(Object.hasOwn(provider.provider_defaults.codex, 'model'), false);
 assert.deepEqual(provider.provider_defaults.codex.secret_env_sources, OPENCODE_PROVIDER_DEFAULTS.codex.secret_env_sources);
 assert.deepEqual(provider.provider_preflight, OPENCODE_PROVIDER_PREFLIGHT);
 assert.deepEqual(provider.runner_readiness, OPENCODE_RUNNER_READINESS);
@@ -105,6 +105,7 @@ assert.equal(manifest.id, 'opencode');
 assert.equal(manifest.name, 'OpenCode');
 assert.equal(manifest.agent_task_executors.length, 1);
 assert.equal(manifest.agent_task_executors[0].capabilities.includes('nested_orchestrator'), true);
+assert.equal(Object.hasOwn(manifest.agent_task_executors[0].provider_defaults.codex, 'model'), false);
 const packageJson = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'package.json'), 'utf8'));
 assert.equal(packageJson.name, 'homeboy-agent-runtime-opencode');
 assert.equal(packageJson.homeboy.agent_runtime_manifest, 'opencode.json');
@@ -131,6 +132,7 @@ try {
 	fs.writeFileSync(mockCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
 assert.equal(process.argv[2], 'run');
+assert.equal(process.argv.includes('--model'), false);
 assert.equal(process.argv.at(-1), 'Prove the OpenCode provider boundary without leaking secrets.');
 assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN, 'refresh-token-must-not-leak');
 assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN, 'access-token-must-not-leak');

--- a/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
+++ b/agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
@@ -27,6 +27,8 @@ assert.doesNotMatch(descriptorSource, /run-agent-task', '--help/);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'wp-codebox.json'), 'utf8'));
 assert.equal(manifest.component_path_defaults, undefined);
+assert.equal(manifest.agent_task_executors[0].cli.default_ai_disclosure, 'OpenCode');
+assert.equal(Object.hasOwn(manifest.agent_task_executors[0].cli, 'profiles'), false);
 const runtimePreflightCheck = manifest.agent_task_executors[0].runtime_contract.preflight_checks.find((check) => check.id === 'wp-codebox.provider_plugin.runtime_package_shadow');
 assert.equal(runtimePreflightCheck.enforcement, 'error');
 assert.deepEqual(runtimePreflightCheck.target.component.metadata_equals, { loadAs: 'plugin' });

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "wp-codebox",
   "name": "WP Codebox",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
   "contract_producers": [
     {
@@ -229,15 +229,7 @@
       },
       "cli": {
         "reserved_selector_hints": ["opencode", "codex", "claude-code"],
-        "profiles": [
-          {
-            "name": "opencode-codex-gpt55",
-            "backend": "opencode",
-            "model": "gpt-5.5",
-            "ai_disclosure": "OpenCode (GPT-5.5)"
-          }
-        ],
-        "default_ai_disclosure": "OpenCode (GPT-5.5)"
+        "default_ai_disclosure": "OpenCode"
       },
       "request_schema": "homeboy/agent-task-request/v1",
       "outcome_schema": "homeboy/agent-task-outcome/v1",


### PR DESCRIPTION
## Summary
Remove stale concrete model defaults from agent runtime metadata.

## What changed
- OpenCode and Codex provider defaults no longer publish gpt-5.5; WP Codebox no longer exposes a GPT-5.5 profile or model-specific default disclosure; omitted-model executor boundaries are covered.

## How to test
1. Run `node --test agent-runtimes/opencode/tests/*.test.js agent-runtimes/codex/tests/*.test.js agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js tests/wp-codebox-provider-plugin-defaults-smoke.mjs`; expect five runtime boundary tests pass.

## Compatibility
Explicit caller/config model forwarding remains unchanged; omitted models now remain omitted.

## Evidence
- Base unchanged since verification: main remains at 24b6358947397c8bdf4d2a86e86557527807f44c.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy-extensions/issues/2367
- Verified finalization base: main at 24b6358947397c8bdf4d2a86e86557527807f44c
- runtime-boundaries: passed (5 tests passed) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** OpenCode traced model selection and metadata contracts, implemented the runtime and manifest changes, and added omitted-model boundary coverage; I reviewed the diff and reran all targeted tests.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2367
