### PR TITLE
fix(opencode): honor required output contracts

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -500,7 +500,7 @@ function opencodeSuccessOutcome(context) {
 }
 
 function structuredOpenCodeReviewOutput(context = {}) {
-	if (context.request?.inputs?.cook_loop?.review_form_required !== true) {
+	if (!requiresReviewForm(context.request)) {
 		return {};
 	}
 	const textEvents = parseJsonObjectsFromText(context.spawnResult?.stdout)
@@ -518,15 +518,32 @@ function structuredOpenCodeReviewOutput(context = {}) {
 				review_form_status: 'harvested',
 			};
 		}
-		return reviewFormOutputDiagnostic(
+		return {
+			outputs: { review_form: envelope.review_form },
+			...reviewFormOutputDiagnostic(
 			'invalid',
 			'OpenCode emitted a review_form with an invalid schema.'
-		);
+			),
+		};
 	}
 	return reviewFormOutputDiagnostic(
 		'missing',
 		'OpenCode completed without a structured review_form in its final answer.'
 	);
+}
+
+function requiresReviewForm(request = {}) {
+	const requiredOutputs = request.inputs?.required_outputs;
+	if (Array.isArray(requiredOutputs)) {
+		return requiredOutputs.some((output) => (
+			output
+			&& output.name === 'review_form'
+			&& output.required === true
+			&& output.schema === 'homeboy/agent-task-review-form/v1'
+		));
+	}
+	// Retain compatibility for Cook recipes persisted before the typed contract.
+	return request.inputs?.cook_loop?.review_form_required === true;
 }
 
 function openCodeTextParts(frame = {}) {
@@ -1003,8 +1020,16 @@ function opencodeRunArgs(request = {}, config = {}, commandSpec = {}) {
 		...(config.agent ? ['--agent', config.agent] : []),
 		...(config.variant ? ['--variant', config.variant] : []),
 		...(config.title ? ['--title', config.title] : []),
-		request.instructions,
+		`${request.instructions}${requiredOutputInstructions(request)}`,
 	];
+}
+
+function requiredOutputInstructions(request = {}) {
+	const outputs = request.inputs?.required_outputs;
+	if (!Array.isArray(outputs) || outputs.length === 0) {
+		return '';
+	}
+	return `\n\nReturn the required outputs as JSON using an \`outputs\` object. The OpenCode adapter parses the response against this contract: ${JSON.stringify(outputs)}.`;
 }
 
 function resolveOpenCodeCwd(request = {}, config = {}) {

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -62,6 +62,8 @@ const OPENCODE_GIT_CAPTURE_OPTIONS = {
 	encoding: 'utf8',
 	maxBuffer: 16 * 1024 * 1024,
 };
+const MAX_STRUCTURED_OUTPUT_BYTES = 64 * 1024;
+const MAX_STRUCTURED_ANSWER_BYTES = MAX_STRUCTURED_OUTPUT_BYTES + 16 * 1024;
 
 const OPENCODE_CAPABILITIES = [
 	'cli_runtime',
@@ -509,20 +511,27 @@ function structuredOpenCodeReviewOutput(context = {}) {
 	const candidates = finalAnswers.length > 0 ? finalAnswers : textEvents.slice(-1);
 	for (const event of candidates.reverse()) {
 		const envelope = parseStructuredAnswer(event.text);
-		if (!envelope || !Object.hasOwn(envelope, 'review_form')) {
+		const reviewForm = structuredReviewFormValue(envelope);
+		if (reviewForm === undefined) {
 			continue;
 		}
-		if (validReviewForm(envelope.review_form)) {
+		if (!boundedStructuredOutput(reviewForm)) {
+			return reviewFormOutputDiagnostic(
+				'invalid',
+				'OpenCode emitted a review_form that exceeded the structured output size limit.'
+			);
+		}
+		if (validReviewForm(reviewForm)) {
 			return {
-				outputs: { review_form: envelope.review_form },
+				outputs: { review_form: reviewForm },
 				review_form_status: 'harvested',
 			};
 		}
 		return {
-			outputs: { review_form: envelope.review_form },
+			outputs: { review_form: reviewForm },
 			...reviewFormOutputDiagnostic(
-			'invalid',
-			'OpenCode emitted a review_form with an invalid schema.'
+				'invalid',
+				'OpenCode emitted a review_form with an invalid schema.'
 			),
 		};
 	}
@@ -530,6 +539,27 @@ function structuredOpenCodeReviewOutput(context = {}) {
 		'missing',
 		'OpenCode completed without a structured review_form in its final answer.'
 	);
+}
+
+function structuredReviewFormValue(envelope) {
+	if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) {
+		return undefined;
+	}
+	// The canonical adapter contract places values under `outputs`. Accept the
+	// direct form emitted by earlier Cook prompts while their persisted recipes age out.
+	if (envelope.outputs && typeof envelope.outputs === 'object' && !Array.isArray(envelope.outputs)
+		&& Object.hasOwn(envelope.outputs, 'review_form')) {
+		return envelope.outputs.review_form;
+	}
+	return Object.hasOwn(envelope, 'review_form') ? envelope.review_form : undefined;
+}
+
+function boundedStructuredOutput(value) {
+	try {
+		return Buffer.byteLength(JSON.stringify(value)) <= MAX_STRUCTURED_OUTPUT_BYTES;
+	} catch {
+		return false;
+	}
 }
 
 function requiresReviewForm(request = {}) {
@@ -564,6 +594,9 @@ function parseStructuredAnswer(text = '') {
 		candidates.unshift(match[1].trim());
 	}
 	for (const candidate of candidates) {
+		if (Buffer.byteLength(candidate) > MAX_STRUCTURED_ANSWER_BYTES) {
+			continue;
+		}
 		try {
 			const parsed = JSON.parse(candidate);
 			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -1039,6 +1039,10 @@ process.stdout.write(JSON.stringify({ type: 'result', result: { summary: 'Review
 	const structuredReviewCliPath = path.join(root, 'mock-opencode-structured-review.cjs');
 	fs.writeFileSync(structuredReviewCliPath, `#!/usr/bin/env node
 const mode = process.env.REVIEW_FORM_MODE;
+const prompt = process.argv.at(-1);
+if (!prompt.includes('homeboy/agent-task-review-form/v1')) {
+  throw new Error('OpenCode did not receive the required-output schema.');
+}
 const text = mode === 'valid'
 	? ${JSON.stringify(`\`\`\`json\n${JSON.stringify({ review_form: {
 		summary: 'Preserve the reviewed cleanup scope in the apply command.',
@@ -1057,7 +1061,18 @@ process.stdout.write(JSON.stringify({
 	const structuredReviewRequest = {
 		...request,
 		task_id: 'opencode-structured-review',
-		inputs: { cook_loop: { review_form_required: true } },
+	inputs: {
+		cook_loop: { review_form_required: true },
+		required_outputs: [{
+			name: 'review_form',
+			required: true,
+			schema: 'homeboy/agent-task-review-form/v1',
+			json_schema: {
+				type: 'object',
+				required: ['summary', 'what_changed', 'compatibility', 'used_for'],
+			},
+		}],
+	},
 		workspace: { root: reviewWorkspace },
 		executor: {
 			...request.executor,
@@ -1073,6 +1088,7 @@ process.stdout.write(JSON.stringify({
 	assert.equal(structuredReviewResult.status, 'no_op');
 	assert.deepEqual(structuredReviewResult.outputs.review_form, structuredReviewForm);
 	assert.equal(structuredReviewResult.metadata.review_form_status, 'harvested');
+	assert.equal(structuredReviewResult.metadata.opencode_session.status, 'not_discovered');
 	const structuredAgentResult = structuredReviewResult.artifacts.find((artifact) => artifact.name === 'agent_result');
 	const structuredAgentResultPayload = JSON.parse(fs.readFileSync(structuredAgentResult.path, 'utf8'));
 	assert.equal(structuredAgentResultPayload.status, 'no_op');
@@ -1093,8 +1109,11 @@ process.stdout.write(JSON.stringify({
 				},
 			},
 		}, { env: fixtureEnv });
-		assert.equal(incompleteReviewResult.status, 'succeeded');
-		assert.deepEqual(incompleteReviewResult.outputs, {});
+		assert.equal(incompleteReviewResult.status, mode === 'invalid' ? 'no_op' : 'succeeded');
+		assert.deepEqual(
+			incompleteReviewResult.outputs,
+			mode === 'invalid' ? { review_form: { summary: [] } } : {}
+		);
 		assert.equal(incompleteReviewResult.diagnostics.some((diagnostic) => diagnostic.class === diagnosticClass), true);
 	}
 } finally {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -1040,18 +1040,21 @@ process.stdout.write(JSON.stringify({ type: 'result', result: { summary: 'Review
 	fs.writeFileSync(structuredReviewCliPath, `#!/usr/bin/env node
 const mode = process.env.REVIEW_FORM_MODE;
 const prompt = process.argv.at(-1);
-if (!prompt.includes('homeboy/agent-task-review-form/v1')) {
+const contract = JSON.parse(prompt.match(/against this contract: (\\[.*\\])\\.$/s)?.[1] || 'null');
+if (contract?.[0]?.name !== 'review_form' || contract[0].required !== true || contract[0].schema !== 'homeboy/agent-task-review-form/v1') {
   throw new Error('OpenCode did not receive the required-output schema.');
 }
 const text = mode === 'valid'
-	? ${JSON.stringify(`\`\`\`json\n${JSON.stringify({ review_form: {
+	? ${JSON.stringify(`\`\`\`json\n${JSON.stringify({ outputs: { review_form: {
 		summary: 'Preserve the reviewed cleanup scope in the apply command.',
 		what_changed: ['Added the scoped apply command to cleanup output.'],
 		compatibility: 'The output change is additive.',
 		used_for: 'Inspected the candidate and summarized its verified behavior.',
-	} }, null, 2)}\n\`\`\``)}
+	} } }, null, 2)}\n\`\`\``)}
 	: mode === 'invalid'
-		? ${JSON.stringify('```json\n{"review_form":{"summary":[]}}\n```')}
+		? ${JSON.stringify('```json\n{"outputs":{"review_form":{"summary":[]}}}\n```')}
+		: mode === 'oversized'
+			? JSON.stringify({ outputs: { review_form: { summary: 'x'.repeat(70 * 1024) } } })
 		: 'Review completed without structured output.';
 process.stdout.write(JSON.stringify({
 	type: 'text',
@@ -1085,7 +1088,7 @@ process.stdout.write(JSON.stringify({
 		},
 	};
 	const structuredReviewResult = await executeOpenCodeAgentTask(structuredReviewRequest, { env: fixtureEnv });
-	assert.equal(structuredReviewResult.status, 'no_op');
+	assert.equal(structuredReviewResult.status, 'no_op', JSON.stringify(structuredReviewResult.diagnostics));
 	assert.deepEqual(structuredReviewResult.outputs.review_form, structuredReviewForm);
 	assert.equal(structuredReviewResult.metadata.review_form_status, 'harvested');
 	assert.equal(structuredReviewResult.metadata.opencode_session.status, 'not_discovered');
@@ -1097,6 +1100,7 @@ process.stdout.write(JSON.stringify({
 	for (const [mode, diagnosticClass] of [
 		['missing', 'opencode.review_form_missing'],
 		['invalid', 'opencode.review_form_invalid'],
+		['oversized', 'opencode.review_form_invalid'],
 	]) {
 		const incompleteReviewResult = await executeOpenCodeAgentTask({
 			...structuredReviewRequest,


### PR DESCRIPTION
## Summary
- read the canonical required_outputs contract before harvesting a Cook review form
- pass the contract through the OpenCode prompt and retain malformed emitted values for Homeboy's recoverable outcome classifier
- parse the canonical `outputs.review_form` final-event envelope independently of session discovery, retaining direct legacy envelopes during persisted-recipe migration
- bound structured-answer parsing and retained structured output to avoid trusting oversized provider text
- prove output capture succeeds when session discovery is unavailable and leaves optional tasks unchanged

Relates to Extra-Chill/homeboy#9653 and Extra-Chill/homeboy#10094.

## Verification
- npm run test:opencode-agent-task-executor --prefix agent-runtimes/opencode
- npm run test:opencode-progress-events --prefix agent-runtimes/opencode
- npm run check:runtime-manifest --prefix agent-runtimes/opencode

## AI Assistance
OpenCode (OpenAI GPT-5.6 Sol) independently reviewed the adapter boundary, identified and remediated the canonical output-envelope mismatch, and extended the runtime-boundary tests. Chris remains responsible for every line.