### PR TITLE
fix(wordpress): exclude generated ESLint output

### DIFF
--- a/tests/wordpress-eslint-scope-smoke.sh
+++ b/tests/wordpress-eslint-scope-smoke.sh
@@ -86,6 +86,10 @@ SH
 cat > "$FAKE_EXTENSION/node_modules/.bin/eslint" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$ESLINT_ARGS_FILE"
+if [ "${ESLINT_FATAL:-}" = "1" ]; then
+    echo "simulated ESLint configuration failure" >&2
+    exit 2
+fi
 for arg in "$@"; do
     if [ "$arg" = "--format" ]; then
         printf '[{"filePath":"%s/assets/bad.js","errorCount":1,"warningCount":0,"fixableErrorCount":1,"fixableWarningCount":0,"messages":[{"ruleId":"no-undef","severity":2,"message":"bad is not defined","line":1,"column":7,"fix":{"range":[0,3],"text":"good"}}]}]\n' "$ESLINT_COMPONENT_DIR"
@@ -165,6 +169,27 @@ assert_contains "$TMP_DIR/js-success.out" "ESLint linting passed"
 assert_contains "$ESLINT_ARGS_FILE" "--config"
 assert_contains "$ESLINT_ARGS_FILE" "$FAKE_EXTENSION/eslint.config.mjs"
 assert_contains "$ESLINT_ARGS_FILE" "assets/admin.js"
+
+set +e
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
+ESLINT_FATAL=1 \
+HOMEBOY_LINT_FILE='assets/admin.js' \
+    bash "$RUNNER" > "$TMP_DIR/js-fatal.out" 2>&1
+fatal_status=$?
+set -e
+
+if [ "$fatal_status" -eq 0 ]; then
+    echo "Expected ESLint fatal failure to propagate" >&2
+    cat "$TMP_DIR/js-fatal.out" >&2
+    exit 1
+fi
+
+assert_contains "$TMP_DIR/js-fatal.out" "simulated ESLint configuration failure"
 
 cat > "$COMPONENT_DIR/assets/bad.js" <<'JS'
 const bad = true;

--- a/wordpress/eslint.config.mjs
+++ b/wordpress/eslint.config.mjs
@@ -7,9 +7,13 @@ export default [
   {
     ignores: [
       'node_modules/',
-      'vendor/',
+      '**/vendor/**',
+      '**/vendor_prefixed/**',
+      '**/vendor-prefixed/**',
+      '**/vendor_scoped/**',
+      '**/vendor-scoped/**',
       '**/build/**',
-      'dist/',
+      '**/dist/**',
       '*.min.js',
       'tests/',
     ],

--- a/wordpress/scripts/lint/eslint-build-ignore-smoke.sh
+++ b/wordpress/scripts/lint/eslint-build-ignore-smoke.sh
@@ -7,11 +7,28 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 component_dir="${TMPDIR}/component"
-mkdir -p "${component_dir}/build" "${component_dir}/nested/build" "${component_dir}/nested/src"
+mkdir -p "${component_dir}/build" "${component_dir}/nested/build" "${component_dir}/nested/dist" "${component_dir}/nested/vendor/package" "${component_dir}/nested/src"
 
 printf '%s\n' 'const = rootBuild;' > "${component_dir}/build/app.js"
 printf '%s\n' 'const = nestedBuild;' > "${component_dir}/nested/build/app.js"
+printf '%s\n' 'const = nestedDist;' > "${component_dir}/nested/dist/app.js"
+printf '%s\n' 'const = nestedVendor;' > "${component_dir}/nested/vendor/package/app.js"
 printf '%s\n' 'export {};' > "${component_dir}/nested/src/app.js"
+
+# Reproduce the release failure's scale without placing generated bundles in
+# the repository. These files must never become runner arguments or findings.
+for index in $(seq 1 1500); do
+    printf 'const = generated%s;\n' "$index" > "${component_dir}/nested/build/generated-${index}.js"
+done
+
+cat > "${component_dir}/eslint.config.mjs" <<JS
+/**
+ * External dependencies
+ */
+import config from '${EXTENSION_PATH}/eslint.config.mjs';
+
+export default config;
+JS
 
 run_eslint() {
     HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
@@ -21,9 +38,47 @@ run_eslint() {
         bash "${SCRIPT_DIR}/eslint-runner.sh"
 }
 
+run_package_eslint() {
+    (
+        cd "$component_dir"
+        "${EXTENSION_PATH}/node_modules/.bin/eslint" .
+    )
+}
+
 run_eslint > "${TMPDIR}/build-only.out"
 
+if grep -Fq "generated-" "${TMPDIR}/build-only.out" || [ "$(wc -l < "${TMPDIR}/build-only.out" | tr -d ' ')" -gt 10 ]; then
+    echo "Expected generated-only lint output to stay bounded" >&2
+    sed 's/^/  /' "${TMPDIR}/build-only.out" >&2
+    exit 1
+fi
+
+# Package-style ESLint and the runner must agree: generated output is ignored,
+# while an authored source violation remains a failure in both entry points.
+if ! run_package_eslint > "${TMPDIR}/package-valid.out" 2>&1; then
+    echo "Expected package-style ESLint to ignore generated output" >&2
+    sed 's/^/  /' "${TMPDIR}/package-valid.out" >&2
+    exit 1
+fi
+
+if ! HOMEBOY_LINT_GLOB='nested/build/generated-*.js' run_eslint > "${TMPDIR}/generated-scope.out" 2>&1; then
+    echo "Expected generated-only changed scope to skip ESLint" >&2
+    sed 's/^/  /' "${TMPDIR}/generated-scope.out" >&2
+    exit 1
+fi
+
+if ! grep -Fq "No JS/TS files match pattern: nested/build/generated-*.js" "${TMPDIR}/generated-scope.out"; then
+    echo "Expected generated-only changed scope to be filtered before ESLint" >&2
+    sed 's/^/  /' "${TMPDIR}/generated-scope.out" >&2
+    exit 1
+fi
+
 printf '%s\n' 'const = source;' > "${component_dir}/nested/src/app.js"
+if run_package_eslint > "${TMPDIR}/package-invalid.out" 2>&1; then
+    echo "Expected package-style ESLint to retain authored source findings" >&2
+    exit 1
+fi
+
 if run_eslint > "${TMPDIR}/invalid-source.out" 2>&1; then
     echo "Expected sibling source to remain linted" >&2
     exit 1

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -60,24 +60,27 @@ write_eslint_findings_sidecar() {
     HOMEBOY_LINT_FINDINGS_FILE="$previous_target"
 }
 
-# Check if component has JavaScript files.
-#
-# This count is a gate: zero means skip ESLint entirely. The installed
-# dependency tree must be excluded or any component with dependencies installed
-# looks like it has JavaScript of its own, defeating the skip.
-js_file_count=$(find "$PLUGIN_PATH" -type f \( -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) \
-    -not -path "*/node_modules/*" \
-    -not -path "*/vendor/*" \
-    -not -path "*/vendor_prefixed/*" \
-    -not -path "*/vendor-prefixed/*" \
-    -not -path "*/vendor_scoped/*" \
-    -not -path "*/vendor-scoped/*" \
-    -not -path "*/dist/*" \
-    -not -path "*/build/*" \
-    -not -name "*.min.js" \
-    2>/dev/null | wc -l | tr -d ' ')
+# Return false for dependency trees and generated assets. Repository-specific
+# ignores remain ESLint configuration policy; this prevents generated output
+# from becoming an explicit CLI target that can bypass that policy.
+is_lint_source_file() {
+    case "$1" in
+        */node_modules/*|*/vendor/*|*/vendor_prefixed/*|*/vendor-prefixed/*|*/vendor_scoped/*|*/vendor-scoped/*|*/dist/*|*/build/*|*.min.js)
+            return 1
+            ;;
+    esac
 
-if [ "$js_file_count" -eq 0 ]; then
+    return 0
+}
+
+SOURCE_FILES=()
+while IFS= read -r source_file; do
+    if is_lint_source_file "$source_file"; then
+        SOURCE_FILES+=("${source_file#"$PLUGIN_PATH"/}")
+    fi
+done < <(find "$PLUGIN_PATH" -type f \( -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) 2>/dev/null)
+
+if [ ${#SOURCE_FILES[@]} -eq 0 ]; then
     echo "No JavaScript files found, skipping ESLint."
     exit 0
 fi
@@ -104,6 +107,11 @@ if [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
             exit 0
             ;;
     esac
+
+    if ! is_lint_source_file "${LINT_FILES[0]}"; then
+        echo "Skipping generated or dependency JavaScript file: ${HOMEBOY_LINT_FILE}"
+        exit 0
+    fi
 elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     cd "$PLUGIN_PATH"
 
@@ -120,7 +128,9 @@ elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     for matched_file in "${MATCHED_FILES[@]}"; do
         case "$matched_file" in
             *.js|*.jsx|*.ts|*.tsx)
-                JS_FILES+=("$matched_file")
+                if is_lint_source_file "$matched_file"; then
+                    JS_FILES+=("$matched_file")
+                fi
                 ;;
         esac
     done
@@ -135,6 +145,7 @@ elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     cd - > /dev/null
 else
     echo "Running JavaScript linting..."
+    LINT_FILES=("${SOURCE_FILES[@]}")
 fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -204,10 +215,17 @@ if [[ "${HOMEBOY_FIX_ONLY:-}" == "1" ]]; then
 fi
 
 # Get JSON report for summary
+homeboy_runner_harness_temp ESLINT_JSON_STDERR "homeboy-eslint-stderr.XXXXXX"
 set +e
-json_output=$("$ESLINT_BIN" "${eslint_base_args[@]}" --format json "${LINT_FILES[@]}" 2>/dev/null)
+json_output=$("$ESLINT_BIN" "${eslint_base_args[@]}" --format json "${LINT_FILES[@]}" 2>"$ESLINT_JSON_STDERR")
 json_exit=$?
 set -e
+
+# ESLint normally writes its report to stdout. Keep fatal diagnostics visible
+# when it cannot produce JSON rather than discarding the only actionable error.
+if [ -z "$json_output" ] && [ -s "$ESLINT_JSON_STDERR" ]; then
+    cat "$ESLINT_JSON_STDERR" >&2
+fi
 
 # Write ESLint lint findings sidecar for homeboy baseline and drill-down.
 # The top-level lint runner passes a temp file here, then merges it with PHPCS


### PR DESCRIPTION
## Summary
- select authored JavaScript and TypeScript files before invoking the WordPress ESLint runner, excluding dependency and generated build, dist, and vendor trees in full and changed scopes
- align shared ESLint global ignores with nested generated and vendor output while leaving repository-specific policy to repository ESLint configuration, consistent with #2407
- retain fatal ESLint diagnostics when JSON reporting cannot be produced and cover a 1,500-file generated-output regression fixture

Closes #2433

## Verification
- `npm run test:eslint-build-ignore`
- `npm run test:eslint-dependency-tree-scope`
- `bash scripts/lint/eslint-no-files-smoke.sh`
- `HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy@controller-origin-main-7628 bash scripts/lint/eslint-glob-filter-smoke.sh`
- `HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy@controller-origin-main-7628 bash tests/wordpress-eslint-scope-smoke.sh`
- `npm run lint:js` (reports 52 pre-existing errors and 6 warnings outside this change)

## AI assistance
GPT-5.6 Terra via OpenCode drafted the runner/config/test changes and ran the focused verification. Chris Huber reviewed and remains responsible for the change.