### PR TITLE
fix(wordpress): trust resolved PHPUnit dependencies

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -242,18 +242,17 @@ function clean(value) { return Object.fromEntries(Object.entries(value).filter((
 async function dependencyPaths(configuration, primarySources) {
   const configured = Array.isArray(configuration.validation_dependencies) ? configuration.validation_dependencies : [];
   const canonical = (process.env.HOMEBOY_WORDPRESS_DEPENDENCY_PATHS || '').split('\n');
-  const declared = configured.map((value) => {
+  // The shell resolver owns slug-to-path resolution and exports its final paths
+  // here. Settings can still contribute explicit paths when this adapter is run
+  // directly, but metadata slugs must not be resolved or rejected a second time.
+  const explicit = configured.map((value) => {
     if (typeof value === 'string') { return value; }
     if (isObject(value)) { return value.path || value.local_path || value.source || ''; }
     return '';
-  }).filter(Boolean);
-  const unresolved = declared.filter((value) => !path.isAbsolute(value));
-  if (unresolved.length > 0) {
-    throw new Error(`Declared WordPress validation dependencies were not resolved to source paths: ${unresolved.join(', ')}`);
-  }
+  }).filter((value) => path.isAbsolute(value));
   // Preserve explicitly declared paths in recipe provenance while canonicalizing
   // aliases solely for identity and duplicate detection.
-  const sources = [...new Set([...declared, ...canonical].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
+  const sources = [...new Set([...explicit, ...canonical].filter((value) => typeof value === 'string' && path.isAbsolute(value)))];
   const resolved = await Promise.all(sources.map(async (source) => {
     try { return { source, canonicalSource: await realpath(source) }; } catch { throw new Error(`Declared WordPress validation dependency sources are unavailable: ${source}`); }
   }));

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -12,19 +12,26 @@ const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
 const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-aggregate-'));
 const component = path.join(root, 'component');
 const dependency = path.join(root, 'dependency');
+const dataMachine = path.join(root, 'data-machine');
+const conflictingDataMachine = path.join(root, 'conflicting', 'data-machine');
 const cli = path.join(root, 'wp-codebox');
 const resultsWriter = path.join(root, 'write-results.sh');
 await mkdir(path.join(component, 'tests'), { recursive: true });
 await mkdir(dependency);
+await mkdir(dataMachine);
+await mkdir(conflictingDataMachine, { recursive: true });
 await writeFile(path.join(component, 'component.php'), '<?php /* Plugin Name: Component */\n');
 await writeFile(path.join(component, 'tests', 'bootstrap.php'), '<?php require_once __DIR__ . "/../component.php";\n');
 await writeFile(path.join(component, 'phpunit.xml.dist'), '<phpunit bootstrap="tests/bootstrap.php"><testsuites><testsuite name="suite"><directory>tests</directory></testsuite></testsuites></phpunit>\n');
 await writeFile(path.join(dependency, 'dependency.php'), '<?php /* Plugin Name: Dependency */\n');
+await writeFile(path.join(dataMachine, 'data-machine.php'), '<?php /* Plugin Name: Data Machine */\n');
+await writeFile(path.join(conflictingDataMachine, 'data-machine.php'), '<?php /* Plugin Name: Conflicting Data Machine */\n');
 await writeFile(resultsWriter, 'homeboy_write_test_results() { printf \'{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\\n\' "$1" "$2" "$3" "$4" > "$HOMEBOY_TEST_RESULTS_FILE"; }\n');
 await writeFile(cli, `#!/usr/bin/env node
 import fs from 'node:fs';
 const args = process.argv.slice(2);
 const value = (name) => args[args.indexOf(name) + 1];
+if (process.env.DISPATCHED) { fs.appendFileSync(process.env.DISPATCHED, JSON.stringify(args) + '\\n'); }
 if (args[0] === 'recipe') { fs.writeFileSync(value('--output'), JSON.stringify({ schema: 'wp-codebox/workspace-recipe/v1' })); process.exit(0); }
 const artifacts = value('--artifacts');
 const mode = process.env.FIXTURE_MODE;
@@ -65,6 +72,41 @@ try {
   const missing = spawnSync(runner, [], { env: { ...process.env, HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [path.join(root, 'missing')] }) }, encoding: 'utf8' });
   assert.notEqual(missing.status, 0);
   assert.match(missing.stderr, /dependency sources are unavailable/);
+
+  const bin = path.join(root, 'bin');
+  const dispatched = path.join(root, 'dispatched.jsonl');
+  await mkdir(bin);
+  await writeFile(path.join(bin, 'homeboy'), `#!/usr/bin/env sh
+printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingDataMachine } } })}'
+`);
+  await chmod(path.join(bin, 'homeboy'), 0o755);
+  const metadataArtifacts = path.join(root, 'metadata-artifacts');
+  const metadataResults = path.join(root, 'metadata-results.json');
+  const metadataRun = spawnSync(runner, [], {
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      DISPATCHED: dispatched,
+      FIXTURE_MODE: 'success',
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'component',
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: metadataArtifacts,
+      HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter,
+      HOMEBOY_TEST_RESULTS_FILE: metadataResults,
+      HOMEBOY_WORDPRESS_DEPENDENCY_PATHS: `${dataMachine}\n${dataMachine}`,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: ['data-machine'] }),
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(metadataRun.status, 0, metadataRun.stderr);
+  assert.match(metadataRun.stdout, /WP Codebox test run complete\./);
+  assert.deepEqual((await readFile(dispatched, 'utf8')).trim().split('\n').map(JSON.parse).map((args) => args[0]), ['recipe', 'recipe-run']);
+  const metadataRunArtifact = path.join(metadataArtifacts, (await readdir(metadataArtifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.')));
+  const metadataOptions = JSON.parse(await readFile(path.join(metadataRunArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
+  const metadataProvenance = JSON.parse(await readFile(path.join(metadataRunArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));
+  assert.deepEqual(metadataOptions.extra_plugins.slice(1), [{ source: dataMachine, slug: 'data-machine', activate: true }]);
+  assert.deepEqual(metadataProvenance.source_refs.slice(1), [{ slug: 'data-machine', source: dataMachine }]);
 } finally {
   await rm(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- make the final `HOMEBOY_WORDPRESS_DEPENDENCY_PATHS` contract authoritative for WP Codebox PHPUnit dependency sources
- retain explicit absolute settings paths and their missing-path failures
- add an end-to-end fixture proving `data-machine` metadata resolves to one canonical source despite duplicate paths and a conflicting component-registry candidate, then dispatches PHPUnit

Closes #2429

## Verification
- `npm run test:wp-codebox-phpunit-aggregate`
- `npm run test:wp-codebox-phpunit-evidence`
- `npm run test:wp-codebox-canonical-cli-adapters`
- `bash tests/wp-codebox-phpunit-source-root-recipe-smoke.sh`
- `bash tests/validation-dependencies-smoke.sh`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode drafted the implementation and regression fixture; Chris Huber reviewed the resulting change.