### PR TITLE
Route composed Node tests in WordPress projects

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -27,7 +27,7 @@ assert_not_contains() {
 }
 
 component="${TMPDIR}/component"
-mkdir -p "${component}/tests/Unit" "${component}/wordpress/tests" "${component}/bin/tests/i18n-tools" "${TMPDIR}/stubs"
+mkdir -p "${component}/tests/Unit" "${component}/wordpress/tests" "${component}/tools" "${component}/bin/tests/i18n-tools" "${TMPDIR}/stubs"
 
 # Simulate a caller with a managed Codebox installation whose CLI and core module
 # are incompatible with this fixture. The smoke owns its runtime inputs below.
@@ -80,6 +80,13 @@ set -euo pipefail
 echo "shell contract smoke ran"
 SH
 chmod +x "${component}/tests/shell-contract-smoke.sh"
+
+cat > "${component}/tools/fixture-matrix.test.mjs" <<'JS'
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('composed Node test runs', () => assert.equal(2 + 2, 4));
+JS
 
 cat > "${component}/wordpress/tests/codebox-agent-task-matrix-smoke.js" <<'JS'
 console.log('prefixed codebox agent task matrix smoke ran');
@@ -277,6 +284,19 @@ HOMEBOY_TEST_SCOPE_ENV_VALUE=$'tests/import-agent-ability-smoke.php\ntests/queue
 assert_contains "${TMPDIR}/changed-smoke-files.out" "PHP_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
 assert_contains "${TMPDIR}/changed-smoke-files.out" "PHP_SMOKE_OK:tests/import-agent-ability-smoke.php"
 assert_contains "${TMPDIR}/changed-smoke-files.out" "PHP_SMOKE_SUMMARY:passed=1 failed=0"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_CHANGED_TEST_FILES="tools/fixture-matrix.test.mjs" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/node-test-file.out"
+
+assert_contains "${TMPDIR}/node-test-file.out" "Backend: node-test"
+assert_contains "${TMPDIR}/node-test-file.out" "NODE_TEST_BEGIN:tools/fixture-matrix.test.mjs"
+assert_contains "${TMPDIR}/node-test-file.out" "NODE_TEST_OK:tools/fixture-matrix.test.mjs"
+assert_contains "${TMPDIR}/node-test-file.out" "NODE_TEST_SUMMARY:passed=1 failed=0"
+assert_not_contains "${TMPDIR}/node-test-file.out" "WP_CODEBOX_STUB"
 assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/queue-routing-smoke.php"
 assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_SUMMARY:passed=1 failed=0"
 assert_not_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -406,6 +406,52 @@ homeboy_wordpress_is_js_smoke_file() {
     esac
 }
 
+homeboy_wordpress_is_node_test_file() {
+    case "$1" in
+        *.test.js|*.test.cjs|*.test.mjs)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+homeboy_wordpress_run_node_test_files() {
+    local test_files_raw="$1"
+    local node_bin="${HOMEBOY_NODE_BIN:-node}"
+    local test_file test_abs rel_path exit_code
+    local passed=0
+    local failed=0
+    local last_failure_exit=0
+
+    echo "Running Node test files..."
+    echo "  Component: ${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
+    echo "  Backend: node-test"
+
+    while IFS= read -r test_file; do
+        [ -n "$test_file" ] || continue
+        if ! rel_path="$(homeboy_wordpress_rel_test_file "$test_file")"; then
+            echo "ERROR: requested Node test file not found or outside the component: ${test_file}" >&2
+            return 2
+        fi
+        test_abs="${PLUGIN_PATH}/${rel_path}"
+        echo "NODE_TEST_BEGIN:${rel_path}"
+        if "$node_bin" --test "$test_abs"; then
+            echo "NODE_TEST_OK:${rel_path}"
+            passed=$((passed + 1))
+        else
+            exit_code=$?
+            echo "NODE_TEST_FAIL:${rel_path}:exit=${exit_code}"
+            failed=$((failed + 1))
+            last_failure_exit="$exit_code"
+        fi
+    done <<< "$test_files_raw"
+
+    echo "NODE_TEST_SUMMARY:passed=${passed} failed=${failed}"
+    [ "$failed" -eq 0 ] || return "$last_failure_exit"
+}
+
 homeboy_wordpress_run_shell_smoke_files() {
     local smoke_files_raw="$1"
     local smoke_files=()
@@ -512,6 +558,7 @@ fi
 if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     changed_js_smoke_files=""
     changed_shell_smoke_files=""
+    changed_node_test_files=""
     changed_non_host_smoke_files=0
     while IFS= read -r changed_test_file; do
         [ -n "$changed_test_file" ] || continue
@@ -529,19 +576,33 @@ if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
                 changed_shell_smoke_files+=$'\n'
             fi
             changed_shell_smoke_files+="$changed_test_rel"
+        elif homeboy_wordpress_is_node_test_file "$changed_test_rel"; then
+            if [ -n "$changed_node_test_files" ]; then
+                changed_node_test_files+=$'\n'
+            fi
+            changed_node_test_files+="$changed_test_rel"
         else
             changed_non_host_smoke_files=1
         fi
     done <<< "$HOMEBOY_CHANGED_TEST_FILES"
 
-    if [ -n "$changed_js_smoke_files" ] && [ -z "$changed_shell_smoke_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
+    if [ -n "$changed_js_smoke_files" ] && [ -z "$changed_shell_smoke_files" ] && [ -z "$changed_node_test_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
         homeboy_wordpress_run_js_smoke_files "$changed_js_smoke_files"
         exit 0
     fi
 
-    if [ -z "$changed_js_smoke_files" ] && [ -n "$changed_shell_smoke_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
+    if [ -z "$changed_js_smoke_files" ] && [ -n "$changed_shell_smoke_files" ] && [ -z "$changed_node_test_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
         homeboy_wordpress_run_shell_smoke_files "$changed_shell_smoke_files"
         exit 0
+    fi
+
+    if [ -z "$changed_js_smoke_files" ] && [ -z "$changed_shell_smoke_files" ] && [ -n "$changed_node_test_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
+        homeboy_wordpress_run_node_test_files "$changed_node_test_files"
+        exit $?
+    fi
+
+    if [ -n "$changed_node_test_files" ]; then
+        homeboy_wordpress_run_node_test_files "$changed_node_test_files" || exit $?
     fi
 fi
 
@@ -552,6 +613,11 @@ if [ -n "$TARGET_FILE" ]; then
     fi
 
     target_base="$(basename "$target_rel")"
+    if homeboy_wordpress_is_node_test_file "$target_rel"; then
+        homeboy_wordpress_run_node_test_files "$target_rel"
+        exit $?
+    fi
+
     if homeboy_wordpress_is_js_smoke_file "$target_rel"; then
         homeboy_wordpress_run_js_smoke_files "$target_rel"
         exit 0


### PR DESCRIPTION
## Summary

- route selected `*.test.js`, `*.test.cjs`, and `*.test.mjs` files through `node --test` inside the WordPress composition
- preserve WordPress as the sole capability and release owner for mixed WordPress/Node projects
- cover changed-file and direct-file routing with deterministic Node test markers

Fixes #2450.

Consumer evidence: https://github.com/Automattic/static-site-importer/pull/740
Failed before repair: https://github.com/Automattic/static-site-importer/actions/runs/30284484444

## Verification

- `HOMEBOY_RUNTIME_RUNNER_PRELUDE="$HOME/.config/homeboy/runtime/runner-prelude.sh" bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- routed `tools/fixture-matrix.test.mjs` from Static Site Importer through this source extension: 199 tests passed
- `git diff --check`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode diagnosed the mixed-runtime routing defect, drafted the router and regression coverage, and ran verification. Chris Huber reviewed and remains responsible for every line.