### PR TITLE
fix: defer PHPUnit validation dependency loading

### DIFF
--- a/.github/workflows/wp-codebox-test-runtime-canary.yml
+++ b/.github/workflows/wp-codebox-test-runtime-canary.yml
@@ -8,6 +8,8 @@ on:
       - wordpress/scripts/test/**
       - wordpress/tests/fixtures/test-db-activation-host/**
       - wordpress/tests/fixtures/bench-db-activation-dep/**
+      - wordpress/tests/fixtures/test-managed-dependency-order-host/**
+      - wordpress/tests/fixtures/managed-dependency-order-dep/**
 
 permissions:
   contents: read
@@ -61,6 +63,13 @@ jobs:
           HOMEBOY_WP_CODEBOX_CORE_MODULE: ${{ github.workspace }}/.ci/wp-codebox/packages/runtime-core/dist/index.js
           HOMEBOY_CORE_DIR: ${{ github.workspace }}/.ci/homeboy
         run: bash wordpress/scripts/test/playground-db-activation-smoke.sh
+
+      - name: Run managed dependency ordering canary
+        env:
+          HOMEBOY_WP_CODEBOX_BIN: ${{ github.workspace }}/.ci/wp-codebox/packages/cli/dist/index.js
+          HOMEBOY_WP_CODEBOX_CORE_MODULE: ${{ github.workspace }}/.ci/wp-codebox/packages/runtime-core/dist/index.js
+          HOMEBOY_CORE_DIR: ${{ github.workspace }}/.ci/homeboy
+        run: bash wordpress/scripts/test/playground-managed-dependency-order-smoke.sh
 
       - name: Run raw extra_plugins Composer autoload canary
         env:

--- a/wordpress/scripts/test/playground-managed-dependency-order-smoke.sh
+++ b/wordpress/scripts/test/playground-managed-dependency-order-smoke.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
+CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR}/crates/homeboy-extension/src/runtime"
+HOST_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/test-managed-dependency-order-host"
+DEP_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/managed-dependency-order-dep"
+ARTIFACTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-managed-dependency-order.XXXXXX")"
+trap 'rm -rf "$ARTIFACTS_DIR"' EXIT
+
+if [ -e "${DEP_FIXTURE_DIR}/vendor/autoload.php" ]; then
+    echo "ERROR: dependency fixture unexpectedly has a prepared Composer autoloader" >&2
+    exit 1
+fi
+
+SETTINGS_JSON=$(jq -nc --arg dependency "$DEP_FIXTURE_DIR" '{validation_dependencies: [$dependency]}')
+
+set +e
+runner_output=$(HOMEBOY_COMPONENT_ID=test-managed-dependency-order-host \
+    HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${CORE_RUNTIME_DIR}/runner-prelude.sh}" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${CORE_RUNTIME_DIR}/resolve-context.sh}" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${CORE_RUNTIME_DIR}/runner-steps.sh}" \
+    HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="$ARTIFACTS_DIR" \
+    bash "${SCRIPT_DIR}/test-runner.sh" 2>&1)
+runner_status=$?
+set -e
+printf '%s\n' "$runner_output"
+
+if [ "$runner_status" -ne 0 ]; then
+    exit "$runner_status"
+fi
+
+if [[ "$runner_output" =~ Constant\ (DB_NAME|DB_USER|DB_HOST|ABSPATH)\ already\ defined ]] || \
+   [[ "$runner_output" == *'Undefined variable $wpdb'* ]]; then
+    echo "ERROR: dependency loaded before the managed PHPUnit install completed" >&2
+    exit 1
+fi
+
+if [[ "$runner_output" != *"WP Codebox test run complete."* ]]; then
+    echo "ERROR: expected managed PHPUnit success classification" >&2
+    exit 1
+fi
+
+echo "Managed PHPUnit dependency ordering smoke passed."

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -35,7 +35,7 @@ const options = clean({
   pluginSlug: slug,
   extra_plugins: [
     { source: root, sourceSubpath: subpath, slug, activate: false },
-    ...dependencies.map(({ source, slug: dependencySlug }) => ({ source, slug: dependencySlug, activate: true })),
+    ...dependencies.map(({ source, slug: dependencySlug }) => ({ source, slug: dependencySlug, activate: false })),
   ],
   dependencyMounts: [...new Set([sandboxPluginDirectory(slug), ...dependencies.map(({ sandboxDirectory }) => sandboxDirectory)])],
   testRoot: settings.wp_codebox_phpunit_test_root,

--- a/wordpress/tests/fixtures/managed-dependency-order-dep/composer.json
+++ b/wordpress/tests/fixtures/managed-dependency-order-dep/composer.json
@@ -1,0 +1,7 @@
+{
+  "autoload": {
+    "psr-4": {
+      "HomeboyManagedDependencyOrder\\": "src/"
+    }
+  }
+}

--- a/wordpress/tests/fixtures/managed-dependency-order-dep/managed-dependency-order-dep.php
+++ b/wordpress/tests/fixtures/managed-dependency-order-dep/managed-dependency-order-dep.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: Managed Dependency Order Fixture
+ */
+
+$GLOBALS['homeboy_managed_dependency_class_preloaded'] = class_exists(
+    \HomeboyManagedDependencyOrder\Canary::class,
+    false
+);
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$GLOBALS['homeboy_managed_dependency_loaded'] = class_exists(
+    \HomeboyManagedDependencyOrder\Canary::class
+);
+
+register_activation_hook( __FILE__, static function (): void {
+    global $wpdb;
+
+    if ( ! $wpdb instanceof wpdb ) {
+        throw new RuntimeException( 'Managed dependency activation received an invalid $wpdb.' );
+    }
+
+    update_option( 'homeboy_managed_dependency_activated', \HomeboyManagedDependencyOrder\Canary::value() );
+} );

--- a/wordpress/tests/fixtures/managed-dependency-order-dep/src/Canary.php
+++ b/wordpress/tests/fixtures/managed-dependency-order-dep/src/Canary.php
@@ -1,0 +1,8 @@
+<?php
+namespace HomeboyManagedDependencyOrder;
+
+final class Canary {
+    public static function value(): string {
+        return 'managed-dependency-loaded';
+    }
+}

--- a/wordpress/tests/fixtures/test-managed-dependency-order-host/test-managed-dependency-order-host.php
+++ b/wordpress/tests/fixtures/test-managed-dependency-order-host/test-managed-dependency-order-host.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Plugin Name: Managed Dependency Order Host Fixture
+ */
+
+$GLOBALS['homeboy_managed_dependency_available_during_install'] = class_exists(
+    \HomeboyManagedDependencyOrder\Canary::class,
+    false
+);
+
+add_action( 'plugins_loaded', static function (): void {
+    $GLOBALS['homeboy_managed_dependency_component_value'] = \HomeboyManagedDependencyOrder\Canary::value();
+} );

--- a/wordpress/tests/fixtures/test-managed-dependency-order-host/tests/ManagedDependencyOrderTest.php
+++ b/wordpress/tests/fixtures/test-managed-dependency-order-host/tests/ManagedDependencyOrderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+class ManagedDependencyOrderTest extends WP_UnitTestCase {
+    public function test_dependency_loads_after_install_before_component_lifecycle(): void {
+        $this->assertFalse( $GLOBALS['homeboy_managed_dependency_available_during_install'] );
+        $this->assertFalse( $GLOBALS['homeboy_managed_dependency_class_preloaded'] );
+        $this->assertTrue( $GLOBALS['homeboy_managed_dependency_loaded'] );
+        $this->assertSame(
+            'managed-dependency-loaded',
+            $GLOBALS['homeboy_managed_dependency_component_value']
+        );
+        $this->assertSame(
+            'managed-dependency-loaded',
+            get_option( 'homeboy_managed_dependency_activated' )
+        );
+    }
+
+    public function test_managed_install_preserves_wordpress_database(): void {
+        global $wpdb;
+
+        $this->assertInstanceOf( wpdb::class, $wpdb );
+        $this->assertSame( '1', (string) $wpdb->get_var( 'SELECT 1' ) );
+    }
+}

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -68,8 +68,8 @@ try {
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
   ]);
   assert.deepEqual(options[1].extra_plugins.slice(1), [
-    { source: component, slug: 'canonical-plugin', activate: true },
-    { source: dependency, slug: 'db-touching-dependency', activate: true },
+    { source: component, slug: 'canonical-plugin', activate: false },
+    { source: dependency, slug: 'db-touching-dependency', activate: false },
   ]);
   assert.deepEqual(options[1].dependencyMounts, [
     '/wordpress/wp-content/plugins/canonical-plugin',


### PR DESCRIPTION
## Summary
- mount PHPUnit validation dependencies inactive while preserving the existing `dependencyMounts` handoff
- let managed WP Codebox PHPUnit load and activate dependencies after test installation instead of during recipe setup
- add a Composer-autoloaded dependency canary proving code is absent during install, available to component lifecycle/tests afterward, and leaves the managed `$wpdb` usable

Fixes #2394.

This unblocks the managed PHPUnit consumer failure in Extra-Chill/data-machine-events#530, where pre-activation produced duplicate `DB_*`/`ABSPATH` definitions and an undefined `$wpdb` after the real Data Machine dependency was mounted.

## Evidence
- generated PHPUnit options keep the component and validation dependencies at `activate: false`
- `dependencyMounts` remains unchanged and includes both component and dependency sandbox paths
- real WP Codebox 0.13.2 canary: `OK (2 tests, 7 assertions)`
- canary verifies the Composer dependency class is unavailable during managed installation, available to deferred component lifecycle and PHPUnit tests, activation can write through WordPress, and `$wpdb->get_var( 'SELECT 1' )` succeeds
- canary rejects duplicate `DB_NAME`, `DB_USER`, `DB_HOST`, or `ABSPATH` definitions and undefined `$wpdb` diagnostics

## Verification
- `node tests/wp-codebox-canonical-cli-adapters-smoke.mjs`
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `bash scripts/test/playground-managed-dependency-order-smoke.sh` with explicit Homeboy runtime helpers
- declared WordPress extension lint checks
- PHP syntax checks for all new fixtures
- Prettier workflow validation
- declared extension tests passed except `wordpress-fuzz-runner-smoke.js`, which is unrelated and currently expects public fuzz contracts absent from the installed WP Codebox 0.13.2 runtime descriptor
- `git diff --check`

## Residual Risk
- the local runtime canary used WP Codebox 0.13.2; CI checks out and builds current WP Codebox `main`, so the PR canary remains authoritative for current cross-repository compatibility
- the unrelated fuzz-runner smoke remains blocked by local WP Codebox runtime-contract drift