### PR TITLE
feat(wordpress): select native database services

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -15,6 +15,7 @@
       "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
       "node tests/wp-codebox-database-service-smoke.mjs",
+      "node tests/wp-codebox-native-database-canary.mjs",
       "bash scripts/test/full-suite-no-phpunit-smoke.sh",
       "node tests/codebox-client-boundary.test.js",
       "node tests/wp-codebox-fuzz-run-smoke.js",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -123,6 +123,7 @@
     "test:wp-codebox-canonical-cli-adapters": "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
     "test:wp-codebox-phpunit-evidence": "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
     "test:wp-codebox-database-service": "node tests/wp-codebox-database-service-smoke.mjs",
+    "test:wp-codebox-native-database-canary": "node tests/wp-codebox-native-database-canary.mjs",
     "test:wp-codebox-doctor": "bash scripts/test/wp-codebox-doctor-smoke.sh",
     "test:extension-composer-vendor-integrity": "bash tests/extension-composer-vendor-integrity-smoke.sh",
     "test:wordpress-multisite-e2e-rig": "node rigs/wordpress-multisite-e2e/tests/contract.test.mjs",

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -16,6 +16,7 @@ const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const extensionRoot = path.resolve(scriptDirectory, '../..');
 const harnessSource = path.join(extensionRoot, 'vendor');
 const NATIVE_MARIADB_CAPABILITY = 'runtime-service:mysql:native:mariadb';
+const RUNTIME_SERVICE_CAPABILITIES_SCHEMA = 'wp-codebox/runtime-service-capabilities/v1';
 const slug = process.env.COMPONENT_ID || path.basename(componentPath);
 const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
@@ -369,7 +370,15 @@ function requireDatabaseServiceCapability(service) {
   } catch {
     descriptor = null;
   }
-  if (!descriptor || !Array.isArray(descriptor.capabilities) || !descriptor.capabilities.includes(service.requiredCapability)) {
+  const runtimeServices = descriptor?.contractManifest?.capabilities?.runtimeServices;
+  if (
+    descriptor?.schema !== 'wp-codebox/runtime-descriptor/v1'
+    || !Array.isArray(descriptor.capabilities)
+    || !descriptor.capabilities.includes(service.requiredCapability)
+    || runtimeServices?.schema !== RUNTIME_SERVICE_CAPABILITIES_SCHEMA
+    || !Array.isArray(runtimeServices.capabilities)
+    || !runtimeServices.capabilities.includes(service.requiredCapability)
+  ) {
     throw new Error('WP Codebox runtime does not advertise the required native MariaDB service capability');
   }
 }
@@ -440,13 +449,14 @@ async function requireHarness(source) {
 }
 async function handoffArtifacts(artifactRoot, execution) {
   let pointer;
-  try { pointer = await readFile(path.join(artifactRoot, 'latest-runtime.json'), 'utf8'); } catch { return; }
-  const runtime = json(pointer, {}).paths?.runtimeDirectory;
+  try { pointer = json(await readFile(path.join(artifactRoot, 'latest-runtime.json'), 'utf8'), null); } catch { return; }
+  const runtime = pointer?.paths?.runtimeDirectory;
   if (typeof runtime !== 'string' || !/^runtime-[A-Za-z0-9][A-Za-z0-9-]*$/.test(runtime)) {
     return;
   }
   const artifactDirectory = path.join(artifactRoot, runtime);
-  await preservePhpunitOutput(artifactDirectory, execution);
+  const managedRuntimeServices = Array.isArray(pointer.managedRuntimeServices) ? pointer.managedRuntimeServices : [];
+  await preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices);
   if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
     runScript('parse-test-results.sh', [artifactDirectory]);
   }
@@ -454,12 +464,12 @@ async function handoffArtifacts(artifactRoot, execution) {
     runScript('parse-test-failures.sh', [artifactDirectory, componentPath]);
   }
 }
-async function preservePhpunitOutput(artifactDirectory, execution) {
+async function preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices) {
   const filesDirectory = path.join(artifactDirectory, 'files');
   const logsDirectory = path.join(artifactDirectory, 'logs');
   const testResultsPath = path.join(filesDirectory, 'test-results.json');
   const phpunitOutputPath = path.join(filesDirectory, 'phpunit-output.log');
-  const runtimeMetadataPath = path.join(artifactDirectory, 'metadata.json');
+  const managedRuntimeServicesPath = path.join(filesDirectory, 'managed-runtime-services.json');
   await mkdir(filesDirectory, { recursive: true });
   await mkdir(logsDirectory, { recursive: true });
   await copyFile(execution.stdoutPath, path.join(logsDirectory, 'recipe-run.stdout.log'));
@@ -469,6 +479,9 @@ async function preservePhpunitOutput(artifactDirectory, execution) {
   const stderr = await readFile(execution.stderrPath, 'utf8');
   const output = extractPhpunitOutput(stdout, stderr);
   await writeFile(phpunitOutputPath, output);
+  if (managedRuntimeServices.length > 0) {
+    await writeFile(managedRuntimeServicesPath, `${JSON.stringify(managedRuntimeServices, null, 2)}\n`);
+  }
 
   let results;
   try { results = json(await readFile(testResultsPath, 'utf8'), null); } catch { results = null; }
@@ -484,24 +497,18 @@ async function preservePhpunitOutput(artifactDirectory, execution) {
       { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
       { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
     ];
-    try {
-      const runtimeMetadata = json(await readFile(runtimeMetadataPath, 'utf8'), null);
-      if (Array.isArray(runtimeMetadata?.managedRuntimeServices)) {
-        evidenceReferences.push({ kind: 'managed-runtime-services', uri: 'artifact://metadata.json' });
-      }
-    } catch {}
+    if (managedRuntimeServices.length > 0) {
+      evidenceReferences.push({ kind: 'managed-runtime-services', uri: 'artifact://files/managed-runtime-services.json' });
+    }
     results.evidenceReferences = evidenceReferences;
     await writeFile(testResultsPath, `${JSON.stringify(results, null, 2)}\n`);
   }
 
   process.stdout.write('Structured PHPUnit evidence: artifact://files/test-results.json\n');
   process.stdout.write('Full PHPUnit output: artifact://files/phpunit-output.log\n');
-  try {
-    const runtimeMetadata = json(await readFile(runtimeMetadataPath, 'utf8'), null);
-    if (Array.isArray(runtimeMetadata?.managedRuntimeServices)) {
-      process.stdout.write('Managed runtime service evidence: artifact://metadata.json\n');
-    }
-  } catch {}
+  if (managedRuntimeServices.length > 0) {
+    process.stdout.write('Managed runtime service evidence: artifact://files/managed-runtime-services.json\n');
+  }
 }
 function extractPhpunitOutput(stdout, stderr) {
   const payload = json(stdout.trim(), null);

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -15,12 +15,14 @@ const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMP
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const extensionRoot = path.resolve(scriptDirectory, '../..');
 const harnessSource = path.join(extensionRoot, 'vendor');
+const NATIVE_MARIADB_CAPABILITY = 'runtime-service:mysql:native:mariadb';
 const slug = process.env.COMPONENT_ID || path.basename(componentPath);
 const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
 const pluginSourceDirectory = subpath ? path.join(root, subpath) : root;
 const multisite = await resolveMultisite(settings, pluginSourceDirectory);
 const databaseService = resolveDatabaseService(settings, process.env);
+requireDatabaseServiceCapability(databaseService);
 runPrepareSteps(settings.wp_codebox_prepare_steps, pluginSourceDirectory);
 const directory = await mkdtemp(path.join(tmpdir(), 'homeboy-wp-codebox-phpunit-'));
 const optionsPath = path.join(directory, 'options.json');
@@ -62,7 +64,7 @@ try {
   await applyDatabaseServiceAuthorization(recipePath);
   await mkdir(runArtifacts, { recursive: true });
   const executionArgs = ['recipe-run', '--recipe', recipePath, '--artifacts', runArtifacts, '--json'];
-  if (databaseService) {
+  if (databaseService?.boundary) {
     executionArgs.push('--approve-external-service-writes', '--policy', JSON.stringify(databaseService.policy));
   }
   const execution = await runCaptured(executionArgs);
@@ -257,7 +259,7 @@ function resolveDatabaseService(configuration, environment) {
     return undefined;
   }
   if (!isObject(value)) {
-    throw new Error('wp_codebox_database_service must be an object shaped as {provider,secret_env}');
+    throw new Error('wp_codebox_database_service must be an object');
   }
   const unknownKeys = Object.keys(value).filter((key) => !['provider', 'engine', 'allowed_hosts', 'secret_env'].includes(key));
   if (unknownKeys.length > 0) {
@@ -266,8 +268,27 @@ function resolveDatabaseService(configuration, environment) {
   if (configuration.database_type !== 'mysql') {
     throw new Error('wp_codebox_database_service requires database_type=mysql');
   }
-  if (value.provider !== 'external') {
-    throw new Error('wp_codebox_database_service.provider must be external');
+  if (!['external', 'native'].includes(value.provider)) {
+    throw new Error('wp_codebox_database_service.provider must be external or native');
+  }
+  if (value.provider === 'native') {
+    const nativeUnknownKeys = Object.keys(value).filter((key) => !['provider', 'engine'].includes(key));
+    if (nativeUnknownKeys.length > 0) {
+      throw new Error(`wp_codebox_database_service native provider contains unsupported fields: ${nativeUnknownKeys.join(', ')}`);
+    }
+    if (value.engine !== 'mariadb') {
+      throw new Error('wp_codebox_database_service native provider requires engine=mariadb');
+    }
+    return {
+      service: {
+        id: 'wordpress-database',
+        kind: 'mysql',
+        configuration: { provider: 'native', engine: 'mariadb' },
+        outputs: { host: 'DB_HOST', port: 'DB_PORT', username: 'DB_USER', password: 'DB_PASSWORD', database: 'DB_NAME' },
+      },
+      secretEnv: [],
+      requiredCapability: NATIVE_MARIADB_CAPABILITY,
+    };
   }
   if (value.engine !== undefined && !['mysql', 'mariadb'].includes(value.engine)) {
     throw new Error('wp_codebox_database_service.engine must be mysql or mariadb');
@@ -333,6 +354,25 @@ function resolveDatabaseService(configuration, environment) {
     },
   };
 }
+function requireDatabaseServiceCapability(service) {
+  if (!service?.requiredCapability) {
+    return;
+  }
+  const result = spawnSync(process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', ['runtime', 'descriptor', '--json'], {
+    cwd: componentPath,
+    env: environmentWithoutDatabaseAdministration(),
+    encoding: 'utf8',
+  });
+  let descriptor;
+  try {
+    descriptor = result.status === 0 ? JSON.parse(result.stdout) : null;
+  } catch {
+    descriptor = null;
+  }
+  if (!descriptor || !Array.isArray(descriptor.capabilities) || !descriptor.capabilities.includes(service.requiredCapability)) {
+    throw new Error('WP Codebox runtime does not advertise the required native MariaDB service capability');
+  }
+}
 function isObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -344,7 +384,7 @@ function environmentWithoutDatabaseAdministration() {
   return environment;
 }
 async function applyDatabaseServiceAuthorization(target) {
-  if (!databaseService) {
+  if (!databaseService?.boundary) {
     return;
   }
   let recipe;
@@ -419,6 +459,7 @@ async function preservePhpunitOutput(artifactDirectory, execution) {
   const logsDirectory = path.join(artifactDirectory, 'logs');
   const testResultsPath = path.join(filesDirectory, 'test-results.json');
   const phpunitOutputPath = path.join(filesDirectory, 'phpunit-output.log');
+  const runtimeMetadataPath = path.join(artifactDirectory, 'metadata.json');
   await mkdir(filesDirectory, { recursive: true });
   await mkdir(logsDirectory, { recursive: true });
   await copyFile(execution.stdoutPath, path.join(logsDirectory, 'recipe-run.stdout.log'));
@@ -439,15 +480,28 @@ async function preservePhpunitOutput(artifactDirectory, execution) {
       { path: 'logs/recipe-run.stdout.log', kind: 'recipe-run-stdout' },
       { path: 'logs/recipe-run.stderr.log', kind: 'recipe-run-stderr' },
     ];
-    results.evidenceReferences = [
+    const evidenceReferences = [
       { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
       { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
     ];
+    try {
+      const runtimeMetadata = json(await readFile(runtimeMetadataPath, 'utf8'), null);
+      if (Array.isArray(runtimeMetadata?.managedRuntimeServices)) {
+        evidenceReferences.push({ kind: 'managed-runtime-services', uri: 'artifact://metadata.json' });
+      }
+    } catch {}
+    results.evidenceReferences = evidenceReferences;
     await writeFile(testResultsPath, `${JSON.stringify(results, null, 2)}\n`);
   }
 
   process.stdout.write('Structured PHPUnit evidence: artifact://files/test-results.json\n');
   process.stdout.write('Full PHPUnit output: artifact://files/phpunit-output.log\n');
+  try {
+    const runtimeMetadata = json(await readFile(runtimeMetadataPath, 'utf8'), null);
+    if (Array.isArray(runtimeMetadata?.managedRuntimeServices)) {
+      process.stdout.write('Managed runtime service evidence: artifact://metadata.json\n');
+    }
+  } catch {}
 }
 function extractPhpunitOutput(stdout, stderr) {
   const payload = json(stdout.trim(), null);

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -22,7 +22,15 @@ import { appendFile, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
 if (args[0] === 'runtime' && args[1] === 'descriptor') {
   const capabilities = process.env.OMIT_NATIVE_DATABASE_CAPABILITY === '1' ? [] : ['runtime-service:mysql:native:mariadb'];
-  process.stdout.write(JSON.stringify({ schema: 'wp-codebox/runtime-descriptor/v1', capabilities }));
+  process.stdout.write(JSON.stringify({
+    schema: 'wp-codebox/runtime-descriptor/v1',
+    capabilities,
+    contractManifest: {
+      capabilities: {
+        runtimeServices: { schema: 'wp-codebox/runtime-service-capabilities/v1', capabilities },
+      },
+    },
+  }));
   process.exit(0);
 }
 if (args[0] === 'recipe' && args[1] === 'build') {

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { strict as assert } from 'node:assert';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
@@ -17,6 +20,11 @@ await writeFile(path.join(dependency, 'composer.json'), '{}\n');
 await writeFile(cli, `#!/usr/bin/env node
 import { appendFile, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
+if (args[0] === 'runtime' && args[1] === 'descriptor') {
+  const capabilities = process.env.OMIT_NATIVE_DATABASE_CAPABILITY === '1' ? [] : ['runtime-service:mysql:native:mariadb'];
+  process.stdout.write(JSON.stringify({ schema: 'wp-codebox/runtime-descriptor/v1', capabilities }));
+  process.exit(0);
+}
 if (args[0] === 'recipe' && args[1] === 'build') {
   const options = JSON.parse(await readFile(args[args.indexOf('--options') + 1], 'utf8'));
   const configuration = options.services?.[0]?.configuration || {};
@@ -95,6 +103,58 @@ try {
   assert.equal('secretEnv' in defaultBuild, false, 'omitted provider adds no secret declarations');
   assert.equal(defaultBuild.databaseType, 'mysql');
   assert.equal(defaultBuild.multisite, true);
+
+  const inheritedSecret = 'must-not-enter-native-recipe';
+  const nativeInvocation = invoke({
+    database_type: 'mysql',
+    wp_codebox_multisite: true,
+    wp_codebox_database_service: { provider: 'native', engine: 'mariadb' },
+  }, { PROVIDER_ADMIN_PASSWORD: inheritedSecret });
+  assert.equal(nativeInvocation.result.status, 0, nativeInvocation.result.stderr);
+  const nativeObservations = await observations(nativeInvocation.observed);
+  assert.deepEqual(nativeObservations[0].options.services, [{
+    id: 'wordpress-database',
+    kind: 'mysql',
+    configuration: { provider: 'native', engine: 'mariadb' },
+    outputs: { host: 'DB_HOST', port: 'DB_PORT', username: 'DB_USER', password: 'DB_PASSWORD', database: 'DB_NAME' },
+  }]);
+  assert.equal('secretEnv' in nativeObservations[0].options, false, 'native mode inherits no caller secret declaration');
+  assert.equal(JSON.stringify(nativeObservations).includes(inheritedSecret), false, 'native recipe translation contains no ambient secret values');
+  assert.equal(nativeObservations[1].args.includes('--approve-external-service-writes'), false, 'native mode requires no external-write approval');
+  assert.equal(nativeObservations[1].args.includes('--policy'), false, 'native mode preserves the WP Codebox default network policy');
+  assert.equal('externalServices' in nativeObservations[1].recipe.inputs, false, 'native mode adds no external-service boundary');
+
+  const missingNativeCapability = expectPreflightFailure({
+    database_type: 'mysql',
+    wp_codebox_database_service: { provider: 'native', engine: 'mariadb' },
+  }, /does not advertise the required native MariaDB service capability/, { OMIT_NATIVE_DATABASE_CAPABILITY: '1' });
+  assert.deepEqual(await observations(missingNativeCapability.observed), [], 'missing upstream capability fails before recipe build');
+
+  for (const engine of [undefined, 'mysql', 'unsupported', 42]) {
+    const rejectedEngine = expectPreflightFailure({
+      database_type: 'mysql',
+      wp_codebox_database_service: { provider: 'native', ...(engine === undefined ? {} : { engine }) },
+    }, /native provider requires engine=mariadb/);
+    assert.deepEqual(await observations(rejectedEngine.observed), [], 'unsupported native engines fail before recipe build');
+    if (engine !== undefined) {
+      assert.equal(rejectedEngine.result.stderr.includes(String(engine)), false, 'native engine diagnostics omit rejected values');
+    }
+  }
+
+  for (const field of ['secret_env', 'allowed_hosts', 'host', 'port', 'username', 'password', 'socket', 'config', 'defaults', 'datadir', 'pid_path', 'log_path', 'externalService', 'args']) {
+    const forbiddenField = expectPreflightFailure({
+      database_type: 'mysql',
+      wp_codebox_database_service: { provider: 'native', engine: 'mariadb', [field]: 'forbidden-native-value' },
+    }, /contains unsupported fields/);
+    assert.deepEqual(await observations(forbiddenField.observed), [], 'native connection, administration, path, and process fields fail before recipe build');
+    assert.equal(forbiddenField.result.stderr.includes('forbidden-native-value'), false, 'native field diagnostics omit rejected values');
+  }
+
+  const nativeDatabaseMismatch = expectPreflightFailure({
+    database_type: 'sqlite',
+    wp_codebox_database_service: { provider: 'native', engine: 'mariadb' },
+  }, /requires database_type=mysql/);
+  assert.deepEqual(await observations(nativeDatabaseMismatch.observed), [], 'native database type mismatch fails before recipe build');
 
   const secretValues = {
     PROVIDER_ADMIN_HOST: 'database.internal.example',
@@ -205,15 +265,15 @@ try {
   const missingProvider = expectPreflightFailure({
     database_type: 'mysql',
     wp_codebox_database_service: { secret_env: { host: 'PROVIDER_ADMIN_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
-  }, /provider must be external/, secretValues);
+  }, /provider must be external or native/, secretValues);
   assert.deepEqual(await observations(missingProvider.observed), [], 'missing provider fails before WP Codebox execution');
 
   for (const provider of ['docker', 'unregistered', 42]) {
     const rejectedProvider = expectPreflightFailure({
       ...configured,
       wp_codebox_database_service: { ...configured.wp_codebox_database_service, provider },
-    }, /provider must be external/, secretValues);
-    assert.deepEqual(await observations(rejectedProvider.observed), [], 'non-external providers fail before recipe build');
+    }, /provider must be external or native/, secretValues);
+    assert.deepEqual(await observations(rejectedProvider.observed), [], 'unsupported providers fail before recipe build');
     assert.equal(rejectedProvider.result.stderr.includes(String(provider)), false, 'provider diagnostics omit rejected values');
   }
 

--- a/wordpress/tests/wp-codebox-native-database-canary.mjs
+++ b/wordpress/tests/wp-codebox-native-database-canary.mjs
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { strict as assert } from 'node:assert';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -20,15 +20,17 @@ try {
 } catch {
   descriptor = null;
 }
-if (!descriptor?.capabilities?.includes('runtime-service:mysql:native:mariadb')) {
-  console.log('WP Codebox native database canary skipped: CLI does not advertise native MariaDB support.');
-  process.exit(0);
-}
+const capability = 'runtime-service:mysql:native:mariadb';
+assert.equal(descriptor?.schema, 'wp-codebox/runtime-descriptor/v1', 'candidate CLI must expose the public runtime descriptor');
+assert.equal(descriptor?.capabilities?.includes(capability), true, 'candidate CLI must advertise native MariaDB support');
+assert.equal(descriptor?.contractManifest?.capabilities?.runtimeServices?.schema, 'wp-codebox/runtime-service-capabilities/v1');
+assert.equal(descriptor?.contractManifest?.capabilities?.runtimeServices?.capabilities?.includes(capability), true);
 
 const extension = path.resolve(import.meta.dirname, '..');
 const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
 const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-native-database-canary-'));
 const component = path.join(root, 'native-database-canary');
+const artifacts = path.join(root, 'artifacts');
 try {
   await mkdir(path.join(component, 'tests'), { recursive: true });
   await writeFile(path.join(component, 'native-database-canary.php'), '<?php\n/* Plugin Name: Native Database Canary */\n');
@@ -47,6 +49,7 @@ class Native_Database_Canary_Test extends WP_UnitTestCase {
       HOMEBOY_COMPONENT_PATH: component,
       COMPONENT_ID: 'native-database-canary',
       HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
       HOMEBOY_SETTINGS_JSON: JSON.stringify({
         database_type: 'mysql',
         wp_codebox_database_service: { provider: 'native', engine: 'mariadb' },
@@ -56,6 +59,22 @@ class Native_Database_Canary_Test extends WP_UnitTestCase {
     timeout: 180_000,
   });
   assert.equal(run.status, 0, `${run.stdout}\n${run.stderr}`);
+  const runDirectory = (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
+  assert.ok(runDirectory, 'adapter must retain the WP Codebox run artifacts');
+  const pointer = JSON.parse(await readFile(path.join(artifacts, runDirectory, 'latest-runtime.json'), 'utf8'));
+  const services = pointer.managedRuntimeServices;
+  assert.equal(services?.length, 1, 'final artifact pointer must expose one managed database service');
+  assert.equal(services[0].provider, 'native');
+  assert.equal(services[0].lifecycle, 'released');
+  assert.equal(services[0].teardown, 'completed');
+  const allowedEvidenceFields = new Set(['id', 'kind', 'provider', 'version', 'readiness', 'lifecycle', 'teardown', 'diagnostic', 'controls', 'memory']);
+  assert.deepEqual(Object.keys(services[0]).filter((key) => !allowedEvidenceFields.has(key)), [], 'lifecycle evidence must remain bounded');
+  const serializedEvidence = JSON.stringify(services);
+  assert.doesNotMatch(serializedEvidence, /(?:password|credential|secret|token|socket|datadir|pid.file|log.file)/i);
+  assert.doesNotMatch(serializedEvidence, /(?:\/tmp\/|wp-codebox-mariadb-)/);
+  const runtimeDirectory = pointer.paths.runtimeDirectory;
+  const handedOff = JSON.parse(await readFile(path.join(artifacts, runDirectory, runtimeDirectory, 'files/managed-runtime-services.json'), 'utf8'));
+  assert.deepEqual(handedOff, services, 'adapter must hand off the final upstream lifecycle evidence without rewriting it');
 } finally {
   await rm(root, { recursive: true, force: true });
 }

--- a/wordpress/tests/wp-codebox-native-database-canary.mjs
+++ b/wordpress/tests/wp-codebox-native-database-canary.mjs
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const cli = process.env.WP_CODEBOX_NATIVE_CANARY_BIN;
+if (!cli) {
+  console.log('WP Codebox native database canary skipped: WP_CODEBOX_NATIVE_CANARY_BIN is not set.');
+  process.exit(0);
+}
+
+const descriptorRun = spawnSync(cli, ['runtime', 'descriptor', '--json'], { encoding: 'utf8' });
+let descriptor;
+try {
+  descriptor = descriptorRun.status === 0 ? JSON.parse(descriptorRun.stdout) : null;
+} catch {
+  descriptor = null;
+}
+if (!descriptor?.capabilities?.includes('runtime-service:mysql:native:mariadb')) {
+  console.log('WP Codebox native database canary skipped: CLI does not advertise native MariaDB support.');
+  process.exit(0);
+}
+
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-native-database-canary-'));
+const component = path.join(root, 'native-database-canary');
+try {
+  await mkdir(path.join(component, 'tests'), { recursive: true });
+  await writeFile(path.join(component, 'native-database-canary.php'), '<?php\n/* Plugin Name: Native Database Canary */\n');
+  await writeFile(path.join(component, 'tests/test-native-database.php'), `<?php
+class Native_Database_Canary_Test extends WP_UnitTestCase {
+    public function test_managed_mysql_connection(): void {
+        global $wpdb;
+        $this->assertSame( 'mysql', $wpdb->get_var( 'SELECT @@version_comment IS NOT NULL' ) ? 'mysql' : 'unavailable' );
+    }
+}
+`);
+
+  const run = spawnSync(runner, [], {
+    env: {
+      ...process.env,
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'native-database-canary',
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({
+        database_type: 'mysql',
+        wp_codebox_database_service: { provider: 'native', engine: 'mariadb' },
+      }),
+    },
+    encoding: 'utf8',
+    timeout: 180_000,
+  });
+  assert.equal(run.status, 0, `${run.stdout}\n${run.stderr}`);
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox native database canary passed.');

--- a/wordpress/tests/wp-codebox-native-database-canary.mjs
+++ b/wordpress/tests/wp-codebox-native-database-canary.mjs
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { strict as assert } from 'node:assert';
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -31,14 +31,22 @@ const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
 const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-native-database-canary-'));
 const component = path.join(root, 'native-database-canary');
 const artifacts = path.join(root, 'artifacts');
+const routingGuardBin = path.join(root, 'routing-guard-bin');
+const dockerMarker = path.join(root, 'docker-selected');
 try {
   await mkdir(path.join(component, 'tests'), { recursive: true });
+  await mkdir(routingGuardBin, { recursive: true });
+  const dockerGuard = path.join(routingGuardBin, 'docker');
+  await writeFile(dockerGuard, '#!/bin/sh\n: > "$WP_CODEBOX_NATIVE_CANARY_DOCKER_MARKER"\nexit 97\n');
+  await chmod(dockerGuard, 0o755);
   await writeFile(path.join(component, 'native-database-canary.php'), '<?php\n/* Plugin Name: Native Database Canary */\n');
   await writeFile(path.join(component, 'tests/test-native-database.php'), `<?php
 class Native_Database_Canary_Test extends WP_UnitTestCase {
     public function test_managed_mysql_connection(): void {
         global $wpdb;
-        $this->assertSame( 'mysql', $wpdb->get_var( 'SELECT @@version_comment IS NOT NULL' ) ? 'mysql' : 'unavailable' );
+        $version = $wpdb->get_var( 'SELECT VERSION()' );
+        $this->assertIsString( $version );
+        $this->assertStringContainsString( 'MariaDB', $version );
     }
 }
 `);
@@ -46,10 +54,12 @@ class Native_Database_Canary_Test extends WP_UnitTestCase {
   const run = spawnSync(runner, [], {
     env: {
       ...process.env,
+      PATH: `${routingGuardBin}${path.delimiter}${process.env.PATH || ''}`,
       HOMEBOY_COMPONENT_PATH: component,
       COMPONENT_ID: 'native-database-canary',
       HOMEBOY_WP_CODEBOX_BIN: cli,
       HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
+      WP_CODEBOX_NATIVE_CANARY_DOCKER_MARKER: dockerMarker,
       HOMEBOY_SETTINGS_JSON: JSON.stringify({
         database_type: 'mysql',
         wp_codebox_database_service: { provider: 'native', engine: 'mariadb' },
@@ -59,6 +69,7 @@ class Native_Database_Canary_Test extends WP_UnitTestCase {
     timeout: 180_000,
   });
   assert.equal(run.status, 0, `${run.stdout}\n${run.stderr}`);
+  await assert.rejects(access(dockerMarker), { code: 'ENOENT' }, 'native provider routing must not invoke Docker');
   const runDirectory = (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
   assert.ok(runDirectory, 'adapter must retain the WP Codebox run artifacts');
   const pointer = JSON.parse(await readFile(path.join(artifacts, runDirectory, 'latest-runtime.json'), 'utf8'));

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { strict as assert } from 'node:assert';
 import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
@@ -30,6 +33,17 @@ const artifacts = args[args.indexOf('--artifacts') + 1];
 const runtime = path.join(artifacts, 'runtime-fixture');
 fs.mkdirSync(path.join(runtime, 'files'), { recursive: true });
 fs.writeFileSync(path.join(artifacts, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+fs.writeFileSync(path.join(runtime, 'metadata.json'), JSON.stringify({
+  managedRuntimeServices: [{
+    id: 'wordpress-database',
+    kind: 'mysql',
+    provider: 'native',
+    version: 'mariadb',
+    readiness: 'ready',
+    lifecycle: 'released',
+    generatedSecrets: [{ target: 'DB_PASSWORD', source: 'provider-generated' }],
+  }],
+}));
 fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify({
   schema: 'wp-codebox/test-results/v1',
   status: 'failed',
@@ -92,6 +106,7 @@ try {
   assert.equal(run.status, 1, run.stderr);
   assert.match(run.stdout, /Structured PHPUnit evidence: artifact:\/\/files\/test-results\.json/);
   assert.match(run.stdout, /Full PHPUnit output: artifact:\/\/files\/phpunit-output\.log/);
+  assert.match(run.stdout, /Managed runtime service evidence: artifact:\/\/metadata\.json/);
 
   const runDirectory = (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
   assert.ok(runDirectory);
@@ -112,7 +127,12 @@ try {
   assert.deepEqual(artifactResults.evidenceReferences, [
     { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
     { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
+    { kind: 'managed-runtime-services', uri: 'artifact://metadata.json' },
   ]);
+  const runtimeMetadata = JSON.parse(await readFile(path.join(runtime, 'metadata.json'), 'utf8'));
+  assert.equal(runtimeMetadata.managedRuntimeServices[0].lifecycle, 'released');
+  assert.deepEqual(runtimeMetadata.managedRuntimeServices[0].generatedSecrets, [{ target: 'DB_PASSWORD', source: 'provider-generated' }]);
+  assert.equal(JSON.stringify(runtimeMetadata).includes('fixture-secret-value'), false, 'provider-neutral lifecycle handoff contains no secret values');
   assert.deepEqual(JSON.parse(await readFile(resultsFile, 'utf8')), { total: 3, passed: 0, failed: 2, skipped: 1 });
 
   const analysisInput = JSON.parse(await readFile(failuresFile, 'utf8'));

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -33,17 +33,6 @@ const artifacts = args[args.indexOf('--artifacts') + 1];
 const runtime = path.join(artifacts, 'runtime-fixture');
 fs.mkdirSync(path.join(runtime, 'files'), { recursive: true });
 fs.writeFileSync(path.join(artifacts, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
-fs.writeFileSync(path.join(runtime, 'metadata.json'), JSON.stringify({
-  managedRuntimeServices: [{
-    id: 'wordpress-database',
-    kind: 'mysql',
-    provider: 'native',
-    version: 'mariadb',
-    readiness: 'ready',
-    lifecycle: 'released',
-    generatedSecrets: [{ target: 'DB_PASSWORD', source: 'provider-generated' }],
-  }],
-}));
 fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify({
   schema: 'wp-codebox/test-results/v1',
   status: 'failed',
@@ -106,7 +95,6 @@ try {
   assert.equal(run.status, 1, run.stderr);
   assert.match(run.stdout, /Structured PHPUnit evidence: artifact:\/\/files\/test-results\.json/);
   assert.match(run.stdout, /Full PHPUnit output: artifact:\/\/files\/phpunit-output\.log/);
-  assert.match(run.stdout, /Managed runtime service evidence: artifact:\/\/metadata\.json/);
 
   const runDirectory = (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
   assert.ok(runDirectory);
@@ -127,12 +115,7 @@ try {
   assert.deepEqual(artifactResults.evidenceReferences, [
     { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
     { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
-    { kind: 'managed-runtime-services', uri: 'artifact://metadata.json' },
   ]);
-  const runtimeMetadata = JSON.parse(await readFile(path.join(runtime, 'metadata.json'), 'utf8'));
-  assert.equal(runtimeMetadata.managedRuntimeServices[0].lifecycle, 'released');
-  assert.deepEqual(runtimeMetadata.managedRuntimeServices[0].generatedSecrets, [{ target: 'DB_PASSWORD', source: 'provider-generated' }]);
-  assert.equal(JSON.stringify(runtimeMetadata).includes('fixture-secret-value'), false, 'provider-neutral lifecycle handoff contains no secret values');
   assert.deepEqual(JSON.parse(await readFile(resultsFile, 'utf8')), { total: 3, passed: 0, failed: 2, skipped: 1 });
 
   const analysisInput = JSON.parse(await readFile(failuresFile, 'utf8'));

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1291,7 +1291,7 @@
       "label": "WP Codebox database service provider",
       "type": "object",
       "default": {},
-      "description": "Optional external host-managed WP Codebox MySQL service shaped as {provider:'external',engine?,allowed_hosts,secret_env:{host,port?,username,password}}. engine may be mysql or mariadb; allowed_hosts declares the non-secret external-service network boundary; secret_env maps administrative connection fields to host environment variable names. Administrative names must not collide with bench_env. Credential values are resolved by WP Codebox and never serialized into component settings or recipes. Omit this setting to preserve WP Codebox's default Docker provider and engine; provider:'docker' is not accepted here."
+      "description": "Optional WP Codebox MySQL-compatible service selection. Native ephemeral mode is {provider:'native',engine:'mariadb'} and accepts no connection, administration, path, process, secret_env, or network-boundary fields. External host-managed mode remains {provider:'external',engine?,allowed_hosts,secret_env:{host,port?,username,password}}; engine may be mysql or mariadb, allowed_hosts declares its external-service boundary, and secret_env maps administrative fields to host environment variable names. Omit this setting to preserve WP Codebox's default Docker provider and engine; provider:'docker' is not accepted here."
     },
     {
       "id": "wp_codebox_phpunit_project_bootstrap",


### PR DESCRIPTION
## Summary
- add strict `provider: native` / `engine: mariadb` translation for WP Codebox-managed ephemeral MySQL services
- fail closed on missing runtime capability, unsupported provider/engine values, and all native connection, administration, path, process, secret, and external-boundary fields before recipe build
- preserve default Docker omission and external provider authorization while handing off provider-neutral lifecycle and generated-secret metadata by artifact reference
- add an opt-in upstream CLI canary without duplicating provider lifecycle logic

## Layer Boundaries
Homeboy Extensions only validates component configuration and translates it into WP Codebox's generic runtime service recipe contract. Native mode does not initialize, start, stop, configure, or clean up MariaDB; it adds no external-service boundary, network allowlist, or write approval. WP Codebox remains the sole owner of native process isolation, generated runtime credentials, lifecycle cleanup, and lifecycle evidence.

External mode retains its existing administrative environment references, host allowlist, external-service boundary, and explicit write approval. Native mode accepts only provider and the advertised MariaDB engine capability, and fails closed when the selected WP Codebox runtime does not advertise `runtime-service:mysql:native:mariadb`.

## Tests
- `npm run test:wp-codebox-database-service`
- `npm run test:wp-codebox-phpunit-evidence`
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `npm run test:wordpress-manifest-settings`
- `npm run test:wp-codebox-native-database-canary` (skip unless `WP_CODEBOX_NATIVE_CANARY_BIN` advertises native MariaDB)
- upstream branch build canary probe (expected skip until Automattic/wp-codebox#2060 advertises the capability)
- `npx eslint --no-ignore scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-database-service-smoke.mjs tests/wp-codebox-phpunit-evidence-smoke.mjs tests/wp-codebox-native-database-canary.mjs`
- WordPress extension manifest, shell syntax, JavaScript syntax, canonical CLI adapter, doctor, installed-helper, Composer integrity, routing, Codebox boundary, fuzz-run, artifact snapshot, and manifest self-checks

The pre-existing `wordpress-fuzz-runner-smoke.js` runtime-descriptor fixture failure remains tracked separately in #2409.

Closes #2412

Upstream: Automattic/wp-codebox#2060