### PR TITLE
fix(wordpress): compose Codebox PHPUnit tests

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -14,6 +14,8 @@
       "bash tests/installed-test-helper-resolution-smoke.sh",
       "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
+      "node tests/wp-codebox-phpunit-aggregate-smoke.mjs",
+      "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
       "node tests/wp-codebox-database-service-smoke.mjs",
       "node tests/wp-codebox-native-database-canary.mjs",
       "bash scripts/test/full-suite-no-phpunit-smoke.sh",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -123,6 +123,7 @@
     "test:wp-codebox-fuzz-plan-recipe-builder": "node tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js",
     "test:wp-codebox-canonical-cli-adapters": "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
     "test:wp-codebox-phpunit-evidence": "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
+    "test:wp-codebox-phpunit-aggregate": "node tests/wp-codebox-phpunit-aggregate-smoke.mjs",
     "test:wp-codebox-database-service": "node tests/wp-codebox-database-service-smoke.mjs",
     "test:wp-codebox-native-database-canary": "node tests/wp-codebox-native-database-canary.mjs",
     "test:wp-codebox-doctor": "bash scripts/test/wp-codebox-doctor-smoke.sh",

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -2,4 +2,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATION_DEPENDENCIES="${HOMEBOY_WORDPRESS_VALIDATION_DEPENDENCIES_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
+
+# Resolve the component declaration before handing the recipe to WP Codebox. The
+# adapter consumes the resulting generic path contract; it never knows consumer
+# repository names or component registry details.
+if [ -f "$VALIDATION_DEPENDENCIES" ]; then
+    # shellcheck source=../lib/validation-dependencies.sh
+    source "$VALIDATION_DEPENDENCIES"
+    if type homeboy_export_validation_dependency_paths >/dev/null 2>&1; then
+        homeboy_export_validation_dependency_paths "${HOMEBOY_COMPONENT_PATH:?HOMEBOY_COMPONENT_PATH is required}"
+    fi
+fi
+
 exec node "${SCRIPT_DIR}/wp-codebox-phpunit-adapter.mjs" "$@"

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, existsSync } from 'node:fs';
 import { access, copyFile, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -21,6 +21,7 @@ const slug = process.env.COMPONENT_ID || path.basename(componentPath);
 const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
 const pluginSourceDirectory = subpath ? path.join(root, subpath) : root;
+const phpunitProfile = await resolvePhpunitProfile(settings, pluginSourceDirectory, slug);
 const multisite = await resolveMultisite(settings, pluginSourceDirectory);
 const databaseService = resolveDatabaseService(settings, process.env);
 requireDatabaseServiceCapability(databaseService);
@@ -43,12 +44,12 @@ const options = clean({
   pluginSlug: slug,
   extra_plugins: [
     { source: root, sourceSubpath: subpath, slug, activate: false },
-    ...dependencies.map(({ source, slug: dependencySlug, composer }) => clean({ source, slug: dependencySlug, activate: false, composer })),
+    ...dependencies.map(({ source, slug: dependencySlug, composer }) => clean({ source, slug: dependencySlug, activate: true, composer })),
   ],
   dependencyMounts: [...new Set([sandboxPluginDirectory(slug), ...dependencies.map(({ sandboxDirectory }) => sandboxDirectory)])],
-  testRoot: settings.wp_codebox_phpunit_test_root,
-  phpunitXml: settings.wp_codebox_phpunit_config,
-  cwd: settings.wp_codebox_phpunit_cwd,
+  testRoot: phpunitProfile.testRoot,
+  phpunitXml: phpunitProfile.config,
+  cwd: phpunitProfile.cwd,
   phpunitArgs: process.argv.slice(2),
   env: settings.bench_env,
   wpConfigDefines: settings.wp_config_defines,
@@ -64,6 +65,7 @@ try {
   run(['recipe', 'build', 'phpunit', '--options', optionsPath, '--output', recipePath]);
   await applyDatabaseServiceAuthorization(recipePath);
   await mkdir(runArtifacts, { recursive: true });
+  await persistRecipeEvidence(runArtifacts, options, recipePath, phpunitProfile, dependencies);
   const executionArgs = ['recipe-run', '--recipe', recipePath, '--artifacts', runArtifacts, '--json'];
   if (databaseService?.boundary) {
     executionArgs.push('--approve-external-service-writes', '--policy', JSON.stringify(databaseService.policy));
@@ -96,12 +98,10 @@ async function runCaptured(args) {
     child.stdout.on('data', (chunk) => {
       chunk = stdoutRedactor.write(chunk);
       stdoutFile.write(chunk);
-      process.stdout.write(chunk);
     });
     child.stderr.on('data', (chunk) => {
       chunk = stderrRedactor.write(chunk);
       stderrFile.write(chunk);
-      process.stderr.write(chunk);
     });
     child.on('error', (error) => { childError = error; });
     child.on('close', (status) => {
@@ -109,8 +109,6 @@ async function runCaptured(args) {
       const stderrTail = stderrRedactor.end();
       stdoutFile.write(stdoutTail);
       stderrFile.write(stderrTail);
-      process.stdout.write(stdoutTail);
-      process.stderr.write(stderrTail);
       stdoutFile.end();
       stderrFile.end();
       Promise.all([
@@ -147,7 +145,14 @@ function createLineRedactor(secretValues) {
     write(chunk) {
       pending += decoder.write(chunk);
       const boundary = pending.lastIndexOf('\n') + 1;
-      if (boundary === 0) { return ''; }
+      // JSON recipe responses can be a single line larger than a pipe buffer.
+      // Flush bounded chunks so a crashed PHPUnit run cannot deadlock at 64 KiB.
+      if (boundary === 0) {
+        if (pending.length < 8192) { return ''; }
+        const buffered = pending;
+        pending = '';
+        return redact(buffered);
+      }
       const completeLines = pending.slice(0, boundary);
       pending = pending.slice(boundary);
       return redact(completeLines);
@@ -233,7 +238,23 @@ function clean(value) { return Object.fromEntries(Object.entries(value).filter((
 function dependencyPaths(configuration) {
   const configured = Array.isArray(configuration.validation_dependencies) ? configuration.validation_dependencies : [];
   const canonical = (process.env.HOMEBOY_WORDPRESS_DEPENDENCY_PATHS || '').split('\n');
-  return [...new Set([...canonical, ...configured].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
+  const declared = configured.map((value) => {
+    if (typeof value === 'string') { return value; }
+    if (isObject(value)) { return value.path || value.local_path || value.source || ''; }
+    return '';
+  }).filter(Boolean);
+  const unresolved = declared.filter((value) => !path.isAbsolute(value));
+  if (unresolved.length > 0) {
+    throw new Error(`Declared WordPress validation dependencies were not resolved to source paths: ${unresolved.join(', ')}`);
+  }
+  const sources = [...new Set([...canonical, ...declared].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
+  const missing = sources.filter((source) => {
+    try { return !existsSync(source); } catch { return true; }
+  });
+  if (missing.length > 0) {
+    throw new Error(`Declared WordPress validation dependency sources are unavailable: ${missing.join(', ')}`);
+  }
+  return sources;
 }
 async function composerPreparation(source) {
   try {
@@ -449,7 +470,19 @@ async function requireHarness(source) {
 }
 async function handoffArtifacts(artifactRoot, execution) {
   let pointer;
-  try { pointer = json(await readFile(path.join(artifactRoot, 'latest-runtime.json'), 'utf8'), null); } catch { return; }
+  try { pointer = json(await readFile(path.join(artifactRoot, 'latest-runtime.json'), 'utf8'), null); } catch {
+    // A crashed workload may never write a runtime pointer. Preserve and parse
+    // the captured aggregate at the stable artifact root rather than reporting
+    // a zero-test run.
+    await preservePhpunitOutput(artifactRoot, execution, []);
+    if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
+      runScript('parse-test-results.sh', [artifactRoot]);
+    }
+    if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
+      runScript('parse-test-failures.sh', [artifactRoot, componentPath]);
+    }
+    return;
+  }
   const runtime = pointer?.paths?.runtimeDirectory;
   if (typeof runtime !== 'string' || !/^runtime-[A-Za-z0-9][A-Za-z0-9-]*$/.test(runtime)) {
     return;
@@ -483,9 +516,17 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     await writeFile(managedRuntimeServicesPath, `${JSON.stringify(managedRuntimeServices, null, 2)}\n`);
   }
 
+  const aggregate = phpunitAggregate(output);
   let results;
   try { results = json(await readFile(testResultsPath, 'utf8'), null); } catch { results = null; }
+  if (!results && aggregate) {
+    results = { schema: 'wp-codebox/test-results/v1', status: aggregate.failed > 0 ? 'failed' : 'passed', summary: aggregate };
+  }
   if (results && typeof results === 'object') {
+    const summary = isObject(results.summary) ? results.summary : {};
+    if (aggregate && Number(summary.total || 0) < aggregate.total) {
+      results.summary = { ...summary, ...aggregate };
+    }
     const references = Array.isArray(results.rawLogReferences) ? results.rawLogReferences : [];
     results.rawLogReferences = [
       ...references.filter((reference) => reference?.path !== 'files/phpunit-output.log'),
@@ -523,6 +564,58 @@ function extractPhpunitOutput(stdout, stderr) {
     }
   }
   return stdout + stderr;
+}
+function phpunitAggregate(output) {
+  const ok = output.match(/\bOK \((\d+) tests?,\s*(\d+) assertions?\)/i);
+  if (ok) {
+    return { total: Number(ok[1]), passed: Number(ok[1]), failed: 0, skipped: 0, assertions: Number(ok[2]) };
+  }
+  const summary = [...output.matchAll(/\bTests:\s*(\d+),\s*Assertions:\s*(\d+)([^\n]*)/gi)].pop();
+  if (!summary) { return null; }
+  const total = Number(summary[1]);
+  const assertions = Number(summary[2]);
+  const tail = summary[3];
+  const count = (name) => Number((tail.match(new RegExp(`\\b${name}:\\s*(\\d+)`, 'i')) || [])[1] || 0);
+  const failed = count('Errors') + count('Failures');
+  const skipped = count('Skipped') + count('Incomplete');
+  return { total, passed: Math.max(0, total - failed - skipped), failed, skipped, assertions };
+}
+async function resolvePhpunitProfile(configuration, pluginDirectory, pluginSlug) {
+  const sandboxRoot = sandboxPluginDirectory(pluginSlug);
+  const configured = typeof configuration.wp_codebox_phpunit_config === 'string' ? configuration.wp_codebox_phpunit_config : '';
+  let config = configured;
+  let hostConfig = '';
+  if (configured) {
+    hostConfig = path.isAbsolute(configured) ? configured : path.join(pluginDirectory, configured);
+  } else {
+    for (const candidate of ['phpunit.xml', 'phpunit.xml.dist']) {
+      try { await access(path.join(pluginDirectory, candidate)); config = `${sandboxRoot}/${candidate}`; hostConfig = path.join(pluginDirectory, candidate); break; } catch {}
+    }
+  }
+  const testRoot = configuration.wp_codebox_phpunit_test_root || `${sandboxRoot}/tests`;
+  const cwd = configuration.wp_codebox_phpunit_cwd || sandboxRoot;
+  let environment = 'wordpress-integration';
+  if (hostConfig) {
+    try {
+      const xml = await readFile(hostConfig, 'utf8');
+      const bootstrap = xml.match(/\bbootstrap\s*=\s*["']([^"']+)["']/i)?.[1];
+      if (bootstrap) {
+        const bootstrapPath = path.resolve(path.dirname(hostConfig), bootstrap);
+        const source = await readFile(bootstrapPath, 'utf8').catch(() => '');
+        environment = /WP_UnitTestCase|wp-load\.php|WP_TESTS_DIR|wp-tests-config/i.test(source) ? 'wordpress-integration' : 'standalone-php';
+      }
+    } catch {}
+  }
+  return { config, testRoot, cwd, environment, hostConfig };
+}
+async function persistRecipeEvidence(artifactDirectory, recipeOptions, generatedRecipePath, profile, resolvedDependencies) {
+  const sourceRefs = [{ slug, source: root, source_subpath: subpath || null }, ...resolvedDependencies.map((dependency) => ({ slug: dependency.slug, source: dependency.source }))];
+  await Promise.all([
+    copyFile(generatedRecipePath, path.join(artifactDirectory, 'wp-codebox-phpunit-recipe.json')),
+    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-recipe-options.json'), `${JSON.stringify(recipeOptions, null, 2)}\n`),
+    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-profile.json'), `${JSON.stringify({ phpunit: { config: profile.config, cwd: profile.cwd, test_root: profile.testRoot, environment: profile.environment, bootstrap_mode: recipeOptions.bootstrapMode, passthrough_args: recipeOptions.phpunitArgs, extra_mounts: recipeOptions.mounts } }, null, 2)}\n`),
+    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-provenance.json'), `${JSON.stringify({ source_refs: sourceRefs, wp_codebox: { cli_bin: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', resolved_cli_path: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', command: [process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'] } }, null, 2)}\n`),
+  ]);
 }
 function runScript(script, args) {
   const result = spawnSync('bash', [path.join(scriptDirectory, script), ...args], { cwd: componentPath, env: environmentWithoutDatabaseAdministration(), encoding: 'utf8', stdio: 'inherit' });

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -2,8 +2,8 @@
 /**
  * External dependencies
  */
-import { createWriteStream, existsSync } from 'node:fs';
-import { access, copyFile, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { access, copyFile, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
@@ -31,7 +31,7 @@ const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
 const artifacts = process.env.HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR || path.join(directory, 'artifacts');
 const runArtifacts = path.join(artifacts, `wp-codebox-phpunit.${process.pid}`);
-const dependencies = await Promise.all(dependencyPaths(settings).map(async (source) => {
+const dependencies = await Promise.all((await dependencyPaths(settings, [componentPath, pluginSourceDirectory])).map(async (source) => {
   const dependencySlug = path.basename(source).replace(/@[^/]+$/, '');
   return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug), composer: await composerPreparation(source) };
 }));
@@ -135,6 +135,7 @@ function configuredSecretValues() {
 function createLineRedactor(secretValues) {
   const decoder = new StringDecoder('utf8');
   let pending = '';
+  const overlap = Math.max(0, ...secretValues.map((secret) => secret.length - 1));
   const redact = (text) => {
     for (const secret of secretValues) {
       text = text.replaceAll(secret, '[REDACTED]');
@@ -149,8 +150,9 @@ function createLineRedactor(secretValues) {
       // Flush bounded chunks so a crashed PHPUnit run cannot deadlock at 64 KiB.
       if (boundary === 0) {
         if (pending.length < 8192) { return ''; }
-        const buffered = pending;
-        pending = '';
+        // Keep enough input to redact a secret split across the flush boundary.
+        const buffered = pending.slice(0, Math.max(0, pending.length - overlap));
+        pending = pending.slice(buffered.length);
         return redact(buffered);
       }
       const completeLines = pending.slice(0, boundary);
@@ -235,7 +237,7 @@ function parseSettings(value) {
 }
 function json(value, fallback) { try { return value ? JSON.parse(value) : fallback; } catch { return fallback; } }
 function clean(value) { return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== '' && !(Array.isArray(entry) && entry.length === 0))); }
-function dependencyPaths(configuration) {
+async function dependencyPaths(configuration, primarySources) {
   const configured = Array.isArray(configuration.validation_dependencies) ? configuration.validation_dependencies : [];
   const canonical = (process.env.HOMEBOY_WORDPRESS_DEPENDENCY_PATHS || '').split('\n');
   const declared = configured.map((value) => {
@@ -247,14 +249,19 @@ function dependencyPaths(configuration) {
   if (unresolved.length > 0) {
     throw new Error(`Declared WordPress validation dependencies were not resolved to source paths: ${unresolved.join(', ')}`);
   }
-  const sources = [...new Set([...canonical, ...declared].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
-  const missing = sources.filter((source) => {
-    try { return !existsSync(source); } catch { return true; }
-  });
-  if (missing.length > 0) {
-    throw new Error(`Declared WordPress validation dependency sources are unavailable: ${missing.join(', ')}`);
-  }
-  return sources;
+  // Preserve explicitly declared paths in recipe provenance while canonicalizing
+  // aliases solely for identity and duplicate detection.
+  const sources = [...new Set([...declared, ...canonical].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
+  const resolved = await Promise.all(sources.map(async (source) => {
+    try { return { source, canonicalSource: await realpath(source) }; } catch { throw new Error(`Declared WordPress validation dependency sources are unavailable: ${source}`); }
+  }));
+  const primary = new Set(await Promise.all(primarySources.map(async (source) => {
+    try { return await realpath(source); } catch { return path.resolve(source); }
+  })));
+  const seen = new Set();
+  return resolved
+    .filter(({ canonicalSource }) => !primary.has(canonicalSource) && !seen.has(canonicalSource) && Boolean(seen.add(canonicalSource)))
+    .map(({ source }) => source);
 }
 async function composerPreparation(source) {
   try {
@@ -524,7 +531,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   }
   if (results && typeof results === 'object') {
     const summary = isObject(results.summary) ? results.summary : {};
-    if (aggregate && Number(summary.total || 0) < aggregate.total) {
+    if (aggregate) {
       results.summary = { ...summary, ...aggregate };
     }
     const references = Array.isArray(results.rawLogReferences) ? results.rawLogReferences : [];

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { strict as assert } from 'node:assert';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
@@ -68,8 +71,7 @@ try {
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
   ]);
   assert.deepEqual(options[1].extra_plugins.slice(1), [
-    { source: component, slug: 'canonical-plugin', activate: false },
-    { source: dependency, slug: 'db-touching-dependency', activate: false },
+    { source: dependency, slug: 'db-touching-dependency', activate: true },
   ]);
   assert.deepEqual(options[1].dependencyMounts, [
     '/wordpress/wp-content/plugins/canonical-plugin',

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -31,7 +31,7 @@ const mode = process.env.FIXTURE_MODE;
 if (mode !== 'crash') {
   fs.mkdirSync(artifacts + '/runtime-fixture/files', { recursive: true });
   fs.writeFileSync(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
-  fs.writeFileSync(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: mode === 'success' ? 'passed' : 'failed', summary: { total: 0, passed: 0, failed: 0, skipped: 0 } }));
+  fs.writeFileSync(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: mode === 'success' ? 'passed' : 'failed', summary: { total: mode === 'failure' ? 281 : 0, passed: 0, failed: 0, skipped: 0 } }));
 }
 const output = mode === 'success' ? 'OK (3 tests, 76 assertions)\\n' : 'ERRORS!\\nTests: 281, Assertions: 329, Errors: 46, Failures: 100.\\n';
 process.stdout.write(JSON.stringify({ executions: [{ stdout: output, stderr: '' }] }));
@@ -52,8 +52,15 @@ try {
     assert.deepEqual(JSON.parse(await readFile(results, 'utf8')), expected);
     const runArtifact = path.join(artifacts, (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.')));
     const options = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
+    const profile = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-profile.json'), 'utf8'));
+    const provenance = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));
     assert.equal(options.extra_plugins[1].activate, true);
     assert.equal(options.phpunitXml, '/wordpress/wp-content/plugins/component/phpunit.xml.dist');
+    assert.equal(profile.phpunit.environment, 'standalone-php');
+    assert.deepEqual(provenance.source_refs, [
+      { slug: 'component', source: component, source_subpath: null },
+      { slug: 'dependency', source: dependency },
+    ]);
   }
   const missing = spawnSync(runner, [], { env: { ...process.env, HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [path.join(root, 'missing')] }) }, encoding: 'utf8' });
   assert.notEqual(missing.status, 0);

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-aggregate-'));
+const component = path.join(root, 'component');
+const dependency = path.join(root, 'dependency');
+const cli = path.join(root, 'wp-codebox');
+const resultsWriter = path.join(root, 'write-results.sh');
+await mkdir(path.join(component, 'tests'), { recursive: true });
+await mkdir(dependency);
+await writeFile(path.join(component, 'component.php'), '<?php /* Plugin Name: Component */\n');
+await writeFile(path.join(component, 'tests', 'bootstrap.php'), '<?php require_once __DIR__ . "/../component.php";\n');
+await writeFile(path.join(component, 'phpunit.xml.dist'), '<phpunit bootstrap="tests/bootstrap.php"><testsuites><testsuite name="suite"><directory>tests</directory></testsuite></testsuites></phpunit>\n');
+await writeFile(path.join(dependency, 'dependency.php'), '<?php /* Plugin Name: Dependency */\n');
+await writeFile(resultsWriter, 'homeboy_write_test_results() { printf \'{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\\n\' "$1" "$2" "$3" "$4" > "$HOMEBOY_TEST_RESULTS_FILE"; }\n');
+await writeFile(cli, `#!/usr/bin/env node
+import fs from 'node:fs';
+const args = process.argv.slice(2);
+const value = (name) => args[args.indexOf(name) + 1];
+if (args[0] === 'recipe') { fs.writeFileSync(value('--output'), JSON.stringify({ schema: 'wp-codebox/workspace-recipe/v1' })); process.exit(0); }
+const artifacts = value('--artifacts');
+const mode = process.env.FIXTURE_MODE;
+if (mode !== 'crash') {
+  fs.mkdirSync(artifacts + '/runtime-fixture/files', { recursive: true });
+  fs.writeFileSync(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+  fs.writeFileSync(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: mode === 'success' ? 'passed' : 'failed', summary: { total: 0, passed: 0, failed: 0, skipped: 0 } }));
+}
+const output = mode === 'success' ? 'OK (3 tests, 76 assertions)\\n' : 'ERRORS!\\nTests: 281, Assertions: 329, Errors: 46, Failures: 100.\\n';
+process.stdout.write(JSON.stringify({ executions: [{ stdout: output, stderr: '' }] }));
+process.exitCode = mode === 'success' ? 0 : 2;
+`);
+await chmod(cli, 0o755);
+
+try {
+  for (const [mode, expected] of [
+    ['failure', { total: 281, passed: 135, failed: 146, skipped: 0 }],
+    ['success', { total: 3, passed: 3, failed: 0, skipped: 0 }],
+    ['crash', { total: 281, passed: 135, failed: 146, skipped: 0 }],
+  ]) {
+    const artifacts = path.join(root, `${mode}-artifacts`);
+    const results = path.join(root, `${mode}-results.json`);
+    const run = spawnSync(runner, [], { env: { ...process.env, FIXTURE_MODE: mode, HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: results, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [dependency] }) }, encoding: 'utf8' });
+    assert.equal(run.status, mode === 'success' ? 0 : 2, run.stderr);
+    assert.deepEqual(JSON.parse(await readFile(results, 'utf8')), expected);
+    const runArtifact = path.join(artifacts, (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.')));
+    const options = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
+    assert.equal(options.extra_plugins[1].activate, true);
+    assert.equal(options.phpunitXml, '/wordpress/wp-content/plugins/component/phpunit.xml.dist');
+  }
+  const missing = spawnSync(runner, [], { env: { ...process.env, HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [path.join(root, 'missing')] }) }, encoding: 'utf8' });
+  assert.notEqual(missing.status, 0);
+  assert.match(missing.stderr, /dependency sources are unavailable/);
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox PHPUnit aggregate smoke passed.');

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -39,7 +39,7 @@ fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringif
   summary: { total: 3, passed: 0, failed: 2, skipped: 1, unknown: 0 },
   suites: [{ name: 'phpunit', tests: 3, passed: 0, failed: 2, skipped: 1 }],
 }));
-const output = 'x'.repeat(70 * 1024) + '\\n' + [
+const output = 'x'.repeat(8192 - 32) + 'fixture-secret-value' + 'x'.repeat(70 * 1024) + '\\n' + [
   'PHPUnit 9.6.22 by Sebastian Bergmann and contributors.',
   'fixture token: fixture-secret-value',
   '',
@@ -104,9 +104,12 @@ try {
   assert.ok(Buffer.byteLength(retainedOutput) > 64 * 1024);
   assert.equal(retainedOutput, expectedOutput);
   assert.doesNotMatch(retainedOutput, /fixture-secret-value/);
+  assert.match(retainedOutput, /\[REDACTED\]x{100}/);
   assert.match(retainedOutput, /fixture token: \[REDACTED\]/);
 
   const artifactResults = JSON.parse(await readFile(path.join(runtime, 'files/test-results.json'), 'utf8'));
+  const profile = JSON.parse(await readFile(path.join(artifacts, runDirectory, 'wp-codebox-phpunit-profile.json'), 'utf8'));
+  assert.equal(profile.phpunit.environment, 'wordpress-integration');
   assert.deepEqual(artifactResults.rawLogReferences.slice(-3), [
     { path: 'files/phpunit-output.log', kind: 'phpunit-output' },
     { path: 'logs/recipe-run.stdout.log', kind: 'recipe-run-stdout' },

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -69,7 +69,7 @@ const output = 'x'.repeat(70 * 1024) + '\\n' + [
   .replaceAll('SamplePluginRunner', ['SamplePlugin', 'Runner'].join(String.fromCharCode(92)));
 fs.writeFileSync('${expectedOutputFile}', output);
 process.stdout.write(JSON.stringify({ success: false, executions: [{ stdout: output, stderr: '' }] }));
-process.exit(1);
+process.exitCode = 1;
 `);
 await chmod(cli, 0o755);
 

--- a/wordpress/tests/wp-codebox-phpunit-failure-artifacts-smoke.sh
+++ b/wordpress/tests/wp-codebox-phpunit-failure-artifacts-smoke.sh
@@ -11,7 +11,6 @@ PLUGIN_DIR="${TMPDIR}/sample-plugin"
 ARTIFACTS_DIR="${TMPDIR}/artifacts"
 FAKE_BIN="${TMPDIR}/wp-codebox"
 RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
-CORE_MODULE="${ROOT_DIR}/tests/fixtures/wp-codebox-core-recipe-builder.mjs"
 EXTRA_MOUNT="${TMPDIR}/extra.php"
 
 mkdir -p "${PLUGIN_DIR}/tests" "$ARTIFACTS_DIR"
@@ -38,6 +37,18 @@ set -euo pipefail
 
 if [ "${1:-}" = "commands" ]; then
 	exit 0
+fi
+
+if [ "${1:-}" = "recipe" ] && [ "${2:-}" = "build" ]; then
+	shift 3
+	while [ "$#" -gt 0 ]; do
+		if [ "$1" = "--output" ]; then
+			printf '%s\n' '{"schema":"wp-codebox/workspace-recipe/v1"}' > "$2"
+			exit 0
+		fi
+		shift
+	done
+	exit 2
 fi
 
 recipe=""
@@ -82,7 +93,6 @@ HOMEBOY_EXTENSION_PATH="$ROOT_DIR" \
 HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
 HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
-HOMEBOY_WP_CODEBOX_CORE_MODULE="$CORE_MODULE" \
 HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="$ARTIFACTS_DIR" \
 HOMEBOY_SETTINGS_JSON='{"wp_codebox_phpunit_test_root":"tests","wp_codebox_phpunit_config":"phpunit.xml.dist","wp_codebox_phpunit_cwd":"tests","wp_codebox_phpunit_bootstrap_mode":"managed","wp_codebox_phpunit_mounts":[{"source":"'"$EXTRA_MOUNT"'","target":"/tmp/extra.php","mode":"readonly"}]}' \
     bash "$RUNNER" --filter SampleFilter > "${TMPDIR}/runner.out" 2>&1
@@ -94,16 +104,17 @@ if [ "$status" -eq 0 ]; then
 	exit 1
 fi
 
-node - "$ARTIFACTS_DIR" "$FAKE_BIN" "$CORE_MODULE" <<'NODE'
+node - "$ARTIFACTS_DIR" "$FAKE_BIN" <<'NODE'
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
 const artifactsDir = process.argv[2];
 const fakeBin = process.argv[3];
-const coreModule = process.argv[4];
 
-const readJson = (name) => JSON.parse(fs.readFileSync(path.join(artifactsDir, name), 'utf8'));
+const runDirectory = fs.readdirSync(artifactsDir).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
+assert.ok(runDirectory, 'expected a PHPUnit artifact directory');
+const readJson = (name) => JSON.parse(fs.readFileSync(path.join(artifactsDir, runDirectory, name), 'utf8'));
 const recipe = readJson('wp-codebox-phpunit-recipe.json');
 const options = readJson('wp-codebox-phpunit-recipe-options.json');
 const provenance = readJson('wp-codebox-phpunit-provenance.json');
@@ -118,7 +129,6 @@ assert.deepEqual(options.phpunitArgs, ['--filter', 'SampleFilter']);
 assert.equal(provenance.wp_codebox.cli_bin, fakeBin);
 assert.equal(provenance.wp_codebox.resolved_cli_path, fakeBin);
 assert.deepEqual(provenance.wp_codebox.command, [fakeBin]);
-assert.equal(provenance.wp_codebox.recipe_builder_source, `file://${coreModule}`);
 assert.equal(profile.phpunit.test_root, 'tests');
 assert.equal(profile.phpunit.config, 'phpunit.xml.dist');
 assert.equal(profile.phpunit.cwd, 'tests');

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.34.1",
+  "version": "3.34.2",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
Fixes #2422

## Summary
- Resolve and mount declared sibling WordPress plugins into the WP Codebox PHPUnit recipe.
- Respect discovered component PHPUnit configuration/bootstrap paths and retain bounded recipe, profile, and source-ref evidence.
- Preserve PHPUnit aggregates on success, nonzero, and no-runtime-pointer crash paths.

## Verification
- `npm run test:wp-codebox-phpunit-aggregate`
- `npm run test:wp-codebox-phpunit-evidence`
- `bash tests/wp-codebox-phpunit-source-root-recipe-smoke.sh`
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `npm run lint:js -- --no-ignore scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-aggregate-smoke.mjs`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the WordPress/WP Codebox adapter changes and regression fixtures. Chris Huber reviewed and remains responsible for the change.