### PR TITLE
fix(wordpress): publish durable Codebox test artifacts

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -28,6 +28,15 @@ assert_not_contains() {
 
 component="${TMPDIR}/component"
 mkdir -p "${component}/tests/Unit" "${component}/wordpress/tests" "${component}/tools" "${component}/bin/tests/i18n-tools" "${TMPDIR}/stubs"
+runner_prelude="${TMPDIR}/runner-prelude.sh"
+cat > "${runner_prelude}" <<'SH'
+homeboy_runner_init() {
+    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:?HOMEBOY_COMPONENT_PATH is required}"
+    PLUGIN_PATH="$COMPONENT_PATH"
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:?HOMEBOY_EXTENSION_PATH is required}"
+}
+SH
+export HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude"
 
 # Simulate a caller with a managed Codebox installation whose CLI and core module
 # are incompatible with this fixture. The smoke owns its runtime inputs below.
@@ -245,6 +254,7 @@ SH
 chmod +x "${TMPDIR}/stubs/npm"
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
@@ -297,6 +307,21 @@ assert_contains "${TMPDIR}/node-test-file.out" "NODE_TEST_BEGIN:tools/fixture-ma
 assert_contains "${TMPDIR}/node-test-file.out" "NODE_TEST_OK:tools/fixture-matrix.test.mjs"
 assert_contains "${TMPDIR}/node-test-file.out" "NODE_TEST_SUMMARY:passed=1 failed=0"
 assert_not_contains "${TMPDIR}/node-test-file.out" "WP_CODEBOX_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_CHANGED_TEST_FILES=$'tools/fixture-matrix.test.mjs\ntests/Unit/ImportAgentAbilityTest.php' \
+HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/mixed-test-files.out"
+
+assert_contains "${TMPDIR}/mixed-test-files.out" "NODE_TEST_BEGIN:tools/fixture-matrix.test.mjs"
+assert_contains "${TMPDIR}/mixed-test-files.out" "NODE_TEST_OK:tools/fixture-matrix.test.mjs"
+assert_contains "${TMPDIR}/mixed-test-files.out" "WP_CODEBOX_STUB"
+assert_contains "${TMPDIR}/mixed-test-files.out" "CHANGED=tools/fixture-matrix.test.mjs"
+assert_contains "${TMPDIR}/mixed-test-files.out" "tests/Unit/ImportAgentAbilityTest.php"
 assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/queue-routing-smoke.php"
 assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_SUMMARY:passed=1 failed=0"
 assert_not_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -587,8 +587,10 @@ async function withInvocationArtifactLock(invocationRoot, action) {
   let lease;
   for (let attempt = 0; attempt < 100; attempt += 1) {
     try {
+      const startToken = await processStartToken(process.pid);
+      if (!startToken) { throw new Error('Cannot establish WP Codebox publication lock process identity'); }
       await mkdir(lockPath, { mode: 0o700 });
-      const metadata = { schema: 'homeboy/wp-codebox-publication-lease/v1', pid: process.pid, hostname: hostname(), acquired_at: new Date().toISOString(), token: `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}` };
+      const metadata = { schema: 'homeboy/wp-codebox-publication-lease/v1', pid: process.pid, hostname: hostname(), start_token: startToken, acquired_at: new Date().toISOString(), token: `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}` };
       await atomicWrite(path.join(lockPath, 'owner.json'), `${JSON.stringify(metadata)}\n`);
       const readyFile = process.env.HOMEBOY_WP_CODEBOX_PUBLICATION_LOCK_READY_FILE;
       if (readyFile) { await atomicWrite(readyFile, `${JSON.stringify(metadata)}\n`); }
@@ -627,7 +629,7 @@ async function reclaimDeadInvocationArtifactLock(lockPath) {
   // atomic owner metadata publication. Wait out that short setup window; a
   // crashed owner without a lease remains fail-closed when the bounded wait ends.
   if (!metadata) { return false; }
-  const liveness = invocationArtifactLeaseLiveness(metadata);
+  const liveness = await invocationArtifactLeaseLiveness(metadata);
   if (liveness === 'live') { return false; }
   if (liveness !== 'dead') { throw new Error('WP Codebox publication lock has unknown ownership'); }
 
@@ -639,7 +641,7 @@ async function reclaimDeadInvocationArtifactLock(lockPath) {
     throw error;
   }
   const quarantinedMetadata = await readInvocationArtifactLease(path.join(quarantine, 'owner.json'));
-  if (invocationArtifactLeaseLiveness(quarantinedMetadata) !== 'dead') {
+  if (await invocationArtifactLeaseLiveness(quarantinedMetadata) !== 'dead') {
     throw new Error('WP Codebox publication lock ownership changed during reclaim');
   }
   await rm(quarantine, { recursive: true, force: true });
@@ -649,20 +651,39 @@ async function readInvocationArtifactLease(leasePath) {
   try {
     await assertRegularOrMissing(leasePath);
     const metadata = JSON.parse(await readFile(leasePath, 'utf8'));
-    return isObject(metadata) && metadata.schema === 'homeboy/wp-codebox-publication-lease/v1' && Number.isInteger(metadata.pid) && metadata.pid > 0 && typeof metadata.hostname === 'string' && metadata.hostname !== '' && typeof metadata.token === 'string' && metadata.token !== '' ? metadata : null;
+    return isObject(metadata) && metadata.schema === 'homeboy/wp-codebox-publication-lease/v1' && Number.isInteger(metadata.pid) && metadata.pid > 0 && typeof metadata.hostname === 'string' && metadata.hostname !== '' && typeof metadata.start_token === 'string' && metadata.start_token !== '' && typeof metadata.token === 'string' && metadata.token !== '' ? metadata : null;
   } catch {
     return null;
   }
 }
-function invocationArtifactLeaseLiveness(metadata) {
+async function invocationArtifactLeaseLiveness(metadata) {
   if (!metadata || metadata.hostname !== hostname()) { return 'unknown'; }
   try {
     process.kill(metadata.pid, 0);
-    return 'live';
   } catch (error) {
     if (error.code === 'ESRCH') { return 'dead'; }
     return 'unknown';
   }
+  const startToken = await processStartToken(metadata.pid);
+  if (!startToken) { return 'unknown'; }
+  return startToken === metadata.start_token ? 'live' : 'dead';
+}
+async function processStartToken(pid) {
+  if (process.platform === 'linux') {
+    try {
+      const stat = await readFile(`/proc/${pid}/stat`, 'utf8');
+      const close = stat.lastIndexOf(')');
+      const fields = close === -1 ? [] : stat.slice(close + 1).trim().split(/\s+/);
+      const startTime = fields[19];
+      if (/^\d+$/.test(startTime || '')) { return `linux:${startTime}`; }
+    } catch {}
+  }
+  if (['darwin', 'linux', 'freebsd'].includes(process.platform)) {
+    const result = spawnSync('ps', ['-o', 'lstart=', '-p', String(pid)], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 1000 });
+    const startTime = result.status === 0 ? result.stdout.trim().replace(/\s+/g, ' ') : '';
+    if (startTime) { return `ps:${startTime}`; }
+  }
+  return '';
 }
 async function assertDirectoryTree(directoryRoot, segments) {
   const rootStat = await lstat(directoryRoot);

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -482,36 +482,94 @@ async function handoffArtifacts(artifactRoot, execution) {
     // A crashed workload may never write a runtime pointer. Preserve and parse
     // the captured aggregate at the stable artifact root rather than reporting
     // a zero-test run.
-    const status = await preservePhpunitOutput(artifactRoot, execution, []);
-    if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
-      runScript('parse-test-results.sh', [artifactRoot]);
-    }
-    if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
-      runScript('parse-test-failures.sh', [artifactRoot, componentPath]);
-    }
-    return status;
+    return parsePublishedArtifacts(await publishPhpunitArtifacts(
+      artifactRoot,
+      await preservePhpunitOutput(artifactRoot, execution, []),
+    ));
   }
   const runtime = pointer?.paths?.runtimeDirectory;
   if (typeof runtime !== 'string' || !/^runtime-[A-Za-z0-9][A-Za-z0-9-]*$/.test(runtime)) {
-    const status = await preservePhpunitOutput(artifactRoot, execution, []);
-    if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
-      runScript('parse-test-results.sh', [artifactRoot]);
-    }
-    if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
-      runScript('parse-test-failures.sh', [artifactRoot, componentPath]);
-    }
-    return status;
+    return parsePublishedArtifacts(await publishPhpunitArtifacts(
+      artifactRoot,
+      await preservePhpunitOutput(artifactRoot, execution, []),
+    ));
   }
   const artifactDirectory = path.join(artifactRoot, runtime);
   const managedRuntimeServices = Array.isArray(pointer.managedRuntimeServices) ? pointer.managedRuntimeServices : [];
-  const status = await preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices);
+  return parsePublishedArtifacts(await publishPhpunitArtifacts(
+    artifactDirectory,
+    await preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices),
+  ));
+}
+async function publishPhpunitArtifacts(artifactDirectory, status) {
+  const invocationArtifacts = process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR;
+  if (!invocationArtifacts) {
+    return { directory: artifactDirectory, status, failuresPath: '' };
+  }
+
+  const publishedFilesDirectory = path.join(invocationArtifacts, 'wp-codebox-phpunit', 'files');
+  const files = [
+    { name: 'test-results.json', kind: 'test-results', role: 'structured-test-results', semantic_key: 'test_results', content_type: 'application/json' },
+    { name: 'phpunit-output.log', kind: 'phpunit-output', role: 'raw-test-output', semantic_key: 'phpunit_output', content_type: 'text/plain' },
+  ];
+  await mkdir(publishedFilesDirectory, { recursive: true });
+  for (const file of files) {
+    await copyFile(path.join(artifactDirectory, 'files', file.name), path.join(publishedFilesDirectory, file.name));
+  }
+  await registerInvocationArtifacts(invocationArtifacts, files.map((file) => ({
+    ...file,
+    path: path.join('wp-codebox-phpunit', 'files', file.name).replaceAll(path.sep, '/'),
+  })));
+  return { directory: path.join(invocationArtifacts, 'wp-codebox-phpunit'), status, failuresPath: path.join(publishedFilesDirectory, 'test-failures.json') };
+}
+async function parsePublishedArtifacts(published) {
   if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
-    runScript('parse-test-results.sh', [artifactDirectory]);
+    runScript('parse-test-results.sh', [published.directory]);
   }
-  if (process.env.HOMEBOY_TEST_FAILURES_FILE) {
-    runScript('parse-test-failures.sh', [artifactDirectory, componentPath]);
+  if (process.env.HOMEBOY_TEST_FAILURES_FILE || published.failuresPath) {
+    const requestedFailuresPath = process.env.HOMEBOY_TEST_FAILURES_FILE;
+    if (published.failuresPath) {
+      process.env.HOMEBOY_TEST_FAILURES_FILE = published.failuresPath;
+    }
+    runScript('parse-test-failures.sh', [published.directory, componentPath]);
+    if (published.failuresPath) {
+      await registerInvocationArtifacts(process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR, [{
+        name: 'test-failures.json',
+        path: 'wp-codebox-phpunit/files/test-failures.json',
+        kind: 'test-failures',
+        role: 'structured-test-failures',
+        semantic_key: 'test_failures',
+        content_type: 'application/json',
+      }]);
+      if (requestedFailuresPath && requestedFailuresPath !== published.failuresPath) {
+        await copyFile(published.failuresPath, requestedFailuresPath);
+      }
+      if (requestedFailuresPath) {
+        process.env.HOMEBOY_TEST_FAILURES_FILE = requestedFailuresPath;
+      } else {
+        delete process.env.HOMEBOY_TEST_FAILURES_FILE;
+      }
+    }
   }
-  return status;
+  return published.status;
+}
+async function registerInvocationArtifacts(invocationRoot, publishedArtifacts) {
+  const manifestPath = path.join(invocationRoot, 'homeboy-artifact-manifest.json');
+  let manifest = { schema: 'homeboy/artifact-manifest/v1', artifacts: [] };
+  try {
+    manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  } catch (error) {
+    if (error.code !== 'ENOENT') { throw error; }
+  }
+  if (!isObject(manifest) || manifest.schema !== 'homeboy/artifact-manifest/v1') {
+    throw new Error('HOMEBOY_INVOCATION_ARTIFACT_DIR contains an invalid artifact manifest');
+  }
+  const existing = Array.isArray(manifest.artifacts) ? manifest.artifacts : [];
+  manifest.artifacts = [
+    ...existing.filter((entry) => !publishedArtifacts.some((artifact) => artifact.path === entry?.path)),
+    ...publishedArtifacts.map(({ name, ...artifact }) => ({ id: name, label: name, ...artifact })),
+  ];
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 async function preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices) {
   const filesDirectory = path.join(artifactDirectory, 'files');

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -3,8 +3,8 @@
  * External dependencies
  */
 import { createWriteStream } from 'node:fs';
-import { access, copyFile, lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, unlink, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { access, copyFile, lstat, mkdir, mkdtemp, readdir, readFile, realpath, rename, rm, unlink, writeFile } from 'node:fs/promises';
+import { hostname, tmpdir } from 'node:os';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { fileURLToPath } from 'node:url';
@@ -584,22 +584,84 @@ async function registerInvocationArtifacts(invocationRoot, publishedArtifacts) {
 async function withInvocationArtifactLock(invocationRoot, action) {
   await assertDirectoryTree(invocationRoot, []);
   const lockPath = path.join(invocationRoot, '.wp-codebox-phpunit-publication.lock');
-  let lock;
+  let lease;
   for (let attempt = 0; attempt < 100; attempt += 1) {
     try {
-      lock = await open(lockPath, 'wx', 0o600);
+      await mkdir(lockPath, { mode: 0o700 });
+      const metadata = { schema: 'homeboy/wp-codebox-publication-lease/v1', pid: process.pid, hostname: hostname(), acquired_at: new Date().toISOString(), token: `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}` };
+      await atomicWrite(path.join(lockPath, 'owner.json'), `${JSON.stringify(metadata)}\n`);
+      const readyFile = process.env.HOMEBOY_WP_CODEBOX_PUBLICATION_LOCK_READY_FILE;
+      if (readyFile) { await atomicWrite(readyFile, `${JSON.stringify(metadata)}\n`); }
+      const holdMilliseconds = Number(process.env.HOMEBOY_WP_CODEBOX_PUBLICATION_LOCK_HOLD_MS || 0);
+      if (Number.isFinite(holdMilliseconds) && holdMilliseconds > 0) { await new Promise((resolve) => setTimeout(resolve, holdMilliseconds)); }
+      lease = { path: lockPath, token: metadata.token };
       break;
     } catch (error) {
       if (error.code !== 'EEXIST') { throw error; }
+      const reclaimed = await reclaimDeadInvocationArtifactLock(lockPath);
+      if (reclaimed) { continue; }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
   }
-  if (!lock) { throw new Error('Timed out waiting to publish WP Codebox test artifacts'); }
+  if (!lease) { throw new Error('Timed out waiting to publish WP Codebox test artifacts'); }
   try {
     return await action();
   } finally {
-    await lock.close();
-    await unlink(lockPath).catch(() => {});
+    const metadata = await readInvocationArtifactLease(path.join(lease.path, 'owner.json'));
+    if (metadata?.token === lease.token) {
+      await rm(lease.path, { recursive: true, force: true });
+    }
+  }
+}
+async function reclaimDeadInvocationArtifactLock(lockPath) {
+  let stat;
+  try { stat = await lstat(lockPath); } catch (error) {
+    if (error.code === 'ENOENT') { return true; }
+    throw error;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error('WP Codebox publication lock has unknown ownership');
+  }
+  const metadata = await readInvocationArtifactLease(path.join(lockPath, 'owner.json'));
+  // A contender can observe the directory between atomic mkdir acquisition and
+  // atomic owner metadata publication. Wait out that short setup window; a
+  // crashed owner without a lease remains fail-closed when the bounded wait ends.
+  if (!metadata) { return false; }
+  const liveness = invocationArtifactLeaseLiveness(metadata);
+  if (liveness === 'live') { return false; }
+  if (liveness !== 'dead') { throw new Error('WP Codebox publication lock has unknown ownership'); }
+
+  const quarantine = `${lockPath}.reclaimed-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  try {
+    await rename(lockPath, quarantine);
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'EEXIST') { return true; }
+    throw error;
+  }
+  const quarantinedMetadata = await readInvocationArtifactLease(path.join(quarantine, 'owner.json'));
+  if (invocationArtifactLeaseLiveness(quarantinedMetadata) !== 'dead') {
+    throw new Error('WP Codebox publication lock ownership changed during reclaim');
+  }
+  await rm(quarantine, { recursive: true, force: true });
+  return true;
+}
+async function readInvocationArtifactLease(leasePath) {
+  try {
+    await assertRegularOrMissing(leasePath);
+    const metadata = JSON.parse(await readFile(leasePath, 'utf8'));
+    return isObject(metadata) && metadata.schema === 'homeboy/wp-codebox-publication-lease/v1' && Number.isInteger(metadata.pid) && metadata.pid > 0 && typeof metadata.hostname === 'string' && metadata.hostname !== '' && typeof metadata.token === 'string' && metadata.token !== '' ? metadata : null;
+  } catch {
+    return null;
+  }
+}
+function invocationArtifactLeaseLiveness(metadata) {
+  if (!metadata || metadata.hostname !== hostname()) { return 'unknown'; }
+  try {
+    process.kill(metadata.pid, 0);
+    return 'live';
+  } catch (error) {
+    if (error.code === 'ESRCH') { return 'dead'; }
+    return 'unknown';
   }
 }
 async function assertDirectoryTree(directoryRoot, segments) {

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { createWriteStream } from 'node:fs';
-import { access, copyFile, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
@@ -507,20 +507,28 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
     return { directory: artifactDirectory, status, failuresPath: '' };
   }
 
-  const publishedFilesDirectory = path.join(invocationArtifacts, 'wp-codebox-phpunit', 'files');
+  const publishedDirectory = path.join(invocationArtifacts, 'wp-codebox-phpunit');
+  const publishedFilesDirectory = path.join(publishedDirectory, 'files');
   const files = [
     { name: 'test-results.json', kind: 'test-results', role: 'structured-test-results', semantic_key: 'test_results', content_type: 'application/json' },
     { name: 'phpunit-output.log', kind: 'phpunit-output', role: 'raw-test-output', semantic_key: 'phpunit_output', content_type: 'text/plain' },
+    { name: 'test-failures.json', kind: 'test-failures', role: 'structured-test-failures', semantic_key: 'test_failures', content_type: 'application/json' },
   ];
-  await mkdir(publishedFilesDirectory, { recursive: true });
-  for (const file of files) {
-    await copyFile(path.join(artifactDirectory, 'files', file.name), path.join(publishedFilesDirectory, file.name));
-  }
-  await registerInvocationArtifacts(invocationArtifacts, files.map((file) => ({
-    ...file,
-    path: path.join('wp-codebox-phpunit', 'files', file.name).replaceAll(path.sep, '/'),
-  })));
-  return { directory: path.join(invocationArtifacts, 'wp-codebox-phpunit'), status, failuresPath: path.join(publishedFilesDirectory, 'test-failures.json') };
+  await withInvocationArtifactLock(invocationArtifacts, async () => {
+    await assertDirectoryTree(invocationArtifacts, ['wp-codebox-phpunit', 'files']);
+    await assertDirectoryTree(artifactDirectory, ['files']);
+    for (const file of files.slice(0, 2)) {
+      await atomicCopy(path.join(artifactDirectory, 'files', file.name), path.join(publishedFilesDirectory, file.name));
+    }
+    // The parser replaces this durable placeholder atomically. Its registration
+    // survives a parser crash so reviewers can still locate the expected evidence.
+    await atomicWrite(path.join(publishedFilesDirectory, 'test-failures.json'), '{}\n');
+    await registerInvocationArtifacts(invocationArtifacts, files.map((file) => ({
+      ...file,
+      path: path.join('wp-codebox-phpunit', 'files', file.name).replaceAll(path.sep, '/'),
+    })));
+  });
+  return { directory: publishedDirectory, status, failuresPath: path.join(publishedFilesDirectory, 'test-failures.json') };
 }
 async function parsePublishedArtifacts(published) {
   if (process.env.HOMEBOY_TEST_RESULTS_FILE) {
@@ -528,22 +536,23 @@ async function parsePublishedArtifacts(published) {
   }
   if (process.env.HOMEBOY_TEST_FAILURES_FILE || published.failuresPath) {
     const requestedFailuresPath = process.env.HOMEBOY_TEST_FAILURES_FILE;
+    const temporaryFailuresPath = published.failuresPath ? `${published.failuresPath}.${process.pid}.parse` : requestedFailuresPath;
     if (published.failuresPath) {
-      process.env.HOMEBOY_TEST_FAILURES_FILE = published.failuresPath;
+      process.env.HOMEBOY_TEST_FAILURES_FILE = temporaryFailuresPath;
     }
-    runScript('parse-test-failures.sh', [published.directory, componentPath]);
-    if (published.failuresPath) {
-      await registerInvocationArtifacts(process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR, [{
-        name: 'test-failures.json',
-        path: 'wp-codebox-phpunit/files/test-failures.json',
-        kind: 'test-failures',
-        role: 'structured-test-failures',
-        semantic_key: 'test_failures',
-        content_type: 'application/json',
-      }]);
-      if (requestedFailuresPath && requestedFailuresPath !== published.failuresPath) {
-        await copyFile(published.failuresPath, requestedFailuresPath);
+    try {
+      runScript('parse-test-failures.sh', [published.directory, componentPath]);
+      if (published.failuresPath) {
+        await withInvocationArtifactLock(process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR, async () => {
+          await assertDirectoryTree(process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR, ['wp-codebox-phpunit', 'files']);
+          await atomicCopy(temporaryFailuresPath, published.failuresPath);
+        });
+        if (requestedFailuresPath && requestedFailuresPath !== published.failuresPath) {
+          await atomicCopy(published.failuresPath, requestedFailuresPath);
+        }
       }
+    } finally {
+      if (published.failuresPath) { await unlink(temporaryFailuresPath).catch(() => {}); }
       if (requestedFailuresPath) {
         process.env.HOMEBOY_TEST_FAILURES_FILE = requestedFailuresPath;
       } else {
@@ -555,13 +564,14 @@ async function parsePublishedArtifacts(published) {
 }
 async function registerInvocationArtifacts(invocationRoot, publishedArtifacts) {
   const manifestPath = path.join(invocationRoot, 'homeboy-artifact-manifest.json');
+  await assertRegularOrMissing(manifestPath);
   let manifest = { schema: 'homeboy/artifact-manifest/v1', artifacts: [] };
   try {
     manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
   } catch (error) {
     if (error.code !== 'ENOENT') { throw error; }
   }
-  if (!isObject(manifest) || manifest.schema !== 'homeboy/artifact-manifest/v1') {
+  if (!isObject(manifest) || manifest.schema !== 'homeboy/artifact-manifest/v1' || (Object.hasOwn(manifest, 'artifacts') && !Array.isArray(manifest.artifacts))) {
     throw new Error('HOMEBOY_INVOCATION_ARTIFACT_DIR contains an invalid artifact manifest');
   }
   const existing = Array.isArray(manifest.artifacts) ? manifest.artifacts : [];
@@ -569,7 +579,71 @@ async function registerInvocationArtifacts(invocationRoot, publishedArtifacts) {
     ...existing.filter((entry) => !publishedArtifacts.some((artifact) => artifact.path === entry?.path)),
     ...publishedArtifacts.map(({ name, ...artifact }) => ({ id: name, label: name, ...artifact })),
   ];
-  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  await atomicWrite(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+async function withInvocationArtifactLock(invocationRoot, action) {
+  await assertDirectoryTree(invocationRoot, []);
+  const lockPath = path.join(invocationRoot, '.wp-codebox-phpunit-publication.lock');
+  let lock;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      lock = await open(lockPath, 'wx', 0o600);
+      break;
+    } catch (error) {
+      if (error.code !== 'EEXIST') { throw error; }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  if (!lock) { throw new Error('Timed out waiting to publish WP Codebox test artifacts'); }
+  try {
+    return await action();
+  } finally {
+    await lock.close();
+    await unlink(lockPath).catch(() => {});
+  }
+}
+async function assertDirectoryTree(directoryRoot, segments) {
+  const rootStat = await lstat(directoryRoot);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error(`WP Codebox artifact directory must be a non-symlink directory: ${directoryRoot}`);
+  }
+  const canonicalRoot = await realpath(directoryRoot);
+  let current = directoryRoot;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    try {
+      const stat = await lstat(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) { throw new Error(`WP Codebox artifact directory contains a symlink or non-directory: ${current}`); }
+    } catch (error) {
+      if (error.code !== 'ENOENT') { throw error; }
+      await mkdir(current);
+    }
+    const canonicalCurrent = await realpath(current);
+    if (canonicalCurrent !== canonicalRoot && !canonicalCurrent.startsWith(`${canonicalRoot}${path.sep}`)) {
+      throw new Error(`WP Codebox artifact directory escapes its invocation root: ${current}`);
+    }
+  }
+}
+async function assertRegularOrMissing(target) {
+  try {
+    const stat = await lstat(target);
+    if (!stat.isFile() || stat.isSymbolicLink()) { throw new Error(`WP Codebox artifact target must be a non-symlink file: ${target}`); }
+  } catch (error) {
+    if (error.code !== 'ENOENT') { throw error; }
+  }
+}
+async function atomicCopy(source, target) {
+  await assertRegularOrMissing(source);
+  await assertRegularOrMissing(target);
+  const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
+  await copyFile(source, temporary);
+  await rename(temporary, target);
+}
+async function atomicWrite(target, content) {
+  await assertRegularOrMissing(target);
+  const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(temporary, content);
+  await rename(temporary, target);
 }
 async function preservePhpunitOutput(artifactDirectory, execution, managedRuntimeServices) {
   const filesDirectory = path.join(artifactDirectory, 'files');

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import { strict as assert } from 'node:assert';
-import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 const extension = path.resolve(import.meta.dirname, '..');
 const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
@@ -145,6 +145,70 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
   const metadataProvenance = JSON.parse(await readFile(path.join(metadataRunArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));
   assert.deepEqual(metadataOptions.extra_plugins.slice(1), [{ source: dataMachine, slug: 'data-machine', activate: true }]);
   assert.deepEqual(metadataProvenance.source_refs.slice(1), [{ slug: 'data-machine', source: dataMachine }]);
+
+  const malformedManifestArtifacts = path.join(root, 'malformed-manifest-artifacts');
+  await mkdir(malformedManifestArtifacts);
+  await writeFile(path.join(malformedManifestArtifacts, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1","artifacts":{}}\n');
+  const malformedManifestRun = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'malformed-manifest-run'), HOMEBOY_INVOCATION_ARTIFACT_DIR: malformedManifestArtifacts, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, 'malformed-manifest-results.json'), HOMEBOY_SETTINGS_JSON: '{}' }, encoding: 'utf8' });
+  assert.notEqual(malformedManifestRun.status, 0);
+  assert.match(malformedManifestRun.stderr, /invalid artifact manifest/);
+
+  for (const symlinkCase of ['root', 'directory', 'manifest']) {
+    const invocationRoot = path.join(root, `symlink-${symlinkCase}`);
+    const target = path.join(root, `symlink-${symlinkCase}-target`);
+    await mkdir(target, { recursive: true });
+    if (symlinkCase === 'root') {
+      await symlink(target, invocationRoot);
+    } else {
+      await mkdir(invocationRoot);
+      await writeFile(path.join(invocationRoot, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
+      if (symlinkCase === 'directory') {
+        await symlink(target, path.join(invocationRoot, 'wp-codebox-phpunit'));
+      } else {
+        await rm(path.join(invocationRoot, 'homeboy-artifact-manifest.json'));
+        await symlink(path.join(target, 'manifest.json'), path.join(invocationRoot, 'homeboy-artifact-manifest.json'));
+      }
+    }
+    const rejected = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, `symlink-${symlinkCase}-run`), HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationRoot, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, `symlink-${symlinkCase}-results.json`), HOMEBOY_SETTINGS_JSON: '{}' }, encoding: 'utf8' });
+    assert.notEqual(rejected.status, 0, symlinkCase);
+    assert.match(rejected.stderr, /non-symlink|symlink/, symlinkCase);
+  }
+
+  const parserFailureInvocation = path.join(root, 'parser-failure-invocation');
+  const parserFailureBin = path.join(root, 'parser-failure-bin');
+  await mkdir(parserFailureInvocation);
+  await mkdir(parserFailureBin);
+  await writeFile(path.join(parserFailureInvocation, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
+  await writeFile(path.join(parserFailureBin, 'php'), '#!/usr/bin/env sh\nexit 1\n');
+  await chmod(path.join(parserFailureBin, 'php'), 0o755);
+  const parserFailureRun = spawnSync(runner, [], { env: { ...process.env, PATH: `${parserFailureBin}:${process.env.PATH}`, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'parser-failure-run'), HOMEBOY_INVOCATION_ARTIFACT_DIR: parserFailureInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, 'parser-failure-results.json'), HOMEBOY_TEST_FAILURES_FILE: path.join(root, 'parser-failure-failures.json'), HOMEBOY_SETTINGS_JSON: '{}' }, encoding: 'utf8' });
+  assert.notEqual(parserFailureRun.status, 0);
+  const parserFailureManifest = JSON.parse(await readFile(path.join(parserFailureInvocation, 'homeboy-artifact-manifest.json'), 'utf8'));
+  assert.ok(parserFailureManifest.artifacts.some((artifact) => artifact.path === 'wp-codebox-phpunit/files/test-failures.json'));
+  assert.equal(await readFile(path.join(parserFailureInvocation, 'wp-codebox-phpunit/files/test-failures.json'), 'utf8'), '{}\n');
+
+  const concurrentInvocation = path.join(root, 'concurrent-invocation');
+  await mkdir(concurrentInvocation);
+  await writeFile(path.join(concurrentInvocation, 'homeboy-artifact-manifest.json'), JSON.stringify({ schema: 'homeboy/artifact-manifest/v1', artifacts: [{ id: 'unrelated', path: 'unrelated.json', kind: 'proof', provenance: { producer: 'fixture' } }] }));
+  await writeFile(path.join(concurrentInvocation, 'unrelated.json'), '{}\n');
+  const concurrentRun = (index) => new Promise((resolve, reject) => {
+    const child = spawn(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, `concurrent-run-${index}`), HOMEBOY_INVOCATION_ARTIFACT_DIR: concurrentInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, `concurrent-results-${index}.json`), HOMEBOY_SETTINGS_JSON: '{}' }, stdio: 'ignore' });
+    child.on('error', reject);
+    child.on('close', (status) => resolve(status));
+  });
+  let atomicReaderError;
+  let atomicReaderReads = 0;
+  const reader = setInterval(() => {
+    readFile(path.join(concurrentInvocation, 'homeboy-artifact-manifest.json'), 'utf8').then((text) => { JSON.parse(text); atomicReaderReads += 1; }).catch((error) => { atomicReaderError ||= error; });
+  }, 1);
+  const concurrentStatuses = await Promise.all([concurrentRun(1), concurrentRun(2)]);
+  clearInterval(reader);
+  assert.deepEqual(concurrentStatuses, [0, 0]);
+  assert.ok(atomicReaderReads > 0);
+  assert.equal(atomicReaderError, undefined);
+  const concurrentManifest = JSON.parse(await readFile(path.join(concurrentInvocation, 'homeboy-artifact-manifest.json'), 'utf8'));
+  assert.equal(concurrentManifest.artifacts.find((artifact) => artifact.id === 'unrelated').provenance.producer, 'fixture');
+  assert.equal(concurrentManifest.artifacts.filter((artifact) => artifact.path === 'wp-codebox-phpunit/files/test-results.json').length, 1);
 } finally {
   await rm(root, { recursive: true, force: true });
 }

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -192,9 +192,11 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
   await writeFile(path.join(concurrentInvocation, 'homeboy-artifact-manifest.json'), JSON.stringify({ schema: 'homeboy/artifact-manifest/v1', artifacts: [{ id: 'unrelated', path: 'unrelated.json', kind: 'proof', provenance: { producer: 'fixture' } }] }));
   await writeFile(path.join(concurrentInvocation, 'unrelated.json'), '{}\n');
   const concurrentRun = (index) => new Promise((resolve, reject) => {
-    const child = spawn(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, `concurrent-run-${index}`), HOMEBOY_INVOCATION_ARTIFACT_DIR: concurrentInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, `concurrent-results-${index}.json`), HOMEBOY_SETTINGS_JSON: '{}' }, stdio: 'ignore' });
+    const child = spawn(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, `concurrent-run-${index}`), HOMEBOY_INVOCATION_ARTIFACT_DIR: concurrentInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, `concurrent-results-${index}.json`), HOMEBOY_SETTINGS_JSON: '{}' }, stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
     child.on('error', reject);
-    child.on('close', (status) => resolve(status));
+    child.on('close', (status) => resolve({ status, stderr }));
   });
   let atomicReaderError;
   let atomicReaderReads = 0;
@@ -203,14 +205,49 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
   }, 1);
   const concurrentStatuses = await Promise.all([concurrentRun(1), concurrentRun(2)]);
   clearInterval(reader);
-  assert.deepEqual(concurrentStatuses, [0, 0]);
+  assert.deepEqual(concurrentStatuses.map(({ status }) => status), [0, 0], concurrentStatuses.map(({ stderr }) => stderr).join('\n'));
   assert.ok(atomicReaderReads > 0);
   assert.equal(atomicReaderError, undefined);
   const concurrentManifest = JSON.parse(await readFile(path.join(concurrentInvocation, 'homeboy-artifact-manifest.json'), 'utf8'));
   assert.equal(concurrentManifest.artifacts.find((artifact) => artifact.id === 'unrelated').provenance.producer, 'fixture');
   assert.equal(concurrentManifest.artifacts.filter((artifact) => artifact.path === 'wp-codebox-phpunit/files/test-results.json').length, 1);
+
+  const crashedInvocation = path.join(root, 'crashed-invocation');
+  const crashedReady = path.join(root, 'crashed-lock-ready.json');
+  await mkdir(crashedInvocation);
+  await writeFile(path.join(crashedInvocation, 'homeboy-artifact-manifest.json'), JSON.stringify({ schema: 'homeboy/artifact-manifest/v1', artifacts: [{ id: 'unrelated', path: 'unrelated.json', kind: 'proof', provenance: { producer: 'fixture' } }] }));
+  await writeFile(path.join(crashedInvocation, 'unrelated.json'), '{}\n');
+  const crashedOwner = spawn(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'crashed-owner-run'), HOMEBOY_INVOCATION_ARTIFACT_DIR: crashedInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, 'crashed-owner-results.json'), HOMEBOY_WP_CODEBOX_PUBLICATION_LOCK_READY_FILE: crashedReady, HOMEBOY_WP_CODEBOX_PUBLICATION_LOCK_HOLD_MS: '5000', HOMEBOY_SETTINGS_JSON: '{}' }, stdio: 'ignore' });
+  const ownerLease = JSON.parse(await waitForFile(crashedReady));
+  const liveContender = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'live-contender-run'), HOMEBOY_INVOCATION_ARTIFACT_DIR: crashedInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, 'live-contender-results.json'), HOMEBOY_SETTINGS_JSON: '{}' }, encoding: 'utf8' });
+  assert.notEqual(liveContender.status, 0);
+  assert.match(liveContender.stderr, /Timed out waiting/);
+  assert.equal(JSON.parse(await readFile(path.join(crashedInvocation, '.wp-codebox-phpunit-publication.lock', 'owner.json'), 'utf8')).token, ownerLease.token);
+  crashedOwner.kill('SIGKILL');
+  await new Promise((resolve) => crashedOwner.once('close', resolve));
+
+  const recoverRun = (index) => new Promise((resolve, reject) => {
+    const child = spawn(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, `recovered-run-${index}`), HOMEBOY_INVOCATION_ARTIFACT_DIR: crashedInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, `recovered-results-${index}.json`), HOMEBOY_SETTINGS_JSON: '{}' }, stdio: 'ignore' });
+    child.on('error', reject);
+    child.on('close', (status) => resolve(status));
+  });
+  assert.deepEqual(await Promise.all([recoverRun(1), recoverRun(2)]), [0, 0]);
+  assert.deepEqual(JSON.parse(await readFile(path.join(root, 'recovered-results-1.json'), 'utf8')), { total: 3, passed: 3, failed: 0, skipped: 0 });
+  const recoveredManifest = JSON.parse(await readFile(path.join(crashedInvocation, 'homeboy-artifact-manifest.json'), 'utf8'));
+  assert.equal(recoveredManifest.artifacts.find((artifact) => artifact.id === 'unrelated').provenance.producer, 'fixture');
+  assert.equal(recoveredManifest.artifacts.filter((artifact) => artifact.path === 'wp-codebox-phpunit/files/test-results.json').length, 1);
 } finally {
   await rm(root, { recursive: true, force: true });
 }
 
 console.log('WP Codebox PHPUnit aggregate smoke passed.');
+
+async function waitForFile(target) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try { return await readFile(target, 'utf8'); } catch (error) {
+      if (error.code !== 'ENOENT') { throw error; }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error(`Timed out waiting for ${target}`);
+}

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -219,6 +219,8 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
   await writeFile(path.join(crashedInvocation, 'unrelated.json'), '{}\n');
   const crashedOwner = spawn(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'crashed-owner-run'), HOMEBOY_INVOCATION_ARTIFACT_DIR: crashedInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, 'crashed-owner-results.json'), HOMEBOY_WP_CODEBOX_PUBLICATION_LOCK_READY_FILE: crashedReady, HOMEBOY_WP_CODEBOX_PUBLICATION_LOCK_HOLD_MS: '5000', HOMEBOY_SETTINGS_JSON: '{}' }, stdio: 'ignore' });
   const ownerLease = JSON.parse(await waitForFile(crashedReady));
+  assert.equal(typeof ownerLease.start_token, 'string');
+  assert.notEqual(ownerLease.start_token, '');
   const liveContender = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'live-contender-run'), HOMEBOY_INVOCATION_ARTIFACT_DIR: crashedInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, 'live-contender-results.json'), HOMEBOY_SETTINGS_JSON: '{}' }, encoding: 'utf8' });
   assert.notEqual(liveContender.status, 0);
   assert.match(liveContender.stderr, /Timed out waiting/);
@@ -236,6 +238,15 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
   const recoveredManifest = JSON.parse(await readFile(path.join(crashedInvocation, 'homeboy-artifact-manifest.json'), 'utf8'));
   assert.equal(recoveredManifest.artifacts.find((artifact) => artifact.id === 'unrelated').provenance.producer, 'fixture');
   assert.equal(recoveredManifest.artifacts.filter((artifact) => artifact.path === 'wp-codebox-phpunit/files/test-results.json').length, 1);
+
+  const reusedPidInvocation = path.join(root, 'reused-pid-invocation');
+  const reusedPidLock = path.join(reusedPidInvocation, '.wp-codebox-phpunit-publication.lock');
+  await mkdir(reusedPidLock, { recursive: true });
+  await writeFile(path.join(reusedPidInvocation, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
+  await writeFile(path.join(reusedPidLock, 'owner.json'), JSON.stringify({ schema: 'homeboy/wp-codebox-publication-lease/v1', pid: process.pid, hostname: ownerLease.hostname, start_token: 'reused-pid-token', token: 'stale-owner' }));
+  const reusedPidRun = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify({ sidecar: unknownSidecar, output: green }), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'reused-pid-run'), HOMEBOY_INVOCATION_ARTIFACT_DIR: reusedPidInvocation, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: path.join(root, 'reused-pid-results.json'), HOMEBOY_SETTINGS_JSON: '{}' }, encoding: 'utf8' });
+  assert.equal(reusedPidRun.status, 0, reusedPidRun.stderr);
+  assert.deepEqual(JSON.parse(await readFile(path.join(root, 'reused-pid-results.json'), 'utf8')), { total: 3, passed: 3, failed: 0, skipped: 0 });
 } finally {
   await rm(root, { recursive: true, force: true });
 }

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -51,12 +51,15 @@ await chmod(cli, 0o755);
 
 try {
   const unknownSidecar = { schema: 'wp-codebox/test-results/v1', status: 'unknown', summary: { total: 0, passed: 0, failed: 0, skipped: 0 } };
+  const tenPassingSidecar = { schema: 'wp-codebox/test-results/v1', status: 'passed', summary: { total: 10, passed: 10, failed: 0, skipped: 0 }, suites: [], rawLogReferences: [] };
   const passedSidecar = { schema: 'wp-codebox/test-results/v1', status: 'passed', summary: { total: 3, passed: 3, failed: 0, skipped: 0 }, suites: [], rawLogReferences: [] };
   const failedSidecar = { schema: 'wp-codebox/test-results/v1', status: 'failed', summary: { total: 3, passed: 3, failed: 0, skipped: 0 } };
   const green = 'OK (3 tests, 76 assertions)\n';
+  const tenGreen = 'OK (10 tests, 10 assertions)\n';
   const failures = 'ERRORS!\nTests: 281, Assertions: 329, Errors: 46, Failures: 100.\n';
   const testCases = [
     { name: 'unknown-green', fixture: { sidecar: unknownSidecar, output: green }, status: 0, artifactStatus: 'passed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'ten-passing-tests', fixture: { sidecar: tenPassingSidecar, output: tenGreen }, status: 0, artifactStatus: 'passed', expected: { total: 10, passed: 10, failed: 0, skipped: 0 } },
     { name: 'failed-green', fixture: { sidecar: failedSidecar, output: green }, status: 1, artifactStatus: 'failed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
     { name: 'nonzero-green', fixture: { sidecar: unknownSidecar, output: green, exitCode: 2 }, status: 2, artifactStatus: 'failed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
     { name: 'zero-tests', fixture: { sidecar: unknownSidecar, output: 'OK (0 tests, 0 assertions)\n' }, settings: { phpunit_no_tests: 'fail' }, status: 1, artifactStatus: 'failed', expected: { total: 0, passed: 0, failed: 0, skipped: 0 } },
@@ -71,13 +74,28 @@ try {
   for (const testCase of testCases) {
     const artifacts = path.join(root, `${testCase.name}-artifacts`);
     const results = path.join(root, `${testCase.name}-results.json`);
-    const run = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify(testCase.fixture), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: results, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [dependency], ...testCase.settings }) }, encoding: 'utf8' });
+    const invocationArtifacts = path.join(root, `${testCase.name}-invocation-artifacts`);
+    await mkdir(invocationArtifacts, { recursive: true });
+    await writeFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
+    const run = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify(testCase.fixture), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts, HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: results, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [dependency], ...testCase.settings }) }, encoding: 'utf8' });
     assert.equal(run.status, testCase.status, `${testCase.name}: ${run.stderr}`);
     assert.deepEqual(JSON.parse(await readFile(results, 'utf8')), testCase.expected, testCase.name);
     const runArtifact = path.join(artifacts, (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.')));
     const artifactDirectory = testCase.fixture.crash || testCase.fixture.pointer === 'malformed' ? runArtifact : path.join(runArtifact, 'runtime-fixture');
     const artifactResults = JSON.parse(await readFile(path.join(artifactDirectory, 'files', 'test-results.json'), 'utf8'));
     assert.equal(artifactResults.status, testCase.artifactStatus, testCase.name);
+    const manifest = JSON.parse(await readFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), 'utf8'));
+    assert.deepEqual(manifest.artifacts.map(({ path: artifactPath }) => artifactPath), [
+      'wp-codebox-phpunit/files/test-results.json',
+      'wp-codebox-phpunit/files/phpunit-output.log',
+      'wp-codebox-phpunit/files/test-failures.json',
+    ], testCase.name);
+    const durableSummary = JSON.parse(await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/test-results.json'), 'utf8')).summary;
+    assert.deepEqual(
+      Object.fromEntries(['total', 'passed', 'failed', 'skipped'].map((key) => [key, durableSummary[key]])),
+      testCase.expected,
+      testCase.name,
+    );
     const options = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
     const profile = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-profile.json'), 'utf8'));
     const provenance = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -14,10 +14,13 @@ const cli = path.join(root, 'wp-codebox');
 const resultsFile = path.join(root, 'test-results.json');
 const failuresFile = path.join(root, 'test-failures.json');
 const expectedOutputFile = path.join(root, 'expected-output.log');
+const invocationArtifacts = path.join(root, 'invocation-artifacts');
 const writeResults = path.join(root, 'write-test-results.sh');
 const extension = path.resolve(import.meta.dirname, '..');
 
 await mkdir(component, { recursive: true });
+await mkdir(invocationArtifacts, { recursive: true });
+await writeFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
 await writeFile(path.join(component, 'sample-plugin.php'), '<?php\n/* Plugin Name: Sample Plugin */\n');
 await writeFile(writeResults, `homeboy_write_test_results() { printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$1" "$2" "$3" "$4" > "$HOMEBOY_TEST_RESULTS_FILE"; }
 `);
@@ -82,6 +85,7 @@ try {
       HOMEBOY_EXTENSION_PATH: extension,
       HOMEBOY_WP_CODEBOX_BIN: cli,
       HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
+      HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts,
       HOMEBOY_TEST_RESULTS_FILE: resultsFile,
       HOMEBOY_TEST_FAILURES_FILE: failuresFile,
       HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: writeResults,
@@ -120,6 +124,13 @@ try {
     { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
   ]);
   assert.deepEqual(JSON.parse(await readFile(resultsFile, 'utf8')), { total: 3, passed: 0, failed: 2, skipped: 1 });
+  const invocationManifest = JSON.parse(await readFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), 'utf8'));
+  assert.deepEqual(invocationManifest.artifacts.map(({ path: artifactPath }) => artifactPath), [
+    'wp-codebox-phpunit/files/test-results.json',
+    'wp-codebox-phpunit/files/phpunit-output.log',
+    'wp-codebox-phpunit/files/test-failures.json',
+  ]);
+  assert.deepEqual(JSON.parse(await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/test-failures.json'), 'utf8')).failures.length, 2);
 
   const analysisInput = JSON.parse(await readFile(failuresFile, 'utf8'));
   assert.equal(analysisInput.total, 3);


### PR DESCRIPTION
## Summary

- copy PHPUnit structured results and output into the invocation artifact boundary before parsing or return
- register `test-results.json`, `test-failures.json`, and `phpunit-output.log` in the durable artifact manifest
- parse structured counts only from registered invocation-contained artifacts
- preserve existing manifest entries and provenance through atomic, concurrency-safe publication
- reject symlink escapes and malformed manifest artifact collections
- recover publication leases after hard crashes while protecting live process instances and PID reuse
- preserve mixed PHP PHPUnit and Node `.mjs` changed-scope routing

## Failure fixed

WP Codebox could execute 10 tests with 10 assertions and zero failures/errors while writing `test-failures.json` outside the invocation artifact root. The invocation manifest remained empty, so Homeboy reported no structured counts and CI appeared failed.

## Verification

- `node wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs`
- `node wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- JS lint and adapter syntax checks
- shell syntax checks
- isolated artifact snapshot, canonical CLI, and database-service tests
- `git diff --check`

Coverage includes the exact 10 tests / 10 assertions / 0 failures / 0 errors result; empty-manifest reproduction; registration-before-parse and parser failure; concurrent writers/readers; unrelated provenance preservation; symlink rejection; malformed manifests; SIGKILL recovery; concurrent reclaimers; and simulated PID reuse.

## Compatibility

The existing artifact manifest schema and structured count schemas are preserved. Publication merges unrelated entries rather than replacing them. Unverifiable foreign or process-instance ownership remains fail-closed.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented the repair and iteratively hardened it through independent reviews covering publication ordering, concurrency, containment, crash recovery, and PID reuse. Chris Huber reviewed and remains responsible for every line.

Fixes #2448.