### PR TITLE
Declare Rust lint toolchain readiness

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.29.5",
+  "version": "1.30.0",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
@@ -68,6 +68,15 @@
   "env_provider": {
     "script": "scripts/env-provider.sh"
   },
+  "toolchain_readiness": [
+    {
+      "id": "cargo-lint-toolchain",
+      "capabilities": ["lint"],
+      "command": "cargo --version && cargo fmt --version",
+      "repair_command": "rustup default stable",
+      "diagnostic_env": ["PATH", "CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"]
+    }
+  ],
   "lint": {
     "extension_script": "scripts/lint-runner.sh"
   },

--- a/tests/extension-shape-lint.mjs
+++ b/tests/extension-shape-lint.mjs
@@ -159,6 +159,20 @@ function validateComposition(extensionId, composition) {
   }
 }
 
+function validateRustToolchainReadiness(manifest) {
+  const expected = [{
+    id: 'cargo-lint-toolchain',
+    capabilities: ['lint'],
+    command: 'cargo --version && cargo fmt --version',
+    repair_command: 'rustup default stable',
+    diagnostic_env: ['PATH', 'CARGO_HOME', 'RUSTUP_HOME', 'RUSTUP_TOOLCHAIN'],
+  }];
+
+  if (JSON.stringify(manifest.toolchain_readiness) !== JSON.stringify(expected)) {
+    fail('rust: toolchain_readiness must declare the Cargo lint toolchain probe');
+  }
+}
+
 function validateExtension(extensionId) {
   const extensionDir = path.join(rootDir, extensionId);
   const manifestPath = path.join(extensionDir, `${extensionId}.json`);
@@ -198,6 +212,10 @@ function validateExtension(extensionId) {
 
   if (Object.hasOwn(standardDiscoveryMarkers, extensionId)) {
     validateComposition(extensionId, manifest.composition);
+  }
+
+  if (extensionId === 'rust') {
+    validateRustToolchainReadiness(manifest);
   }
 
   if (manifest.provides?.capabilities !== undefined) {


### PR DESCRIPTION
## Summary
- declare a Rust lint readiness probe for usable Cargo and rustfmt toolchains
- provide runner-owned repair guidance and non-secret diagnostic environment names
- validate the exact declaration in extension shape lint

Downstream activation for Extra-Chill/homeboy#10712. Depends on Extra-Chill/homeboy#10721.

## Verification
- `node tests/extension-shape-lint.mjs`
- Rust env-provider, fingerprint-policy, and zero-test-fallback self-checks
- declared readiness command against Cargo 1.95.0 and rustfmt 1.9.0-stable
- `git diff --check`

## Compatibility
The declaration is consumed only after the additive Homeboy manifest contract lands.

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode implemented and validated the extension declaration. Chris Huber reviewed and owns the submitted change.