### PR TITLE
Resolve validation helpers from installed extension layout

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -20,7 +20,13 @@ set -euo pipefail
 
 homeboy_get_validation_dependencies_raw() {
     if ! type homeboy_setting_json >/dev/null 2>&1; then
-        local settings_helper="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib/settings.sh}"
+        local settings_helper="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-}"
+        local shared_lib_dir="${HOMEBOY_SHARED_LIB_DIR:-}"
+        if [ -z "$shared_lib_dir" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
+            shared_lib_dir="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
+        fi
+        shared_lib_dir="${shared_lib_dir:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)}"
+        settings_helper="${settings_helper:-${shared_lib_dir}/settings.sh}"
         # shellcheck source=/dev/null
         source "$settings_helper"
     fi

--- a/wordpress/tests/installed-test-helper-resolution-smoke.sh
+++ b/wordpress/tests/installed-test-helper-resolution-smoke.sh
@@ -8,11 +8,14 @@ trap 'rm -rf "$FIXTURE_ROOT"' EXIT
 
 mkdir -p \
     "${FIXTURE_ROOT}/extension-sources/wordpress/scripts/test" \
+    "${FIXTURE_ROOT}/extension-sources/wordpress/scripts/lib" \
     "${FIXTURE_ROOT}/extensions/scripts/lib" \
     "${FIXTURE_ROOT}/component"
 cp "${WORDPRESS_ROOT}/scripts/test/test-runner.sh" \
     "${WORDPRESS_ROOT}/scripts/test/parse-test-results.sh" \
     "${FIXTURE_ROOT}/extension-sources/wordpress/scripts/test/"
+cp "${WORDPRESS_ROOT}/scripts/lib/validation-dependencies.sh" \
+    "${FIXTURE_ROOT}/extension-sources/wordpress/scripts/lib/"
 cp "${REPOSITORY_ROOT}/scripts/lib/settings.sh" \
     "${REPOSITORY_ROOT}/scripts/lib/test-result-adapters.sh" \
     "${FIXTURE_ROOT}/extensions/scripts/lib/"
@@ -34,5 +37,10 @@ printf '%s\n' 'OK (1 test, 1 assertion)' > "${FIXTURE_ROOT}/phpunit-output.txt"
 HOMEBOY_EXTENSION_PATH="${FIXTURE_ROOT}/extensions/wordpress" \
     bash "${FIXTURE_ROOT}/extensions/wordpress/scripts/test/parse-test-results.sh" \
         "${FIXTURE_ROOT}/phpunit-output.txt" phpunit
+
+HOMEBOY_EXTENSION_PATH="${FIXTURE_ROOT}/extensions/wordpress" \
+HOMEBOY_SETTINGS_JSON='{}' \
+    bash -c 'source "$1"; homeboy_get_validation_dependencies_raw' bash \
+        "${FIXTURE_ROOT}/extensions/wordpress/scripts/lib/validation-dependencies.sh" >/dev/null
 
 printf '%s\n' 'installed test helper resolution smoke passed'


### PR DESCRIPTION
## Summary
- resolve the settings helper through the installed shared library directory
- preserve the core-provided runtime helper override
- cover validation dependency resolution in the installed-layout smoke test

## Verification
- `bash wordpress/tests/installed-test-helper-resolution-smoke.sh`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode traced the isolated Lab helper failure, drafted the shell change and regression coverage, and ran verification. Chris Huber reviewed and remains responsible for the change.

Fixes #2341