### PR TITLE
Fail multisite browser scenarios closed to local origins

### DIFF
--- a/wordpress/rigs/wordpress-multisite-e2e/run.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/run.mjs
@@ -83,6 +83,8 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
             args: [
               'url=http://localhost/alpha/fixture-check/',
               'route-host=localhost',
+              'network-policy=block',
+              'allow-host=localhost',
               'assert=exists:#synthetic-site-alpha',
               'assert=exists:#synthetic-auth-anonymous',
               'assert=no-console-errors',
@@ -95,6 +97,9 @@ export async function buildRecipe(settings = {}, cwd = process.cwd()) {
             args: [
               'auth=wordpress-admin',
               'auth-user-id=1',
+              'route-host=localhost',
+              'network-policy=block',
+              'allow-host=localhost',
               `steps-json=${JSON.stringify([
                 { kind: 'navigate', url: '/alpha/fixture-check/', waitFor: 'load' },
                 { kind: 'expect', selector: '#synthetic-site-alpha', state: 'visible' },
@@ -350,7 +355,7 @@ async function browserScenarioSteps(value, cwd) {
       : entry;
     scenarios.push({
       command: 'wordpress.browser-scenario',
-      args: [`scenario-json=${JSON.stringify(scenario)}`, 'route-host=localhost'],
+      args: [`scenario-json=${JSON.stringify(scenario)}`, 'route-host=localhost', 'network-policy=block', 'allow-host=localhost'],
     });
   }
   return scenarios;

--- a/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
+++ b/wordpress/rigs/wordpress-multisite-e2e/tests/contract.test.mjs
@@ -104,8 +104,13 @@ try {
     metadata: { provenance: { revision: 'fedcba9876543210' } },
   }]);
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.bench'));
-  assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario'));
-  assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-scenario' && step.args.includes('route-host=localhost')));
+  const browserSteps = recipe.workflow.steps.filter((step) => ['wordpress.browser-probe', 'wordpress.browser-actions', 'wordpress.browser-scenario'].includes(step.command));
+  assert.ok(browserSteps.some((step) => step.command === 'wordpress.browser-scenario'));
+  for (const step of browserSteps) {
+    assert.ok(step.args.includes('route-host=localhost'));
+    assert.ok(step.args.includes('network-policy=block'));
+    assert.ok(step.args.includes('allow-host=localhost'));
+  }
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-probe'));
   assert.ok(recipe.workflow.steps.some((step) => step.command === 'wordpress.browser-actions'));
   const seedIndex = recipe.workflow.steps.findIndex((step) => step.args?.some((arg) => arg.includes('network-seed.php')));


### PR DESCRIPTION
## Summary
- enable WP Codebox's blocking network policy for every multisite rig browser probe, action sequence, and consumer scenario
- allow and route only the localhost fixture host alongside the runtime's first-party preview origin
- enforce the policy in the rig contract test

This prevents mounted product code with canonical production URLs from letting a disposable browser scenario contact production. It composes WP Codebox's existing network boundary rather than adding another guardrail.

Fixes #2379.

## Verification
- `node --check rigs/wordpress-multisite-e2e/run.mjs`
- `node --test rigs/wordpress-multisite-e2e/tests/contract.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool:** OpenCode with GPT-5.6 Sol
- **Used for:** Reproducing the external navigation in an auth campaign, tracing existing WP Codebox policy support, implementing the composition fix, and testing it.