### PR TITLE
fix(wordpress): exclude the installed dependency tree from lint discovery

### DIFF
--- a/wordpress/eslint.config.mjs
+++ b/wordpress/eslint.config.mjs
@@ -6,7 +6,7 @@ import wordpress from '@wordpress/eslint-plugin';
 export default [
   {
     ignores: [
-      'node_extensions/',
+      'node_modules/',
       'vendor/',
       '**/build/**',
       'dist/',

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -5,7 +5,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/build/install-composer-dependencies.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh",
+      "bash -n scripts/build/install-composer-dependencies.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
       "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs"
     ],
     "test": [
@@ -22,7 +22,8 @@
       "node tests/wordpress-fuzz-runner-smoke.js",
       "node tests/wp-codebox-artifacts-isolated-snapshot-smoke.js",
       "node tests/wordpress-manifest-settings-smoke.js",
-      "node tests/wordpress-artifact-cleanup-declarations-smoke.js"
+      "node tests/wordpress-artifact-cleanup-declarations-smoke.js",
+      "bash scripts/lint/eslint-dependency-tree-scope-smoke.sh"
     ]
   }
 }

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -82,6 +82,7 @@
   "scripts": {
     "lint:js": "eslint",
     "test:eslint-build-ignore": "bash scripts/lint/eslint-build-ignore-smoke.sh",
+    "test:eslint-dependency-tree-scope": "bash scripts/lint/eslint-dependency-tree-scope-smoke.sh",
     "test:admin-page-scenarios": "node tests/admin-page-scenarios-smoke.js",
     "test:admin-page-fuzz-surfaces": "node tests/admin-page-fuzz-surfaces-smoke.js",
     "test:wordpress-admin-form-action-surfaces": "node tests/wordpress-admin-form-action-surfaces-smoke.js",

--- a/wordpress/scripts/lint/eslint-dependency-tree-scope-smoke.sh
+++ b/wordpress/scripts/lint/eslint-dependency-tree-scope-smoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# ESLint discovery must ignore the installed dependency tree.
+#
+# The JavaScript file count is a gate, not a metric: zero means skip ESLint
+# entirely. Counting dependency-tree files makes every component that has
+# dependencies installed look like it ships JavaScript of its own, so the skip
+# never fires and a PHP-only component pays for a pointless ESLint run.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL_EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_PATH="${TMPDIR}/extension"
+component_dir="${TMPDIR}/component"
+eslint_log="${TMPDIR}/eslint-args.txt"
+
+mkdir -p "${EXTENSION_PATH}/node_modules/.bin"
+touch "${EXTENSION_PATH}/eslint.config.mjs"
+
+cat > "${EXTENSION_PATH}/node_modules/.bin/eslint" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${ESLINT_LOG}"
+printf '[]\n'
+SH
+chmod +x "${EXTENSION_PATH}/node_modules/.bin/eslint"
+
+run_eslint_runner() {
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_ID="component" \
+    HOMEBOY_COMPONENT_PATH="$component_dir" \
+    HOMEBOY_COMPONENT_TEXT_DOMAIN="component" \
+    HOMEBOY_SUMMARY_MODE=1 \
+    ESLINT_LOG="$eslint_log" \
+        bash "${REAL_EXTENSION_PATH}/scripts/lint/eslint-runner.sh" > "$1"
+}
+
+# A PHP-only component that has its build dependencies installed. Every JS file
+# present belongs to the dependency tree, including nested trees.
+mkdir -p \
+    "${component_dir}/inc" \
+    "${component_dir}/node_modules/example-package" \
+    "${component_dir}/inc/blocks/example/node_modules/nested-package"
+printf '%s\n' '<?php' > "${component_dir}/inc/Thing.php"
+printf '%s\n' 'module.exports = {};' > "${component_dir}/node_modules/example-package/index.js"
+printf '%s\n' 'export const nested = 1;' \
+    > "${component_dir}/inc/blocks/example/node_modules/nested-package/index.js"
+
+rm -f "$eslint_log"
+run_eslint_runner "${TMPDIR}/dependency-only.out"
+
+if ! grep -Fq "No JavaScript files found, skipping ESLint." "${TMPDIR}/dependency-only.out"; then
+    echo "FAIL: dependency-tree JavaScript must not satisfy the ESLint discovery gate" >&2
+    sed 's/^/  /' "${TMPDIR}/dependency-only.out" >&2
+    exit 1
+fi
+
+if [ -f "$eslint_log" ]; then
+    echo "FAIL: ESLint ran for a component whose only JavaScript is installed dependencies" >&2
+    sed 's/^/  /' "$eslint_log" >&2
+    exit 1
+fi
+
+# The gate must still open for JavaScript the component actually owns.
+mkdir -p "${component_dir}/assets"
+printf '%s\n' 'const answer = 42;' > "${component_dir}/assets/app.js"
+
+rm -f "$eslint_log"
+run_eslint_runner "${TMPDIR}/component-js.out"
+
+if ! grep -Fq "Running JavaScript linting..." "${TMPDIR}/component-js.out"; then
+    echo "FAIL: component-owned JavaScript should still be linted" >&2
+    sed 's/^/  /' "${TMPDIR}/component-js.out" >&2
+    exit 1
+fi
+
+if [ ! -f "$eslint_log" ]; then
+    echo "FAIL: ESLint should have run for component-owned JavaScript" >&2
+    sed 's/^/  /' "${TMPDIR}/component-js.out" >&2
+    exit 1
+fi
+
+echo "ESLint dependency tree scope smoke passed"

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -60,9 +60,13 @@ write_eslint_findings_sidecar() {
     HOMEBOY_LINT_FINDINGS_FILE="$previous_target"
 }
 
-# Check if component has JavaScript files
+# Check if component has JavaScript files.
+#
+# This count is a gate: zero means skip ESLint entirely. The installed
+# dependency tree must be excluded or any component with dependencies installed
+# looks like it has JavaScript of its own, defeating the skip.
 js_file_count=$(find "$PLUGIN_PATH" -type f \( -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) \
-    -not -path "*/node_extensions/*" \
+    -not -path "*/node_modules/*" \
     -not -path "*/vendor/*" \
     -not -path "*/vendor_prefixed/*" \
     -not -path "*/vendor-prefixed/*" \
@@ -141,9 +145,6 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
 fi
 
 ESLINT_BIN="${EXTENSION_PATH}/node_modules/.bin/eslint"
-if [ ! -f "$ESLINT_BIN" ]; then
-    ESLINT_BIN="${EXTENSION_PATH}/node_extensions/.bin/eslint"
-fi
 ESLINT_CONFIG="${EXTENSION_PATH}/eslint.config.mjs"
 
 # Validate tools exist

--- a/wordpress/scripts/lint/php-fixers/fixer-helpers.php
+++ b/wordpress/scripts/lint/php-fixers/fixer-helpers.php
@@ -52,7 +52,6 @@ function fixer_path_is_excluded($path) {
         'vendor-prefixed',
         'vendor_scoped',
         'vendor-scoped',
-        'node_extensions',
         'node_modules',
         'dist',
         'build',

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -397,7 +397,6 @@ generate_scoped_context_config() {
             -not -path "*/.homeboy-build/*" \
             -not -path "*/vendor/*" \
             -not -path "*/vendor_prefixed/*" \
-            -not -path "*/node_extensions/*" \
             -not -path "*/node_modules/*" \
             -not -path "*/build/*" \
             -not -path "*/dist/*" \
@@ -491,7 +490,7 @@ resolve_phpstan_targets() {
                     -not -path "*/.homeboy-build/*" \
                     -not -path "*/vendor/*" \
                     -not -path "*/vendor_prefixed/*" \
-                    -not -path "*/node_extensions/*" \
+                    -not -path "*/node_modules/*" \
                     -not -path "*/build/*" \
                     -not -path "*/dist/*" \
                     -not -path "*/tools/*" \
@@ -521,7 +520,6 @@ resolve_phpstan_full_targets() {
         -not -path "*/.homeboy-build/*" \
         -not -path "*/vendor/*" \
         -not -path "*/vendor_prefixed/*" \
-        -not -path "*/node_extensions/*" \
         -not -path "*/node_modules/*" \
         -not -path "*/build/*" \
         -not -path "*/dist/*" \

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -200,6 +200,17 @@ assert_contains "${COMPONENT_DIR}/includes/extra.php" "glob scope includes match
 assert_not_contains "assets/app.js" "glob scope ignores non-PHP files"
 assert_file_contains "$OUTPUT_FILE" "PHPStan scoped lint: analyzing 2 PHP file(s)" "relative glob scope reports analyzed PHP files"
 
+# A glob that resolves to a directory expands through a find, which is the one
+# scope that walks whatever the directory happens to contain. An installed
+# dependency tree ships PHP of its own, and analyzing it is neither the
+# component's code nor the component's problem.
+mkdir -p "${COMPONENT_DIR}/includes/node_modules/example-package"
+printf '%s\n' '<?php missing_function();' > "${COMPONENT_DIR}/includes/node_modules/example-package/shim.php"
+HOMEBOY_LINT_GLOB='{includes,main.php}' run_phpstan
+assert_contains "${COMPONENT_DIR}/includes/extra.php" "directory glob scope includes component PHP files"
+assert_not_contains "node_modules" "directory glob scope excludes the installed dependency tree"
+rm -rf "${COMPONENT_DIR}/includes/node_modules"
+
 HOMEBOY_LINT_GLOB="{${COMPONENT_DIR}/main.php,${COMPONENT_DIR}/assets/app.js,${COMPONENT_DIR}/includes/extra.php}" run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "absolute glob scope includes matching PHP source file"
 assert_contains "${COMPONENT_DIR}/includes/extra.php" "absolute glob scope includes matching PHP runtime file"


### PR DESCRIPTION
Closes #2421.

## Problem

A term rename left `node_extensions` in place of `node_modules` across the WordPress lint tooling. npm never produces `node_extensions`, so every one of those filters matched nothing.

The issue assumed one live bug. Auditing all six occurrences found **two**, because in those two the stale entry was the *only* dependency-tree filter on that scan:

| Site | Status | Why |
|---|---|---|
| `eslint-runner.sh:65` — JS discovery | **live** | no `node_modules` filter |
| `phpstan-runner.sh:494` — directory-target find | **live** | no `node_modules` filter |
| `eslint-runner.sh:145` — ESLint binary fallback | dead | real path tried first, fallback unreachable |
| `phpstan-runner.sh:400` — scoped context scan | dead | `node_modules` already filtered |
| `phpstan-runner.sh:524` — full-target scan | dead | `node_modules` already filtered |
| `fixer-helpers.php:55` — excluded dirs | dead | `node_modules` already listed |
| `eslint.config.mjs:9` — global ignores | dead | ESLint ignores `node_modules` by default |

### Impact of the live ones

**ESLint discovery is a gate, not a metric.** `js_file_count == 0` means skip ESLint entirely. Counting dependency-tree JavaScript makes any component with dependencies installed — i.e. any WordPress plugin with a build step — look like it ships JavaScript of its own. The skip never fires and a PHP-only component pays for a full ESLint run. (ESLint's own default ignores mean dependency files are not *linted*; the cost is the defeated skip, not bogus findings.)

**PHPStan directory targets.** A `HOMEBOY_LINT_GLOB` that resolves to a directory expands through a `find`, the one scope that walks whatever the directory happens to contain. npm packages that ship PHP were handed to PHPStan as component code. Reproduced in the harness — against the unfixed runner the args contain `includes/node_modules/example-package/shim.php`.

## Approach

Live filters corrected. Dead references **removed** rather than corrected, so the remaining filter lists say exactly what they do. `eslint.config.mjs` is the one exception — corrected to `node_modules/` to keep the explicit enumeration alongside its `vendor/`, `dist/`, `build/` siblings, even though ESLint would ignore it by default.

## Tests

Both new assertions were verified to **fail against the unfixed runners**, so they are load-bearing rather than decorative:

- **New `scripts/lint/eslint-dependency-tree-scope-smoke.sh`.** A PHP-only component with root *and* nested (`inc/blocks/*/node_modules`) dependency trees must report `No JavaScript files found, skipping ESLint.` and must not invoke ESLint; then component-owned JavaScript must still lint. Against the unfixed runner it fails with `Running JavaScript linting...`. Wired into `wordpress/homeboy.json` `self_checks` (both `lint` syntax check and `test`) so it actually runs, plus a `package.json` script.
- **`phpstan-scoped-smoke.sh`** gains a directory-glob case asserting dependency-tree PHP never reaches PHPStan.

Verified locally: new smoke passes, and `eslint-glob-filter-smoke`, `eslint-build-ignore-smoke`, `eslint-no-files-smoke`, `vendor-prefixed-exclusion-smoke`, `tests/wordpress-eslint-scope-smoke.sh`, `tests/extension-shape-lint.mjs` (8 extensions), `jq empty wordpress.json`, `bash -n` over the touched scripts, `php -l fixer-helpers.php`, and loading `eslint.config.mjs` all pass.

Two lint smokes — `wordpress-lint-role-smoke.sh` and a later assertion in `phpstan-scoped-smoke.sh` (`non-PHP single-file scope should skip PHPStan`) — fail **identically on pristine `main`** in this environment; they exercise real phpcs/phpstan toolchain paths. Confirmed by stashing and re-running. Not regressions from this change, and the new phpstan assertion sits before that pre-existing failure point and does pass.

## Scope

`wordpress.json` `build.cleanup_paths` holds the seventh and last occurrence. It is left to #2420, which owns that declaration; touching it here would put the same one-line change in two open PRs.

Used for: auditing and fixing stale dependency-tree path filters in the WordPress lint runners, with regression coverage.