### PR TITLE
fix(opencode): generalize declared outputs

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -478,13 +478,13 @@ function findArtifact(artifacts, declaration) {
 }
 
 function opencodeSuccessOutcome(context) {
-	const structured = structuredOpenCodeReviewOutput(context);
+	const structured = structuredOpenCodeOutputs(context);
 	const evidence = collectOpenCodeArtifacts(context, structured);
 	const emptyPatch = evidence.artifacts?.some((artifact) => artifact.name === 'patch' && artifact.bytes === 0);
 	return withPolicyDeniedOutcome(context, {
 		status: structured.outputs && emptyPatch ? 'no_op' : 'succeeded',
 		summary: structured.outputs && emptyPatch
-			? 'OpenCode completed the requested review form without workspace changes.'
+			? 'OpenCode completed without workspace changes.'
 			: 'OpenCode completed successfully.',
 		diagnostics: [
 			{ classification: 'provider', message: 'OpenCode CLI exited with status 0.' },
@@ -494,15 +494,15 @@ function opencodeSuccessOutcome(context) {
 			exit_code: 0,
 			opencode_session: sessionMetadata(context),
 			opencode_progress: progressMetadata(context),
-			...(structured.review_form_status ? { review_form_status: structured.review_form_status } : {}),
 		},
 		...(structured.outputs ? { outputs: structured.outputs } : {}),
 		...evidence,
 	});
 }
 
-function structuredOpenCodeReviewOutput(context = {}) {
-	if (!requiresReviewForm(context.request)) {
+function structuredOpenCodeOutputs(context = {}) {
+	const declarations = outputDeclarations(context.request);
+	if (declarations.length === 0) {
 		return {};
 	}
 	const textEvents = parseJsonObjectsFromText(context.spawnResult?.stdout)
@@ -511,47 +511,46 @@ function structuredOpenCodeReviewOutput(context = {}) {
 	const candidates = finalAnswers.length > 0 ? finalAnswers : textEvents.slice(-1);
 	for (const event of candidates.reverse()) {
 		const envelope = parseStructuredAnswer(event.text);
-		const reviewForm = structuredReviewFormValue(envelope);
-		if (reviewForm === undefined) {
+		const values = declaredOutputValues(envelope, declarations);
+		if (!values) {
 			continue;
 		}
-		if (!boundedStructuredOutput(reviewForm)) {
-			return reviewFormOutputDiagnostic(
-				'invalid',
-				'OpenCode emitted a review_form that exceeded the structured output size limit.'
-			);
+		const outputs = {};
+		const oversized = [];
+		for (const declaration of declarations) {
+			if (!Object.hasOwn(values, declaration.name)) {
+				continue;
+			}
+			if (boundedStructuredOutput(values[declaration.name])) {
+				// Core owns declaration-schema validation; retain bounded provider values.
+				outputs[declaration.name] = values[declaration.name];
+			} else {
+				oversized.push(declaration.name);
+			}
 		}
-		if (validReviewForm(reviewForm)) {
-			return {
-				outputs: { review_form: reviewForm },
-				review_form_status: 'harvested',
-			};
-		}
+		const missing = declarations.filter((declaration) => declaration.required && !Object.hasOwn(outputs, declaration.name));
 		return {
-			outputs: { review_form: reviewForm },
-			...reviewFormOutputDiagnostic(
-				'invalid',
-				'OpenCode emitted a review_form with an invalid schema.'
-			),
+			...(Object.keys(outputs).length > 0 ? { outputs } : {}),
+			diagnostics: outputDiagnostics(missing, oversized),
 		};
 	}
-	return reviewFormOutputDiagnostic(
-		'missing',
-		'OpenCode completed without a structured review_form in its final answer.'
-	);
+	return { diagnostics: outputDiagnostics(declarations.filter((declaration) => declaration.required), []) };
 }
 
-function structuredReviewFormValue(envelope) {
+function declaredOutputValues(envelope, declarations) {
 	if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) {
-		return undefined;
+		return null;
 	}
-	// The canonical adapter contract places values under `outputs`. Accept the
-	// direct form emitted by earlier Cook prompts while their persisted recipes age out.
+	// OpenCode's current prompt contract is the canonical `outputs` envelope.
 	if (envelope.outputs && typeof envelope.outputs === 'object' && !Array.isArray(envelope.outputs)
-		&& Object.hasOwn(envelope.outputs, 'review_form')) {
-		return envelope.outputs.review_form;
+		&& declarations.some((declaration) => Object.hasOwn(envelope.outputs, declaration.name))) {
+		return envelope.outputs;
 	}
-	return Object.hasOwn(envelope, 'review_form') ? envelope.review_form : undefined;
+	// Persisted pre-envelope recipes can only expose their explicitly declared names.
+	const legacy = Object.fromEntries(declarations
+		.filter((declaration) => Object.hasOwn(envelope, declaration.name))
+		.map((declaration) => [declaration.name, envelope[declaration.name]]));
+	return Object.keys(legacy).length > 0 ? legacy : null;
 }
 
 function boundedStructuredOutput(value) {
@@ -560,20 +559,6 @@ function boundedStructuredOutput(value) {
 	} catch {
 		return false;
 	}
-}
-
-function requiresReviewForm(request = {}) {
-	const requiredOutputs = request.inputs?.required_outputs;
-	if (Array.isArray(requiredOutputs)) {
-		return requiredOutputs.some((output) => (
-			output
-			&& output.name === 'review_form'
-			&& output.required === true
-			&& output.schema === 'homeboy/agent-task-review-form/v1'
-		));
-	}
-	// Retain compatibility for Cook recipes persisted before the typed contract.
-	return request.inputs?.cook_loop?.review_form_required === true;
 }
 
 function openCodeTextParts(frame = {}) {
@@ -609,24 +594,28 @@ function parseStructuredAnswer(text = '') {
 	return null;
 }
 
-function validReviewForm(form) {
-	return form && typeof form === 'object' && !Array.isArray(form)
-		&& typeof form.summary === 'string'
-		&& Array.isArray(form.what_changed)
-		&& form.what_changed.every((item) => typeof item === 'string')
-		&& typeof form.compatibility === 'string'
-		&& typeof form.used_for === 'string';
+function outputDeclarations(request = {}) {
+	return arrayValue(request.inputs?.required_outputs)
+		.filter((declaration) => declaration && typeof declaration === 'object'
+			&& typeof declaration.name === 'string' && declaration.name.trim() !== '')
+		.map((declaration) => ({ ...declaration, name: declaration.name.trim(), required: declaration.required === true }));
 }
 
-function reviewFormOutputDiagnostic(status, message) {
-	return {
-		review_form_status: status,
-		diagnostics: [{
-			class: `opencode.review_form_${status}`,
+function outputDiagnostics(missing, oversized) {
+	return [
+		...(missing.length > 0 ? [{
+			class: 'opencode.required_outputs_missing',
 			classification: 'provider',
-			message,
-		}],
-	};
+			message: `OpenCode completed without required structured output(s): ${missing.map((declaration) => declaration.name).join(', ')}.`,
+			data: { missing_outputs: missing.map((declaration) => declaration.name) },
+		}] : []),
+		...(oversized.length > 0 ? [{
+			class: 'opencode.declared_outputs_oversized',
+			classification: 'provider',
+			message: `OpenCode emitted structured output(s) exceeding the size limit: ${oversized.join(', ')}.`,
+			data: { oversized_outputs: oversized },
+		}] : []),
+	];
 }
 
 function opencodeFailureOutcome(context) {
@@ -1058,11 +1047,11 @@ function opencodeRunArgs(request = {}, config = {}, commandSpec = {}) {
 }
 
 function requiredOutputInstructions(request = {}) {
-	const outputs = request.inputs?.required_outputs;
-	if (!Array.isArray(outputs) || outputs.length === 0) {
+	const declarations = outputDeclarations(request);
+	if (declarations.length === 0) {
 		return '';
 	}
-	return `\n\nReturn the required outputs as JSON using an \`outputs\` object. The OpenCode adapter parses the response against this contract: ${JSON.stringify(outputs)}.`;
+	return `\n\nReturn one JSON object in your final answer with declared values under \`outputs\`. Include every required declaration and any optional declaration you produced. Output declarations: ${JSON.stringify(declarations)}.`;
 }
 
 function resolveOpenCodeCwd(request = {}, config = {}) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -1030,96 +1030,102 @@ process.stdout.write(JSON.stringify({ type: 'result', result: { summary: 'Review
 	assert.equal(reviewConfig.permission.read['../*'], 'deny');
 	assert.equal(reviewConfig.permission.read['*.env'], 'deny');
 
-	const structuredReviewForm = {
-		summary: 'Preserve the reviewed cleanup scope in the apply command.',
-		what_changed: ['Added the scoped apply command to cleanup output.'],
-		compatibility: 'The output change is additive.',
-		used_for: 'Inspected the candidate and summarized its verified behavior.',
-	};
-	const structuredReviewCliPath = path.join(root, 'mock-opencode-structured-review.cjs');
-	fs.writeFileSync(structuredReviewCliPath, `#!/usr/bin/env node
-const mode = process.env.REVIEW_FORM_MODE;
+	const structuredOutputCliPath = path.join(root, 'mock-opencode-structured-outputs.cjs');
+	fs.writeFileSync(structuredOutputCliPath, `#!/usr/bin/env node
+const mode = process.env.OUTPUT_MODE;
 const prompt = process.argv.at(-1);
-const contract = JSON.parse(prompt.match(/against this contract: (\\[.*\\])\\.$/s)?.[1] || 'null');
-if (contract?.[0]?.name !== 'review_form' || contract[0].required !== true || contract[0].schema !== 'homeboy/agent-task-review-form/v1') {
-  throw new Error('OpenCode did not receive the required-output schema.');
+const declarations = JSON.parse(prompt.match(/Output declarations: (\\[.*\\])\\.$/s)?.[1] || 'null');
+if (declarations?.[0]?.name !== 'release_notes' || declarations[0].required !== true || declarations?.[1]?.name !== 'verification' || declarations[1].required !== false) {
+  throw new Error('OpenCode did not receive generic output declarations.');
 }
 const text = mode === 'valid'
-	? ${JSON.stringify(`\`\`\`json\n${JSON.stringify({ outputs: { review_form: {
-		summary: 'Preserve the reviewed cleanup scope in the apply command.',
-		what_changed: ['Added the scoped apply command to cleanup output.'],
-		compatibility: 'The output change is additive.',
-		used_for: 'Inspected the candidate and summarized its verified behavior.',
-	} } }, null, 2)}\n\`\`\``)}
-	: mode === 'invalid'
-		? ${JSON.stringify('```json\n{"outputs":{"review_form":{"summary":[]}}}\n```')}
-		: mode === 'oversized'
-			? JSON.stringify({ outputs: { review_form: { summary: 'x'.repeat(70 * 1024) } } })
-		: 'Review completed without structured output.';
+	? ${JSON.stringify(`\`\`\`json\n${JSON.stringify({ outputs: { release_notes: ['Added generic output handling.'], verification: { passed: true } } }, null, 2)}\n\`\`\``)}
+	: mode === 'malformed'
+		? ${JSON.stringify('```json\n{"outputs":{"release_notes":{"unexpected":[]},"verification":false}}\n```')}
+	: mode === 'oversized'
+			? JSON.stringify({ outputs: { release_notes: 'x'.repeat(70 * 1024) } })
+			: mode === 'optional-absent'
+				? ${JSON.stringify('```json\n{"outputs":{"release_notes":["Optional output omitted"]}}\n```')}
+			: mode === 'legacy'
+				? ${JSON.stringify('```json\n{"release_notes":["Legacy declaration mapping"],"ignored":"not declared"}\n```')}
+				: 'Completed without structured output.';
 process.stdout.write(JSON.stringify({
 	type: 'text',
 	part: { type: 'text', text, metadata: { openai: { phase: 'final_answer' } } },
 }) + '\\n');
 `);
-	const structuredReviewRequest = {
+	const structuredOutputRequest = {
 		...request,
-		task_id: 'opencode-structured-review',
-	inputs: {
-		cook_loop: { review_form_required: true },
-		required_outputs: [{
-			name: 'review_form',
-			required: true,
-			schema: 'homeboy/agent-task-review-form/v1',
-			json_schema: {
-				type: 'object',
-				required: ['summary', 'what_changed', 'compatibility', 'used_for'],
-			},
-		}],
-	},
+		task_id: 'opencode-structured-outputs',
+		inputs: {
+			required_outputs: [
+				{ name: 'release_notes', required: true, json_schema: { type: 'array', items: { type: 'string' } } },
+				{ name: 'verification', required: false, json_schema: { type: 'object' } },
+			],
+		},
 		workspace: { root: reviewWorkspace },
 		executor: {
 			...request.executor,
 			config: {
 				...request.executor.config,
-				command_args: [structuredReviewCliPath],
+				command_args: [structuredOutputCliPath],
 				cwd: reviewWorkspace,
-				runtime_env: { REVIEW_FORM_MODE: 'valid' },
+				runtime_env: { OUTPUT_MODE: 'valid' },
 			},
 		},
 	};
-	const structuredReviewResult = await executeOpenCodeAgentTask(structuredReviewRequest, { env: fixtureEnv });
-	assert.equal(structuredReviewResult.status, 'no_op', JSON.stringify(structuredReviewResult.diagnostics));
-	assert.deepEqual(structuredReviewResult.outputs.review_form, structuredReviewForm);
-	assert.equal(structuredReviewResult.metadata.review_form_status, 'harvested');
-	assert.equal(structuredReviewResult.metadata.opencode_session.status, 'not_discovered');
-	const structuredAgentResult = structuredReviewResult.artifacts.find((artifact) => artifact.name === 'agent_result');
+	const structuredOutputResult = await executeOpenCodeAgentTask(structuredOutputRequest, { env: fixtureEnv });
+	assert.equal(structuredOutputResult.status, 'no_op', JSON.stringify(structuredOutputResult.diagnostics));
+	assert.deepEqual(structuredOutputResult.outputs, { release_notes: ['Added generic output handling.'], verification: { passed: true } });
+	assert.equal(structuredOutputResult.metadata.opencode_session.status, 'not_discovered');
+	const structuredAgentResult = structuredOutputResult.artifacts.find((artifact) => artifact.name === 'agent_result');
 	const structuredAgentResultPayload = JSON.parse(fs.readFileSync(structuredAgentResult.path, 'utf8'));
 	assert.equal(structuredAgentResultPayload.status, 'no_op');
-	assert.deepEqual(structuredAgentResultPayload.outputs.review_form, structuredReviewForm);
+	assert.deepEqual(structuredAgentResultPayload.outputs, structuredOutputResult.outputs);
 
-	for (const [mode, diagnosticClass] of [
-		['missing', 'opencode.review_form_missing'],
-		['invalid', 'opencode.review_form_invalid'],
-		['oversized', 'opencode.review_form_invalid'],
+	for (const [mode, outputs, diagnosticClass] of [
+		['missing', {}, 'opencode.required_outputs_missing'],
+		['malformed', { release_notes: { unexpected: [] }, verification: false }, undefined],
+		['oversized', {}, 'opencode.declared_outputs_oversized'],
 	]) {
-		const incompleteReviewResult = await executeOpenCodeAgentTask({
-			...structuredReviewRequest,
-			task_id: `opencode-structured-review-${mode}`,
+		const incompleteOutputResult = await executeOpenCodeAgentTask({
+			...structuredOutputRequest,
+			task_id: `opencode-structured-outputs-${mode}`,
 			executor: {
-				...structuredReviewRequest.executor,
+				...structuredOutputRequest.executor,
 				config: {
-					...structuredReviewRequest.executor.config,
-					runtime_env: { REVIEW_FORM_MODE: mode },
+					...structuredOutputRequest.executor.config,
+					runtime_env: { OUTPUT_MODE: mode },
 				},
 			},
 		}, { env: fixtureEnv });
-		assert.equal(incompleteReviewResult.status, mode === 'invalid' ? 'no_op' : 'succeeded');
-		assert.deepEqual(
-			incompleteReviewResult.outputs,
-			mode === 'invalid' ? { review_form: { summary: [] } } : {}
-		);
-		assert.equal(incompleteReviewResult.diagnostics.some((diagnostic) => diagnostic.class === diagnosticClass), true);
+		assert.equal(incompleteOutputResult.status, mode === 'malformed' ? 'no_op' : 'succeeded');
+		assert.deepEqual(incompleteOutputResult.outputs, outputs);
+		assert.equal(incompleteOutputResult.diagnostics.some((diagnostic) => diagnostic.class === diagnosticClass), diagnosticClass !== undefined);
 	}
+
+	const optionalAbsentResult = await executeOpenCodeAgentTask({
+		...structuredOutputRequest,
+		task_id: 'opencode-structured-outputs-optional-absent',
+		executor: {
+			...structuredOutputRequest.executor,
+			config: { ...structuredOutputRequest.executor.config, runtime_env: { OUTPUT_MODE: 'optional-absent' } },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(optionalAbsentResult.status, 'no_op');
+	assert.deepEqual(optionalAbsentResult.outputs, { release_notes: ['Optional output omitted'] });
+	assert.equal(optionalAbsentResult.diagnostics.some((diagnostic) => diagnostic.class === 'opencode.required_outputs_missing'), false);
+
+	const legacyOutputResult = await executeOpenCodeAgentTask({
+		...structuredOutputRequest,
+		task_id: 'opencode-structured-outputs-legacy',
+		executor: {
+			...structuredOutputRequest.executor,
+			config: { ...structuredOutputRequest.executor.config, runtime_env: { OUTPUT_MODE: 'legacy' } },
+		},
+	}, { env: fixtureEnv });
+	assert.deepEqual(legacyOutputResult.outputs, { release_notes: ['Legacy declaration mapping'] });
+	assert.equal(legacyOutputResult.outputs.ignored, undefined);
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- compile arbitrary Homeboy output declarations into the OpenCode final-answer prompt
- harvest only declared values from canonical `outputs` final events, retaining bounded malformed values for Homeboy core validation
- map only declared legacy direct-envelope names while preserving OpenCode-native parsing and session metadata behavior

Fixes Extra-Chill/homeboy#9653.

## Verification
- `npm run test:opencode-agent-task-executor --prefix agent-runtimes/opencode`
- `npm run test:opencode-progress-events --prefix agent-runtimes/opencode`
- `npm run check:runtime-manifest --prefix agent-runtimes/opencode`

## AI Assistance
OpenCode, powered by OpenAI GPT-5.6 Terra, drafted the generic declaration handling and boundary tests. Chris Huber reviewed the implementation and remains responsible for every line.