### PR TITLE
fix(rust): preserve toolchain homes for isolated gates

### DIFF
--- a/rust/scripts/env-provider.sh
+++ b/rust/scripts/env-provider.sh
@@ -48,15 +48,19 @@ data_dir="${HOMEBOY_DATA_DIR:-${XDG_DATA_HOME:-${HOME}/.local/share}/homeboy}"
 target_dir="${data_dir}/cargo-targets/${label}-${hash:0:12}"
 toolchain_env_json="$(homeboy_rust_toolchain_env_json)"
 
-python3 - "$target_dir" "$toolchain_env_json" <<'PY'
+python3 - "$target_dir" "$toolchain_env_json" "${CARGO_HOME:-${HOME}/.cargo}" "${RUSTUP_HOME:-${HOME}/.rustup}" <<'PY'
 import json
 import sys
 
-target_dir = sys.argv[1]
-toolchain_env = json.loads(sys.argv[2])
+target_dir, toolchain_env_json, cargo_home, rustup_home = sys.argv[1:]
+toolchain_env = json.loads(toolchain_env_json)
 env = {
     "CARGO_TARGET_DIR": target_dir,
     "HOMEBOY_CARGO_TARGET_DIR": target_dir,
+    # Isolated gate HOME values must not redirect Cargo/Rustup away from the
+    # runtime-owned toolchain installation.
+    "CARGO_HOME": cargo_home,
+    "RUSTUP_HOME": rustup_home,
 }
 env.update(toolchain_env)
 print(json.dumps(env))

--- a/rust/tests/env-provider-smoke.sh
+++ b/rust/tests/env-provider-smoke.sh
@@ -52,6 +52,7 @@ git -C "$worktree" remote add origin git@github.com:Extra-Chill/homeboy.git
 
 primary_target="$(target_dir_for "$primary")"
 worktree_target="$(target_dir_for "$worktree")"
+toolchain_env="$(env_for "$primary")"
 
 if [ -z "$primary_target" ] || [ "$primary_target" != "$worktree_target" ]; then
     printf 'Expected matching shared target dirs, got primary=%s worktree=%s\n' "$primary_target" "$worktree_target" >&2
@@ -65,6 +66,13 @@ case "$primary_target" in
         exit 1
         ;;
 esac
+
+cargo_home="$(printf '%s' "$toolchain_env" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("CARGO_HOME", ""))')"
+rustup_home="$(printf '%s' "$toolchain_env" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("RUSTUP_HOME", ""))')"
+if [ "$cargo_home" != "$HOME/.cargo" ] || [ "$rustup_home" != "$HOME/.rustup" ]; then
+    printf 'Expected Rust toolchain homes from the runtime environment, got CARGO_HOME=%s RUSTUP_HOME=%s\n' "$cargo_home" "$rustup_home" >&2
+    exit 1
+fi
 
 explicit_output="$(
     CARGO_TARGET_DIR="$explicit" \


### PR DESCRIPTION
## Summary
- emit explicit CARGO_HOME and RUSTUP_HOME from the Rust runtime environment provider
- preserve the installed Rust toolchain when a Cook gate isolates HOME and XDG directories
- cover the declaration in the extension smoke test

Depends on https://github.com/Extra-Chill/homeboy/pull/10203.

## Verification
- Rust env provider smoke passed

## AI assistance
- Model: OpenAI gpt-5.6-terra
- Tool: OpenCode via Kimaki
- Used for: reviewed the Cook isolation failure, implemented the runtime-owned environment declaration, and added smoke coverage. Chris remains responsible for every line.