### PR TITLE
fix: preserve PHPUnit parser failure evidence

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 
 const settings = parseSettings(process.env.HOMEBOY_SETTINGS_JSON);
 const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMPONENT_PATH');
@@ -520,9 +521,12 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
     for (const file of files.slice(0, 2)) {
       await atomicCopy(path.join(artifactDirectory, 'files', file.name), path.join(publishedFilesDirectory, file.name));
     }
-    // The parser replaces this durable placeholder atomically. Its registration
-    // survives a parser crash so reviewers can still locate the expected evidence.
-    await atomicWrite(path.join(publishedFilesDirectory, 'test-failures.json'), '{}\n');
+    // The parser replaces this valid fallback atomically. Its registration and
+    // aggregate counts survive a parser crash without poisoning Homeboy's sidecar.
+    await atomicWrite(
+      path.join(publishedFilesDirectory, 'test-failures.json'),
+      await fallbackTestFailures(publishedFilesDirectory),
+    );
     await registerInvocationArtifacts(invocationArtifacts, files.map((file) => ({
       ...file,
       path: path.join('wp-codebox-phpunit', 'files', file.name).replaceAll(path.sep, '/'),
@@ -551,6 +555,18 @@ async function parsePublishedArtifacts(published) {
           await atomicCopy(published.failuresPath, requestedFailuresPath);
         }
       }
+    } catch (error) {
+      if (published.failuresPath) {
+        const fallback = await fallbackTestFailures(path.dirname(published.failuresPath), error);
+        await withInvocationArtifactLock(process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR, async () => {
+          await assertDirectoryTree(process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR, ['wp-codebox-phpunit', 'files']);
+          await atomicWrite(published.failuresPath, fallback);
+        });
+        if (requestedFailuresPath && requestedFailuresPath !== published.failuresPath) {
+          await atomicCopy(published.failuresPath, requestedFailuresPath);
+        }
+      }
+      throw error;
     } finally {
       if (published.failuresPath) { await unlink(temporaryFailuresPath).catch(() => {}); }
       if (requestedFailuresPath) {
@@ -561,6 +577,48 @@ async function parsePublishedArtifacts(published) {
     }
   }
   return published.status;
+}
+async function fallbackTestFailures(publishedFilesDirectory, error = null) {
+  let summary = {};
+  try {
+    const results = JSON.parse(await readFile(path.join(publishedFilesDirectory, 'test-results.json'), 'utf8'));
+    summary = isObject(results?.summary) ? results.summary : {};
+  } catch {}
+
+  const failures = [];
+  if (error) {
+    const testId = 'wp-codebox-phpunit-failure-parser';
+    const errorType = 'WPCodeboxFailureParserError';
+    const message = `Unable to parse preserved WP Codebox PHPUnit failure evidence: ${error.message}`;
+    failures.push({
+      test_name: testId,
+      test_file: null,
+      error_type: errorType,
+      message,
+      source_file: null,
+      source_line: 0,
+      test_id: testId,
+      suite: 'wp-codebox-harness',
+      file: null,
+      line: 0,
+      failure_type: errorType,
+      fingerprint: createHash('sha256').update(`${testId}|${errorType}|${message}`).digest('hex'),
+      stdout_excerpt: '',
+      stderr_excerpt: '',
+    });
+  }
+
+  return `${JSON.stringify({
+    failures,
+    total: Number(summary.total) || 0,
+    passed: Number(summary.passed) || 0,
+    metadata: {
+      assertions: 0,
+      failures: Number(summary.failed) || 0,
+      errors: 0,
+      skipped: Number(summary.skipped) || 0,
+    },
+  }, null, 2)}\n`;
 }
 async function registerInvocationArtifacts(invocationRoot, publishedArtifacts) {
   const manifestPath = path.join(invocationRoot, 'homeboy-artifact-manifest.json');

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -185,7 +185,17 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
   assert.notEqual(parserFailureRun.status, 0);
   const parserFailureManifest = JSON.parse(await readFile(path.join(parserFailureInvocation, 'homeboy-artifact-manifest.json'), 'utf8'));
   assert.ok(parserFailureManifest.artifacts.some((artifact) => artifact.path === 'wp-codebox-phpunit/files/test-failures.json'));
-  assert.equal(await readFile(path.join(parserFailureInvocation, 'wp-codebox-phpunit/files/test-failures.json'), 'utf8'), '{}\n');
+  const parserFailureDirectory = path.join(parserFailureInvocation, 'wp-codebox-phpunit/files');
+  const parserFailureSidecar = JSON.parse(await readFile(path.join(parserFailureDirectory, 'test-failures.json'), 'utf8'));
+  assert.equal(parserFailureSidecar.total, 3);
+  assert.equal(parserFailureSidecar.passed, 3);
+  assert.equal(parserFailureSidecar.failures.length, 1);
+  assert.equal(parserFailureSidecar.failures[0].test_id, 'wp-codebox-phpunit-failure-parser');
+  assert.equal(parserFailureSidecar.failures[0].failure_type, 'WPCodeboxFailureParserError');
+  assert.equal(parserFailureSidecar.failures[0].fingerprint.length, 64);
+  assert.match(parserFailureSidecar.failures[0].message, /parse-test-failures\.sh failed with exit code 1/);
+  assert.match(await readFile(path.join(parserFailureDirectory, 'phpunit-output.log'), 'utf8'), /OK \(3 tests, 76 assertions\)/);
+  assert.deepEqual(JSON.parse(await readFile(path.join(root, 'parser-failure-failures.json'), 'utf8')), parserFailureSidecar);
 
   const concurrentInvocation = path.join(root, 'concurrent-invocation');
   await mkdir(concurrentInvocation);

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -130,7 +130,12 @@ try {
     'wp-codebox-phpunit/files/phpunit-output.log',
     'wp-codebox-phpunit/files/test-failures.json',
   ]);
-  assert.deepEqual(JSON.parse(await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/test-failures.json'), 'utf8')).failures.length, 2);
+  const publishedDirectory = path.join(invocationArtifacts, 'wp-codebox-phpunit/files');
+  assert.equal(await readFile(path.join(publishedDirectory, 'phpunit-output.log'), 'utf8'), expectedOutput);
+  assert.deepEqual(JSON.parse(await readFile(path.join(publishedDirectory, 'test-results.json'), 'utf8')), artifactResults);
+  const publishedFailures = JSON.parse(await readFile(path.join(publishedDirectory, 'test-failures.json'), 'utf8'));
+  assert.equal(publishedFailures.failures.length, 2);
+  assert.doesNotMatch(await readFile(path.join(publishedDirectory, 'phpunit-output.log'), 'utf8'), /fixture-secret-value/);
 
   const analysisInput = JSON.parse(await readFile(failuresFile, 'utf8'));
   assert.equal(analysisInput.total, 3);


### PR DESCRIPTION
## Summary
- replace the malformed `{}` PHPUnit failure placeholder with a valid aggregate sidecar
- atomically publish a fingerprinted harness failure when failure parsing itself crashes
- preserve and register raw PHPUnit output, structured results, and failure evidence for Homeboy observation export

## Why
WP Codebox already copied `test-results.json` and `phpunit-output.log` into the invocation artifact directory, but a parser error left `test-failures.json` as `{}`. Homeboy rejected that sidecar and reported zero failures while the referenced raw artifacts were absent from review evidence.

## Tests
- `npm run test:wp-codebox-phpunit-evidence`
- `npm run test:wp-codebox-phpunit-aggregate`
- `bash scripts/test/parse-test-failures-sidecar-smoke.sh`
- `bash scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- ESLint on the changed adapter: passed; smoke files are intentionally ignored by the repository lint configuration

Closes #2466