### PR TITLE
fix(wordpress): clean Composer hydration artifacts

### DIFF
--- a/wordpress/scripts/deps/deps-runner.sh
+++ b/wordpress/scripts/deps/deps-runner.sh
@@ -6,6 +6,49 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-${PROJECT_PATH:-$(pwd)}}"
 ACTION="${1:-status}"
 PACKAGE_FILTER="${2:-}"
+COMPOSER_METADATA_SNAPSHOT_DIR=""
+COMPOSER_METADATA_PATHS=()
+COMPOSER_METADATA_STATES=()
+
+snapshot_composer_metadata() {
+    local repository_root project_prefix tracked_path snapshot_path
+    repository_root="$(git -C "$PROJECT_PATH" rev-parse --show-toplevel 2>/dev/null)" || return 0
+    project_prefix="$(git -C "$PROJECT_PATH" rev-parse --show-prefix 2>/dev/null)"
+    COMPOSER_METADATA_SNAPSHOT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-composer-metadata.XXXXXX")"
+
+    while IFS= read -r -d '' tracked_path; do
+        snapshot_path="$COMPOSER_METADATA_SNAPSHOT_DIR/${#COMPOSER_METADATA_PATHS[@]}"
+        COMPOSER_METADATA_PATHS+=("$tracked_path")
+        if [ -e "$repository_root/$tracked_path" ]; then
+            cp -p "$repository_root/$tracked_path" "$snapshot_path"
+            COMPOSER_METADATA_STATES+=("present")
+        else
+            COMPOSER_METADATA_STATES+=("absent")
+        fi
+    done < <(git -C "$PROJECT_PATH" ls-files -z --full-name -- ":(top)${project_prefix}vendor/composer")
+}
+
+restore_composer_metadata() {
+    local status=$? repository_root index tracked_path snapshot_path state
+    [ -n "$COMPOSER_METADATA_SNAPSHOT_DIR" ] || return "$status"
+    repository_root="$(git -C "$PROJECT_PATH" rev-parse --show-toplevel 2>/dev/null)" || return "$status"
+
+    for index in "${!COMPOSER_METADATA_PATHS[@]}"; do
+        tracked_path="${COMPOSER_METADATA_PATHS[$index]}"
+        snapshot_path="$COMPOSER_METADATA_SNAPSHOT_DIR/$index"
+        state="${COMPOSER_METADATA_STATES[$index]}"
+        if [ "$state" = "present" ] && ! cmp -s "$snapshot_path" "$repository_root/$tracked_path"; then
+            mkdir -p "$(dirname "$repository_root/$tracked_path")"
+            cp -p "$snapshot_path" "$repository_root/$tracked_path"
+        elif [ "$state" = "absent" ] && [ -e "$repository_root/$tracked_path" ]; then
+            rm -f "$repository_root/$tracked_path"
+        fi
+    done
+
+    rm -rf "$COMPOSER_METADATA_SNAPSHOT_DIR"
+    COMPOSER_METADATA_SNAPSHOT_DIR=""
+    return "$status"
+}
 
 has_composer() {
     [ -f "${PROJECT_PATH}/composer.json" ]
@@ -91,7 +134,11 @@ run_install() {
     local ran=0
     if has_composer; then
         echo "Installing WordPress PHP dependencies with composer" >&2
+        snapshot_composer_metadata
+        trap 'restore_composer_metadata' EXIT
         (cd "$PROJECT_PATH" && composer install --no-interaction --prefer-dist)
+        trap - EXIT
+        restore_composer_metadata
         ran=1
     fi
     if has_package_json; then

--- a/wordpress/tests/wordpress-deps-provider-smoke.sh
+++ b/wordpress/tests/wordpress-deps-provider-smoke.sh
@@ -6,7 +6,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-PROJECT_DIR="$TMP_DIR/project"
+REPOSITORY_DIR="$TMP_DIR/repository"
+PROJECT_DIR="$REPOSITORY_DIR/fixture-wordpress-component"
 BIN_DIR="$TMP_DIR/bin"
 mkdir -p "$PROJECT_DIR" "$BIN_DIR"
 
@@ -44,7 +45,9 @@ JSON
 cat >"$BIN_DIR/composer" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"${HOMEBOY_FAKE_COMPOSER_LOG:?}"
-exit 0
+mkdir -p vendor/composer
+printf '%s\n' "${HOMEBOY_FAKE_COMPOSER_METADATA:-hydrated metadata}" >vendor/composer/installed.php
+exit "${HOMEBOY_FAKE_COMPOSER_EXIT:-0}"
 SH
 cat >"$BIN_DIR/npm" <<'SH'
 #!/usr/bin/env bash
@@ -57,6 +60,14 @@ export HOMEBOY_COMPONENT_PATH="$PROJECT_DIR"
 export HOMEBOY_FAKE_COMPOSER_LOG="$TMP_DIR/composer.log"
 export HOMEBOY_FAKE_NPM_LOG="$TMP_DIR/npm.log"
 export PATH="$BIN_DIR:$PATH"
+
+mkdir -p "$PROJECT_DIR/vendor/composer"
+printf '%s\n' 'tracked metadata' >"$PROJECT_DIR/vendor/composer/installed.php"
+git -C "$REPOSITORY_DIR" init -q
+git -C "$REPOSITORY_DIR" config user.email 'homeboy-test@example.invalid'
+git -C "$REPOSITORY_DIR" config user.name 'Homeboy Test'
+git -C "$REPOSITORY_DIR" add fixture-wordpress-component
+git -C "$REPOSITORY_DIR" commit -qm 'fixture'
 
 status_json="$("$ROOT_DIR/scripts/deps/deps-runner.sh" status)"
 STATUS_JSON="$status_json" node <<'NODE'
@@ -84,6 +95,42 @@ if [ "$(cat "$HOMEBOY_FAKE_COMPOSER_LOG")" != "install --no-interaction --prefer
 fi
 if [ "$(cat "$HOMEBOY_FAKE_NPM_LOG")" != "ci" ]; then
     echo "expected npm ci command" >&2
+    exit 1
+fi
+if [ "$(cat "$PROJECT_DIR/vendor/composer/installed.php")" != 'tracked metadata' ]; then
+    echo "expected tracked Composer metadata to be restored after hydration" >&2
+    exit 1
+fi
+if ! git -C "$PROJECT_DIR" diff --quiet -- vendor/composer/installed.php; then
+    echo "expected successful hydration to leave tracked Composer metadata clean" >&2
+    exit 1
+fi
+
+export HOMEBOY_FAKE_COMPOSER_METADATA='failed hydration metadata'
+export HOMEBOY_FAKE_COMPOSER_EXIT=17
+if "$ROOT_DIR/scripts/deps/deps-runner.sh" install >/dev/null 2>&1; then
+    echo "expected Composer hydration failure" >&2
+    exit 1
+fi
+unset HOMEBOY_FAKE_COMPOSER_EXIT
+if [ "$(cat "$PROJECT_DIR/vendor/composer/installed.php")" != 'tracked metadata' ]; then
+    echo "expected tracked Composer metadata to be restored after failed hydration" >&2
+    exit 1
+fi
+if ! git -C "$PROJECT_DIR" diff --quiet -- vendor/composer/installed.php; then
+    echo "expected failed hydration to leave tracked Composer metadata clean" >&2
+    exit 1
+fi
+
+printf '%s\n' 'pre-existing user metadata' >"$PROJECT_DIR/vendor/composer/installed.php"
+export HOMEBOY_FAKE_COMPOSER_METADATA='hydrated metadata over user change'
+"$ROOT_DIR/scripts/deps/deps-runner.sh" install >/dev/null
+if [ "$(cat "$PROJECT_DIR/vendor/composer/installed.php")" != 'pre-existing user metadata' ]; then
+    echo "expected pre-existing tracked Composer metadata change to be retained" >&2
+    exit 1
+fi
+if git -C "$PROJECT_DIR" diff --quiet -- vendor/composer/installed.php; then
+    echo "expected pre-existing tracked Composer metadata change to remain visible" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
Preserve tracked Composer metadata during WordPress dependency installation so Composer hydration does not leave repository changes.

## What changed
- Snapshot tracked vendor/composer files before composer install and restore them afterward, including on install failure.
- Added smoke coverage for successful installs, failed installs, and pre-existing user modifications to tracked Composer metadata.

## How to test
1. Run `cd wordpress && npm run test:wordpress-deps-provider`; expect passes as recorded by Cook's deterministic gate.
2. Run `cd wordpress && npm run test:extension-composer-vendor-integrity`; expect passes as recorded by Cook's deterministic gate.
3. Run `bash -n wordpress/scripts/deps/deps-runner.sh`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
No interface changes. Composer installation behavior is retained while tracked Composer metadata is restored to its pre-install state; untracked generated files are unaffected.

## Evidence
- Base unchanged since verification: main remains at 747542c70ba855a07136c9487ae78e6ecfdb38b4.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 3 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/data-machine-code/issues/958
- Task objective: Implement https://github.com/Extra-Chill/data-machine-code/issues/958 in the WordPress extension. Investigate the exact extension-owned Composer hydration path before editing; keep Homeboy core generic and make the smallest owning-layer fix. Runner-managed hydration must not leave tracked generated Composer metadata such as vendor/composer/installed.php modified after success or failure. Cleanup must be ownership-aware: snapshot relevant pre-hydration state and restore only mutations introduced by the hydration step, preserving every change that predated it. Prefer isolation if the existing extension contract supports it. Add deterministic regression coverage that reproduces a tracked vendor/composer/installed.php rewrite, proves cleanup on success and failure where applicable, and proves pre-existing user changes are retained. Report cleanup or intentionally retained files in existing structured evidence if that surface exists. Do not change release versions or changelogs. Run focused tests and inspect the final diff for unrelated generated artifacts.
- Verified candidate scope: 2 changed file(s): wordpress/scripts/deps/deps-runner.sh, wordpress/tests/wordpress-deps-provider-smoke.sh.
- Verified finalization base: main at 747542c70ba855a07136c9487ae78e6ecfdb38b4
- deterministic gate passed: sh -lc bash -n wordpress/scripts/deps/deps-runner.sh (Passed)
- deterministic gate passed: sh -lc cd wordpress && npm run test:extension-composer-vendor-integrity (Passed)
- deterministic gate passed: sh -lc cd wordpress && npm run test:wordpress-deps-provider (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode (openai/gpt-5.6-sol))
- **Model:** openai/gpt-5.6-terra
- **Used for:** I inspected the promoted candidate commit to identify the implemented behavior and its test coverage, then distilled that evidence into a reviewer-focused change record without altering the worktree.
