### PR TITLE
feat(wordpress): configure WP Codebox database providers

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -14,6 +14,7 @@
       "bash tests/installed-test-helper-resolution-smoke.sh",
       "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
+      "node tests/wp-codebox-database-service-smoke.mjs",
       "bash scripts/test/full-suite-no-phpunit-smoke.sh",
       "node tests/codebox-client-boundary.test.js",
       "node tests/wp-codebox-fuzz-run-smoke.js",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -122,6 +122,7 @@
     "test:wp-codebox-fuzz-plan-recipe-builder": "node tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js",
     "test:wp-codebox-canonical-cli-adapters": "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
     "test:wp-codebox-phpunit-evidence": "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
+    "test:wp-codebox-database-service": "node tests/wp-codebox-database-service-smoke.mjs",
     "test:wp-codebox-doctor": "bash scripts/test/wp-codebox-doctor-smoke.sh",
     "test:extension-composer-vendor-integrity": "bash tests/extension-composer-vendor-integrity-smoke.sh",
     "test:wordpress-multisite-e2e-rig": "node rigs/wordpress-multisite-e2e/tests/contract.test.mjs",

--- a/wordpress/scripts/test/wp-codebox-extra-plugins-autoload-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-extra-plugins-autoload-smoke.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 # WP Codebox raw extra_plugins Composer autoload smoke (homeboy-extensions#1398).
 #
 # This intentionally does not run Composer in Homeboy Extensions. It sends a raw
-# plugin source with composer.json and no vendor/autoload.php through the normal
-# WordPress/WP Codebox recipe flow, then asserts WP Codebox prepared the plugin
-# before activation/workload execution.
+# plugin source with composer.json, no vendor/autoload.php, and the explicit
+# composer preparation contract through the normal WordPress/WP Codebox recipe
+# flow, then asserts WP Codebox prepared the plugin before execution.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -119,7 +119,8 @@ SETTINGS_JSON=$(jq -nc \
             source: $extraSource,
             slug: "hbex-extra-plugin-autoload",
             pluginFile: "hbex-extra-plugin-autoload/hbex-extra-plugin-autoload.php",
-            activate: true
+            activate: true,
+            composer: "install"
         }]
     }')
 
@@ -152,8 +153,8 @@ printf '%s\n' "$output"
 if [ "$status" -ne 0 ]; then
     echo "" >&2
     echo "ERROR: WP Codebox could not run a raw extra_plugins source that requires Composer autoload preparation." >&2
-    echo "  This smoke expects WP Codebox recipe-run to prepare composer.json before activating extra_plugins." >&2
-    echo "  Do not add Composer preparation in Homeboy Extensions; update WP Codebox if vendor/autoload.php is missing." >&2
+    echo "  This smoke explicitly requests WP Codebox staged Composer preparation before extra_plugins activation." >&2
+    echo "  Do not run Composer against the source checkout; WP Codebox owns preparation in its temporary copy." >&2
     echo "  Extra plugin source: $EXTRA_PLUGIN_ROOT" >&2
     echo "  Artifacts: $ARTIFACTS_DIR" >&2
     exit "$status"

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -27,10 +27,10 @@ const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
 const artifacts = process.env.HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR || path.join(directory, 'artifacts');
 const runArtifacts = path.join(artifacts, `wp-codebox-phpunit.${process.pid}`);
-const dependencies = dependencyPaths(settings).map((source) => {
+const dependencies = await Promise.all(dependencyPaths(settings).map(async (source) => {
   const dependencySlug = path.basename(source).replace(/@[^/]+$/, '');
-  return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug) };
-});
+  return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug), composer: await composerPreparation(source) };
+}));
 await requireHarness(harnessSource);
 const options = clean({
   wordpressVersion: settings.wordpress_runtime_version,
@@ -40,7 +40,7 @@ const options = clean({
   pluginSlug: slug,
   extra_plugins: [
     { source: root, sourceSubpath: subpath, slug, activate: false },
-    ...dependencies.map(({ source, slug: dependencySlug }) => ({ source, slug: dependencySlug, activate: false })),
+    ...dependencies.map(({ source, slug: dependencySlug, composer }) => clean({ source, slug: dependencySlug, activate: false, composer })),
   ],
   dependencyMounts: [...new Set([sandboxPluginDirectory(slug), ...dependencies.map(({ sandboxDirectory }) => sandboxDirectory)])],
   testRoot: settings.wp_codebox_phpunit_test_root,
@@ -231,6 +231,19 @@ function dependencyPaths(configuration) {
   const configured = Array.isArray(configuration.validation_dependencies) ? configuration.validation_dependencies : [];
   const canonical = (process.env.HOMEBOY_WORDPRESS_DEPENDENCY_PATHS || '').split('\n');
   return [...new Set([...canonical, ...configured].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
+}
+async function composerPreparation(source) {
+  try {
+    await access(path.join(source, 'composer.json'));
+  } catch {
+    return undefined;
+  }
+  try {
+    await access(path.join(source, 'vendor/autoload.php'));
+    return undefined;
+  } catch {
+    return 'install';
+  }
 }
 function sandboxPluginDirectory(pluginSlug) {
   return `/wordpress/wp-content/plugins/${pluginSlug}`;

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -20,6 +20,7 @@ const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
 const pluginSourceDirectory = subpath ? path.join(root, subpath) : root;
 const multisite = await resolveMultisite(settings, pluginSourceDirectory);
+const databaseService = resolveDatabaseService(settings, process.env);
 runPrepareSteps(settings.wp_codebox_prepare_steps, pluginSourceDirectory);
 const directory = await mkdtemp(path.join(tmpdir(), 'homeboy-wp-codebox-phpunit-'));
 const optionsPath = path.join(directory, 'options.json');
@@ -35,6 +36,7 @@ const options = clean({
   wordpressVersion: settings.wordpress_runtime_version,
   phpVersion: settings.wordpress_runtime_php_version,
   databaseType: settings.database_type,
+  services: databaseService ? [databaseService.service] : undefined,
   pluginSlug: slug,
   extra_plugins: [
     { source: root, sourceSubpath: subpath, slug, activate: false },
@@ -118,8 +120,9 @@ async function runCaptured(args) {
 }
 function configuredSecretValues() {
   const configured = settings.bench_env && typeof settings.bench_env === 'object' ? settings.bench_env : {};
+  const databaseSecretNames = databaseService?.secretEnv || [];
   return Object.entries({ ...process.env, ...configured })
-    .filter(([name, value]) => /(?:auth|cookie|credential|key|nonce|passw|secret|session|token)/i.test(name) && typeof value === 'string' && value.length >= 8)
+    .filter(([name, value]) => typeof value === 'string' && value.length > 0 && (databaseSecretNames.includes(name) || (/(?:auth|cookie|credential|key|nonce|passw|secret|session|token)/i.test(name) && value.length >= 8)))
     .map(([, value]) => value)
     .sort((left, right) => right.length - left.length);
 }
@@ -214,6 +217,64 @@ function sandboxPluginDirectory(pluginSlug) {
 }
 function canonicalMounts(value) {
   return Array.isArray(value) ? value : [];
+}
+function resolveDatabaseService(configuration, environment) {
+  const value = configuration.wp_codebox_database_service;
+  if (value === undefined || value === null || (isObject(value) && Object.keys(value).length === 0)) {
+    return undefined;
+  }
+  if (!isObject(value)) {
+    throw new Error('wp_codebox_database_service must be an object shaped as {provider,secret_env}');
+  }
+  const unknownKeys = Object.keys(value).filter((key) => !['provider', 'secret_env'].includes(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(`wp_codebox_database_service contains unsupported fields: ${unknownKeys.join(', ')}`);
+  }
+  if (configuration.database_type !== 'mysql') {
+    throw new Error('wp_codebox_database_service requires database_type=mysql');
+  }
+  if (typeof value.provider !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(value.provider)) {
+    throw new Error('wp_codebox_database_service.provider must name a registered WP Codebox provider');
+  }
+  if (!isObject(value.secret_env)) {
+    throw new Error('wp_codebox_database_service.secret_env must contain provider secret environment references');
+  }
+  const unknownSecretFields = Object.keys(value.secret_env).filter((key) => !['host', 'port', 'username', 'password'].includes(key));
+  if (unknownSecretFields.length > 0) {
+    throw new Error(`wp_codebox_database_service.secret_env contains unsupported fields: ${unknownSecretFields.join(', ')}`);
+  }
+  const requiredSecretFields = ['host', 'username', 'password'];
+  const missingSecretFields = requiredSecretFields.filter((field) => value.secret_env[field] === undefined);
+  if (missingSecretFields.length > 0) {
+    throw new Error(`wp_codebox_database_service.secret_env is missing required references: ${missingSecretFields.join(', ')}`);
+  }
+  for (const [field, name] of Object.entries(value.secret_env)) {
+    if (typeof name !== 'string' || !/^[A-Z_][A-Z0-9_]*$/.test(name)) {
+      throw new Error('wp_codebox_database_service.secret_env must map provider fields to environment variable names');
+    }
+    if (typeof environment[name] !== 'string' || (field !== 'password' && environment[name].trim() === '')) {
+      throw new Error(`wp_codebox_database_service secret environment variable is unavailable: ${name}`);
+    }
+  }
+  const secretEnv = [...new Set(Object.values(value.secret_env))];
+  return {
+    service: {
+      id: 'wordpress-database',
+      kind: 'mysql',
+      configuration: {
+        provider: value.provider,
+        hostEnv: value.secret_env.host,
+        ...(value.secret_env.port ? { portEnv: value.secret_env.port } : {}),
+        usernameEnv: value.secret_env.username,
+        passwordEnv: value.secret_env.password,
+      },
+      outputs: { host: 'DB_HOST', port: 'DB_PORT', username: 'DB_USER', password: 'DB_PASSWORD', database: 'DB_NAME' },
+    },
+    secretEnv,
+  };
+}
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 function runPrepareSteps(steps, sourceRoot) {
   if (!Array.isArray(steps)) {

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -59,8 +59,13 @@ const options = clean({
 try {
   await writeFile(optionsPath, `${JSON.stringify(options)}\n`);
   run(['recipe', 'build', 'phpunit', '--options', optionsPath, '--output', recipePath]);
+  await applyDatabaseServiceAuthorization(recipePath);
   await mkdir(runArtifacts, { recursive: true });
-  const execution = await runCaptured(['recipe-run', '--recipe', recipePath, '--artifacts', runArtifacts, '--json']);
+  const executionArgs = ['recipe-run', '--recipe', recipePath, '--artifacts', runArtifacts, '--json'];
+  if (databaseService) {
+    executionArgs.push('--approve-external-service-writes', '--policy', JSON.stringify(databaseService.policy));
+  }
+  const execution = await runCaptured(executionArgs);
   await handoffArtifacts(runArtifacts, execution);
   if (execution.status !== 0) {
     process.exitCode = execution.status;
@@ -241,7 +246,7 @@ function resolveDatabaseService(configuration, environment) {
   if (!isObject(value)) {
     throw new Error('wp_codebox_database_service must be an object shaped as {provider,secret_env}');
   }
-  const unknownKeys = Object.keys(value).filter((key) => !['provider', 'engine', 'secret_env'].includes(key));
+  const unknownKeys = Object.keys(value).filter((key) => !['provider', 'engine', 'allowed_hosts', 'secret_env'].includes(key));
   if (unknownKeys.length > 0) {
     throw new Error(`wp_codebox_database_service contains unsupported fields: ${unknownKeys.join(', ')}`);
   }
@@ -253,6 +258,9 @@ function resolveDatabaseService(configuration, environment) {
   }
   if (value.engine !== undefined && !['mysql', 'mariadb'].includes(value.engine)) {
     throw new Error('wp_codebox_database_service.engine must be mysql or mariadb');
+  }
+  if (!Array.isArray(value.allowed_hosts) || value.allowed_hosts.length === 0 || !value.allowed_hosts.every((host) => typeof host === 'string' && /^[a-z0-9.-]+(?::\d+)?$/i.test(host))) {
+    throw new Error('wp_codebox_database_service.allowed_hosts must contain hostnames with optional ports');
   }
   if (!isObject(value.secret_env)) {
     throw new Error('wp_codebox_database_service.secret_env must contain provider secret environment references');
@@ -275,6 +283,7 @@ function resolveDatabaseService(configuration, environment) {
     }
   }
   const secretEnv = [...new Set(Object.values(value.secret_env))];
+  const allowedHosts = [...new Set(value.allowed_hosts.map((host) => host.toLowerCase()))];
   const benchEnv = isObject(configuration.bench_env) ? configuration.bench_env : {};
   const collisions = secretEnv.filter((name) => Object.hasOwn(benchEnv, name));
   if (collisions.length > 0) {
@@ -286,6 +295,7 @@ function resolveDatabaseService(configuration, environment) {
       kind: 'mysql',
       configuration: {
         provider: value.provider,
+        externalService: 'wordpress-database-administration',
         ...(value.engine ? { engine: value.engine } : {}),
         hostEnv: value.secret_env.host,
         ...(value.secret_env.port ? { portEnv: value.secret_env.port } : {}),
@@ -295,6 +305,19 @@ function resolveDatabaseService(configuration, environment) {
       outputs: { host: 'DB_HOST', port: 'DB_PORT', username: 'DB_USER', password: 'DB_PASSWORD', database: 'DB_NAME' },
     },
     secretEnv,
+    boundary: {
+      id: 'wordpress-database-administration',
+      environment: 'external',
+      allowedHosts,
+      writes: 'allowed-with-approval',
+    },
+    policy: {
+      network: { allowHosts: allowedHosts },
+      filesystem: 'readwrite-mounts',
+      commands: ['inspect-mounted-inputs', 'wordpress.run-php', 'wordpress.phpunit'],
+      secrets: 'connector-scoped',
+      approvals: 'on-write',
+    },
   };
 }
 function isObject(value) {
@@ -306,6 +329,28 @@ function environmentWithoutDatabaseAdministration() {
     delete environment[name];
   }
   return environment;
+}
+async function applyDatabaseServiceAuthorization(target) {
+  if (!databaseService) {
+    return;
+  }
+  let recipe;
+  try {
+    recipe = JSON.parse(await readFile(target, 'utf8'));
+  } catch {
+    throw new Error('WP Codebox produced an invalid PHPUnit recipe');
+  }
+  if (!isObject(recipe) || !isObject(recipe.inputs) || !Array.isArray(recipe.inputs.services)) {
+    throw new Error('WP Codebox PHPUnit recipe omitted configured runtime services');
+  }
+  const service = recipe.inputs.services.find((candidate) => candidate?.id === databaseService.service.id);
+  if (!isObject(service) || !isObject(service.configuration)) {
+    throw new Error('WP Codebox PHPUnit recipe omitted the configured database service');
+  }
+  service.configuration.externalService = databaseService.boundary.id;
+  const boundaries = Array.isArray(recipe.inputs.externalServices) ? recipe.inputs.externalServices : [];
+  recipe.inputs.externalServices = [...boundaries.filter((boundary) => boundary?.id !== databaseService.boundary.id), databaseService.boundary];
+  await writeFile(target, `${JSON.stringify(recipe)}\n`);
 }
 function runPrepareSteps(steps, sourceRoot) {
   if (!Array.isArray(steps)) {

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -10,7 +10,7 @@ import { StringDecoder } from 'node:string_decoder';
 import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
 
-const settings = json(process.env.HOMEBOY_SETTINGS_JSON, {});
+const settings = parseSettings(process.env.HOMEBOY_SETTINGS_JSON);
 const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMPONENT_PATH');
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const extensionRoot = path.resolve(scriptDirectory, '../..');
@@ -152,7 +152,7 @@ function createLineRedactor(secretValues) {
 }
 
 function run(args) {
-  const result = spawnSync(process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', args, { cwd: componentPath, encoding: 'utf8', stdio: 'inherit' });
+  const result = spawnSync(process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', args, { cwd: componentPath, env: environmentWithoutDatabaseAdministration(), encoding: 'utf8', stdio: 'inherit' });
   if (result.error) {
     throw result.error;
   }
@@ -205,6 +205,21 @@ function truthy(value) {
   if (typeof value !== 'string') { return false; }
   return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
 }
+function parseSettings(value) {
+  if (value === undefined || value === '') {
+    return {};
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error('HOMEBOY_SETTINGS_JSON must contain a valid JSON object');
+  }
+  if (!isObject(parsed)) {
+    throw new Error('HOMEBOY_SETTINGS_JSON must contain a valid JSON object');
+  }
+  return parsed;
+}
 function json(value, fallback) { try { return value ? JSON.parse(value) : fallback; } catch { return fallback; } }
 function clean(value) { return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== '' && !(Array.isArray(entry) && entry.length === 0))); }
 function dependencyPaths(configuration) {
@@ -226,7 +241,7 @@ function resolveDatabaseService(configuration, environment) {
   if (!isObject(value)) {
     throw new Error('wp_codebox_database_service must be an object shaped as {provider,secret_env}');
   }
-  const unknownKeys = Object.keys(value).filter((key) => !['provider', 'secret_env'].includes(key));
+  const unknownKeys = Object.keys(value).filter((key) => !['provider', 'engine', 'secret_env'].includes(key));
   if (unknownKeys.length > 0) {
     throw new Error(`wp_codebox_database_service contains unsupported fields: ${unknownKeys.join(', ')}`);
   }
@@ -235,6 +250,9 @@ function resolveDatabaseService(configuration, environment) {
   }
   if (typeof value.provider !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(value.provider)) {
     throw new Error('wp_codebox_database_service.provider must name a registered WP Codebox provider');
+  }
+  if (value.engine !== undefined && !['mysql', 'mariadb'].includes(value.engine)) {
+    throw new Error('wp_codebox_database_service.engine must be mysql or mariadb');
   }
   if (!isObject(value.secret_env)) {
     throw new Error('wp_codebox_database_service.secret_env must contain provider secret environment references');
@@ -257,12 +275,18 @@ function resolveDatabaseService(configuration, environment) {
     }
   }
   const secretEnv = [...new Set(Object.values(value.secret_env))];
+  const benchEnv = isObject(configuration.bench_env) ? configuration.bench_env : {};
+  const collisions = secretEnv.filter((name) => Object.hasOwn(benchEnv, name));
+  if (collisions.length > 0) {
+    throw new Error(`bench_env must not expose database service administration environment: ${collisions.join(', ')}`);
+  }
   return {
     service: {
       id: 'wordpress-database',
       kind: 'mysql',
       configuration: {
         provider: value.provider,
+        ...(value.engine ? { engine: value.engine } : {}),
         hostEnv: value.secret_env.host,
         ...(value.secret_env.port ? { portEnv: value.secret_env.port } : {}),
         usernameEnv: value.secret_env.username,
@@ -275,6 +299,13 @@ function resolveDatabaseService(configuration, environment) {
 }
 function isObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+function environmentWithoutDatabaseAdministration() {
+  const environment = { ...process.env };
+  for (const name of databaseService?.secretEnv || []) {
+    delete environment[name];
+  }
+  return environment;
 }
 function runPrepareSteps(steps, sourceRoot) {
   if (!Array.isArray(steps)) {
@@ -290,7 +321,7 @@ function runPrepareSteps(steps, sourceRoot) {
     if (relative.startsWith('..') || path.isAbsolute(relative)) {
       throw new Error(`wp_codebox_prepare_steps cwd escapes the source root: ${step.cwd}`);
     }
-    const result = spawnSync(step.command, args, { cwd, encoding: 'utf8', stdio: 'inherit' });
+    const result = spawnSync(step.command, args, { cwd, env: environmentWithoutDatabaseAdministration(), encoding: 'utf8', stdio: 'inherit' });
     if (result.error) {
       throw result.error;
     }
@@ -375,7 +406,7 @@ function extractPhpunitOutput(stdout, stderr) {
   return stdout + stderr;
 }
 function runScript(script, args) {
-  const result = spawnSync('bash', [path.join(scriptDirectory, script), ...args], { cwd: componentPath, encoding: 'utf8', stdio: 'inherit' });
+  const result = spawnSync('bash', [path.join(scriptDirectory, script), ...args], { cwd: componentPath, env: environmentWithoutDatabaseAdministration(), encoding: 'utf8', stdio: 'inherit' });
   if (result.error) {
     throw result.error;
   }

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -253,8 +253,8 @@ function resolveDatabaseService(configuration, environment) {
   if (configuration.database_type !== 'mysql') {
     throw new Error('wp_codebox_database_service requires database_type=mysql');
   }
-  if (typeof value.provider !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(value.provider)) {
-    throw new Error('wp_codebox_database_service.provider must name a registered WP Codebox provider');
+  if (value.provider !== 'external') {
+    throw new Error('wp_codebox_database_service.provider must be external');
   }
   if (value.engine !== undefined && !['mysql', 'mariadb'].includes(value.engine)) {
     throw new Error('wp_codebox_database_service.engine must be mysql or mariadb');

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -15,7 +15,7 @@ assert.ok(
 	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
 );
 
-for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wp_codebox_multisite', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version', 'wordpress_runtime_workload_plugin_slug']) {
+for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wp_codebox_multisite', 'wp_codebox_database_service', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version', 'wordpress_runtime_workload_plugin_slug']) {
 	assert.ok(settingIds.has(settingId), `wordpress manifest declares ${settingId}`);
 }
 

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -36,7 +36,7 @@ if (args[0] === 'recipe' && args[1] === 'build') {
 }
 if (args[0] === 'recipe-run') {
   const recipe = JSON.parse(await readFile(args[args.indexOf('--recipe') + 1], 'utf8'));
-  await appendFile(process.env.OBSERVED, JSON.stringify({ phase: 'run', recipe }) + '\\n');
+  await appendFile(process.env.OBSERVED, JSON.stringify({ phase: 'run', recipe, args }) + '\\n');
   const configuration = recipe.inputs.services?.[0]?.configuration || {};
   for (const name of [configuration.hostEnv, configuration.portEnv, configuration.usernameEnv, configuration.passwordEnv].filter(Boolean)) {
     process.stdout.write('provider stdout ' + process.env[name] + '\\n');
@@ -104,6 +104,7 @@ try {
     wp_codebox_multisite: true,
     wp_codebox_database_service: {
       provider: 'external',
+      allowed_hosts: ['database.internal.example:3306'],
       secret_env: {
         host: 'PROVIDER_ADMIN_HOST',
         port: 'PROVIDER_ADMIN_PORT',
@@ -130,6 +131,7 @@ try {
     kind: 'mysql',
     configuration: {
       provider: 'external',
+      externalService: 'wordpress-database-administration',
       hostEnv: 'PROVIDER_ADMIN_HOST',
       portEnv: 'PROVIDER_ADMIN_PORT',
       usernameEnv: 'PROVIDER_ADMIN_USER',
@@ -141,10 +143,22 @@ try {
   const serializedRecipe = JSON.stringify(externalObservations[1].recipe);
   for (const value of Object.values(secretValues)) {
     assert.equal(serializedOptions.includes(value), false, 'builder options omit provider credential values');
-    assert.equal(serializedRecipe.includes(value), false, 'generated recipe omits provider credential values');
     assert.equal(externalInvocation.result.stdout.includes(value), false, 'Homeboy stdout omits provider credential values');
     assert.equal(externalInvocation.result.stderr.includes(value), false, 'Homeboy stderr omits provider credential values');
   }
+  for (const value of [secretValues.PROVIDER_ADMIN_USER, secretValues.PROVIDER_ADMIN_PASSWORD]) {
+    assert.equal(serializedRecipe.includes(value), false, 'generated recipe omits provider credential values');
+  }
+  assert.deepEqual(externalObservations[1].recipe.inputs.externalServices, [{
+    id: 'wordpress-database-administration',
+    environment: 'external',
+    allowedHosts: ['database.internal.example:3306'],
+    writes: 'allowed-with-approval',
+  }]);
+  assert.equal(externalObservations[1].args.includes('--approve-external-service-writes'), true);
+  const policy = JSON.parse(externalObservations[1].args[externalObservations[1].args.indexOf('--policy') + 1]);
+  assert.deepEqual(policy.network, { allowHosts: ['database.internal.example:3306'] });
+  assert.equal(policy.approvals, 'on-write');
   assert.match(externalInvocation.result.stdout, /provider stdout \[REDACTED\]/);
   assert.match(externalInvocation.result.stderr, /provider stderr \[REDACTED\]/);
 
@@ -191,19 +205,23 @@ try {
 
   expectPreflightFailure({
     database_type: 'mysql',
-    wp_codebox_database_service: { provider: 'external' },
+    wp_codebox_database_service: { provider: 'external', secret_env: configured.wp_codebox_database_service.secret_env },
+  }, /allowed_hosts must contain hostnames with optional ports/, secretValues);
+  expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { provider: 'external', allowed_hosts: ['database.internal.example'] },
   }, /secret_env must contain provider secret environment references/);
   expectPreflightFailure({
     database_type: 'mysql',
-    wp_codebox_database_service: { provider: 'external', secret_env: { host: 'PROVIDER_ADMIN_HOST' } },
+    wp_codebox_database_service: { provider: 'external', allowed_hosts: ['database.internal.example'], secret_env: { host: 'PROVIDER_ADMIN_HOST' } },
   }, /missing required references: username, password/, secretValues);
   expectPreflightFailure({
     database_type: 'mysql',
-    wp_codebox_database_service: { provider: 'external', secret_env: { host: 'MISSING_PROVIDER_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
+    wp_codebox_database_service: { provider: 'external', allowed_hosts: ['database.internal.example'], secret_env: { host: 'MISSING_PROVIDER_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
   }, /secret environment variable is unavailable: MISSING_PROVIDER_HOST/, secretValues);
   expectPreflightFailure({
     database_type: 'mysql',
-    wp_codebox_database_service: { provider: 'external', secret_env: ['PROVIDER_ADMIN_HOST'] },
+    wp_codebox_database_service: { provider: 'external', allowed_hosts: ['database.internal.example'], secret_env: ['PROVIDER_ADMIN_HOST'] },
   }, /secret_env must contain provider secret environment references/);
   expectPreflightFailure({
     ...configured,
@@ -220,7 +238,7 @@ try {
 
   const unsupported = expectPreflightFailure({
     database_type: 'mysql',
-    wp_codebox_database_service: { provider: 'unregistered', secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
+    wp_codebox_database_service: { provider: 'unregistered', allowed_hosts: ['database.internal.example'], secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
   }, /Unsupported managed runtime service provider: unregistered/, secretValues);
   assert.deepEqual((await observations(unsupported.observed)).map(({ phase }) => phase), ['build'], 'unsupported providers fail before workload execution');
 } finally {

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -8,9 +8,12 @@ const extension = path.resolve(import.meta.dirname, '..');
 const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
 const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-database-service-'));
 const component = path.join(root, 'plugin');
+const dependency = path.join(root, 'dependency');
 const cli = path.join(root, 'wp-codebox');
 await mkdir(component, { recursive: true });
+await mkdir(dependency, { recursive: true });
 await writeFile(path.join(component, 'plugin.php'), '<?php\n/**\n * Plugin Name: Provider Test\n */\n');
+await writeFile(path.join(dependency, 'composer.json'), '{}\n');
 await writeFile(cli, `#!/usr/bin/env node
 import { appendFile, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
@@ -102,6 +105,7 @@ try {
   const configured = {
     database_type: 'mysql',
     wp_codebox_multisite: true,
+    validation_dependencies: [dependency],
     wp_codebox_database_service: {
       provider: 'external',
       allowed_hosts: ['database.internal.example:3306'],
@@ -125,6 +129,7 @@ try {
   }, 'recipe build receives administrative names without host values');
   assert.equal(options.databaseType, 'mysql');
   assert.equal(options.multisite, true, 'external MySQL remains compatible with multisite PHPUnit');
+  assert.equal(options.extra_plugins[1].composer, 'install', 'source-form validation dependencies explicitly request staged Composer preparation');
   assert.equal('secretEnv' in options, false, 'administrative credentials are not forwarded into the sandbox runtime');
   assert.deepEqual(options.services, [{
     id: 'wordpress-database',

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -1,0 +1,172 @@
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-database-service-'));
+const component = path.join(root, 'plugin');
+const cli = path.join(root, 'wp-codebox');
+await mkdir(component, { recursive: true });
+await writeFile(path.join(component, 'plugin.php'), '<?php\n/**\n * Plugin Name: Provider Test\n */\n');
+await writeFile(cli, `#!/usr/bin/env node
+import { appendFile, readFile, writeFile } from 'node:fs/promises';
+const args = process.argv.slice(2);
+if (args[0] === 'recipe' && args[1] === 'build') {
+  const options = JSON.parse(await readFile(args[args.indexOf('--options') + 1], 'utf8'));
+  await appendFile(process.env.OBSERVED, JSON.stringify({ phase: 'build', options }) + '\\n');
+  if (options.services?.[0]?.configuration?.provider === 'unregistered') {
+    process.stderr.write('Unsupported managed runtime service provider: unregistered\\n');
+    process.exit(2);
+  }
+  const recipe = { schema: 'wp-codebox/workspace-recipe/v1', inputs: { services: options.services } };
+  await writeFile(args[args.indexOf('--output') + 1], JSON.stringify(recipe));
+  process.exit(0);
+}
+if (args[0] === 'recipe-run') {
+  const recipe = JSON.parse(await readFile(args[args.indexOf('--recipe') + 1], 'utf8'));
+  await appendFile(process.env.OBSERVED, JSON.stringify({ phase: 'run', recipe }) + '\\n');
+  const configuration = recipe.inputs.services?.[0]?.configuration || {};
+  for (const name of [configuration.hostEnv, configuration.portEnv, configuration.usernameEnv, configuration.passwordEnv].filter(Boolean)) {
+    process.stdout.write('provider stdout ' + process.env[name] + '\\n');
+    process.stderr.write('provider stderr ' + process.env[name] + '\\n');
+  }
+}
+`);
+await chmod(cli, 0o755);
+
+let scenario = 0;
+function invoke(settings, env = {}) {
+  scenario += 1;
+  const observed = path.join(root, `observed-${scenario}.jsonl`);
+  const result = spawnSync(runner, [], {
+    env: {
+      ...process.env,
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'provider-test',
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify(settings),
+      OBSERVED: observed,
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+  return { result, observed };
+}
+
+async function observations(file) {
+  try {
+    return (await readFile(file, 'utf8')).trim().split('\n').filter(Boolean).map(JSON.parse);
+  } catch {
+    return [];
+  }
+}
+
+function expectPreflightFailure(settings, pattern, env = {}) {
+  const invocation = invoke(settings, env);
+  assert.notEqual(invocation.result.status, 0);
+  assert.match(invocation.result.stderr, pattern);
+  return invocation;
+}
+
+try {
+  const defaultInvocation = invoke({ database_type: 'mysql', wp_codebox_multisite: true });
+  assert.equal(defaultInvocation.result.status, 0, defaultInvocation.result.stderr);
+  const defaultBuild = (await observations(defaultInvocation.observed))[0].options;
+  assert.equal('services' in defaultBuild, false, 'omitted provider preserves WP Codebox service defaults');
+  assert.equal('secretEnv' in defaultBuild, false, 'omitted provider adds no secret declarations');
+  assert.equal(defaultBuild.databaseType, 'mysql');
+  assert.equal(defaultBuild.multisite, true);
+
+  const secretValues = {
+    PROVIDER_ADMIN_HOST: 'database.internal.example',
+    PROVIDER_ADMIN_PORT: '3306',
+    PROVIDER_ADMIN_USER: 'temporary-database-admin',
+    PROVIDER_ADMIN_PASSWORD: 'do-not-persist-this-password',
+  };
+  const configured = {
+    database_type: 'mysql',
+    wp_codebox_multisite: true,
+    wp_codebox_database_service: {
+      provider: 'external',
+      secret_env: {
+        host: 'PROVIDER_ADMIN_HOST',
+        port: 'PROVIDER_ADMIN_PORT',
+        username: 'PROVIDER_ADMIN_USER',
+        password: 'PROVIDER_ADMIN_PASSWORD',
+      },
+    },
+  };
+  const externalInvocation = invoke(configured, secretValues);
+  assert.equal(externalInvocation.result.status, 0, externalInvocation.result.stderr);
+  const externalObservations = await observations(externalInvocation.observed);
+  const options = externalObservations[0].options;
+  assert.equal(options.databaseType, 'mysql');
+  assert.equal(options.multisite, true, 'external MySQL remains compatible with multisite PHPUnit');
+  assert.equal('secretEnv' in options, false, 'administrative credentials are not forwarded into the sandbox runtime');
+  assert.deepEqual(options.services, [{
+    id: 'wordpress-database',
+    kind: 'mysql',
+    configuration: {
+      provider: 'external',
+      hostEnv: 'PROVIDER_ADMIN_HOST',
+      portEnv: 'PROVIDER_ADMIN_PORT',
+      usernameEnv: 'PROVIDER_ADMIN_USER',
+      passwordEnv: 'PROVIDER_ADMIN_PASSWORD',
+    },
+    outputs: { host: 'DB_HOST', port: 'DB_PORT', username: 'DB_USER', password: 'DB_PASSWORD', database: 'DB_NAME' },
+  }]);
+  const serializedOptions = JSON.stringify(options);
+  const serializedRecipe = JSON.stringify(externalObservations[1].recipe);
+  for (const value of Object.values(secretValues)) {
+    assert.equal(serializedOptions.includes(value), false, 'builder options omit provider credential values');
+    assert.equal(serializedRecipe.includes(value), false, 'generated recipe omits provider credential values');
+    assert.equal(externalInvocation.result.stdout.includes(value), false, 'Homeboy stdout omits provider credential values');
+    assert.equal(externalInvocation.result.stderr.includes(value), false, 'Homeboy stderr omits provider credential values');
+  }
+  assert.match(externalInvocation.result.stdout, /provider stdout \[REDACTED\]/);
+  assert.match(externalInvocation.result.stderr, /provider stderr \[REDACTED\]/);
+
+  const missingProvider = expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
+  }, /provider must name a registered WP Codebox provider/, secretValues);
+  assert.deepEqual(await observations(missingProvider.observed), [], 'missing provider fails before WP Codebox execution');
+
+  expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { provider: 'external' },
+  }, /secret_env must contain provider secret environment references/);
+  expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { provider: 'external', secret_env: { host: 'PROVIDER_ADMIN_HOST' } },
+  }, /missing required references: username, password/, secretValues);
+  expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { provider: 'external', secret_env: { host: 'MISSING_PROVIDER_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
+  }, /secret environment variable is unavailable: MISSING_PROVIDER_HOST/, secretValues);
+  expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { provider: 'external', secret_env: ['PROVIDER_ADMIN_HOST'] },
+  }, /secret_env must contain provider secret environment references/);
+  expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { provider: 'external', secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' }, password: 'plaintext' },
+  }, /unsupported fields: password/, secretValues);
+  expectPreflightFailure({
+    database_type: 'sqlite',
+    wp_codebox_database_service: { provider: 'external', secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
+  }, /requires database_type=mysql/, secretValues);
+
+  const unsupported = expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { provider: 'unregistered', secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
+  }, /Unsupported managed runtime service provider: unregistered/, secretValues);
+  assert.deepEqual((await observations(unsupported.observed)).map(({ phase }) => phase), ['build'], 'unsupported providers fail before workload execution');
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox database service smoke passed.');

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -200,8 +200,17 @@ try {
   const missingProvider = expectPreflightFailure({
     database_type: 'mysql',
     wp_codebox_database_service: { secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
-  }, /provider must name a registered WP Codebox provider/, secretValues);
+  }, /provider must be external/, secretValues);
   assert.deepEqual(await observations(missingProvider.observed), [], 'missing provider fails before WP Codebox execution');
+
+  for (const provider of ['docker', 'unregistered', 42]) {
+    const rejectedProvider = expectPreflightFailure({
+      ...configured,
+      wp_codebox_database_service: { ...configured.wp_codebox_database_service, provider },
+    }, /provider must be external/, secretValues);
+    assert.deepEqual(await observations(rejectedProvider.observed), [], 'non-external providers fail before recipe build');
+    assert.equal(rejectedProvider.result.stderr.includes(String(provider)), false, 'provider diagnostics omit rejected values');
+  }
 
   expectPreflightFailure({
     database_type: 'mysql',
@@ -236,11 +245,6 @@ try {
     wp_codebox_database_service: { provider: 'external', secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
   }, /requires database_type=mysql/, secretValues);
 
-  const unsupported = expectPreflightFailure({
-    database_type: 'mysql',
-    wp_codebox_database_service: { provider: 'unregistered', allowed_hosts: ['database.internal.example'], secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
-  }, /Unsupported managed runtime service provider: unregistered/, secretValues);
-  assert.deepEqual((await observations(unsupported.observed)).map(({ phase }) => phase), ['build'], 'unsupported providers fail before workload execution');
 } finally {
   await rm(root, { recursive: true, force: true });
 }

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -16,7 +16,16 @@ import { appendFile, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
 if (args[0] === 'recipe' && args[1] === 'build') {
   const options = JSON.parse(await readFile(args[args.indexOf('--options') + 1], 'utf8'));
-  await appendFile(process.env.OBSERVED, JSON.stringify({ phase: 'build', options }) + '\\n');
+  const configuration = options.services?.[0]?.configuration || {};
+  const adminNames = [configuration.hostEnv, configuration.portEnv, configuration.usernameEnv, configuration.passwordEnv].filter(Boolean);
+  const adminEnvironment = Object.fromEntries(adminNames.map((name) => [name, Object.hasOwn(process.env, name)]));
+  await appendFile(process.env.OBSERVED, JSON.stringify({ phase: 'build', options, adminEnvironment }) + '\\n');
+  for (const name of adminNames) {
+    if (process.env[name] !== undefined) {
+      process.stdout.write('build stdout ' + process.env[name] + '\\n');
+      process.stderr.write('build stderr ' + process.env[name] + '\\n');
+    }
+  }
   if (options.services?.[0]?.configuration?.provider === 'unregistered') {
     process.stderr.write('Unsupported managed runtime service provider: unregistered\\n');
     process.exit(2);
@@ -39,6 +48,10 @@ await chmod(cli, 0o755);
 
 let scenario = 0;
 function invoke(settings, env = {}) {
+  return invokeSettingsJson(JSON.stringify(settings), env);
+}
+
+function invokeSettingsJson(settingsJson, env = {}) {
   scenario += 1;
   const observed = path.join(root, `observed-${scenario}.jsonl`);
   const result = spawnSync(runner, [], {
@@ -47,7 +60,7 @@ function invoke(settings, env = {}) {
       HOMEBOY_COMPONENT_PATH: component,
       COMPONENT_ID: 'provider-test',
       HOMEBOY_WP_CODEBOX_BIN: cli,
-      HOMEBOY_SETTINGS_JSON: JSON.stringify(settings),
+      HOMEBOY_SETTINGS_JSON: settingsJson,
       OBSERVED: observed,
       ...env,
     },
@@ -103,6 +116,12 @@ try {
   assert.equal(externalInvocation.result.status, 0, externalInvocation.result.stderr);
   const externalObservations = await observations(externalInvocation.observed);
   const options = externalObservations[0].options;
+  assert.deepEqual(externalObservations[0].adminEnvironment, {
+    PROVIDER_ADMIN_HOST: false,
+    PROVIDER_ADMIN_PORT: false,
+    PROVIDER_ADMIN_USER: false,
+    PROVIDER_ADMIN_PASSWORD: false,
+  }, 'recipe build receives administrative names without host values');
   assert.equal(options.databaseType, 'mysql');
   assert.equal(options.multisite, true, 'external MySQL remains compatible with multisite PHPUnit');
   assert.equal('secretEnv' in options, false, 'administrative credentials are not forwarded into the sandbox runtime');
@@ -129,6 +148,41 @@ try {
   assert.match(externalInvocation.result.stdout, /provider stdout \[REDACTED\]/);
   assert.match(externalInvocation.result.stderr, /provider stderr \[REDACTED\]/);
 
+  const prepareInvocation = invoke({
+    ...configured,
+    wp_codebox_prepare_steps: [{
+      command: process.execPath,
+      args: ['-e', "process.stdout.write(process.env.PROVIDER_ADMIN_PASSWORD || 'prepare-admin-env-absent')"],
+    }],
+  }, secretValues);
+  assert.equal(prepareInvocation.result.status, 0, prepareInvocation.result.stderr);
+  assert.match(prepareInvocation.result.stdout, /prepare-admin-env-absent/);
+  assert.equal(prepareInvocation.result.stdout.includes(secretValues.PROVIDER_ADMIN_PASSWORD), false, 'prepare steps cannot observe database administration values');
+
+  const mariaDbInvocation = invoke({
+    ...configured,
+    wp_codebox_database_service: { ...configured.wp_codebox_database_service, engine: 'mariadb' },
+  }, secretValues);
+  assert.equal(mariaDbInvocation.result.status, 0, mariaDbInvocation.result.stderr);
+  const mariaDbOptions = (await observations(mariaDbInvocation.observed))[0].options;
+  assert.equal(mariaDbOptions.services[0].configuration.engine, 'mariadb', 'MariaDB selects WP Codebox MariaDB client semantics');
+
+  const malformedSettings = invokeSettingsJson('{"database_type":', secretValues);
+  assert.notEqual(malformedSettings.result.status, 0);
+  assert.match(malformedSettings.result.stderr, /HOMEBOY_SETTINGS_JSON must contain a valid JSON object/);
+  assert.equal(malformedSettings.result.stderr.includes('{"database_type":'), false, 'malformed settings diagnostics omit input values');
+  assert.deepEqual(await observations(malformedSettings.observed), [], 'malformed settings fail before recipe build');
+
+  const collision = expectPreflightFailure({
+    ...configured,
+    bench_env: { PROVIDER_ADMIN_HOST: 'serialized-administrative-host' },
+  }, /bench_env must not expose database service administration environment: PROVIDER_ADMIN_HOST/, secretValues);
+  assert.deepEqual(await observations(collision.observed), [], 'bench_env collisions fail before options are serialized');
+  for (const value of [...Object.values(secretValues), 'serialized-administrative-host']) {
+    assert.equal(collision.result.stdout.includes(value), false);
+    assert.equal(collision.result.stderr.includes(value), false);
+  }
+
   const missingProvider = expectPreflightFailure({
     database_type: 'mysql',
     wp_codebox_database_service: { secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
@@ -151,6 +205,10 @@ try {
     database_type: 'mysql',
     wp_codebox_database_service: { provider: 'external', secret_env: ['PROVIDER_ADMIN_HOST'] },
   }, /secret_env must contain provider secret environment references/);
+  expectPreflightFailure({
+    ...configured,
+    wp_codebox_database_service: { ...configured.wp_codebox_database_service, engine: 'unsupported' },
+  }, /engine must be mysql or mariadb/, secretValues);
   expectPreflightFailure({
     database_type: 'mysql',
     wp_codebox_database_service: { provider: 'external', secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' }, password: 'plaintext' },

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1287,6 +1287,13 @@
       "description": "Explicitly enable multisite for plugin PHPUnit, including plugins that are not network-only. False forces single-site; HOMEBOY_WORDPRESS_MULTISITE remains the higher-precedence runtime override."
     },
     {
+      "id": "wp_codebox_database_service",
+      "label": "WP Codebox database service provider",
+      "type": "object",
+      "default": {},
+      "description": "Optional operator-owned WP Codebox MySQL runtime-service selection shaped as {provider,secret_env:{host,port?,username,password}}. provider names a registered WP Codebox provider; secret_env maps administrative connection fields to host environment variable names. Values are resolved by WP Codebox and never serialized into component settings or recipes. Omit this setting to preserve the default WP Codebox provider."
+    },
+    {
       "id": "wp_codebox_phpunit_project_bootstrap",
       "label": "WP Codebox PHPUnit project bootstrap",
       "type": "string",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1291,7 +1291,7 @@
       "label": "WP Codebox database service provider",
       "type": "object",
       "default": {},
-      "description": "Optional operator-owned WP Codebox MySQL runtime-service selection shaped as {provider,engine?,secret_env:{host,port?,username,password}}. provider names a registered WP Codebox provider; engine may be mysql or mariadb; secret_env maps administrative connection fields to host environment variable names. Administrative names must not collide with bench_env. Values are resolved by WP Codebox and never serialized into component settings or recipes. Omit this setting to preserve the default WP Codebox provider and engine."
+      "description": "Optional operator-owned WP Codebox MySQL runtime-service selection shaped as {provider,engine?,allowed_hosts,secret_env:{host,port?,username,password}}. provider names a registered WP Codebox provider; engine may be mysql or mariadb; allowed_hosts declares the non-secret external-service network boundary; secret_env maps administrative connection fields to host environment variable names. Administrative names must not collide with bench_env. Credential values are resolved by WP Codebox and never serialized into component settings or recipes. Omit this setting to preserve the default WP Codebox provider and engine."
     },
     {
       "id": "wp_codebox_phpunit_project_bootstrap",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1291,7 +1291,7 @@
       "label": "WP Codebox database service provider",
       "type": "object",
       "default": {},
-      "description": "Optional operator-owned WP Codebox MySQL runtime-service selection shaped as {provider,engine?,allowed_hosts,secret_env:{host,port?,username,password}}. provider names a registered WP Codebox provider; engine may be mysql or mariadb; allowed_hosts declares the non-secret external-service network boundary; secret_env maps administrative connection fields to host environment variable names. Administrative names must not collide with bench_env. Credential values are resolved by WP Codebox and never serialized into component settings or recipes. Omit this setting to preserve the default WP Codebox provider and engine."
+      "description": "Optional external host-managed WP Codebox MySQL service shaped as {provider:'external',engine?,allowed_hosts,secret_env:{host,port?,username,password}}. engine may be mysql or mariadb; allowed_hosts declares the non-secret external-service network boundary; secret_env maps administrative connection fields to host environment variable names. Administrative names must not collide with bench_env. Credential values are resolved by WP Codebox and never serialized into component settings or recipes. Omit this setting to preserve WP Codebox's default Docker provider and engine; provider:'docker' is not accepted here."
     },
     {
       "id": "wp_codebox_phpunit_project_bootstrap",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1291,7 +1291,7 @@
       "label": "WP Codebox database service provider",
       "type": "object",
       "default": {},
-      "description": "Optional operator-owned WP Codebox MySQL runtime-service selection shaped as {provider,secret_env:{host,port?,username,password}}. provider names a registered WP Codebox provider; secret_env maps administrative connection fields to host environment variable names. Values are resolved by WP Codebox and never serialized into component settings or recipes. Omit this setting to preserve the default WP Codebox provider."
+      "description": "Optional operator-owned WP Codebox MySQL runtime-service selection shaped as {provider,engine?,secret_env:{host,port?,username,password}}. provider names a registered WP Codebox provider; engine may be mysql or mariadb; secret_env maps administrative connection fields to host environment variable names. Administrative names must not collide with bench_env. Values are resolved by WP Codebox and never serialized into component settings or recipes. Omit this setting to preserve the default WP Codebox provider and engine."
     },
     {
       "id": "wp_codebox_phpunit_project_bootstrap",


### PR DESCRIPTION
## Summary

- add an opt-in, external-only `wp_codebox_database_service` setting that translates host-managed MySQL/MariaDB configuration, administrative secret environment references, and non-secret host allowlists into the WP Codebox runtime-service contract
- preserve WP Codebox's default Docker provider and engine only when the setting is omitted; reject `provider: docker`, unknown providers, malformed providers, and missing providers before recipe build with a value-free diagnostic
- fail before recipe/workload execution for malformed settings JSON, malformed provider configuration, missing secret references, unavailable host variables, `bench_env` collisions, and invalid engines/allowlists
- keep administrative values host-only by removing them from recipe-build, prepare-step, and evidence-parser subprocess environments; only `recipe-run` receives them for WP Codebox provisioning
- apply #2046's external-service boundary, network policy, explicit managed-write approval, and generated secret-channel evidence without duplicating provider lifecycle

Closes #2408.
Depends on and coordinates with Automattic/wp-codebox#2043 and merged Automattic/wp-codebox#2046 (`c7ca51b5`, `ddb67026`, `28a9d4c7`).

## Provider Contract

`wp_codebox_database_service` is specifically the external host-managed integration and requires `provider: external`. It cannot be used to select Docker or arbitrary provider identifiers. Existing consumers preserve WP Codebox's current Docker/default behavior by omitting the setting entirely.

The extension maps operator configuration to WP Codebox's committed `WorkspaceRecipeRuntimeService` fields: `configuration.provider`, `externalService`, optional `engine`, `hostEnv`, optional `portEnv`, `usernameEnv`, and `passwordEnv`. It supplies canonical `DB_*` outputs and adds the required provider-neutral external-service boundary after recipe build because WP Codebox's PHPUnit builder does not yet expose `inputs.externalServices`.

WP Codebox remains solely responsible for provider registration, host authorization enforcement, isolation proof, temporary database/user creation, runtime credential generation, cleanup, and lifecycle evidence. The extension contains no hosting vendor, project, production path, database lifecycle, or transport/runtime vendor logic.

## Secret Flow

`wp_codebox_database_service.secret_env` accepts environment variable names only. The adapter verifies required names and host availability before invoking WP Codebox and rejects any name also present in `bench_env`, preventing administrative values from entering builder options, `env-json`, recipes, snapshots, results, or observations.

Recipe build, component prepare steps, and artifact parser subprocesses receive environments with all administrative references removed. `recipe-run` is the only child retaining those host variables, allowing WP Codebox to resolve them during provisioning. Captured recipe-run output is bounded by WP Codebox and redacted again by the adapter. `allowed_hosts` is explicit non-secret policy metadata, not an environment projection.

WP Codebox provisions isolated runtime credentials and injects only the generated workload password through its connector-scoped secret environment. Its final secret-channel commits include generated secret names in redaction/evidence summaries without persisting values.

## Authorization Flow

The configured external provider receives a stable `externalService` reference and an `inputs.externalServices` boundary with explicit allowed hosts and `writes=allowed-with-approval`. The adapter invokes recipe-run with a matching network allowlist, `approvals=on-write`, and `--approve-external-service-writes`. WP Codebox validates the resolved host against both policy and boundary before connecting and owns all subsequent lifecycle work.

## Tests

Passed after the latest review commit:

- `node tests/wp-codebox-database-service-smoke.mjs`
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `node tests/wordpress-manifest-settings-smoke.js`
- `node tests/wp-codebox-canonical-cli-adapters-smoke.mjs`
- `node tests/wp-codebox-artifacts-isolated-snapshot-smoke.js`
- `npx eslint scripts/test/wp-codebox-phpunit-adapter.mjs --max-warnings=0`
- `node --check scripts/test/wp-codebox-phpunit-adapter.mjs`
- `node --check tests/wp-codebox-database-service-smoke.mjs`
- `jq empty wordpress.json`
- `git diff HEAD^ --check`

The database-service smoke covers omitted/default behavior, successful external translation, Docker rejection, unknown-provider rejection, malformed-provider rejection, missing-provider rejection, value-free diagnostics, `bench_env` collision rejection, scrubbed recipe-build and prepare-step environments, malformed settings JSON, missing/malformed references, output redaction, explicit boundary/approval policy, MySQL multisite compatibility, MariaDB engine mapping, and omitted-engine compatibility.

Existing unrelated full-suite blockers:

- raw `npm run lint:js` baseline: #2327
- declared no-PHPUnit self-check bootstrap omission: #2388
- fuzz runner fake runtime descriptor drift: #2409

## WP Codebox Main Alignment

Current WP Codebox `main` also includes merged #2052, which removed implicit Composer preparation for source-form extra plugins. Validation dependencies with `composer.json` and no `vendor/autoload.php` now declare `composer: install`; WP Codebox performs that install in its temporary staged copy without mutating the caller's source checkout. The focused adapter smoke asserts this translation, and the managed dependency ordering CI canary exercises it end to end.

Closes #2411.