### PR TITLE
fix(rust): widen to the full suite when a derived scope runs no tests

### DIFF
--- a/rust/homeboy.json
+++ b/rust/homeboy.json
@@ -6,5 +6,12 @@
       "file": "rust.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
-  ]
+  ],
+  "self_checks": {
+    "test": [
+      "bash tests/env-provider-smoke.sh",
+      "bash tests/fingerprint-policy-flow-smoke.sh",
+      "bash tests/zero-test-scope-fallback-smoke.sh"
+    ]
+  }
 }

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -348,38 +348,82 @@ fi
 
 rust_append_scope_args "$SCOPE_JSON"
 
-COMMAND_LABEL="cargo test"
-COMMAND_BINARY=(cargo "${TEST_ARGS[@]}")
+# Builds COMMAND_LABEL/COMMAND_BINARY from the current TEST_ARGS. Shared so a
+# widened re-run reuses the exact runner selection the first attempt used.
+rust_build_test_command() {
+    COMMAND_LABEL="cargo test"
+    COMMAND_BINARY=(cargo "${TEST_ARGS[@]}")
 
-if [ "$SELECTED_RUNNER" = "cargo" ]; then
-    CARGO_TEST_THREADS="$(rust_cargo_test_threads || true)"
-    if [ -n "$CARGO_TEST_THREADS" ]; then
-        COMMAND_BINARY+=(-- --test-threads="$CARGO_TEST_THREADS")
+    if [ "$SELECTED_RUNNER" = "cargo" ]; then
+        CARGO_TEST_THREADS="$(rust_cargo_test_threads || true)"
+        if [ -n "$CARGO_TEST_THREADS" ]; then
+            COMMAND_BINARY+=(-- --test-threads="$CARGO_TEST_THREADS")
+        fi
     fi
-fi
 
-if [ "$SELECTED_RUNNER" = "nextest" ]; then
-    NEXTEST_ARGS=(
-        run
-        --manifest-path "${PROJECT_PATH}/Cargo.toml"
-    )
-    rust_nextest_args_from_cargo_args
-    COMMAND_LABEL="cargo nextest run"
-    COMMAND_BINARY=(cargo nextest "${NEXTEST_ARGS[@]}")
-fi
+    if [ "$SELECTED_RUNNER" = "nextest" ]; then
+        NEXTEST_ARGS=(
+            run
+            --manifest-path "${PROJECT_PATH}/Cargo.toml"
+        )
+        rust_nextest_args_from_cargo_args
+        COMMAND_LABEL="cargo nextest run"
+        COMMAND_BINARY=(cargo nextest "${NEXTEST_ARGS[@]}")
+    fi
+}
 
-if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-    echo "DEBUG: ${COMMAND_BINARY[*]} $*"
-fi
-
-rust_emit_test_plan "$SELECTED_RUNNER" "$COMMAND_LABEL" "$SCOPE_JSON" "started" 0
-homeboy_run_step_capture TEST_TMPFILE TEST_EXIT "$COMMAND_LABEL" -- "${COMMAND_BINARY[@]}" "$@" || true
-rust_emit_test_plan "$SELECTED_RUNNER" "$COMMAND_LABEL" "$SCOPE_JSON" "completed" "$TEST_EXIT"
-
-# Parse test results for homeboy core (best-effort, non-blocking)
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/parse-test-results.sh"
-if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
-    bash "$PARSE_RESULTS" "$TEST_TMPFILE" || true
+
+rust_execute_test_run() {
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: ${COMMAND_BINARY[*]} $*"
+    fi
+
+    rust_emit_test_plan "$SELECTED_RUNNER" "$COMMAND_LABEL" "$SCOPE_JSON" "started" 0
+    homeboy_run_step_capture TEST_TMPFILE TEST_EXIT "$COMMAND_LABEL" -- "${COMMAND_BINARY[@]}" "$@" || true
+    rust_emit_test_plan "$SELECTED_RUNNER" "$COMMAND_LABEL" "$SCOPE_JSON" "completed" "$TEST_EXIT"
+
+    # Parse test results for homeboy core (best-effort, non-blocking)
+    if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
+        bash "$PARSE_RESULTS" "$TEST_TMPFILE" || true
+    fi
+}
+
+# Reports whether the captured run executed no tests at all. Cargo runs several
+# test binaries (unit, integration, doc-tests) and some legitimately have zero
+# tests, so only a zero total across every summary line counts.
+rust_run_executed_no_tests() {
+    local total
+    total=$( { grep -Eo '[0-9]+ passed' "$TEST_TMPFILE" || true; } | awk '{s+=$1} END {print s+0}' )
+    [ "$total" -eq 0 ]
+}
+
+rust_build_test_command
+rust_execute_test_run "$@"
+
+# A derived scope that selects zero tests is a scope-derivation gap, not a
+# failing test suite: the filter is built from changed file paths, so a module
+# mounted with `#[path]` (or any future derivation gap) compiles a filter that
+# matches nothing. Failing there reports a red build for code that was never
+# executed. Widen to the full suite once instead, so the worst case is a slow
+# pass rather than a false failure.
+if [ "$TEST_EXIT" -eq 0 ] \
+    && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ] \
+    && [ "$SCOPE_KIND" != "workspace" ] && [ "$SCOPE_KIND" != "full" ] \
+    && rust_run_executed_no_tests; then
+    echo ""
+    echo "Derived test scope executed no tests; re-running the full test command."
+    rm -f "$TEST_TMPFILE"
+
+    TEST_ARGS=(
+        test
+        --manifest-path "${PROJECT_PATH}/Cargo.toml"
+        --workspace
+    )
+    SCOPE_KIND="full"
+    SCOPE_JSON="$(printf '%s' "$SCOPE_JSON" | jq -c '.kind = "full" | .args = [] | .reason = "Derived scope executed no tests; widened to the full test command."')"
+    rust_build_test_command
+    rust_execute_test_run "$@"
 fi
 
 TEST_OUTPUT=$(cat "$TEST_TMPFILE")
@@ -420,6 +464,10 @@ fi
 # Detect zero-test runs — only warn if NO test result line shows passed tests.
 # Cargo runs multiple test binaries (unit, integration, doc-tests); some may
 # legitimately have 0 tests while others have hundreds.
+#
+# A derived scope has already been widened to the full command by this point,
+# so reaching here on a changed-files run means the whole suite executed
+# nothing — a real configuration problem rather than a scoping gap.
 TOTAL_PASSED=$( { echo "$TEST_OUTPUT" | grep -Eo '[0-9]+ passed' || true; } | awk '{s+=$1} END {print s+0}' )
 if [ "$TOTAL_PASSED" -eq 0 ]; then
     TEST_FILE_COUNT=$(find "$PROJECT_PATH" -name "*test*" -name "*.rs" -not -path "*/target/*" 2>/dev/null | wc -l | tr -d ' ')

--- a/rust/tests/zero-test-scope-fallback-smoke.sh
+++ b/rust/tests/zero-test-scope-fallback-smoke.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A derived test scope that selects zero tests must widen to the full command
+# rather than reporting a failed build. The filter is built from changed file
+# paths, so a module mounted with `#[path]` compiles a filter matching nothing
+# and the run would otherwise fail for code that was never executed.
+#
+# Guards all four outcomes: widen-and-pass, no needless widening, real failures
+# still failing, and a genuinely empty suite still failing closed.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORK_DIR="$(mktemp -d -t homeboy-rust-zero-scope.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+if ! command -v cargo >/dev/null 2>&1; then
+    printf 'SKIP: cargo is not installed\n'
+    exit 0
+fi
+
+# Mirrors the real breakage: `lib_tests.rs` is mounted by `lib.rs` as `tests`,
+# so a filter derived from the file name matches nothing.
+make_project() {
+    local dir="$1" test_body="$2"
+    mkdir -p "${dir}/src"
+    cat > "${dir}/Cargo.toml" <<TOML
+[package]
+name = "$(basename "${dir}")"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+TOML
+    cat > "${dir}/src/lib.rs" <<'RS'
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;
+RS
+    printf '%s' "${test_body}" > "${dir}/src/lib_tests.rs"
+}
+
+run_runner() {
+    local project="$1" filter="$2" scope_kind="${3:-rust_filter}"
+    set +e
+    HOMEBOY_EXTENSION_PATH="${EXTENSION_DIR}" \
+        HOMEBOY_COMPONENT_PATH="${project}" \
+        HOMEBOY_SKIP_LINT=1 \
+        HOMEBOY_CHANGED_TEST_FILES="src/lib_tests.rs" \
+        HOMEBOY_TEST_SCOPE_KIND="${scope_kind}" \
+        HOMEBOY_TEST_RUNNER_ARGS="$(printf -- '--\n%s' "${filter}")" \
+        bash "${EXTENSION_DIR}/scripts/test-runner.sh" >"${WORK_DIR}/out.log" 2>&1
+    RUNNER_EXIT=$?
+    set -e
+    RUNNER_OUTPUT="$(cat "${WORK_DIR}/out.log")"
+}
+
+passing_test='use super::add;
+
+#[test]
+fn adds() { assert_eq!(add(1, 2), 3); }
+'
+failing_test='use super::add;
+
+#[test]
+fn adds() { assert_eq!(add(1, 2), 99); }
+'
+
+# 1. Filter matches nothing -> widen to the full suite and pass.
+make_project "${WORK_DIR}/widen" "${passing_test}"
+run_runner "${WORK_DIR}/widen" 'lib_tests'
+if [ "${RUNNER_EXIT}" -ne 0 ]; then
+    printf 'FAIL: zero-match scope did not widen to the full suite (exit %s)\n' "${RUNNER_EXIT}"
+    printf '%s\n' "${RUNNER_OUTPUT}"
+    exit 1
+fi
+if ! printf '%s' "${RUNNER_OUTPUT}" | grep -q 'Derived test scope executed no tests'; then
+    printf 'FAIL: zero-match scope widened without reporting why\n'
+    exit 1
+fi
+if ! printf '%s' "${RUNNER_OUTPUT}" | grep -q 'test tests::adds ... ok'; then
+    printf 'FAIL: widened run did not execute the mounted test\n'
+    exit 1
+fi
+printf 'PASS: zero-match derived scope widens to the full suite and passes\n'
+
+# 2. Filter matches tests -> must not widen (no wasted full run).
+make_project "${WORK_DIR}/scoped" "${passing_test}"
+run_runner "${WORK_DIR}/scoped" 'tests::adds'
+if [ "${RUNNER_EXIT}" -ne 0 ]; then
+    printf 'FAIL: matching scope should pass (exit %s)\n' "${RUNNER_EXIT}"
+    exit 1
+fi
+if printf '%s' "${RUNNER_OUTPUT}" | grep -q 'Derived test scope executed no tests'; then
+    printf 'FAIL: matching scope widened to the full suite unnecessarily\n'
+    exit 1
+fi
+printf 'PASS: a scope that selects tests does not widen\n'
+
+# 3. Widening must not mask genuine test failures.
+make_project "${WORK_DIR}/failing" "${failing_test}"
+run_runner "${WORK_DIR}/failing" 'lib_tests'
+if [ "${RUNNER_EXIT}" -eq 0 ]; then
+    printf 'FAIL: widened run reported success despite a failing test\n'
+    exit 1
+fi
+printf 'PASS: widened run still surfaces real test failures\n'
+
+# 4. A suite that genuinely runs nothing must still fail closed.
+make_project "${WORK_DIR}/empty" 'pub fn helper() {}
+'
+run_runner "${WORK_DIR}/empty" 'lib_tests'
+if [ "${RUNNER_EXIT}" -eq 0 ]; then
+    printf 'FAIL: empty suite should fail closed after widening\n'
+    exit 1
+fi
+if ! printf '%s' "${RUNNER_OUTPUT}" | grep -q 'ran 0 tests'; then
+    printf 'FAIL: empty suite did not report the zero-test diagnosis\n'
+    exit 1
+fi
+printf 'PASS: an empty suite still fails closed after widening\n'
+
+printf 'All zero-test scope fallback checks passed.\n'


### PR DESCRIPTION
## Problem

The changed-files test scope compiles a cargo filter from **file paths**, so any gap in that derivation produces a filter that matches zero tests. The runner treated that as a build failure — reporting red for code that was never executed.

homeboy `main` was red on exactly this. `agent_task_service/cook_tests.rs` is mounted by `cook.rs`:

```rust
#[cfg(test)]
#[path = "cook_tests.rs"]
mod tests;
```

so its real module path is `agent_task_service::cook::tests`, and the file-name-derived filter matched nothing:

```
Rust test scope: Scoped to changed files in homeboy-agents: agent_task_service::cook_tests
test result: ok. 0 passed; 0 failed; 1083 filtered out
WARNING: cargo test ran 0 tests
BUILD FAILED: cargo test
```

The derivation itself is fixed in Extra-Chill/homeboy#10180. **This PR is the safety net**, so the next derivation gap degrades to a slow pass instead of a false failure.

## Change

A derived scope that selects nothing is a scoping gap, not a failing suite — widen to the full command once, then judge the result.

Fail-closed behavior is preserved:

- **Genuine failures still fail.** A widened run with a broken test exits non-zero.
- **A truly empty suite still fails closed.** If even the full run executes nothing, that is a real configuration problem and still exits 1.
- **Only *derived* scopes widen.** A `workspace`/`full` run that executes nothing was never scoped, so it keeps failing immediately.
- **No needless work.** A scope that does select tests never triggers a second run.

`rust_build_test_command` / `rust_execute_test_run` are extracted so the retry reuses the exact runner selection (cargo vs nextest, test threads) and result parsing as the first attempt, rather than duplicating that logic.

## Verification

New `rust/tests/zero-test-scope-fallback-smoke.sh` builds a real cargo fixture reproducing the mount (`lib.rs` mounting `lib_tests.rs` as `tests`) and covers all four outcomes:

```
PASS: zero-match derived scope widens to the full suite and passes
PASS: a scope that selects tests does not widen
PASS: widened run still surfaces real test failures
PASS: an empty suite still fails closed after widening
All zero-test scope fallback checks passed.
```

Confirmed load-bearing — neutralizing the widening condition fails it immediately:

```
FAIL: zero-match scope did not widen to the full suite (exit 1)
```

Before the fix, that same fixture reproduced the production failure exactly (`BUILD FAILED: cargo test`, exit 1).

## Drive-by

`rust/homeboy.json` had an empty `self_checks`, so `env-provider-smoke.sh` and `fingerprint-policy-flow-smoke.sh` existed but **nothing ever ran them**. Both pass; registered alongside the new smoke. That is the same class of gap as the scope bug itself, and the direct analogue of Extra-Chill/homeboy-action#301.

`node tests/extension-shape-lint.mjs` passes.