### PR TITLE
fix: ignore nested WordPress build bundles

### DIFF
--- a/wordpress/eslint.config.mjs
+++ b/wordpress/eslint.config.mjs
@@ -8,7 +8,7 @@ export default [
     ignores: [
       'node_extensions/',
       'vendor/',
-      'build/',
+      '**/build/**',
       'dist/',
       '*.min.js',
       'tests/',

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -81,6 +81,7 @@
   },
   "scripts": {
     "lint:js": "eslint",
+    "test:eslint-build-ignore": "bash scripts/lint/eslint-build-ignore-smoke.sh",
     "test:admin-page-scenarios": "node tests/admin-page-scenarios-smoke.js",
     "test:admin-page-fuzz-surfaces": "node tests/admin-page-fuzz-surfaces-smoke.js",
     "test:wordpress-admin-form-action-surfaces": "node tests/wordpress-admin-form-action-surfaces-smoke.js",

--- a/wordpress/scripts/lint/eslint-build-ignore-smoke.sh
+++ b/wordpress/scripts/lint/eslint-build-ignore-smoke.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+component_dir="${TMPDIR}/component"
+mkdir -p "${component_dir}/build" "${component_dir}/nested/build" "${component_dir}/nested/src"
+
+printf '%s\n' 'const = rootBuild;' > "${component_dir}/build/app.js"
+printf '%s\n' 'const = nestedBuild;' > "${component_dir}/nested/build/app.js"
+printf '%s\n' 'export {};' > "${component_dir}/nested/src/app.js"
+
+run_eslint() {
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_ID="component" \
+    HOMEBOY_COMPONENT_PATH="$component_dir" \
+    HOMEBOY_COMPONENT_TEXT_DOMAIN="component" \
+        bash "${SCRIPT_DIR}/eslint-runner.sh"
+}
+
+run_eslint > "${TMPDIR}/build-only.out"
+
+printf '%s\n' 'const = source;' > "${component_dir}/nested/src/app.js"
+if run_eslint > "${TMPDIR}/invalid-source.out" 2>&1; then
+    echo "Expected sibling source to remain linted" >&2
+    exit 1
+fi
+
+if ! grep -Fq "nested/src/app.js" "${TMPDIR}/invalid-source.out"; then
+    echo "Expected ESLint failure to identify nested/src/app.js" >&2
+    sed 's/^/  /' "${TMPDIR}/invalid-source.out" >&2
+    exit 1
+fi
+
+echo "ESLint nested build ignore smoke passed"


### PR DESCRIPTION
## Summary
- ignore generated `build` directories at every nesting depth in the generic WordPress ESLint config
- preserve full-component source discovery and existing generated-file exclusions
- add real-ESLint regression coverage for root and nested build bundles alongside nested source

## Verification
- `npm run test:eslint-build-ignore`
- `npx eslint eslint.config.mjs`
- `bash -n scripts/lint/eslint-build-ignore-smoke.sh`
- `git diff --check`

The adjacent `eslint-glob-filter-smoke.sh` could not start because its expected sibling Homeboy core checkout/helper is unavailable in this workspace. `shellcheck` is not installed.

Closes #2397