### PR TITLE
Fix WordPress test helpers through installed symlinks

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,6 +11,7 @@
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
       "bash scripts/test/wp-codebox-doctor-smoke.sh",
+      "bash tests/installed-test-helper-resolution-smoke.sh",
       "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
       "bash scripts/test/full-suite-no-phpunit-smoke.sh",

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -17,6 +17,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../../scripts/lib" && pwd)}"
 
 OUTPUT_FILE="${1:-}"
 if [ -z "$OUTPUT_FILE" ]; then
@@ -38,7 +43,7 @@ if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; t
     source "$WRITE_TEST_RESULTS_HELPER"
 fi
 
-ADAPTERS_HELPER="${HOMEBOY_RUNTIME_TEST_RESULT_ADAPTERS:-${SCRIPT_DIR}/../../../scripts/lib/test-result-adapters.sh}"
+ADAPTERS_HELPER="${HOMEBOY_RUNTIME_TEST_RESULT_ADAPTERS:-${SHARED_LIB_DIR}/test-result-adapters.sh}"
 # shellcheck source=../../../scripts/lib/test-result-adapters.sh
 source "$ADAPTERS_HELPER"
 WP_CODEBOX_ADAPTERS_HELPER="${HOMEBOY_WP_CODEBOX_TEST_RESULT_ADAPTERS:-${SCRIPT_DIR}/../../../agent-runtimes/wp-codebox/scripts/lib/test-result-adapters.sh}"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -9,13 +9,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:?HOMEBOY_RUNTIME_RUNNER_PRELUDE is required}"
+SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
+if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+    SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+fi
+SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../../scripts/lib" && pwd)}"
 
 SMOKE_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE_WP:-${SCRIPT_DIR}/test-runner-host-smoke-wp.sh}"
 WP_CODEBOX_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX:-${SCRIPT_DIR}/test-runner-wp-codebox.sh}"
 CORE_WP_CODEBOX_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_CORE_WP_CODEBOX:-${SCRIPT_DIR}/test-runner-core-dev-wp-codebox.sh}"
 WORDPRESS_TEST_RUNTIME_BACKEND="${HOMEBOY_WORDPRESS_TEST_RUNTIME_BACKEND:-wp-codebox}"
 
-SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../../../scripts/lib/settings.sh}"
+SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SHARED_LIB_DIR}/settings.sh}"
 # shellcheck source=/dev/null
 source "$RUNNER_PRELUDE"
 homeboy_runner_init --bash 4 --component-alias PLUGIN_PATH

--- a/wordpress/tests/installed-test-helper-resolution-smoke.sh
+++ b/wordpress/tests/installed-test-helper-resolution-smoke.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORDPRESS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPOSITORY_ROOT="$(cd "${WORDPRESS_ROOT}/.." && pwd)"
+FIXTURE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+mkdir -p \
+    "${FIXTURE_ROOT}/extension-sources/wordpress/scripts/test" \
+    "${FIXTURE_ROOT}/extensions/scripts/lib" \
+    "${FIXTURE_ROOT}/component"
+cp "${WORDPRESS_ROOT}/scripts/test/test-runner.sh" \
+    "${WORDPRESS_ROOT}/scripts/test/parse-test-results.sh" \
+    "${FIXTURE_ROOT}/extension-sources/wordpress/scripts/test/"
+cp "${REPOSITORY_ROOT}/scripts/lib/settings.sh" \
+    "${REPOSITORY_ROOT}/scripts/lib/test-result-adapters.sh" \
+    "${FIXTURE_ROOT}/extensions/scripts/lib/"
+ln -s "${FIXTURE_ROOT}/extension-sources/wordpress" "${FIXTURE_ROOT}/extensions/wordpress"
+
+cat > "${FIXTURE_ROOT}/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH}"
+    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH}"
+}
+EOF
+
+HOMEBOY_EXTENSION_PATH="${FIXTURE_ROOT}/extensions/wordpress" \
+HOMEBOY_COMPONENT_PATH="${FIXTURE_ROOT}/component" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="${FIXTURE_ROOT}/runner-prelude.sh" \
+    bash "${FIXTURE_ROOT}/extensions/wordpress/scripts/test/test-runner.sh" --help >/dev/null
+
+printf '%s\n' 'OK (1 test, 1 assertion)' > "${FIXTURE_ROOT}/phpunit-output.txt"
+HOMEBOY_EXTENSION_PATH="${FIXTURE_ROOT}/extensions/wordpress" \
+    bash "${FIXTURE_ROOT}/extensions/wordpress/scripts/test/parse-test-results.sh" \
+        "${FIXTURE_ROOT}/phpunit-output.txt" phpunit
+
+printf '%s\n' 'installed test helper resolution smoke passed'


### PR DESCRIPTION
## Summary

- resolve shared WordPress test helpers from `HOMEBOY_SHARED_LIB_DIR` or the logical installed extension root
- preserve the source-tree fallback for direct repository execution
- add an installed-symlink regression covering both the test runner and result parser

Fixes #2369.

## Verification

- `bash tests/installed-test-helper-resolution-smoke.sh`
- `bash scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash -n scripts/test/test-runner.sh scripts/test/parse-test-results.sh tests/installed-test-helper-resolution-smoke.sh`
- `jq empty homeboy.json`
- `git diff --check`
- Real Lab review succeeded in Homeboy job `26db1ce8-3080-47cc-9a3b-f80765bd0c40` after dev-syncing this extension commit.

The existing `host-smoke-wp-runner-smoke.sh` was not run standalone because it requires Homeboy-provided `HOMEBOY_RUNTIME_RESOLVE_CONTEXT`; the new regression directly reproduces the installed symlink shape that failed on Lab.

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode diagnosed the symlink traversal failure, drafted the helper-resolution fix and regression, and ran verification. Chris Huber reviewed and remains responsible for the change.