### PR TITLE
fix(wordpress): normalize PHPUnit sidecar status

### DIFF
--- a/.github/workflows/wp-codebox-test-runtime-canary.yml
+++ b/.github/workflows/wp-codebox-test-runtime-canary.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - .github/workflows/wp-codebox-test-runtime-canary.yml
       - wordpress/scripts/test/**
+      - wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
       - wordpress/tests/fixtures/test-db-activation-host/**
       - wordpress/tests/fixtures/bench-db-activation-dep/**
       - wordpress/tests/fixtures/test-managed-dependency-order-host/**
@@ -63,6 +64,10 @@ jobs:
           HOMEBOY_WP_CODEBOX_CORE_MODULE: ${{ github.workspace }}/.ci/wp-codebox/packages/runtime-core/dist/index.js
           HOMEBOY_CORE_DIR: ${{ github.workspace }}/.ci/homeboy
         run: bash wordpress/scripts/test/playground-db-activation-smoke.sh
+
+      - name: Run PHPUnit aggregate normalization smoke
+        working-directory: wordpress
+        run: npm run test:wp-codebox-phpunit-aggregate
 
       - name: Run managed dependency ordering canary
         env:

--- a/wordpress/scripts/test/playground-db-activation-smoke.sh
+++ b/wordpress/scripts/test/playground-db-activation-smoke.sh
@@ -109,6 +109,11 @@ for candidate in "${ARTIFACTS_DIR}"/wp-codebox-phpunit.*; do
     [ -d "$candidate" ] && run_artifacts_dir="$candidate"
 done
 runtime_artifact_directory=$(jq -r '.paths.runtimeDirectory // empty' "${run_artifacts_dir}/latest-runtime.json")
+test_results_artifact="${run_artifacts_dir}/${runtime_artifact_directory}/files/test-results.json"
+if [ "$(jq -r '.status // empty' "$test_results_artifact")" != "passed" ] || [ "$(jq -r '.summary.total // 0' "$test_results_artifact")" -le 0 ]; then
+    echo "ERROR: expected normalized passing PHPUnit test-results.json" >&2
+    exit 1
+fi
 result_artifact="${run_artifacts_dir}/${runtime_artifact_directory}/files/phpunit/.pg-test-result.txt"
 if [ ! -f "$result_artifact" ] || ! grep -q '^STAGE_BEGIN:run_tests' "$result_artifact"; then
     echo "ERROR: expected WP Codebox structured PHPUnit diagnostic artifact" >&2

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -534,6 +534,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     const summary = isObject(results.summary) ? results.summary : {};
     if (aggregate) {
       results.summary = { ...summary, ...aggregate };
+      results.status = aggregate.failed > 0 ? 'failed' : 'passed';
     }
     const references = Array.isArray(results.rawLogReferences) ? results.rawLogReferences : [];
     results.rawLogReferences = [

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -71,9 +71,9 @@ try {
     executionArgs.push('--approve-external-service-writes', '--policy', JSON.stringify(databaseService.policy));
   }
   const execution = await runCaptured(executionArgs);
-  await handoffArtifacts(runArtifacts, execution);
-  if (execution.status !== 0) {
-    process.exitCode = execution.status;
+  const artifactStatus = await handoffArtifacts(runArtifacts, execution);
+  if (execution.status !== 0 || !['passed', 'skipped'].includes(artifactStatus)) {
+    process.exitCode = execution.status || 1;
   } else {
     process.stdout.write('WP Codebox test run complete.\n');
   }
@@ -482,28 +482,36 @@ async function handoffArtifacts(artifactRoot, execution) {
     // A crashed workload may never write a runtime pointer. Preserve and parse
     // the captured aggregate at the stable artifact root rather than reporting
     // a zero-test run.
-    await preservePhpunitOutput(artifactRoot, execution, []);
+    const status = await preservePhpunitOutput(artifactRoot, execution, []);
     if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
       runScript('parse-test-results.sh', [artifactRoot]);
     }
     if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
       runScript('parse-test-failures.sh', [artifactRoot, componentPath]);
     }
-    return;
+    return status;
   }
   const runtime = pointer?.paths?.runtimeDirectory;
   if (typeof runtime !== 'string' || !/^runtime-[A-Za-z0-9][A-Za-z0-9-]*$/.test(runtime)) {
-    return;
+    const status = await preservePhpunitOutput(artifactRoot, execution, []);
+    if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
+      runScript('parse-test-results.sh', [artifactRoot]);
+    }
+    if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
+      runScript('parse-test-failures.sh', [artifactRoot, componentPath]);
+    }
+    return status;
   }
   const artifactDirectory = path.join(artifactRoot, runtime);
   const managedRuntimeServices = Array.isArray(pointer.managedRuntimeServices) ? pointer.managedRuntimeServices : [];
-  await preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices);
+  const status = await preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices);
   if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
     runScript('parse-test-results.sh', [artifactDirectory]);
   }
   if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
     runScript('parse-test-failures.sh', [artifactDirectory, componentPath]);
   }
+  return status;
 }
 async function preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices) {
   const filesDirectory = path.join(artifactDirectory, 'files');
@@ -527,15 +535,16 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   const aggregate = phpunitAggregate(output);
   let results;
   try { results = json(await readFile(testResultsPath, 'utf8'), null); } catch { results = null; }
-  if (!results && aggregate) {
-    results = { schema: 'wp-codebox/test-results/v1', status: aggregate.failed > 0 ? 'failed' : 'passed', summary: aggregate };
+  const validResults = validTestResults(results);
+  if (!validResults) {
+    results = { schema: 'wp-codebox/test-results/v1', status: 'unknown', summary: aggregate || emptyTestSummary(), suites: [], rawLogReferences: [] };
   }
   if (results && typeof results === 'object') {
     const summary = isObject(results.summary) ? results.summary : {};
     if (aggregate) {
       results.summary = { ...summary, ...aggregate };
-      results.status = aggregate.failed > 0 ? 'failed' : 'passed';
     }
+    results.status = normalizedTestStatus(results, aggregate, execution.status, validResults);
     const references = Array.isArray(results.rawLogReferences) ? results.rawLogReferences : [];
     results.rawLogReferences = [
       ...references.filter((reference) => reference?.path !== 'files/phpunit-output.log'),
@@ -559,6 +568,32 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   if (managedRuntimeServices.length > 0) {
     process.stdout.write('Managed runtime service evidence: artifact://files/managed-runtime-services.json\n');
   }
+  return results.status;
+}
+function validTestResults(results) {
+  if (!isObject(results) || results.schema !== 'wp-codebox/test-results/v1' || !['passed', 'failed', 'skipped', 'unknown'].includes(results.status) || !isObject(results.summary)) {
+    return false;
+  }
+  return ['total', 'passed', 'failed', 'skipped'].every((key) => Number.isInteger(results.summary[key]) && results.summary[key] >= 0);
+}
+function emptyTestSummary() {
+  return { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 };
+}
+function normalizedTestStatus(results, aggregate, executionStatus, validResults) {
+  if (executionStatus !== 0 || (validResults && results.status === 'failed') || aggregate?.failed > 0) {
+    return 'failed';
+  }
+  if (!validResults) {
+    return 'unknown';
+  }
+  const total = aggregate?.total ?? results.summary.total;
+  if (total === 0) {
+    return ['skip', 'skipped'].includes(settings.phpunit_no_tests || 'skipped') ? 'skipped' : 'failed';
+  }
+  if (results.status === 'unknown' && aggregate) {
+    return 'passed';
+  }
+  return results.status;
 }
 function extractPhpunitOutput(stdout, stderr) {
   const payload = json(stdout.trim(), null);

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { strict as assert } from 'node:assert';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -18,7 +18,7 @@ await mkdir(dependency, { recursive: true });
 await writeFile(path.join(component, 'plugin.php'), '<?php\n/**\n * Plugin Name: Provider Test\n */\n');
 await writeFile(path.join(dependency, 'composer.json'), '{}\n');
 await writeFile(cli, `#!/usr/bin/env node
-import { appendFile, readFile, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
 if (args[0] === 'runtime' && args[1] === 'descriptor') {
   const capabilities = process.env.OMIT_NATIVE_DATABASE_CAPABILITY === '1' ? [] : ['runtime-service:mysql:native:mariadb'];
@@ -55,12 +55,16 @@ if (args[0] === 'recipe' && args[1] === 'build') {
 }
 if (args[0] === 'recipe-run') {
   const recipe = JSON.parse(await readFile(args[args.indexOf('--recipe') + 1], 'utf8'));
+  const artifacts = args[args.indexOf('--artifacts') + 1];
   await appendFile(process.env.OBSERVED, JSON.stringify({ phase: 'run', recipe, args }) + '\\n');
   const configuration = recipe.inputs.services?.[0]?.configuration || {};
   for (const name of [configuration.hostEnv, configuration.portEnv, configuration.usernameEnv, configuration.passwordEnv].filter(Boolean)) {
     process.stdout.write('provider stdout ' + process.env[name] + '\\n');
     process.stderr.write('provider stderr ' + process.env[name] + '\\n');
   }
+  await mkdir(artifacts + '/runtime-fixture/files', { recursive: true });
+  await writeFile(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+  await writeFile(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: 'passed', summary: { total: 1, passed: 1, failed: 0, skipped: 0 }, suites: [], rawLogReferences: [] }));
 }
 `);
 await chmod(cli, 0o755);
@@ -73,6 +77,7 @@ function invoke(settings, env = {}) {
 function invokeSettingsJson(settingsJson, env = {}) {
   scenario += 1;
   const observed = path.join(root, `observed-${scenario}.jsonl`);
+  const artifacts = path.join(root, `artifacts-${scenario}`);
   const result = spawnSync(runner, [], {
     env: {
       ...process.env,
@@ -80,12 +85,13 @@ function invokeSettingsJson(settingsJson, env = {}) {
       COMPONENT_ID: 'provider-test',
       HOMEBOY_WP_CODEBOX_BIN: cli,
       HOMEBOY_SETTINGS_JSON: settingsJson,
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
       OBSERVED: observed,
       ...env,
     },
     encoding: 'utf8',
   });
-  return { result, observed };
+  return { result, observed, artifacts };
 }
 
 async function observations(file) {
@@ -94,6 +100,11 @@ async function observations(file) {
   } catch {
     return [];
   }
+}
+
+async function retainedRuntimeLog(invocation, file) {
+  const runDirectory = (await readdir(invocation.artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
+  return readFile(path.join(invocation.artifacts, runDirectory, 'runtime-fixture', 'logs', file), 'utf8');
 }
 
 function expectPreflightFailure(settings, pattern, env = {}) {
@@ -232,8 +243,8 @@ try {
   const policy = JSON.parse(externalObservations[1].args[externalObservations[1].args.indexOf('--policy') + 1]);
   assert.deepEqual(policy.network, { allowHosts: ['database.internal.example:3306'] });
   assert.equal(policy.approvals, 'on-write');
-  assert.match(externalInvocation.result.stdout, /provider stdout \[REDACTED\]/);
-  assert.match(externalInvocation.result.stderr, /provider stderr \[REDACTED\]/);
+  assert.match(await retainedRuntimeLog(externalInvocation, 'recipe-run.stdout.log'), /provider stdout \[REDACTED\]/);
+  assert.match(await retainedRuntimeLog(externalInvocation, 'recipe-run.stderr.log'), /provider stderr \[REDACTED\]/);
 
   const prepareInvocation = invoke({
     ...configured,

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -38,7 +38,7 @@ const mode = process.env.FIXTURE_MODE;
 if (mode !== 'crash') {
   fs.mkdirSync(artifacts + '/runtime-fixture/files', { recursive: true });
   fs.writeFileSync(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
-  fs.writeFileSync(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: mode === 'success' ? 'passed' : 'failed', summary: { total: mode === 'failure' ? 281 : 0, passed: 0, failed: 0, skipped: 0 } }));
+  fs.writeFileSync(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: 'unknown', summary: { total: mode === 'failure' ? 281 : 0, passed: 0, failed: 0, skipped: 0 } }));
 }
 const output = mode === 'success' ? 'OK (3 tests, 76 assertions)\\n' : 'ERRORS!\\nTests: 281, Assertions: 329, Errors: 46, Failures: 100.\\n';
 process.stdout.write(JSON.stringify({ executions: [{ stdout: output, stderr: '' }] }));
@@ -58,6 +58,10 @@ try {
     assert.equal(run.status, mode === 'success' ? 0 : 2, run.stderr);
     assert.deepEqual(JSON.parse(await readFile(results, 'utf8')), expected);
     const runArtifact = path.join(artifacts, (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.')));
+    if (mode !== 'crash') {
+      const artifactResults = JSON.parse(await readFile(path.join(runArtifact, 'runtime-fixture', 'files', 'test-results.json'), 'utf8'));
+      assert.equal(artifactResults.status, expected.failed > 0 ? 'failed' : 'passed');
+    }
     const options = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
     const profile = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-profile.json'), 'utf8'));
     const provenance = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -34,34 +34,50 @@ const value = (name) => args[args.indexOf(name) + 1];
 if (process.env.DISPATCHED) { fs.appendFileSync(process.env.DISPATCHED, JSON.stringify(args) + '\\n'); }
 if (args[0] === 'recipe') { fs.writeFileSync(value('--output'), JSON.stringify({ schema: 'wp-codebox/workspace-recipe/v1' })); process.exit(0); }
 const artifacts = value('--artifacts');
-const mode = process.env.FIXTURE_MODE;
-if (mode !== 'crash') {
+const fixture = JSON.parse(process.env.FIXTURE || '{}');
+if (!fixture.crash) {
   fs.mkdirSync(artifacts + '/runtime-fixture/files', { recursive: true });
-  fs.writeFileSync(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
-  fs.writeFileSync(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: 'unknown', summary: { total: mode === 'failure' ? 281 : 0, passed: 0, failed: 0, skipped: 0 } }));
+  fs.writeFileSync(artifacts + '/latest-runtime.json', fixture.pointer === 'malformed' ? '{}' : JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+  if (fixture.sidecar === 'malformed') {
+    fs.writeFileSync(artifacts + '/runtime-fixture/files/test-results.json', '{');
+  } else if (fixture.sidecar) {
+    fs.writeFileSync(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify(fixture.sidecar));
+  }
 }
-const output = mode === 'success' ? 'OK (3 tests, 76 assertions)\\n' : 'ERRORS!\\nTests: 281, Assertions: 329, Errors: 46, Failures: 100.\\n';
-process.stdout.write(JSON.stringify({ executions: [{ stdout: output, stderr: '' }] }));
-process.exitCode = mode === 'success' ? 0 : 2;
+process.stdout.write(JSON.stringify({ executions: [{ stdout: fixture.output || '', stderr: '' }] }));
+process.exitCode = fixture.exitCode || 0;
 `);
 await chmod(cli, 0o755);
 
 try {
-  for (const [mode, expected] of [
-    ['failure', { total: 281, passed: 135, failed: 146, skipped: 0 }],
-    ['success', { total: 3, passed: 3, failed: 0, skipped: 0 }],
-    ['crash', { total: 281, passed: 135, failed: 146, skipped: 0 }],
-  ]) {
-    const artifacts = path.join(root, `${mode}-artifacts`);
-    const results = path.join(root, `${mode}-results.json`);
-    const run = spawnSync(runner, [], { env: { ...process.env, FIXTURE_MODE: mode, HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: results, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [dependency] }) }, encoding: 'utf8' });
-    assert.equal(run.status, mode === 'success' ? 0 : 2, run.stderr);
-    assert.deepEqual(JSON.parse(await readFile(results, 'utf8')), expected);
+  const unknownSidecar = { schema: 'wp-codebox/test-results/v1', status: 'unknown', summary: { total: 0, passed: 0, failed: 0, skipped: 0 } };
+  const passedSidecar = { schema: 'wp-codebox/test-results/v1', status: 'passed', summary: { total: 3, passed: 3, failed: 0, skipped: 0 }, suites: [], rawLogReferences: [] };
+  const failedSidecar = { schema: 'wp-codebox/test-results/v1', status: 'failed', summary: { total: 3, passed: 3, failed: 0, skipped: 0 } };
+  const green = 'OK (3 tests, 76 assertions)\n';
+  const failures = 'ERRORS!\nTests: 281, Assertions: 329, Errors: 46, Failures: 100.\n';
+  const testCases = [
+    { name: 'unknown-green', fixture: { sidecar: unknownSidecar, output: green }, status: 0, artifactStatus: 'passed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'failed-green', fixture: { sidecar: failedSidecar, output: green }, status: 1, artifactStatus: 'failed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'nonzero-green', fixture: { sidecar: unknownSidecar, output: green, exitCode: 2 }, status: 2, artifactStatus: 'failed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'zero-tests', fixture: { sidecar: unknownSidecar, output: 'OK (0 tests, 0 assertions)\n' }, settings: { phpunit_no_tests: 'fail' }, status: 1, artifactStatus: 'failed', expected: { total: 0, passed: 0, failed: 0, skipped: 0 } },
+    { name: 'zero-tests-skipped', fixture: { sidecar: unknownSidecar, output: 'OK (0 tests, 0 assertions)\n' }, settings: { phpunit_no_tests: 'skipped' }, status: 0, artifactStatus: 'skipped', expected: { total: 0, passed: 0, failed: 0, skipped: 0 } },
+    { name: 'malformed-sidecar', fixture: { sidecar: 'malformed', output: green }, status: 1, artifactStatus: 'unknown', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'missing-sidecar', fixture: { output: green }, status: 1, artifactStatus: 'unknown', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'malformed-pointer', fixture: { pointer: 'malformed', output: green }, status: 1, artifactStatus: 'unknown', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'errors-and-failures', fixture: { sidecar: unknownSidecar, output: failures, exitCode: 2 }, status: 2, artifactStatus: 'failed', expected: { total: 281, passed: 135, failed: 146, skipped: 0 } },
+    { name: 'managed-passed', fixture: { sidecar: passedSidecar }, status: 0, artifactStatus: 'passed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'crash', fixture: { crash: true, output: failures, exitCode: 2 }, status: 2, artifactStatus: 'failed', expected: { total: 281, passed: 135, failed: 146, skipped: 0 } },
+  ];
+  for (const testCase of testCases) {
+    const artifacts = path.join(root, `${testCase.name}-artifacts`);
+    const results = path.join(root, `${testCase.name}-results.json`);
+    const run = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify(testCase.fixture), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: results, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [dependency], ...testCase.settings }) }, encoding: 'utf8' });
+    assert.equal(run.status, testCase.status, `${testCase.name}: ${run.stderr}`);
+    assert.deepEqual(JSON.parse(await readFile(results, 'utf8')), testCase.expected, testCase.name);
     const runArtifact = path.join(artifacts, (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.')));
-    if (mode !== 'crash') {
-      const artifactResults = JSON.parse(await readFile(path.join(runArtifact, 'runtime-fixture', 'files', 'test-results.json'), 'utf8'));
-      assert.equal(artifactResults.status, expected.failed > 0 ? 'failed' : 'passed');
-    }
+    const artifactDirectory = testCase.fixture.crash || testCase.fixture.pointer === 'malformed' ? runArtifact : path.join(runArtifact, 'runtime-fixture');
+    const artifactResults = JSON.parse(await readFile(path.join(artifactDirectory, 'files', 'test-results.json'), 'utf8'));
+    assert.equal(artifactResults.status, testCase.artifactStatus, testCase.name);
     const options = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
     const profile = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-profile.json'), 'utf8'));
     const provenance = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));
@@ -91,7 +107,7 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
       ...process.env,
       PATH: `${bin}:${process.env.PATH}`,
       DISPATCHED: dispatched,
-      FIXTURE_MODE: 'success',
+      FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }),
       HOMEBOY_COMPONENT_PATH: component,
       COMPONENT_ID: 'component',
       HOMEBOY_WP_CODEBOX_BIN: cli,

--- a/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
@@ -30,6 +30,7 @@ if (args[0] === 'recipe-run') {
   const artifacts = args[args.indexOf('--artifacts') + 1];
   await mkdir(artifacts + '/runtime-fixture/files', { recursive: true });
   await writeFile(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+  await writeFile(artifacts + '/runtime-fixture/files/test-results.json', JSON.stringify({ schema: 'wp-codebox/test-results/v1', status: 'passed', summary: { total: 1, passed: 1, failed: 0, skipped: 0 }, suites: [], rawLogReferences: [] }));
   process.stdout.write(JSON.stringify({ success: true }));
 }
 `);


### PR DESCRIPTION
## Summary
- derive the retained WP Codebox PHPUnit sidecar status from parsed aggregate counts
- cover green and failing runs that begin with an existing `status: unknown` sidecar
- prevent green managed PHPUnit runs from being reported as Homeboy failures

Closes #2435

## Verification
- `npm run test:wp-codebox-phpunit-aggregate`