### PR TITLE
Accept untyped WordPress recovery ZIPs

### DIFF
--- a/wordpress/scripts/release/publish.sh
+++ b/wordpress/scripts/release/publish.sh
@@ -153,6 +153,11 @@ RECOVERY_ARTIFACTS="$(echo "${PAYLOAD}" | jq -c '
     | select(
         type == "object"
         and (.type == "wordpress-zip" or .artifact_type == "wordpress-zip")
+        or (
+          type == "object"
+          and ((.type // .artifact_type // "") == "")
+          and ((.path // "") | type == "string" and endswith(".zip"))
+        )
       )
   ]
 ')"

--- a/wordpress/tests/release-scripts-smoke.sh
+++ b/wordpress/tests/release-scripts-smoke.sh
@@ -315,8 +315,8 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# publish.sh: uses an external recovery ZIP supplied by Homeboy and returns
-# its absolute path in the receipt.
+# publish.sh: uses an untyped external recovery ZIP from Homeboy's directory
+# inventory and returns its absolute path in the receipt.
 # ---------------------------------------------------------------------------
 RECOVERY_DIR="$(mktemp -d -t homeboy-wp-release-recovery.XXXXXX)"
 trap 'rm -rf "${WORK_DIR}" "${STUB_BIN_DIR}" "${HAPPY_DIR}" "${BRANCH_DIR}" "${RECOVERY_DIR}"' EXIT
@@ -332,7 +332,7 @@ publish_out="$(
   cd "${RECOVERY_DIR}" && \
   PATH="${STUB_BIN_DIR}:${PATH}" \
   GITHUB_REPOSITORY="example/recovered-plugin" \
-  HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v1.0.0","component_id":"recovered-plugin","artifacts":[{"path":"'"${RECOVERY_ZIP}"'","artifact_type":"wordpress-zip"}]}}' \
+  HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v1.0.0","component_id":"recovered-plugin","artifacts":[{"path":"'"${RECOVERY_ZIP}"'","phase":"recovery","producer":"from-artifacts","publication_authority":true}]}}' \
   "${PUBLISH_SH}" 2>&1
 )"
 publish_status=$?
@@ -345,7 +345,7 @@ elif ! echo "${publish_out}" | tail -1 | jq -e --arg path "${RECOVERY_ZIP}" '.su
   echo "FAIL: publish.sh receipt did not return recovery ZIP path; got: ${publish_out}" >&2
   failures=$((failures + 1))
 else
-  echo "OK: publish.sh uses the supplied recovery ZIP"
+  echo "OK: publish.sh uses the untyped recovery ZIP"
 fi
 
 # publish.sh: multiple WordPress ZIP recovery artifacts must not silently

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.34.13",
+  "version": "3.34.14",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
## Summary
Allow WordPress publication recovery to consume the unique untyped ZIP emitted by Homeboy's directory artifact inventory.

## What changed
- Recognize untyped artifact entries whose path ends in .zip, while retaining explicit wordpress-zip selection.
- Exercise the exact recovery payload shape with phase, producer, and publication\_authority metadata but no artifact type.
- Bump the WordPress extension to 3.34.14 for automatic release.

## How to test
1. Run `bash wordpress/tests/release-scripts-smoke.sh`; expect All package, publish, recovery, mirroring, and dependency assertions pass, including the live untyped recovery shape..

## Compatibility
Typed WordPress ZIPs remain supported; multiple matching ZIPs still fail closed, and non-ZIP untyped artifacts are ignored.

## Evidence
- Base unchanged since verification: main remains at e9ab2123baa3ce15b26923cfb7d1b997b6de2b44.
- CI expected: Homeboy
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy-extensions/issues/2463
- Reviewer-resolvable evidence from source\_refs\[1\]: https://github.com/Extra-Chill/data-machine-code/releases/tag/v0.54.1
- Verified finalization base: main at e9ab2123baa3ce15b26923cfb7d1b997b6de2b44
- wordpress-release-scripts: passed (untyped recovery and fail-closed cases) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** I compared the live Homeboy release payload with the shipped publisher selector, reduced the mismatch to absent artifact type metadata, implemented an untyped ZIP fallback, and reran the release-script contract suite.

## Source relationships
- Closes Extra-Chill/homeboy-extensions#2463
