### PR TITLE
fix(wordpress): preserve PHPUnit multisite topology

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -22,7 +22,7 @@ const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
 const pluginSourceDirectory = subpath ? path.join(root, subpath) : root;
 const phpunitProfile = await resolvePhpunitProfile(settings, pluginSourceDirectory, slug);
-const multisite = await resolveMultisite(settings, pluginSourceDirectory);
+const topology = await resolveWordPressTopology(settings, pluginSourceDirectory);
 const databaseService = resolveDatabaseService(settings, process.env);
 requireDatabaseServiceCapability(databaseService);
 runPrepareSteps(settings.wp_codebox_prepare_steps, pluginSourceDirectory);
@@ -55,7 +55,7 @@ const options = clean({
   wpConfigDefines: settings.wp_config_defines,
   bootstrapMode: settings.wp_codebox_phpunit_bootstrap_mode,
   projectBootstrap: settings.wp_codebox_phpunit_project_bootstrap,
-  multisite,
+  multisite: topology.multisite,
   preloadFiles: settings.wp_codebox_phpunit_preload_files,
   mounts: [...canonicalMounts(settings.wp_codebox_phpunit_mounts), { source: harnessSource, target: '/wp-codebox-vendor', mode: 'readonly' }],
 });
@@ -176,15 +176,15 @@ function run(args) {
   }
 }
 function required(value, name) { if (!value) { throw new Error(`${name} is required`); } return value; }
-async function resolveMultisite(configuration, pluginDirectory) {
+async function resolveWordPressTopology(configuration, pluginDirectory) {
   const fromEnv = process.env.HOMEBOY_WORDPRESS_MULTISITE;
   if (fromEnv !== undefined && fromEnv !== '') {
-    return truthy(fromEnv);
+    return { multisite: truthy(fromEnv), source: 'environment' };
   }
   if (configuration.wp_codebox_multisite !== undefined) {
-    return truthy(configuration.wp_codebox_multisite);
+    return { multisite: truthy(configuration.wp_codebox_multisite), source: 'setting' };
   }
-  return pluginRequiresNetwork(pluginDirectory);
+  return { multisite: await pluginRequiresNetwork(pluginDirectory), source: 'plugin-header' };
 }
 async function pluginRequiresNetwork(pluginDirectory) {
   if (typeof pluginDirectory !== 'string' || pluginDirectory === '') {
@@ -210,7 +210,9 @@ async function pluginRequiresNetwork(pluginDirectory) {
     if (!/^[\s*#\/]*Plugin Name\s*:/im.test(block)) {
       continue;
     }
-    return /^[\s*#\/]*Network\s*:\s*(true|1|yes|on)\b/im.test(block);
+    if (/^[\s*#\/]*Network\s*:\s*(true|1|yes|on)\b/im.test(block)) {
+      return true;
+    }
   }
   return false;
 }
@@ -620,7 +622,7 @@ async function persistRecipeEvidence(artifactDirectory, recipeOptions, generated
   await Promise.all([
     copyFile(generatedRecipePath, path.join(artifactDirectory, 'wp-codebox-phpunit-recipe.json')),
     writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-recipe-options.json'), `${JSON.stringify(recipeOptions, null, 2)}\n`),
-    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-profile.json'), `${JSON.stringify({ phpunit: { config: profile.config, cwd: profile.cwd, test_root: profile.testRoot, environment: profile.environment, bootstrap_mode: recipeOptions.bootstrapMode, passthrough_args: recipeOptions.phpunitArgs, extra_mounts: recipeOptions.mounts } }, null, 2)}\n`),
+    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-profile.json'), `${JSON.stringify({ wordpress: { topology }, phpunit: { config: profile.config, cwd: profile.cwd, test_root: profile.testRoot, environment: profile.environment, bootstrap_mode: recipeOptions.bootstrapMode, passthrough_args: recipeOptions.phpunitArgs, extra_mounts: recipeOptions.mounts } }, null, 2)}\n`),
     writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-provenance.json'), `${JSON.stringify({ source_refs: sourceRefs, wp_codebox: { cli_bin: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', resolved_cli_path: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', command: [process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'] } }, null, 2)}\n`),
   ]);
 }

--- a/wordpress/tests/fixtures/wp-codebox-phpunit-topology/explicit-multisite/plugin.php
+++ b/wordpress/tests/fixtures/wp-codebox-phpunit-topology/explicit-multisite/plugin.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Explicit Multisite PHPUnit Fixture
+ */

--- a/wordpress/tests/fixtures/wp-codebox-phpunit-topology/network-plugin/a-support.php
+++ b/wordpress/tests/fixtures/wp-codebox-phpunit-topology/network-plugin/a-support.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Network PHPUnit Support Fixture
+ */

--- a/wordpress/tests/fixtures/wp-codebox-phpunit-topology/network-plugin/plugin.php
+++ b/wordpress/tests/fixtures/wp-codebox-phpunit-topology/network-plugin/plugin.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Plugin Name: Network PHPUnit Fixture
+ * Network: true
+ */

--- a/wordpress/tests/fixtures/wp-codebox-phpunit-topology/single-site/plugin.php
+++ b/wordpress/tests/fixtures/wp-codebox-phpunit-topology/single-site/plugin.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Single-site PHPUnit Fixture
+ */

--- a/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
@@ -1,14 +1,14 @@
+/**
+ * External dependencies
+ */
 import { strict as assert } from 'node:assert';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
-// Exercises the plugin PHPUnit adapter's multisite resolution so that
-// network-only plugins (Network: true) boot a multisite runtime instead of
-// crashing in wp_die(). Covers the three supported sources, in precedence
-// order: HOMEBOY_WORDPRESS_MULTISITE env, wp_codebox_multisite setting, and
-// the plugin's own `Network: true` header.
+// Exercises the plugin PHPUnit topology handoff. WP Codebox owns Playground's
+// multisite preinstall, network activation, and PHPUnit bootstrap lifecycle.
 
 const extension = path.resolve(import.meta.dirname, '..');
 const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
@@ -36,14 +36,10 @@ if (args[0] === 'recipe-run') {
 await chmod(cli, 0o755);
 
 let scenario = 0;
-async function resolvedOptions({ pluginPhp, settings = {}, env = {} }) {
+async function resolvedOptions({ fixture, settings = {}, env = {} }) {
   scenario += 1;
-  const component = path.join(root, `plugin-${scenario}`);
+  const component = path.join(extension, 'tests', 'fixtures', 'wp-codebox-phpunit-topology', fixture);
   const observed = path.join(root, `observed-${scenario}.jsonl`);
-  await mkdir(component, { recursive: true });
-  if (pluginPhp !== undefined) {
-    await writeFile(path.join(component, 'plugin.php'), pluginPhp);
-  }
   const result = spawnSync(runner, [], {
     env: {
       ...process.env,
@@ -62,33 +58,32 @@ async function resolvedOptions({ pluginPhp, settings = {}, env = {} }) {
 }
 
 try {
-  const singleSitePlugin = '<?php\n/**\n * Plugin Name: Single Site\n */\n';
-  const networkPlugin = '<?php\n/**\n * Plugin Name: Network Only\n * Network: true\n */\n';
-
   // Default: no signal anywhere -> single-site.
+  const singleSite = await resolvedOptions({ fixture: 'single-site' });
   assert.equal(
-    (await resolvedOptions({ pluginPhp: singleSitePlugin })).multisite,
+    singleSite.multisite,
     false,
     'no signal defaults to single-site',
   );
 
-  // Plugin header Network: true auto-enables multisite with zero config.
+  // A non-network plugin header precedes the network entrypoint in this fixture.
+  // Detection must inspect every supported plugin header before selecting topology.
   assert.equal(
-    (await resolvedOptions({ pluginPhp: networkPlugin })).multisite,
+    (await resolvedOptions({ fixture: 'network-plugin' })).multisite,
     true,
     'Network: true plugin header auto-enables multisite',
   );
 
   // wp_codebox_multisite setting enables multisite for a single-site plugin.
   assert.equal(
-    (await resolvedOptions({ pluginPhp: singleSitePlugin, settings: { wp_codebox_multisite: true } })).multisite,
+    (await resolvedOptions({ fixture: 'explicit-multisite', settings: { wp_codebox_multisite: true } })).multisite,
     true,
     'wp_codebox_multisite setting enables multisite',
   );
 
   // Setting can also explicitly force single-site even for a Network plugin.
   assert.equal(
-    (await resolvedOptions({ pluginPhp: networkPlugin, settings: { wp_codebox_multisite: false } })).multisite,
+    (await resolvedOptions({ fixture: 'network-plugin', settings: { wp_codebox_multisite: false } })).multisite,
     false,
     'explicit wp_codebox_multisite=false overrides Network header',
   );
@@ -96,7 +91,7 @@ try {
   // Env var takes precedence over everything.
   assert.equal(
     (await resolvedOptions({
-      pluginPhp: singleSitePlugin,
+      fixture: 'single-site',
       settings: { wp_codebox_multisite: false },
       env: { HOMEBOY_WORDPRESS_MULTISITE: '1' },
     })).multisite,
@@ -104,18 +99,18 @@ try {
     'HOMEBOY_WORDPRESS_MULTISITE env overrides settings',
   );
 
-  const defaultDatabase = await resolvedOptions({ pluginPhp: singleSitePlugin });
+  const defaultDatabase = singleSite;
   assert.equal('databaseType' in defaultDatabase, false, 'omitted database_type preserves WP Codebox defaults');
   assert.equal(defaultDatabase.extra_plugins.length, 1, 'no dependencies only emits the primary plugin');
   assert.equal(defaultDatabase.extra_plugins[0].activate, false, 'primary plugin remains inactive for the managed PHPUnit bootstrap');
 
-  const mysqlDatabase = await resolvedOptions({ pluginPhp: singleSitePlugin, settings: { database_type: 'mysql' } });
+  const mysqlDatabase = await resolvedOptions({ fixture: 'single-site', settings: { database_type: 'mysql' } });
   assert.equal(mysqlDatabase.databaseType, 'mysql', 'database_type maps to the WP Codebox databaseType contract');
 
-  const defaultPhp = await resolvedOptions({ pluginPhp: singleSitePlugin });
+  const defaultPhp = singleSite;
   assert.equal('phpVersion' in defaultPhp, false, 'omitted runtime PHP version preserves WP Codebox defaults');
 
-  const configuredPhp = await resolvedOptions({ pluginPhp: singleSitePlugin, settings: { wordpress_runtime_php_version: '8.4' } });
+  const configuredPhp = await resolvedOptions({ fixture: 'single-site', settings: { wordpress_runtime_php_version: '8.4' } });
   assert.equal(configuredPhp.phpVersion, '8.4', 'configured runtime PHP version maps to the WP Codebox phpVersion contract');
 } finally {
   await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Closes #2305

Related to https://github.com/Extra-Chill/homeboy/issues/10231

## Summary
- Preserve the selected WordPress topology and its source in PHPUnit profile evidence.
- Detect a network plugin from every supported root-level plugin header rather than stopping at the first non-network header.
- Use deterministic network-plugin, explicit-multisite, and single-site fixtures to prove the Extensions-to-WP-Codebox contract while retaining the single-site path.

## Upstream dependency
- WP Codebox merged the owning multisite PHPUnit lifecycle in Automattic/wp-codebox#2107: it preinstalls multisite before component activation, network-activates the plugin, and reuses the canonical PHPUnit install state exactly once. This Extensions change forwards and records the generic topology contract; it requires a WP Codebox release containing #2107 for end-to-end runtime execution. The locally installed `wp-codebox 0.13.1` predates that merge.

## Verification
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `node tests/wp-codebox-phpunit-aggregate-smoke.mjs`
- `node tests/wp-codebox-phpunit-evidence-smoke.mjs`
- `node tests/wp-codebox-canonical-cli-adapters-smoke.mjs`
- `node tests/wordpress-manifest-settings-smoke.js`
- `node tests/wordpress-artifact-cleanup-declarations-smoke.js`
- `npm run lint:js -- --no-ignore scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `bash scripts/lint/eslint-dependency-tree-scope-smoke.sh`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the WordPress Extensions topology handling, deterministic fixtures, and verification updates. Chris Huber reviewed and remains responsible for the change.