### PR TITLE
fix: restore explicit PHPUnit runtime preparation

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -18,6 +18,7 @@ const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
 const pluginSourceDirectory = subpath ? path.join(root, subpath) : root;
 const multisite = await resolveMultisite(settings, pluginSourceDirectory);
+runPrepareSteps(settings.wp_codebox_prepare_steps, pluginSourceDirectory);
 const directory = await mkdtemp(path.join(tmpdir(), 'homeboy-wp-codebox-phpunit-'));
 const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
@@ -128,6 +129,29 @@ function sandboxPluginDirectory(pluginSlug) {
 }
 function canonicalMounts(value) {
   return Array.isArray(value) ? value : [];
+}
+function runPrepareSteps(steps, sourceRoot) {
+  if (!Array.isArray(steps)) {
+    return;
+  }
+  for (const step of steps) {
+    if (!step || typeof step.command !== 'string' || step.command.trim() === '') {
+      throw new Error('wp_codebox_prepare_steps entries require a non-empty command');
+    }
+    const args = Array.isArray(step.args) && step.args.every((value) => typeof value === 'string') ? step.args : [];
+    const cwd = path.resolve(sourceRoot, typeof step.cwd === 'string' ? step.cwd : '.');
+    const relative = path.relative(sourceRoot, cwd);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error(`wp_codebox_prepare_steps cwd escapes the source root: ${step.cwd}`);
+    }
+    const result = spawnSync(step.command, args, { cwd, encoding: 'utf8', stdio: 'inherit' });
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      throw new Error(`wp_codebox_prepare_steps command failed (${step.command}, exit ${result.status ?? 1})`);
+    }
+  }
 }
 async function requireHarness(source) {
   try {

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -15,7 +15,7 @@ assert.ok(
 	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
 );
 
-for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version', 'wordpress_runtime_workload_plugin_slug']) {
+for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wp_codebox_multisite', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version', 'wordpress_runtime_workload_plugin_slug']) {
 	assert.ok(settingIds.has(settingId), `wordpress manifest declares ${settingId}`);
 }
 

--- a/wordpress/tests/wp-codebox-phpunit-source-root-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-source-root-smoke.js
@@ -60,6 +60,16 @@ process.stdout.write(JSON.stringify({
   fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
 const fs = require('node:fs');
 const path = require('node:path');
+if (process.argv[2] === 'recipe' && process.argv[3] === 'build') {
+  const options = JSON.parse(fs.readFileSync(process.argv[process.argv.indexOf('--options') + 1], 'utf8'));
+  const plugins = (options.extra_plugins || []).map((plugin) => ({ ...plugin, sourceRoot: plugin.source }));
+  fs.writeFileSync(process.argv[process.argv.indexOf('--output') + 1], JSON.stringify({
+    schema: 'wp-codebox/workspace-recipe/v1',
+    inputs: { extra_plugins: plugins },
+    workflow: { steps: [{ command: 'wordpress.phpunit', args: [] }] },
+  }));
+  process.exit(0);
+}
 const recipeIndex = process.argv.indexOf('--recipe');
 if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
   process.exit(2);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1280,6 +1280,13 @@
       "description": "How the WP Codebox PHPUnit backend prepares WordPress tests. Use 'managed' for the Homeboy-managed WordPress test bootstrap, 'project' for the component's native PHPUnit bootstrap, or 'auto' to use project mode when phpunit.xml(.dist) declares a bootstrap attribute."
     },
     {
+      "id": "wp_codebox_multisite",
+      "label": "WP Codebox PHPUnit multisite",
+      "type": "boolean",
+      "default": false,
+      "description": "Explicitly enable multisite for plugin PHPUnit, including plugins that are not network-only. False forces single-site; HOMEBOY_WORDPRESS_MULTISITE remains the higher-precedence runtime override."
+    },
+    {
       "id": "wp_codebox_phpunit_project_bootstrap",
       "label": "WP Codebox PHPUnit project bootstrap",
       "type": "string",


### PR DESCRIPTION
## Summary
- declare the existing `wp_codebox_multisite` adapter setting so Homeboy preserves explicit multisite requests
- execute bounded `wp_codebox_prepare_steps` before PHPUnit recipe construction and readonly sandbox mounting
- restore source-root coverage to the canonical recipe-builder CLI contract

## Verification
- `node tests/wordpress-manifest-settings-smoke.js`
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `node tests/wp-codebox-phpunit-source-root-smoke.js`

Closes #2399.
Closes #2401.

Consumer context: Extra-Chill/data-machine-events#546.