### PR TITLE
fix(discord): accept the --transport flag homeboy sends

### DIFF
--- a/discord/scripts/notify.mjs
+++ b/discord/scripts/notify.mjs
@@ -64,7 +64,11 @@ async function main() {
 
 function parseArgs(tokens) {
   const args = { dryRun: false };
-  const names = new Set(['run-id', 'status', 'title', 'body', 'route']);
+  // Homeboy appends --transport alongside --route whenever the caller
+  // selected a transport explicitly. This extension was already chosen by that
+  // id, so the value carries no new information — but rejecting the flag makes
+  // every explicitly-routed notification fail.
+  const names = new Set(['run-id', 'status', 'title', 'body', 'route', 'transport']);
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
     if (token === '--dry-run') {
@@ -72,12 +76,12 @@ function parseArgs(tokens) {
       continue;
     }
     if (!token.startsWith('--')) {
-      args.error = 'Expected --run-id, --status, --title, and --body; --route and --dry-run are optional.';
+      args.error = 'Expected --run-id, --status, --title, and --body; --transport, --route and --dry-run are optional.';
       return args;
     }
     const [flag, inlineValue] = token.slice(2).split(/=(.*)/s, 2);
     if (!names.has(flag) || (inlineValue === undefined && index + 1 >= tokens.length)) {
-      args.error = 'Expected --run-id, --status, --title, and --body; --route and --dry-run are optional.';
+      args.error = 'Expected --run-id, --status, --title, and --body; --transport, --route and --dry-run are optional.';
       return args;
     }
     const name = flag.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());

--- a/discord/tests/notify.test.mjs
+++ b/discord/tests/notify.test.mjs
@@ -27,7 +27,33 @@ await testCrossModeRouteBeforeNetwork();
 await testAuthFailureClassification();
 await testTruncation();
 await testRedactionAndDryRun();
+await testTransportFlagIsAccepted();
 console.log('discord notification tests passed');
+
+// Homeboy appends --transport alongside --route whenever a caller selects a
+// transport explicitly, so rejecting the flag broke every explicitly-routed
+// notification. Nothing exercised it before, which is why that shipped.
+async function testTransportFlagIsAccepted() {
+  await withServer(async ({ baseUrl, requests }) => {
+    const result = await notify(
+      { DISCORD_BOT_TOKEN: secretToken, DISCORD_API_BASE_URL: `${baseUrl}/api/v10` },
+      { transport: 'discord.run-completion', route: channelRoute(channelId) },
+    );
+    assert.equal(result.status, 'delivered');
+    assert.equal(result.delivery.route_kind, 'channel');
+    assert.equal(requests[0].url, `/api/v10/channels/${channelId}/messages`);
+  });
+
+  // An unknown flag must still be refused, so accepting --transport does not
+  // turn the parser permissive.
+  const run = await notifyRaw(
+    { DISCORD_BOT_TOKEN: secretToken },
+    { route: channelRoute(channelId) },
+    ['--totally-unknown', 'x'],
+  );
+  assert.equal(run.code, 1);
+  assert.match(run.stdout, /input_error/);
+}
 
 async function testConcurrentThreadRoutesDoNotCrossDeliver() {
   await withServer(async ({ baseUrl, requests }) => {
@@ -208,10 +234,12 @@ function notify(env, overrides = {}) {
   });
 }
 
-function notifyRaw(env, overrides = {}) {
+function notifyRaw(env, overrides = {}, extraArgs = []) {
   const args = ['--run-id', overrides.runId || 'run-123', '--status', 'pass', '--title', 'homeboy run pass', '--body', overrides.body || 'Run completed'];
+  if (overrides.transport !== undefined) args.push('--transport', overrides.transport);
   if (overrides.route !== undefined) args.push('--route', overrides.route);
   if (overrides.dryRun) args.push('--dry-run');
+  args.push(...extraArgs);
   return new Promise((resolve, reject) => {
     const childEnv = { ...process.env };
     for (const name of ['DISCORD_BOT_TOKEN', 'DISCORD_WEBHOOK_URL', 'DISCORD_OPERATIONS_CHANNEL_ID', 'DISCORD_API_BASE_URL']) delete childEnv[name];


### PR DESCRIPTION
## Summary

Every explicitly-routed Discord notification fails before any delivery is attempted:

```
$ homeboy <cmd> --notification-transport discord.run-completion \
                --notification-route 'discord:v1:channel:...'

{"schema":"homeboy/discord-notification-result/v1","status":"failed",
 "error":{"kind":"input_error",
 "message":"Expected --run-id, --status, --title, and --body; --route and --dry-run are optional."}}
```

Homeboy appends `--transport` alongside `--route` whenever a caller selects a transport explicitly. `parseArgs` did not list `transport` among its accepted names, so the flag was treated as unknown input and the run was rejected.

Core's contract is explicit about this. `crates/homeboy-core/src/notify.rs` builds `--run-id / --status / --title / --body / --transport / --route`, and its own unit test asserts that exact argv. The extension was out of spec, not core.

The value carries no new information — this extension was already selected *by* that transport id — so it is accepted and ignored rather than validated.

## Reproduction

Isolated against the installed transport, homeboy `0.318.0`:

```
# without --transport
{"status":"dry_run","delivery":{"mode":"bot","route_kind":"channel",...}}

# with --transport
{"status":"failed","error":{"kind":"input_error",...}}
```

Found while wiring a scheduled run: the schedule executed correctly and reported `notify_error: "notification transport exited with exit status: 1"`, which traced back to this.

## Why it shipped

`transport` appeared zero times in `discord/tests/notify.test.mjs`. Every existing test passes `--route` alone, so the one flag homeboy actually sends in the explicitly-routed case was never exercised.

## Tests

- `testTransportFlagIsAccepted` — delivers end to end with `--transport` present, asserting `status: delivered`, the resolved route kind, and the request URL.
- The same test also asserts an **unknown** flag is still refused, so widening the accepted set does not quietly make the parser permissive.
- `notifyRaw` gained an `extraArgs` parameter to make that negative case expressible.

Verified load-bearing: reverting the one-line fix and re-running the suite fails the new test. All existing tests continue to pass.

```
$ node discord/tests/notify.test.mjs
discord notification tests passed
```

This repo has no PR CI, so the suite was run locally.