### PR TITLE
Correct validation dependency slug resolution and parsing

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -172,6 +172,7 @@
     "test:wp-codebox-bench-crawl-helper": "bash scripts/bench/wp-codebox-bench-crawl-helper-smoke.sh",
     "test:wp-codebox-prepared-dependency-cache": "bash tests/prepared-bench-dependency-cache-smoke.sh",
     "test:dependency-plugin-preflight": "bash tests/dependency-plugin-preflight-smoke.sh",
+    "test:validation-dependency-resolution-regressions": "bash tests/validation-dependency-resolution-regressions-smoke.sh",
     "test:build-before-production-prune": "bash scripts/build/build-before-production-prune-smoke.sh",
     "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",
     "test:wp-codebox-bench-prepare-steps": "node tests/wp-codebox-bench-prepare-steps-smoke.js",

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -50,7 +50,10 @@ homeboy_normalize_validation_dependencies() {
         raw=$(printf '%s' "$raw" | jq -r '.')
     fi
 
-    raw=${raw//,/\n}
+    # Bash parameter substitution does not interpret escape sequences, so
+    # `${raw//,/\n}` would splice a literal `n` between entries and weld
+    # neighbouring tokens together. Translate commas to real newlines instead.
+    raw=$(printf '%s' "$raw" | tr ',' '\n')
 
     while IFS= read -r entry; do
         entry="${entry#${entry%%[![:space:]]*}}"
@@ -993,7 +996,12 @@ _homeboy_prepare_cloned_dependency() {
         return 0
     fi
 
-    if ! ( cd "$clone_path" && composer install --no-dev --no-interaction --quiet ); then
+    # `--no-plugins`: dependencies are installed only to supply an autoloader
+    # and vendor tree for analysis and test bootstrapping. Composer plugins
+    # such as `composer/installers` exist to relocate packages inside a real
+    # WordPress tree, which this copy is not, and running them would make
+    # preparation depend on the host's ambient `allow-plugins` policy.
+    if ! ( cd "$clone_path" && composer install --no-dev --no-interaction --no-plugins --quiet ); then
         echo "Warning: Could not install Composer dependencies for validation dependency '${clone_path}'." >&2
         return 1
     fi
@@ -1097,12 +1105,29 @@ homeboy_resolve_validation_dependency_path() {
     # 1. Direct path. Relative settings paths are anchored to the component
     # workspace, then canonicalized before callers embed them in generated
     # config files that may live outside that workspace.
+    #
+    # A bare slug is only satisfied by a directory that is actually a plugin.
+    # Components legitimately contain subdirectories named after a dependency
+    # for other reasons — a bbPress theme-compat template override directory is
+    # the canonical example — and treating those as the dependency mounts a
+    # non-plugin as a plugin and hides the real one. Explicit paths keep their
+    # existing behaviour below, so a deliberate `./path` or `/abs/path` still
+    # reports the location the operator named.
     if [ -d "$direct_path" ]; then
-        direct_path=$(cd "$direct_path" && pwd -P)
-        _homeboy_report_resolved_dependency "$dependency" "direct path" "$direct_path"
-        _homeboy_warn_if_dependency_stale "$dependency" "$direct_path"
-        printf '%s\n' "$direct_path"
-        return 0
+        local direct_path_is_slug=1
+        case "$dependency" in
+            /*|./*|../*) direct_path_is_slug=0 ;;
+        esac
+
+        if [ "$direct_path_is_slug" -eq 0 ] || _homeboy_is_plugin_shaped_path "$direct_path"; then
+            direct_path=$(cd "$direct_path" && pwd -P)
+            _homeboy_report_resolved_dependency "$dependency" "direct path" "$direct_path"
+            _homeboy_warn_if_dependency_stale "$dependency" "$direct_path"
+            printf '%s\n' "$direct_path"
+            return 0
+        fi
+
+        echo "Note: Ignoring '${direct_path}' for validation dependency '${dependency}': directory is not plugin-shaped (no root PHP file with a 'Plugin Name:' header). Continuing dependency resolution." >&2
     fi
 
     # An explicitly relative or absolute path is not a dependency slug. Return
@@ -1860,7 +1885,7 @@ homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
     fi
 
     if ! command -v composer >/dev/null 2>&1; then
-        _homeboy_record_bench_dependency_build_failure "$artifacts_dir" "$dependency_slug" "$dependency_path" "$package_root" "$package_root" "$package_root" 'composer install --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative' 127 ''
+        _homeboy_record_bench_dependency_build_failure "$artifacts_dir" "$dependency_slug" "$dependency_path" "$package_root" "$package_root" "$package_root" 'composer install --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative --no-plugins' 127 ''
         echo "Error: WordPress bench dependency '${dependency_path}' has composer.json but no vendor autoload files, and composer is not available." >&2
         return 1
     fi
@@ -1928,12 +1953,15 @@ homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
     local composer_output composer_exit
     composer_output=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-bench-dependency-composer-${dependency_slug}.XXXXXX")
     set +e
-    composer install --working-dir="$tmp_prepared_plugin_path" --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative >"$composer_output" 2>&1
+    # `--no-plugins`: see _homeboy_install_git_dependency_composer_packages().
+    # The prepared copy only needs an autoloader, so Composer plugins must not
+    # make preparation depend on the host's `allow-plugins` policy.
+    composer install --working-dir="$tmp_prepared_plugin_path" --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative --no-plugins >"$composer_output" 2>&1
     composer_exit=$?
     set -e
     if [ "$composer_exit" -ne 0 ]; then
         cat "$composer_output" >&2
-        _homeboy_record_bench_dependency_build_failure "$artifacts_dir" "$dependency_slug" "$dependency_path" "$package_root" "$prepare_root" "$tmp_prepared_plugin_path" "composer install --working-dir=${tmp_prepared_plugin_path} --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative" "$composer_exit" "$composer_output"
+        _homeboy_record_bench_dependency_build_failure "$artifacts_dir" "$dependency_slug" "$dependency_path" "$package_root" "$prepare_root" "$tmp_prepared_plugin_path" "composer install --working-dir=${tmp_prepared_plugin_path} --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative --no-plugins" "$composer_exit" "$composer_output"
         rm -rf "$tmp_entry"
         rm -f "$composer_output"
         echo "Error: Could not prepare WordPress bench dependency '${dependency_slug}' with Composer at ${tmp_prepared_plugin_path}." >&2

--- a/wordpress/tests/validation-dependency-resolution-regressions-smoke.sh
+++ b/wordpress/tests/validation-dependency-resolution-regressions-smoke.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regressions for validation dependency resolution.
+#
+#   1. Every documented `validation_dependencies` value shape normalizes to the
+#      same token list. The comma-separated form previously spliced a literal
+#      `n` between entries and dropped the trailing dependency.
+#   2. A bare dependency slug is only satisfied by a plugin-shaped directory.
+#      Components legitimately ship subdirectories named after a dependency
+#      (bbPress theme-compat template overrides being the canonical case), and
+#      those must not shadow the real plugin.
+#   3. An explicitly relative or absolute path is still honoured verbatim, so
+#      operators can point validation at a non-plugin directory on purpose.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/lib/validation-dependencies.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# shellcheck source=/dev/null
+source "$HELPER"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+expect_tokens() {
+    local label="$1"
+    local raw="$2"
+    local expected="$3"
+    local actual
+
+    actual=$(homeboy_normalize_validation_dependencies "$raw" | tr '\n' '|')
+    [ "$actual" = "$expected" ] || fail "${label}: expected '${expected}', got '${actual}'"
+}
+
+# 1. Documented value shapes.
+expect_tokens 'comma-separated with spaces' 'data-machine, agents-api' 'data-machine|agents-api|'
+expect_tokens 'comma-separated without spaces' 'a,b,c' 'a|b|c|'
+expect_tokens 'single slug' 'solo-dependency' 'solo-dependency|'
+expect_tokens 'JSON array' '["data-machine", "agents-api"]' 'data-machine|agents-api|'
+expect_tokens 'newline separated' 'first
+second' 'first|second|'
+
+# A literal `n` must never appear as a separator artifact.
+if homeboy_normalize_validation_dependencies 'data-machine, agents-api' | grep -q 'machinen'; then
+    fail 'comma separator was spliced into a literal n'
+fi
+
+# 2. Slug resolution must skip non-plugin directories.
+COMPONENT_DIR="${TMPDIR}/component"
+mkdir -p "${COMPONENT_DIR}/bbpress" "${COMPONENT_DIR}/legit-dep"
+
+# bbPress theme-compat override: real convention, not a plugin.
+cat > "${COMPONENT_DIR}/bbpress/bbpress.php" <<'PHP'
+<?php
+/*
+ * Template Name: bbPress Template
+ */
+get_header();
+PHP
+
+cat > "${COMPONENT_DIR}/legit-dep/legit-dep.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Legit Dep
+ */
+PHP
+
+export _HOMEBOY_DEP_PLUGIN_PATH="$COMPONENT_DIR"
+
+shadow_output=$(homeboy_resolve_validation_dependency_path bbpress 2>&1 || true)
+if grep -F "via direct path: ${COMPONENT_DIR}/bbpress" <<< "$shadow_output" >/dev/null; then
+    fail "non-plugin template directory satisfied slug 'bbpress'"
+fi
+if ! grep -F 'not plugin-shaped' <<< "$shadow_output" >/dev/null; then
+    fail "skipping a non-plugin directory should explain why: ${shadow_output}"
+fi
+
+# A plugin-shaped sibling must still resolve with zero configuration.
+legit_output=$(homeboy_resolve_validation_dependency_path legit-dep 2>&1 || true)
+if ! grep -F "via direct path: ${COMPONENT_DIR}/legit-dep" <<< "$legit_output" >/dev/null; then
+    fail "plugin-shaped sibling directory should resolve: ${legit_output}"
+fi
+
+# 3. Explicit paths remain verbatim even when not plugin-shaped.
+explicit_output=$(homeboy_resolve_validation_dependency_path ./bbpress 2>&1 || true)
+if ! grep -F "via direct path: ${COMPONENT_DIR}/bbpress" <<< "$explicit_output" >/dev/null; then
+    fail "explicit relative path should resolve verbatim: ${explicit_output}"
+fi
+
+echo "Validation dependency resolution regression smoke passed"


### PR DESCRIPTION
Fixes #2474
Fixes #2476
Partially addresses #2475

## Summary

Two dependency-resolution defects, both failing *quietly* — the resulting analysis findings looked like consumer code defects rather than tooling faults. Surfaced while running the Extra Chill release chain.

## #2476 — comma-separated parsing

```bash
raw=${raw//,/\n}
```

Bash parameter substitution does not interpret escape sequences, so this splices a **literal `n`**, not a newline. `"data-machine, agents-api"` normalized to the single token `data-machinen agents-api`; the second dependency was dropped and the warning named a string nobody wrote.

Replaced with `tr ',' '\n'`. All four documented shapes now round-trip identically — verified in the new smoke test.

## #2474 — slug resolution shadowed by non-plugin directories

The direct-path branch accepted *any* directory matching the slug beneath the component root. `extrachill-community` declares `Requires Plugins: bbpress` and also ships `bbpress/` as a **bbPress theme-compat template override** — the standard convention. Its `bbpress.php` is a page template:

```php
<?php
/*
 * Template Name: bbPress Template
 */
```

Resolution stopped there and never reached the real plugin. Two symptoms:

- **PHPUnit:** `Failed to activate extra plugin bbpress/bbpress.php: The plugin does not have a valid header.`
- **PHPStan:** analyzed against a dependency defining zero symbols, producing 11 `property.notFound` findings for properties bbPress genuinely assigns in `setup_globals()`.

Now a **bare slug** requires a plugin-shaped directory, reusing the existing `_homeboy_is_plugin_shaped_path()` helper already used on the composer-vendor path. When the candidate is not plugin-shaped the resolver explains the skip and continues down the chain rather than stopping.

**Explicit paths are unchanged** — `./foo` and `/abs/foo` still resolve verbatim, so operators can still point validation at a non-plugin directory deliberately.

## #2475 — Composer `--no-plugins` (partial)

Added `--no-plugins` to both dependency-hydration call sites in `validation-dependencies.sh`. The prepared copy only needs an autoloader and vendor tree; `composer/installers` exists to relocate packages inside a real WordPress tree, which this copy is not.

**This does not fully close #2475.** After landing it locally I re-ran the Community release and the same `allow-plugins` failure persisted. Tracing it, the failing invocation is **not in this repo** — it is in wp-codebox:

`packages/runtime-core/src/recipe-source-packages.ts:369`

```ts
args: composerInstallArgs ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts"],
```

reached via `composerPreparation()` in `wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs`, which passes `composer: 'install'` into the recipe. That path also pins `COMPOSER_HOME` to `$HOME/.composer` (`composerManagedHostEnv()`), so host-level `allow-plugins` configuration in the default Composer home does not apply.

I've left #2475 open and will re-file the remaining half against wp-codebox rather than claim a fix here.

## Verification

New `wordpress/tests/validation-dependency-resolution-regressions-smoke.sh`, registered as `test:validation-dependency-resolution-regressions`. It covers all four documented value shapes, the bbPress-shaped shadowing case, the plugin-shaped sibling that must still resolve with zero config, and explicit-path passthrough.

I confirmed the test actually fails without each fix — reverting the parser reproduces `data-machinen agents-api`, and reverting the guard reproduces the shadowing.

Existing suites pass unchanged:

- `tests/validation-dependencies-smoke.sh`
- `tests/phpstan-relative-dependency-path-smoke.sh`
- `tests/dependency-plugin-preflight-smoke.sh`

Note: `phpstan-relative-dependency-path-smoke.sh` fixtures a `${COMPONENT_DIR}/bbpress` directory but writes a valid plugin header into it, so the existing suite never covered the non-plugin-shaped case.