### PR TITLE
fix: preserve structured PHPUnit failure evidence

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -121,6 +121,7 @@
     "test:wp-codebox-recipe-helper": "node tests/wp-codebox-recipe-helper-smoke.js",
     "test:wp-codebox-fuzz-plan-recipe-builder": "node tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js",
     "test:wp-codebox-canonical-cli-adapters": "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
+    "test:wp-codebox-phpunit-evidence": "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
     "test:wp-codebox-doctor": "bash scripts/test/wp-codebox-doctor-smoke.sh",
     "test:extension-composer-vendor-integrity": "bash tests/extension-composer-vendor-integrity-smoke.sh",
     "test:wordpress-multisite-e2e-rig": "node rigs/wordpress-multisite-e2e/tests/contract.test.mjs",

--- a/wordpress/scripts/test/parse-test-failures.php
+++ b/wordpress/scripts/test/parse-test-failures.php
@@ -197,6 +197,8 @@ foreach ( $blocks as $block ) {
 		'fingerprint'    => $fingerprint,
 		'stdout_excerpt' => $stdout_excerpt,
 		'stderr_excerpt' => '',
+		'status'         => $block['status'] ?? 'failure',
+		'stack_trace'    => implode( "\n", $trace_lines ),
 	];
 }
 
@@ -324,6 +326,7 @@ $output = [
 	'failures' => $failures,
 	'total'    => $total,
 	'passed'   => $passed,
+	'metadata' => phpunit_failure_metadata( $failures, $raw ),
 ];
 
 echo json_encode( $output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
@@ -356,12 +359,115 @@ function parse_wp_codebox_test_results( array $payload, string $test_results_pat
 		}
 	}
 
+	$raw_output = wp_codebox_raw_phpunit_output( $payload, $artifact_root );
+	if ( $raw_output !== '' && count( $failures ) < (int) ( $summary['failed'] ?? 0 ) ) {
+		$existing_test_ids = array_column( $failures, 'test_id' );
+		foreach ( parse_wp_codebox_phpunit_text( $raw_output, $component_path ) as $text_failure ) {
+			if ( ! in_array( $text_failure['test_id'], $existing_test_ids, true ) ) {
+				$failures[]         = $text_failure;
+				$existing_test_ids[] = $text_failure['test_id'];
+			}
+		}
+	}
 	$failures = array_merge( $failures, wp_codebox_diagnostic_failures( $artifact_root, $component_path, $raw_excerpt ) );
 
 	return [
 		'failures' => $failures,
 		'total'    => $total,
 		'passed'   => $passed,
+		'metadata' => phpunit_failure_metadata( $failures, $raw_output ),
+	];
+}
+
+/**
+ * Parse PHPUnit 9's numbered textual failure and error sections.
+ */
+function parse_wp_codebox_phpunit_text( string $raw, string $component_path ): array {
+	$records = [];
+	foreach ( parse_standard_blocks( explode( "\n", $raw ) ) as $block ) {
+		$test_name    = preg_replace( '/ with data set.*$/', '', $block['header'] );
+		$message_lines = [];
+		$trace_lines   = [];
+		$in_trace      = false;
+		foreach ( $block['body_lines'] as $line ) {
+			$trimmed = trim( $line );
+			if ( $trimmed === '' ) {
+				continue;
+			}
+			if ( preg_match( '#^(/[^\s:]+\.php):\d+$#', $trimmed ) || preg_match( '#^\s*at\s+(/[^\s:]+\.php):\d+#', $line ) ) {
+				$in_trace      = true;
+				$trace_lines[] = preg_replace( '/^at\s+/', '', $trimmed );
+				continue;
+			}
+			if ( ! $in_trace ) {
+				$message_lines[] = $trimmed;
+			}
+		}
+		$message     = implode( "\n", $message_lines );
+		$error_type = classify_error_type( $message );
+		$source      = extract_source_from_trace( $trace_lines, $component_path );
+		$test_file   = $source['test_file'] ?: guess_test_file_from_name( $test_name );
+		$file        = $source['source_file'] ?: $test_file;
+		$line        = $source['source_line'];
+		$records[]   = [
+			'test_name'      => $test_name,
+			'test_file'      => $test_file,
+			'error_type'     => $error_type,
+			'message'        => $message,
+			'source_file'    => $source['source_file'],
+			'source_line'    => $line,
+			'test_id'        => $test_name,
+			'suite'          => 'phpunit',
+			'file'           => $file,
+			'line'           => $line,
+			'failure_type'   => $error_type,
+			'fingerprint'    => make_failure_fingerprint( $test_name, $file, $line, $error_type, $message ),
+			'stdout_excerpt' => make_output_excerpt( array_merge( [ $block['header'] ], $block['body_lines'] ) ),
+			'stderr_excerpt' => '',
+			'status'         => $block['status'] ?? 'failure',
+			'stack_trace'    => implode( "\n", $trace_lines ),
+		];
+	}
+	return $records;
+}
+
+/**
+ * Load the complete PHPUnit stream referenced by WP Codebox.
+ */
+function wp_codebox_raw_phpunit_output( array $payload, string $artifact_root ): string {
+	foreach ( (array) ( $payload['rawLogReferences'] ?? [] ) as $reference ) {
+		if ( ! is_array( $reference ) || ( $reference['kind'] ?? '' ) !== 'phpunit-output' || empty( $reference['path'] ) ) {
+			continue;
+		}
+		$path = substr( $reference['path'], 0, 1 ) === '/' ? $reference['path'] : $artifact_root . '/' . $reference['path'];
+		if ( is_file( $path ) ) {
+			return (string) file_get_contents( $path );
+		}
+	}
+	return '';
+}
+
+/**
+ * Keep aggregate failure/error/assertion metadata aligned with parsed records.
+ */
+function phpunit_failure_metadata( array $failures, string $raw ): array {
+	$phpunit_failures = array_filter( $failures, static fn( $failure ) => strtolower( (string) ( $failure['suite'] ?? 'phpunit' ) ) === 'phpunit' );
+	$errors = count( array_filter( $phpunit_failures, static fn( $failure ) => ( $failure['status'] ?? '' ) === 'error' ) );
+	$assertion_failures = count( array_filter( $phpunit_failures, static fn( $failure ) => ( $failure['status'] ?? 'failure' ) === 'failure' ) );
+	$assertions = 0;
+	$skipped = 0;
+	if ( preg_match_all( '/^Tests:\s*\d+.*$/m', $raw, $summary_lines ) && ! empty( $summary_lines[0] ) ) {
+		$summary = end( $summary_lines[0] );
+		preg_match( '/Assertions:\s*(\d+)/', $summary, $assertion_match );
+		preg_match( '/Skipped:\s*(\d+)/', $summary, $skipped_match );
+		$assertions = (int) ( $assertion_match[1] ?? 0 );
+		$skipped = (int) ( $skipped_match[1] ?? 0 );
+	}
+	return [
+		'assertions' => $assertions,
+		'failures'   => $assertion_failures,
+		'errors'     => $errors,
+		'skipped'    => $skipped,
 	];
 }
 
@@ -424,9 +530,14 @@ function wp_codebox_diagnostic_failures( string $artifact_root, string $componen
 function wp_codebox_failure_entries( array $suite ): array {
 	$entries = [];
 
-	foreach ( [ 'failures', 'errors' ] as $key ) {
+	foreach ( [ 'failures' => 'failure', 'errors' => 'error' ] as $key => $status ) {
 		if ( is_array( $suite[ $key ] ?? null ) ) {
-			$entries = array_merge( $entries, $suite[ $key ] );
+			foreach ( $suite[ $key ] as $entry ) {
+				if ( is_array( $entry ) && empty( $entry['status'] ) ) {
+					$entry['status'] = $status;
+				}
+				$entries[] = $entry;
+			}
 		}
 	}
 
@@ -440,6 +551,9 @@ function wp_codebox_failure_entries( array $suite ): array {
 
 	foreach ( $test_entries as $test ) {
 		if ( is_array( $test ) && in_array( $test['status'] ?? '', [ 'failed', 'error' ], true ) ) {
+			if ( $test['status'] === 'failed' ) {
+				$test['status'] = 'failure';
+			}
 			$entries[] = $test;
 		}
 	}
@@ -484,6 +598,7 @@ function normalize_wp_codebox_failure_entry( array $entry, string $suite_name, s
 	$line           = $source_line;
 	$stdout_excerpt = (string) ( $entry['stdout_excerpt'] ?? $entry['stdout'] ?? $entry['output'] ?? '' );
 	$stderr_excerpt = (string) ( $entry['stderr_excerpt'] ?? $entry['stderr'] ?? '' );
+	$stack_trace    = (string) ( $entry['stack_trace'] ?? $entry['stackTrace'] ?? $entry['trace'] ?? '' );
 
 	if ( $stdout_excerpt === '' ) {
 		$stdout_excerpt = $raw_excerpt;
@@ -509,6 +624,8 @@ function normalize_wp_codebox_failure_entry( array $entry, string $suite_name, s
 		'fingerprint'    => $fingerprint,
 		'stdout_excerpt' => make_output_excerpt( explode( "\n", $stdout_excerpt ) ),
 		'stderr_excerpt' => make_output_excerpt( explode( "\n", $stderr_excerpt ) ),
+		'status'         => in_array( $entry['status'] ?? '', [ 'error', 'failure' ], true ) ? $entry['status'] : 'failure',
+		'stack_trace'    => $stack_trace,
 	];
 }
 

--- a/wordpress/scripts/test/parsers/standard.php
+++ b/wordpress/scripts/test/parsers/standard.php
@@ -29,6 +29,7 @@ require_once __DIR__ . '/classify-error.php';
  */
 function parse_standard_blocks( array $lines ): array {
 	$in_failure_section = false;
+	$section_type       = 'failure';
 	$current_block      = null;
 	$blocks             = [];
 
@@ -36,8 +37,9 @@ function parse_standard_blocks( array $lines ): array {
 		$line = $lines[ $i ];
 
 		// Detect start of failure/error listing sections
-		if ( preg_match( '/^There (?:was|were) \d+ (?:error|failure)/i', $line ) ) {
+		if ( preg_match( '/^There (?:was|were) \d+ (error|failure)/i', $line, $section_match ) ) {
 			$in_failure_section = true;
+			$section_type       = strtolower( $section_match[1] );
 			continue;
 		}
 
@@ -73,6 +75,7 @@ function parse_standard_blocks( array $lines ): array {
 			$current_block = [
 				'header'     => trim( $m[1] ),
 				'body_lines' => [],
+				'status'     => $section_type,
 			];
 			continue;
 		}

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -2,11 +2,13 @@
 /**
  * External dependencies
  */
-import { access, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { access, copyFile, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 import { fileURLToPath } from 'node:url';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 const settings = json(process.env.HOMEBOY_SETTINGS_JSON, {});
 const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMPONENT_PATH');
@@ -55,11 +57,94 @@ try {
   await writeFile(optionsPath, `${JSON.stringify(options)}\n`);
   run(['recipe', 'build', 'phpunit', '--options', optionsPath, '--output', recipePath]);
   await mkdir(runArtifacts, { recursive: true });
-  run(['recipe-run', '--recipe', recipePath, '--artifacts', runArtifacts, '--json']);
-  await handoffArtifacts(runArtifacts);
-  process.stdout.write('WP Codebox test run complete.\n');
+  const execution = await runCaptured(['recipe-run', '--recipe', recipePath, '--artifacts', runArtifacts, '--json']);
+  await handoffArtifacts(runArtifacts, execution);
+  if (execution.status !== 0) {
+    process.exitCode = execution.status;
+  } else {
+    process.stdout.write('WP Codebox test run complete.\n');
+  }
 } finally {
   await rm(directory, { recursive: true, force: true });
+}
+async function runCaptured(args) {
+  const logsDirectory = path.join(runArtifacts, 'logs');
+  const stdoutPath = path.join(logsDirectory, 'recipe-run.stdout.log');
+  const stderrPath = path.join(logsDirectory, 'recipe-run.stderr.log');
+  await mkdir(logsDirectory, { recursive: true });
+  const secretValues = configuredSecretValues();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', args, { cwd: componentPath, stdio: ['ignore', 'pipe', 'pipe'] });
+    const stdoutFile = createWriteStream(stdoutPath);
+    const stderrFile = createWriteStream(stderrPath);
+    const stdoutRedactor = createLineRedactor(secretValues);
+    const stderrRedactor = createLineRedactor(secretValues);
+    let childError;
+
+    child.stdout.on('data', (chunk) => {
+      chunk = stdoutRedactor.write(chunk);
+      stdoutFile.write(chunk);
+      process.stdout.write(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      chunk = stderrRedactor.write(chunk);
+      stderrFile.write(chunk);
+      process.stderr.write(chunk);
+    });
+    child.on('error', (error) => { childError = error; });
+    child.on('close', (status) => {
+      const stdoutTail = stdoutRedactor.end();
+      const stderrTail = stderrRedactor.end();
+      stdoutFile.write(stdoutTail);
+      stderrFile.write(stderrTail);
+      process.stdout.write(stdoutTail);
+      process.stderr.write(stderrTail);
+      stdoutFile.end();
+      stderrFile.end();
+      Promise.all([
+        new Promise((done) => stdoutFile.on('finish', done)),
+        new Promise((done) => stderrFile.on('finish', done)),
+      ]).then(() => {
+        if (childError) {
+          reject(childError);
+          return;
+        }
+        resolve({ status: status ?? 1, stdoutPath, stderrPath });
+      }, reject);
+    });
+  });
+}
+function configuredSecretValues() {
+  const configured = settings.bench_env && typeof settings.bench_env === 'object' ? settings.bench_env : {};
+  return Object.entries({ ...process.env, ...configured })
+    .filter(([name, value]) => /(?:auth|cookie|credential|key|nonce|passw|secret|session|token)/i.test(name) && typeof value === 'string' && value.length >= 8)
+    .map(([, value]) => value)
+    .sort((left, right) => right.length - left.length);
+}
+function createLineRedactor(secretValues) {
+  const decoder = new StringDecoder('utf8');
+  let pending = '';
+  const redact = (text) => {
+    for (const secret of secretValues) {
+      text = text.replaceAll(secret, '[REDACTED]');
+    }
+    return text;
+  };
+  return {
+    write(chunk) {
+      pending += decoder.write(chunk);
+      const boundary = pending.lastIndexOf('\n') + 1;
+      if (boundary === 0) { return ''; }
+      const completeLines = pending.slice(0, boundary);
+      pending = pending.slice(boundary);
+      return redact(completeLines);
+    },
+    end() {
+      pending += decoder.end();
+      return redact(pending);
+    },
+  };
 }
 
 function run(args) {
@@ -139,7 +224,7 @@ async function requireHarness(source) {
     throw new Error(`WP Codebox PHPUnit harness is required at ${source}. Run composer install in ${extensionRoot}.`);
   }
 }
-async function handoffArtifacts(artifactRoot) {
+async function handoffArtifacts(artifactRoot, execution) {
   let pointer;
   try { pointer = await readFile(path.join(artifactRoot, 'latest-runtime.json'), 'utf8'); } catch { return; }
   const runtime = json(pointer, {}).paths?.runtimeDirectory;
@@ -147,12 +232,62 @@ async function handoffArtifacts(artifactRoot) {
     return;
   }
   const artifactDirectory = path.join(artifactRoot, runtime);
+  await preservePhpunitOutput(artifactDirectory, execution);
   if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
     runScript('parse-test-results.sh', [artifactDirectory]);
   }
   if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
     runScript('parse-test-failures.sh', [artifactDirectory, componentPath]);
   }
+}
+async function preservePhpunitOutput(artifactDirectory, execution) {
+  const filesDirectory = path.join(artifactDirectory, 'files');
+  const logsDirectory = path.join(artifactDirectory, 'logs');
+  const testResultsPath = path.join(filesDirectory, 'test-results.json');
+  const phpunitOutputPath = path.join(filesDirectory, 'phpunit-output.log');
+  await mkdir(filesDirectory, { recursive: true });
+  await mkdir(logsDirectory, { recursive: true });
+  await copyFile(execution.stdoutPath, path.join(logsDirectory, 'recipe-run.stdout.log'));
+  await copyFile(execution.stderrPath, path.join(logsDirectory, 'recipe-run.stderr.log'));
+
+  const stdout = await readFile(execution.stdoutPath, 'utf8');
+  const stderr = await readFile(execution.stderrPath, 'utf8');
+  const output = extractPhpunitOutput(stdout, stderr);
+  await writeFile(phpunitOutputPath, output);
+
+  let results;
+  try { results = json(await readFile(testResultsPath, 'utf8'), null); } catch { results = null; }
+  if (results && typeof results === 'object') {
+    const references = Array.isArray(results.rawLogReferences) ? results.rawLogReferences : [];
+    results.rawLogReferences = [
+      ...references.filter((reference) => reference?.path !== 'files/phpunit-output.log'),
+      { path: 'files/phpunit-output.log', kind: 'phpunit-output' },
+      { path: 'logs/recipe-run.stdout.log', kind: 'recipe-run-stdout' },
+      { path: 'logs/recipe-run.stderr.log', kind: 'recipe-run-stderr' },
+    ];
+    results.evidenceReferences = [
+      { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
+      { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
+    ];
+    await writeFile(testResultsPath, `${JSON.stringify(results, null, 2)}\n`);
+  }
+
+  process.stdout.write('Structured PHPUnit evidence: artifact://files/test-results.json\n');
+  process.stdout.write('Full PHPUnit output: artifact://files/phpunit-output.log\n');
+}
+function extractPhpunitOutput(stdout, stderr) {
+  const payload = json(stdout.trim(), null);
+  if (payload && Array.isArray(payload.executions)) {
+    const chunks = [];
+    for (const execution of payload.executions) {
+      if (typeof execution?.stdout === 'string') { chunks.push(execution.stdout); }
+      if (typeof execution?.stderr === 'string') { chunks.push(execution.stderr); }
+    }
+    if (chunks.length > 0) {
+      return chunks.join('');
+    }
+  }
+  return stdout + stderr;
 }
 function runScript(script, args) {
   const result = spawnSync('bash', [path.join(scriptDirectory, script), ...args], { cwd: componentPath, encoding: 'utf8', stdio: 'inherit' });

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -1,0 +1,141 @@
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-evidence-'));
+const component = path.join(root, 'sample-plugin');
+const artifacts = path.join(root, 'artifacts');
+const cli = path.join(root, 'wp-codebox');
+const resultsFile = path.join(root, 'test-results.json');
+const failuresFile = path.join(root, 'test-failures.json');
+const expectedOutputFile = path.join(root, 'expected-output.log');
+const writeResults = path.join(root, 'write-test-results.sh');
+const extension = path.resolve(import.meta.dirname, '..');
+
+await mkdir(component, { recursive: true });
+await writeFile(path.join(component, 'sample-plugin.php'), '<?php\n/* Plugin Name: Sample Plugin */\n');
+await writeFile(writeResults, `homeboy_write_test_results() { printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$1" "$2" "$3" "$4" > "$HOMEBOY_TEST_RESULTS_FILE"; }
+`);
+await writeFile(cli, `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+const args = process.argv.slice(2);
+if (args[0] === 'recipe' && args[1] === 'build') {
+  fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
+  process.exit(0);
+}
+const artifacts = args[args.indexOf('--artifacts') + 1];
+const runtime = path.join(artifacts, 'runtime-fixture');
+fs.mkdirSync(path.join(runtime, 'files'), { recursive: true });
+fs.writeFileSync(path.join(artifacts, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify({
+  schema: 'wp-codebox/test-results/v1',
+  status: 'failed',
+  summary: { total: 3, passed: 0, failed: 2, skipped: 1, unknown: 0 },
+  suites: [{ name: 'phpunit', tests: 3, passed: 0, failed: 2, skipped: 1 }],
+}));
+const output = 'x'.repeat(70 * 1024) + '\\n' + [
+  'PHPUnit 9.6.22 by Sebastian Bergmann and contributors.',
+  'fixture token: fixture-secret-value',
+  '',
+  'There was 1 error:',
+  '',
+  '1) SamplePlugin\\Tests\\MixedTest::test_php_error',
+  'TypeError: SamplePlugin\\Runner::run(): Return value must be of type string, null returned',
+  '${component}/src/Runner.php:18',
+  '${component}/tests/MixedTest.php:24',
+  '',
+  'There was 1 failure:',
+  '',
+  '1) SamplePlugin\\Tests\\MixedTest::test_assertion_diff',
+  'Failed asserting that two strings are identical.',
+  '--- Expected',
+  '+++ Actual',
+  '@@ @@',
+  "-'expected'",
+  "+'actual'",
+  '${component}/tests/MixedTest.php:35',
+  '',
+  'FAILURES!',
+  'Tests: 3, Assertions: 2, Errors: 1, Failures: 1, Skipped: 1.',
+  '',
+].join('\\n')
+  .replaceAll('SamplePluginTestsMixedTest', ['SamplePlugin', 'Tests', 'MixedTest'].join(String.fromCharCode(92)))
+  .replaceAll('SamplePluginRunner', ['SamplePlugin', 'Runner'].join(String.fromCharCode(92)));
+fs.writeFileSync('${expectedOutputFile}', output);
+process.stdout.write(JSON.stringify({ success: false, executions: [{ stdout: output, stderr: '' }] }));
+process.exit(1);
+`);
+await chmod(cli, 0o755);
+
+try {
+  const run = spawnSync(path.join(extension, 'scripts/test/test-runner-wp-codebox.sh'), [], {
+    env: {
+      ...process.env,
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'sample-plugin',
+      HOMEBOY_EXTENSION_PATH: extension,
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
+      HOMEBOY_TEST_RESULTS_FILE: resultsFile,
+      HOMEBOY_TEST_FAILURES_FILE: failuresFile,
+      HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: writeResults,
+      HOMEBOY_SETTINGS_JSON: '{}',
+      PHPUNIT_SECRET_TOKEN: 'fixture-secret-value',
+    },
+    encoding: 'utf8',
+    maxBuffer: 2 * 1024 * 1024,
+  });
+
+  assert.equal(run.status, 1, run.stderr);
+  assert.match(run.stdout, /Structured PHPUnit evidence: artifact:\/\/files\/test-results\.json/);
+  assert.match(run.stdout, /Full PHPUnit output: artifact:\/\/files\/phpunit-output\.log/);
+
+  const runDirectory = (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
+  assert.ok(runDirectory);
+  const runtime = path.join(artifacts, runDirectory, 'runtime-fixture');
+  const expectedOutput = (await readFile(expectedOutputFile, 'utf8')).replaceAll('fixture-secret-value', '[REDACTED]');
+  const retainedOutput = await readFile(path.join(runtime, 'files/phpunit-output.log'), 'utf8');
+  assert.ok(Buffer.byteLength(retainedOutput) > 64 * 1024);
+  assert.equal(retainedOutput, expectedOutput);
+  assert.doesNotMatch(retainedOutput, /fixture-secret-value/);
+  assert.match(retainedOutput, /fixture token: \[REDACTED\]/);
+
+  const artifactResults = JSON.parse(await readFile(path.join(runtime, 'files/test-results.json'), 'utf8'));
+  assert.deepEqual(artifactResults.rawLogReferences.slice(-3), [
+    { path: 'files/phpunit-output.log', kind: 'phpunit-output' },
+    { path: 'logs/recipe-run.stdout.log', kind: 'recipe-run-stdout' },
+    { path: 'logs/recipe-run.stderr.log', kind: 'recipe-run-stderr' },
+  ]);
+  assert.deepEqual(artifactResults.evidenceReferences, [
+    { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
+    { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
+  ]);
+  assert.deepEqual(JSON.parse(await readFile(resultsFile, 'utf8')), { total: 3, passed: 0, failed: 2, skipped: 1 });
+
+  const analysisInput = JSON.parse(await readFile(failuresFile, 'utf8'));
+  assert.equal(analysisInput.total, 3);
+  assert.equal(analysisInput.passed, 0);
+  assert.deepEqual(analysisInput.metadata, { assertions: 2, failures: 1, errors: 1, skipped: 1 });
+  assert.equal(analysisInput.failures.length, 2);
+  assert.deepEqual(analysisInput.failures.map(({ status }) => status), ['error', 'failure']);
+  assert.equal(analysisInput.failures[0].test_id, 'SamplePlugin\\Tests\\MixedTest::test_php_error');
+  assert.equal(analysisInput.failures[0].failure_type, 'TypeError');
+  assert.equal(analysisInput.failures[0].file, 'src/Runner.php');
+  assert.match(analysisInput.failures[0].stack_trace, /tests\/MixedTest\.php:24/);
+  assert.equal(analysisInput.failures[1].test_id, 'SamplePlugin\\Tests\\MixedTest::test_assertion_diff');
+  assert.equal(analysisInput.failures[1].failure_type, 'AssertionFailedError');
+  assert.match(analysisInput.failures[1].message, /--- Expected\n\+\+\+ Actual/);
+  for (const failure of analysisInput.failures) {
+    assert.equal(typeof failure.test_id, 'string');
+    assert.equal(typeof failure.message, 'string');
+    assert.equal(typeof failure.fingerprint, 'string');
+    assert.equal(failure.fingerprint.length, 64);
+  }
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox PHPUnit evidence smoke passed.');


### PR DESCRIPTION
## Summary
- preserve redacted, complete WP Codebox recipe-run streams and extracted PHPUnit output as durable artifacts on success and failure paths
- parse PHPUnit 9 textual error and failure sections into separate structured records with stack traces, assertion diffs, and accurate assertion/failure/error/skipped metadata
- attach valid artifact evidence URIs without adding product-specific behavior to shared parser/runtime layers
- add mixed failure/error/skipped and greater-than-64-KiB fixture coverage, including `--analyze`-compatible sidecar fields

## Verification
- `npm run test:wp-codebox-phpunit-evidence`
- `npm run test:wp-codebox-canonical-cli-adapters`
- `bash scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash scripts/test/parse-test-failures-sidecar-smoke.sh`
- `npm run lint:js -- --no-warn-ignored scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-evidence-smoke.mjs`
- `php -l scripts/test/parse-test-failures.php`
- `php -l scripts/test/parsers/standard.php`
- `cargo test -p homeboy-core failures_file_parser --lib` (4 passed)

Closes #2396
