### PR TITLE
Fix WordPress recovery artifact publication

### DIFF
--- a/wordpress/scripts/release/publish.sh
+++ b/wordpress/scripts/release/publish.sh
@@ -146,10 +146,35 @@ if [[ -z "${COMPONENT_SLUG}" ]]; then
   exit 1
 fi
 
-ARTIFACT_PATH="build/${COMPONENT_SLUG}.zip"
+RECOVERY_ARTIFACTS="$(echo "${PAYLOAD}" | jq -c '
+  [
+    .release.artifacts // []
+    | .[]?
+    | select(
+        type == "object"
+        and (.type == "wordpress-zip" or .artifact_type == "wordpress-zip")
+      )
+  ]
+')"
+
+RECOVERY_ARTIFACT_COUNT="$(echo "${RECOVERY_ARTIFACTS}" | jq 'length')"
+if [[ "${RECOVERY_ARTIFACT_COUNT}" -gt 1 ]]; then
+  echo "Error: release payload contains multiple WordPress ZIP recovery artifacts" >&2
+  exit 1
+fi
+
+if [[ "${RECOVERY_ARTIFACT_COUNT}" -eq 1 ]]; then
+  if ! echo "${RECOVERY_ARTIFACTS}" | jq -e '.[0].path | type == "string" and length > 0' >/dev/null; then
+    echo "Error: WordPress ZIP recovery artifact path must be a non-empty string" >&2
+    exit 1
+  fi
+  ARTIFACT_PATH="$(echo "${RECOVERY_ARTIFACTS}" | jq -r '.[0].path')"
+else
+  ARTIFACT_PATH="build/${COMPONENT_SLUG}.zip"
+fi
 
 if [[ ! -f "${ARTIFACT_PATH}" ]]; then
-  echo "Error: expected release artifact at ${ARTIFACT_PATH}, run release.package first" >&2
+  echo "Error: expected release artifact at ${ARTIFACT_PATH}" >&2
   exit 1
 fi
 

--- a/wordpress/tests/release-scripts-smoke.sh
+++ b/wordpress/tests/release-scripts-smoke.sh
@@ -16,6 +16,8 @@
 #   - scripts/release/publish.sh executes the release-latest branch mirror
 #     when homeboy.json configures it and emits the branch name in the
 #     receipt.
+#   - scripts/release/publish.sh uses a single authoritative WordPress ZIP
+#     recovery artifact and rejects ambiguous or invalid recovery artifacts.
 #
 # Stubs gh and git for the happy-path tests so we never touch the network
 # or a real GitHub repository.
@@ -310,6 +312,107 @@ else
   else
     echo "OK: publish.sh force-pushes release-latest branch when configured"
   fi
+fi
+
+# ---------------------------------------------------------------------------
+# publish.sh: uses an external recovery ZIP supplied by Homeboy and returns
+# its absolute path in the receipt.
+# ---------------------------------------------------------------------------
+RECOVERY_DIR="$(mktemp -d -t homeboy-wp-release-recovery.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}" "${STUB_BIN_DIR}" "${HAPPY_DIR}" "${BRANCH_DIR}" "${RECOVERY_DIR}"' EXIT
+RECOVERY_ZIP="${RECOVERY_DIR}/recovered-plugin.zip"
+python3 -c "
+import zipfile
+with zipfile.ZipFile('${RECOVERY_ZIP}', 'w') as z:
+  z.writestr('recovered-plugin/recovered-plugin.php', '<?php\n/**\n * Plugin Name: Recovered Plugin\n * Version: 1.0.0\n */')
+"
+
+set +e
+publish_out="$(
+  cd "${RECOVERY_DIR}" && \
+  PATH="${STUB_BIN_DIR}:${PATH}" \
+  GITHUB_REPOSITORY="example/recovered-plugin" \
+  HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v1.0.0","component_id":"recovered-plugin","artifacts":[{"path":"'"${RECOVERY_ZIP}"'","artifact_type":"wordpress-zip"}]}}' \
+  "${PUBLISH_SH}" 2>&1
+)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -ne 0 ]]; then
+  echo "FAIL: publish.sh (recovery ZIP) exited ${publish_status}; output: ${publish_out}" >&2
+  failures=$((failures + 1))
+elif ! echo "${publish_out}" | tail -1 | jq -e --arg path "${RECOVERY_ZIP}" '.success == true and .artifact_path == $path' >/dev/null 2>&1; then
+  echo "FAIL: publish.sh receipt did not return recovery ZIP path; got: ${publish_out}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: publish.sh uses the supplied recovery ZIP"
+fi
+
+# publish.sh: multiple WordPress ZIP recovery artifacts must not silently
+# select one based on declaration order.
+set +e
+publish_err="$(
+  cd "${RECOVERY_DIR}" && \
+  PATH="${STUB_BIN_DIR}:${PATH}" \
+  GITHUB_REPOSITORY="example/recovered-plugin" \
+  HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v1.0.0","component_id":"recovered-plugin","artifacts":[{"path":"'"${RECOVERY_ZIP}"'","type":"wordpress-zip"},{"path":"'"${RECOVERY_ZIP}"'","artifact_type":"wordpress-zip"}]}}' \
+  "${PUBLISH_SH}" 2>&1 >/dev/null
+)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -eq 0 ]]; then
+  echo "FAIL: publish.sh accepted ambiguous recovery ZIP artifacts" >&2
+  failures=$((failures + 1))
+elif ! echo "${publish_err}" | grep -q "multiple WordPress ZIP recovery artifacts"; then
+  echo "FAIL: publish.sh did not surface the ambiguous-recovery error; got: ${publish_err}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: publish.sh rejects ambiguous recovery ZIP artifacts"
+fi
+
+# publish.sh: a matching recovery artifact needs a non-empty string path.
+set +e
+publish_err="$(
+  cd "${RECOVERY_DIR}" && \
+  PATH="${STUB_BIN_DIR}:${PATH}" \
+  GITHUB_REPOSITORY="example/recovered-plugin" \
+  HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v1.0.0","component_id":"recovered-plugin","artifacts":[{"path":null,"type":"wordpress-zip"}]}}' \
+  "${PUBLISH_SH}" 2>&1 >/dev/null
+)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -eq 0 ]]; then
+  echo "FAIL: publish.sh accepted an invalid recovery ZIP path" >&2
+  failures=$((failures + 1))
+elif ! echo "${publish_err}" | grep -q "path must be a non-empty string"; then
+  echo "FAIL: publish.sh did not surface the invalid-recovery-path error; got: ${publish_err}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: publish.sh rejects invalid recovery ZIP paths"
+fi
+
+# publish.sh: a selected recovery artifact must resolve to a regular file.
+set +e
+publish_err="$(
+  cd "${RECOVERY_DIR}" && \
+  PATH="${STUB_BIN_DIR}:${PATH}" \
+  GITHUB_REPOSITORY="example/recovered-plugin" \
+  HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v1.0.0","component_id":"recovered-plugin","artifacts":[{"path":"'"${RECOVERY_DIR}"'","type":"wordpress-zip"}]}}' \
+  "${PUBLISH_SH}" 2>&1 >/dev/null
+)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -eq 0 ]]; then
+  echo "FAIL: publish.sh accepted a recovery ZIP path that is not a regular file" >&2
+  failures=$((failures + 1))
+elif ! echo "${publish_err}" | grep -q "expected release artifact"; then
+  echo "FAIL: publish.sh did not reject the non-file recovery path; got: ${publish_err}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: publish.sh rejects recovery ZIP paths that are not regular files"
 fi
 
 # ---------------------------------------------------------------------------

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.34.11",
+  "version": "3.34.12",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
## Summary
Allow WordPress publication retries to use Homeboy's authoritative recovery ZIP instead of requiring package-step filesystem locality.

## What changed
- Resolve one wordpress-zip artifact from release.artifacts, retaining build/\<component\>.zip when no recovery artifact is supplied.
- Reject ambiguous artifacts, invalid paths, and selected paths that are not regular files.
- Add network-free smoke coverage for external recovery publication and failure cases; bump the WordPress extension to 3.34.12.

## How to test
1. Run `bash wordpress/tests/release-scripts-smoke.sh`; expect All package, publish, recovery, mirroring, and dependency smoke assertions pass..

## Compatibility
Normal package-to-publish releases retain the existing local build ZIP path; only recovery payloads containing a WordPress ZIP select an external artifact.

## Evidence
- Base unchanged since verification: main remains at 01bb4f44864cdafa71cf1be94989150b5bf4b43d.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy-extensions/issues/2463
- Reviewer-resolvable evidence from source\_refs\[1\]: https://github.com/Extra-Chill/homeboy/issues/10243
- Verified finalization base: main at 01bb4f44864cdafa71cf1be94989150b5bf4b43d
- wordpress-release-scripts: passed (external recovery and fail-closed cases passed) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-terra
- **Used for:** I traced the failed DMC release through Homeboy's artifact inventory contract, implemented the narrow publisher resolver, exercised both recovery and fail-closed paths, and inspected the resulting candidate before approved manual finalization.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2463
