### PR TITLE
fix: forward PHPUnit runtime PHP version

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -30,6 +30,7 @@ const dependencies = dependencyPaths(settings).map((source) => {
 await requireHarness(harnessSource);
 const options = clean({
   wordpressVersion: settings.wordpress_runtime_version,
+  phpVersion: settings.wordpress_runtime_php_version,
   databaseType: settings.database_type,
   pluginSlug: slug,
   extra_plugins: [

--- a/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
@@ -109,6 +109,12 @@ try {
 
   const mysqlDatabase = await resolvedOptions({ pluginPhp: singleSitePlugin, settings: { database_type: 'mysql' } });
   assert.equal(mysqlDatabase.databaseType, 'mysql', 'database_type maps to the WP Codebox databaseType contract');
+
+  const defaultPhp = await resolvedOptions({ pluginPhp: singleSitePlugin });
+  assert.equal('phpVersion' in defaultPhp, false, 'omitted runtime PHP version preserves WP Codebox defaults');
+
+  const configuredPhp = await resolvedOptions({ pluginPhp: singleSitePlugin, settings: { wordpress_runtime_php_version: '8.4' } });
+  assert.equal(configuredPhp.phpVersion, '8.4', 'configured runtime PHP version maps to the WP Codebox phpVersion contract');
 } finally {
   await rm(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- forward `wordpress_runtime_php_version` into WP Codebox PHPUnit recipe options
- preserve WP Codebox defaults when the setting is omitted
- cover configured and omitted values in the existing adapter smoke test

## Why
Release tests could hydrate PHP 8.4 dependencies on a PHP 8.4 host and then silently launch a PHP 8.3 Playground runtime, causing Composer's platform check to crash before PHPUnit ran.

## Verification
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `node rigs/wordpress-multisite-e2e/tests/contract.test.mjs`
- `node --check scripts/test/wp-codebox-phpunit-adapter.mjs`
- `git diff --check`

Fixes #2382.