### PR TITLE
fix: execute local WP Codebox cache refresh directly

### DIFF
--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -95,16 +95,48 @@ esac
 cat > "${FAKE_BIN}/homeboy" <<'HOMEBOY'
 #!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >> "$HOMEBOY_CALLS"
 printf '%s\n' "$*"
 cat
 HOMEBOY
 chmod +x "${FAKE_BIN}/homeboy"
 
-DRY_RUN_OUTPUT="$(PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --runner example-runner --source "$REMOTE_REPO" --ref fixture-ref --dry-run)"
+HOMEBOY_CALLS="${WORK_DIR}/homeboy-calls"
+LOCAL_DRY_RUN_OUTPUT="$(HOMEBOY_CALLS="$HOMEBOY_CALLS" PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --source "$REMOTE_REPO" --ref fixture-ref --dry-run)"
+if [ -e "$HOMEBOY_CALLS" ]; then
+    echo "Local dry-run unexpectedly dispatched through Homeboy" >&2
+    cat "$HOMEBOY_CALLS" >&2
+    exit 1
+fi
+case "$LOCAL_DRY_RUN_OUTPUT" in
+    *"Fetching WP Codebox ref"*) ;;
+    *)
+        echo "Local dry-run output did not include cache update script" >&2
+        echo "$LOCAL_DRY_RUN_OUTPUT" >&2
+        exit 1
+        ;;
+esac
+case "$LOCAL_DRY_RUN_OUTPUT" in
+    *"runner exec"*)
+        echo "Local dry-run emitted runner dispatch" >&2
+        echo "$LOCAL_DRY_RUN_OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+DRY_RUN_OUTPUT="$(HOMEBOY_CALLS="$HOMEBOY_CALLS" PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --runner example-runner --source "$REMOTE_REPO" --ref fixture-ref --dry-run)"
 case "$DRY_RUN_OUTPUT" in
     "runner exec --script-file - --raw --env SOURCE="*) ;;
     *)
         echo "Dry-run did not pass runner exec options before runner id" >&2
+        echo "$DRY_RUN_OUTPUT" >&2
+        exit 1
+        ;;
+esac
+case "$DRY_RUN_OUTPUT" in
+    *"--env REQUESTED_REF=fixture-ref"*"--env CACHE_DIR="*"--env NPM_BIN=npm --ssh --dry-run example-runner"*) ;;
+    *)
+        echo "Dry-run did not preserve runner environment, SSH dispatch, and target" >&2
         echo "$DRY_RUN_OUTPUT" >&2
         exit 1
         ;;

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -83,20 +83,8 @@ if [ -z "$NPM_BIN" ]; then
     exit 2
 fi
 
-RUNNER_ID="${TARGET:-local}"
-RUNNER_ARGS=(runner exec --script-file - --raw --env "SOURCE=$SOURCE" --env "REQUESTED_REF=$REF" --env "CACHE_DIR=$CACHE_DIR" --env "NPM_BIN=$NPM_BIN")
-
-if [ -n "$TARGET" ]; then
-    RUNNER_ARGS+=(--ssh)
-fi
-
-if [ "$DRY_RUN" -eq 1 ]; then
-    RUNNER_ARGS+=(--dry-run)
-fi
-
-RUNNER_ARGS+=("$RUNNER_ID")
-
-homeboy "${RUNNER_ARGS[@]}" <<'REMOTE_SCRIPT'
+cache_update_script() {
+    cat <<'REMOTE_SCRIPT'
 set -euo pipefail
 
 fail() {
@@ -149,3 +137,28 @@ echo "Building WP Codebox packages..."
 SHA="$(git -C "$CACHE_DIR" rev-parse HEAD)" || fail "failed to read resulting WP Codebox SHA"
 echo "WP Codebox cache SHA: $SHA"
 REMOTE_SCRIPT
+}
+
+if [ -z "$TARGET" ]; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+        cache_update_script
+        exit 0
+    fi
+
+    cache_update_script | env \
+        SOURCE="$SOURCE" \
+        REQUESTED_REF="$REF" \
+        CACHE_DIR="$CACHE_DIR" \
+        NPM_BIN="$NPM_BIN" \
+        bash -s
+    exit 0
+fi
+
+RUNNER_ARGS=(runner exec --script-file - --raw --env "SOURCE=$SOURCE" --env "REQUESTED_REF=$REF" --env "CACHE_DIR=$CACHE_DIR" --env "NPM_BIN=$NPM_BIN" --ssh)
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    RUNNER_ARGS+=(--dry-run)
+fi
+
+RUNNER_ARGS+=("$TARGET")
+cache_update_script | homeboy "${RUNNER_ARGS[@]}"


### PR DESCRIPTION
## Summary
- execute no-target WP Codebox cache refreshes directly through local `bash` instead of unsupported `homeboy runner exec ... local`
- retain the existing SSH runner dispatch for targeted refreshes
- extend cache-refresh smoke coverage for local execution and targeted argument forwarding

## Root cause
`update-wp-codebox-cache.sh` converted an omitted target into the synthetic runner ID `local` and always called `homeboy runner exec`. Current Homeboy direct runner connect supports SSH runners only, so the documented local invocation failed before the generated cache-update script could run.

## Control flow
- Local: generate the shared cache-update script and execute it through `bash -s` with `SOURCE`, `REQUESTED_REF`, `CACHE_DIR`, and `NPM_BIN` explicitly forwarded. Local `--dry-run` prints that script without executing it or calling Homeboy.
- Targeted: pipe the same generated script to `homeboy runner exec --script-file - --raw ... --ssh <runner-id>`, preserving failure propagation and the existing remote behavior.

## Preserved arguments and environment
The source URL, requested ref, cache directory, npm executable, dry-run behavior, SSH selection, and target runner ID remain forwarded on their applicable paths. Both paths execute the same generated update script.

## Regression coverage
The cache-refresh smoke test now proves that a no-target dry-run never invokes Homeboy or emits `runner exec`, while targeted dry-run output still contains the expected environment, `--ssh`, `--dry-run`, and runner ID. Its existing local fixture also verifies clone/update, ref selection, npm install/build, absolute npm paths, resulting SHA output, and failures through real local execution.

## Verification
- `bash wordpress/scripts/build/update-wp-codebox-cache-smoke.sh` (passed)
- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh` (passed)
- `bash wordpress/scripts/test/wp-codebox-doctor-smoke.sh` (passed)
- declared WordPress extension `jq`, shell syntax, and Node syntax self-checks (passed)
- `node wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs` (passed)
- `bash wordpress/tests/installed-test-helper-resolution-smoke.sh` (passed)
- `git diff --check` (passed)

Fixes #2386