### PR TITLE
fix: activate PHPUnit validation dependencies

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -35,7 +35,7 @@ const options = clean({
   pluginSlug: slug,
   extra_plugins: [
     { source: root, sourceSubpath: subpath, slug, activate: false },
-    ...dependencies.map(({ source, slug: dependencySlug }) => ({ source, slug: dependencySlug, activate: false })),
+    ...dependencies.map(({ source, slug: dependencySlug }) => ({ source, slug: dependencySlug, activate: true })),
   ],
   dependencyMounts: [...new Set([sandboxPluginDirectory(slug), ...dependencies.map(({ sandboxDirectory }) => sandboxDirectory)])],
   testRoot: settings.wp_codebox_phpunit_test_root,

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -68,8 +68,8 @@ try {
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
   ]);
   assert.deepEqual(options[1].extra_plugins.slice(1), [
-    { source: component, slug: 'canonical-plugin', activate: false },
-    { source: dependency, slug: 'db-touching-dependency', activate: false },
+    { source: component, slug: 'canonical-plugin', activate: true },
+    { source: dependency, slug: 'db-touching-dependency', activate: true },
   ]);
   assert.deepEqual(options[1].dependencyMounts, [
     '/wordpress/wp-content/plugins/canonical-plugin',

--- a/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
@@ -106,6 +106,8 @@ try {
 
   const defaultDatabase = await resolvedOptions({ pluginPhp: singleSitePlugin });
   assert.equal('databaseType' in defaultDatabase, false, 'omitted database_type preserves WP Codebox defaults');
+  assert.equal(defaultDatabase.extra_plugins.length, 1, 'no dependencies only emits the primary plugin');
+  assert.equal(defaultDatabase.extra_plugins[0].activate, false, 'primary plugin remains inactive for the managed PHPUnit bootstrap');
 
   const mysqlDatabase = await resolvedOptions({ pluginPhp: singleSitePlugin, settings: { database_type: 'mysql' } });
   assert.equal(mysqlDatabase.databaseType, 'mysql', 'database_type maps to the WP Codebox databaseType contract');

--- a/wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh
+++ b/wordpress/tests/wp-codebox-phpunit-source-root-recipe-smoke.sh
@@ -9,17 +9,23 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 MONOREPO_DIR="${TMPDIR}/monorepo"
 PLUGIN_DIR="${MONOREPO_DIR}/plugins/sample-plugin"
+DEPENDENCY_DIR="${TMPDIR}/sample-dependency"
 FAKE_BIN="${TMPDIR}/wp-codebox"
 RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
 CAPTURED_RECIPE="${TMPDIR}/recipe.json"
 RUNNER_OUTPUT="${TMPDIR}/runner-output.txt"
-CORE_MODULE="${ROOT_DIR}/tests/fixtures/wp-codebox-core-recipe-builder.mjs"
 
-mkdir -p "${PLUGIN_DIR}/tests"
+mkdir -p "${PLUGIN_DIR}/tests" "$DEPENDENCY_DIR"
 cat > "${PLUGIN_DIR}/sample-plugin.php" <<'PHP'
 <?php
 /**
  * Plugin Name: Sample Plugin
+ */
+PHP
+cat > "${DEPENDENCY_DIR}/sample-dependency.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Sample Dependency
  */
 PHP
 cat > "${PLUGIN_DIR}/tests/SampleTest.php" <<'PHP'
@@ -32,35 +38,34 @@ class SampleTest extends WP_UnitTestCase {
 }
 PHP
 
-cat > "$FAKE_BIN" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
+cat > "$FAKE_BIN" <<'JS'
+#!/usr/bin/env node
+const fs = require('node:fs');
 
-if [ "${1:-}" = "commands" ]; then
-    printf '%s\n' 'recipe-run'
-    exit 0
-fi
+const args = process.argv.slice(2);
+const option = (name) => args[args.indexOf(name) + 1];
 
-recipe=""
-while [ "$#" -gt 0 ]; do
-	case "$1" in
-		--recipe)
-			shift
-			recipe="${1:-}"
-			;;
-	esac
-	shift || true
-done
+if (args[0] === 'recipe' && args[1] === 'build' && args[2] === 'phpunit') {
+	const options = JSON.parse(fs.readFileSync(option('--options'), 'utf8'));
+	const extraPlugins = (options.extra_plugins || []).map((plugin) => ({
+		...plugin,
+		sourceRoot: plugin.source,
+	}));
+	fs.writeFileSync(option('--output'), JSON.stringify({
+		schema: 'wp-codebox/workspace-recipe/v1',
+		inputs: { extra_plugins: extraPlugins },
+	}));
+	process.exit(0);
+}
 
-if [ -z "$recipe" ]; then
-	echo "missing --recipe" >&2
-	exit 2
-fi
+if (args[0] === 'recipe-run') {
+	fs.copyFileSync(option('--recipe'), process.env.CAPTURED_RECIPE);
+	process.stdout.write('{"executions":[{"stdout":"NO_TEST_FILES"}]}\n');
+	process.exit(0);
+}
 
-cp "$recipe" "$CAPTURED_RECIPE"
-printf '%s\n' 'NO_TEST_FILES' > "${HOMEBOY_PLUGIN_PATH}/.pg-test-result.txt"
-printf '%s\n' '{"executions":[{"stdout":"NO_TEST_FILES"}]}'
-SH
+process.exit(2);
+JS
 chmod +x "$FAKE_BIN"
 
 cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
@@ -81,11 +86,9 @@ HOMEBOY_EXTENSION_PATH="$ROOT_DIR" \
 HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
 HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
-HOMEBOY_WP_CODEBOX_CORE_MODULE="$CORE_MODULE" \
-HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT="$MONOREPO_DIR" \
-HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH="plugins/sample-plugin" \
+HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$DEPENDENCY_DIR" \
 CAPTURED_RECIPE="$CAPTURED_RECIPE" \
-HOMEBOY_SETTINGS_JSON="{\"phpunit_no_tests\":\"skip\"}" \
+HOMEBOY_SETTINGS_JSON="{\"phpunit_no_tests\":\"skip\",\"wp_codebox_source_root\":\"$MONOREPO_DIR\",\"wp_codebox_source_subpath\":\"plugins/sample-plugin\"}" \
 bash "$RUNNER" >"$RUNNER_OUTPUT" 2>&1
 runner_status=$?
 set -e
@@ -94,20 +97,29 @@ if [ "$runner_status" -ne 0 ]; then
     exit "$runner_status"
 fi
 
-node - "$CAPTURED_RECIPE" "$MONOREPO_DIR" <<'NODE'
+node - "$CAPTURED_RECIPE" "$MONOREPO_DIR" "$DEPENDENCY_DIR" <<'NODE'
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 
 const recipe = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
 const monorepo = process.argv[3];
+const dependency = process.argv[4];
 
-assert.deepEqual(recipe.inputs.extra_plugins, [{
-	source: monorepo,
-	sourceRoot: monorepo,
-	sourceSubpath: 'plugins/sample-plugin',
-	slug: 'sample-plugin',
-	activate: false,
-}]);
+assert.deepEqual(recipe.inputs.extra_plugins, [
+	{
+		source: monorepo,
+		sourceRoot: monorepo,
+		sourceSubpath: 'plugins/sample-plugin',
+		slug: 'sample-plugin',
+		activate: false,
+	},
+	{
+		source: dependency,
+		sourceRoot: dependency,
+		slug: 'sample-dependency',
+		activate: true,
+	},
+]);
 NODE
 
 echo "WP Codebox PHPUnit source-root recipe smoke passed"


### PR DESCRIPTION
## Summary
- activate resolved `validation_dependencies` in WP Codebox PHPUnit recipes
- keep the primary tested plugin inactive for the managed PHPUnit bootstrap
- cover dependency activation in both adapter options and the built recipe while preserving source-root/subpath behavior and the no-dependency case

## Root cause
The PHPUnit adapter correctly resolved and mounted validation dependency paths, but hard-coded `activate: false` on every dependency entry in `extra_plugins`. WP Codebox therefore made dependency files available without loading their plugin runtime, leaving helpers such as `extrachill_cross_site_rest_request()` and `extrachill_users_is_uuid_v4()` undefined during PHPUnit.

## Activation behavior
Before:
- primary tested plugin: `activate: false`
- every resolved validation dependency: `activate: false`

After:
- primary tested plugin: `activate: false`
- every resolved validation dependency: `activate: true`
- no declared dependencies: only the inactive primary plugin is emitted

## Contract choice
WP Codebox already represents component activation through the explicit `extra_plugins[].activate` field. Using that existing recipe contract is the owning-layer fix: dependencies remain normal mounted plugin entries, and WP Codebox performs activation before PHPUnit. No parallel activation steps or Homeboy-specific runtime abstraction are introduced.

The existing PHP runtime forwarding from #2383 remains unchanged, as do WordPress version, database type, multisite resolution, source roots/subpaths, dependency mounts, custom mounts, and PHPUnit options.

## Regression coverage
- canonical adapter smoke verifies resolved validation dependencies are sent to `recipe build phpunit` with `activate: true`
- source-root recipe smoke uses a fixture dependency and verifies the built recipe contains an inactive primary plugin plus an active dependency
- multisite smoke verifies the no-dependency case still emits only the inactive primary plugin

## Verification
Passed:
- `node tests/wp-codebox-canonical-cli-adapters-smoke.mjs`
- `bash tests/wp-codebox-phpunit-source-root-recipe-smoke.sh`
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `node rigs/wordpress-multisite-e2e/tests/contract.test.mjs`
- `node --check scripts/test/wp-codebox-phpunit-adapter.mjs`
- changed test syntax checks via `node --check` / `bash -n`
- `jq empty wordpress.json`
- declared WordPress extension shell syntax checks
- `bash scripts/test/wp-codebox-doctor-smoke.sh`
- `bash tests/installed-test-helper-resolution-smoke.sh`
- `bash tests/extension-composer-vendor-integrity-smoke.sh`
- `node tests/codebox-client-boundary.test.js`
- `node tests/wp-codebox-fuzz-run-smoke.js`
- `node tests/wp-codebox-artifacts-isolated-snapshot-smoke.js`
- `node tests/wordpress-manifest-settings-smoke.js`
- `git diff --check`

Unrelated baseline self-check failures discovered on unchanged `origin/main` files are tracked separately:
- #2388: direct no-PHPUnit self-check invocation lacks its required runtime prelude environment
- #2389: WordPress fuzz runner fake runtime descriptor is stale

Fixes #2385