### PR TITLE
Project agent-task write policy into OpenCode capabilities

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -6,6 +6,7 @@
 const {
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 	agentTaskProviderContractFields,
+	agentTaskPolicyToolPermissions,
 	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
 } = require('../../../agent-task-contracts');
@@ -299,22 +300,20 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 			),
 		};
 	}
-	// The native workspace read/inspection tools (read, glob, grep) correspond to
-	// this executor's declared read-only Homeboy workspace capabilities and are
-	// always permitted within the task cwd, with reads outside it still denied.
-	// This must not be gated on resolving concrete workspace read patterns: a
-	// review-only cook (e.g. `--no-finalize` inspecting an existing candidate)
-	// whose cwd does not resolve to an absolute path would otherwise leave the
-	// inherited `read` policy without a `*: allow` rule, so OpenCode falls back to
-	// its default `ask`, is denied non-interactively, and the cook fails with
-	// `opencode.policy_denied` before it can inspect the candidate (#8829).
+	const toolPermissions = agentTaskPolicyToolPermissions(request.policy, {
+		native: OPENCODE_NATIVE_WORKSPACE_PERMISSIONS,
+		workspace: OPENCODE_WORKSPACE_TOOLS,
+	});
+	// The native inspection tools remain available for review-only tasks even
+	// when their cwd is relative. OpenCode otherwise defaults to `ask`.
 	{
-		content.permission = permissionWithWorkspaceToolAllowances(content.permission);
+		content.permission = permissionWithWorkspaceToolAllowances(content.permission, {}, toolPermissions.native);
 		content.agent[primaryAgent] = {
 			...objectValue(content.agent[primaryAgent]),
 			permission: permissionWithWorkspaceToolAllowances(
 				objectValue(content.agent[primaryAgent]).permission,
-				content.permission
+				content.permission,
+				toolPermissions.native
 			),
 		};
 	}
@@ -388,18 +387,21 @@ function permissionWithExternalDirectoryAllowances(permission, patterns) {
 	};
 }
 
-function permissionWithWorkspaceToolAllowances(permission, inheritedPermission = {}) {
+function permissionWithWorkspaceToolAllowances(permission, inheritedPermission = {}, allowedTools) {
 	const rules = typeof permission === 'string'
 		? { '*': permission }
 		: objectValue(permission);
 	const permissionTools = Object.values(OPENCODE_NATIVE_WORKSPACE_PERMISSIONS).flat();
 	return permissionTools.reduce((nextRules, tool) => ({
 		...nextRules,
-		[tool]: workspaceToolPermissionRules(rules[tool], inheritedPermission[tool], tool),
+		[tool]: workspaceToolPermissionRules(rules[tool], inheritedPermission[tool], tool, allowedTools),
 	}), rules);
 }
 
-function workspaceToolPermissionRules(permission, inheritedPermission, tool) {
+function workspaceToolPermissionRules(permission, inheritedPermission, tool, allowedTools) {
+	if (Array.isArray(allowedTools) && !allowedTools.includes(tool)) {
+		return { '*': 'deny' };
+	}
 	const inheritedRules = typeof inheritedPermission === 'string'
 		? { '*': inheritedPermission }
 		: objectValue(inheritedPermission);
@@ -595,10 +597,22 @@ function parseStructuredAnswer(text = '') {
 }
 
 function outputDeclarations(request = {}) {
-	return arrayValue(request.inputs?.required_outputs)
+	const direct = arrayValue(request.output_declarations);
+	const directNames = new Set(direct.map((declaration) => declaration?.name).filter(Boolean));
+	return [...arrayValue(request.inputs?.required_outputs).filter((declaration) => !directNames.has(declaration?.name)), ...direct]
 		.filter((declaration) => declaration && typeof declaration === 'object'
 			&& typeof declaration.name === 'string' && declaration.name.trim() !== '')
-		.map((declaration) => ({ ...declaration, name: declaration.name.trim(), required: declaration.required === true }));
+		.map((declaration) => {
+			const { structural_schema: structuralSchema, ...normalized } = declaration;
+			return {
+				...normalized,
+				name: declaration.name.trim(),
+				required: declaration.required === true,
+				...(declaration.json_schema === undefined && structuralSchema !== undefined
+					? { json_schema: structuralSchema }
+					: {}),
+			};
+		});
 }
 
 function outputDiagnostics(missing, oversized) {

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,7 +9,7 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.2.3',
+		version: '1.2.4',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
 		contract_producers: [
 			{

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "contract_producers": [
     {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -10,6 +10,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { agentTaskPolicyToolPermissions } = require('../../../agent-task-contracts');
 
 /**
  * Internal dependencies
@@ -76,6 +77,17 @@ function concretePath(candidate) {
 
 (async () => {
 const provider = providerContract();
+const policyToolSets = {
+	native: { readonly: ['read', 'glob', 'grep'], readwrite: ['edit', 'bash'] },
+	workspace: OPENCODE_WORKSPACE_TOOLS,
+};
+assert.deepEqual(agentTaskPolicyToolPermissions({ write: 'none' }, policyToolSets).native, ['read', 'glob', 'grep']);
+assert.deepEqual(agentTaskPolicyToolPermissions({ write: 'none' }, policyToolSets).workspace, OPENCODE_WORKSPACE_TOOLS.readonly);
+assert.deepEqual(agentTaskPolicyToolPermissions({ write: 'patch' }, policyToolSets).native, ['read', 'glob', 'grep', 'edit', 'bash']);
+assert.deepEqual(agentTaskPolicyToolPermissions({ write: 'patch' }, policyToolSets).workspace, [
+	...OPENCODE_WORKSPACE_TOOLS.readonly,
+	...OPENCODE_WORKSPACE_TOOLS.readwrite,
+]);
 assert.equal(provider.id, 'opencode.agent-task-executor');
 assert.equal(provider.backend, 'opencode');
 assert.equal(provider.runtime_id, 'opencode');
@@ -379,6 +391,7 @@ process.exit(0);
 		const workspaceRequest = {
 			...request,
 			task_id: `opencode-permission-${permissionWorkspace.label}`,
+			policy: { write: 'patch' },
 			executor: {
 				...request.executor,
 				config: {
@@ -976,10 +989,32 @@ process.exit(0);
 	const reviewCapturePath = path.join(root, 'opencode-review-config.json');
 	const reviewCliPath = path.join(root, 'mock-opencode-review.cjs');
 	fs.writeFileSync(reviewCliPath, `#!/usr/bin/env node
+const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
+const prompt = process.argv.at(-1);
+const declarations = JSON.parse(prompt.match(/Output declarations: (\\[.*\\])\\.$/s)?.[1] || 'null');
+assert.deepEqual(declarations, [{
+ name: 'review_form', required: true, schema: 'homeboy/agent-task-review-form/v1', json_schema: {
+  type: 'object', required: ['summary', 'what_changed', 'compatibility', 'used_for'],
+  properties: {
+   summary: { type: 'string' },
+   what_changed: { type: 'array', items: { type: 'string' } },
+   compatibility: { type: 'string' },
+   used_for: { type: 'string' }
+  }
+ }
+}]);
 fs.writeFileSync(${JSON.stringify(reviewCapturePath)}, JSON.stringify(config));
-process.stdout.write(JSON.stringify({ type: 'result', result: { summary: 'Reviewed candidate; no changes required.' } }));
+process.stdout.write(JSON.stringify({
+ type: 'text',
+ part: { type: 'text', text: JSON.stringify({ outputs: { review_form: {
+   summary: 'Reviewed candidate; no changes required.',
+   what_changed: [],
+   compatibility: 'No compatibility impact.',
+   used_for: 'Pull request review.'
+ } } }), metadata: { openai: { phase: 'final_answer' } } }
+}));
 `);
 	// A review-only cook whose workspace is referenced by a *relative* cwd (the
 	// #8829 trigger): it names a real, existing directory but does not resolve to
@@ -1005,6 +1040,22 @@ process.stdout.write(JSON.stringify({ type: 'result', result: { summary: 'Review
 		...request,
 		task_id: 'opencode-review-only',
 		instructions: 'Review the existing candidate and preserve it when correct.',
+		policy: { write: 'none' },
+		output_declarations: [{
+			name: 'review_form',
+			required: true,
+			schema: 'homeboy/agent-task-review-form/v1',
+			structural_schema: {
+				type: 'object',
+				required: ['summary', 'what_changed', 'compatibility', 'used_for'],
+				properties: {
+					summary: { type: 'string' },
+					what_changed: { type: 'array', items: { type: 'string' } },
+					compatibility: { type: 'string' },
+					used_for: { type: 'string' },
+				},
+			},
+		}],
 		executor: {
 			...request.executor,
 			config: {
@@ -1018,13 +1069,25 @@ process.stdout.write(JSON.stringify({ type: 'result', result: { summary: 'Review
 		},
 	}, { env: fixtureEnv });
 
-	assert.equal(reviewResult.status, 'succeeded', JSON.stringify(reviewResult.diagnostics));
+	assert.equal(reviewResult.status, 'no_op', JSON.stringify(reviewResult.diagnostics));
+	assert.deepEqual(reviewResult.outputs, {
+		review_form: {
+			summary: 'Reviewed candidate; no changes required.',
+			what_changed: [],
+			compatibility: 'No compatibility impact.',
+			used_for: 'Pull request review.',
+		},
+	});
 	const reviewConfig = JSON.parse(fs.readFileSync(reviewCapturePath, 'utf8'));
 	// Read-only inspection is permitted within the workspace...
 	assert.equal(reviewConfig.permission.read['*'], 'allow');
 	assert.equal(reviewConfig.agent.build.permission.read['*'], 'allow');
 	assert.equal(nativeToolAction(reviewConfig, 'build', 'glob', 'src/**/*.js'), 'allow');
 	assert.equal(nativeToolAction(reviewConfig, 'build', 'grep', 'TODO'), 'allow');
+	assert.equal(nativeToolAction(reviewConfig, 'build', 'edit', 'src/index.js'), 'deny');
+	assert.equal(nativeToolAction(reviewConfig, 'build', 'bash', 'git status --short'), 'deny');
+	assert.deepEqual(reviewConfig.permission.edit, { '*': 'deny' });
+	assert.deepEqual(reviewConfig.permission.bash, { '*': 'deny' });
 	// ...while reads outside the workspace and the pre-existing secret deny remain denied.
 	assert.equal(reviewConfig.permission.read['..'], 'deny');
 	assert.equal(reviewConfig.permission.read['../*'], 'deny');

--- a/agent-task-contracts/generic-agent-task-plan.js
+++ b/agent-task-contracts/generic-agent-task-plan.js
@@ -10,6 +10,22 @@ const GENERIC_AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
 const GENERIC_AGENT_TASK_REQUEST_SCHEMA = AGENT_TASK_REQUEST_SCHEMA;
 const GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 
+function agentTaskPolicyToolPermissions(policy = {}, toolSets = {}) {
+  // Read-only behavior is expressed by policy, not workflow names, so every
+  // runtime can map its own native and workspace tool families consistently.
+  const readOnly = policy && typeof policy === 'object' && !Array.isArray(policy)
+    && policy.write === 'none';
+  return {
+    native: policyToolSet(toolSets.native, readOnly),
+    workspace: policyToolSet(toolSets.workspace, readOnly),
+  };
+}
+
+function policyToolSet(toolSet = {}, readOnly) {
+  const readonly = normalizeArray(toolSet.readonly);
+  return readOnly ? readonly : uniqueStrings([...readonly, ...normalizeArray(toolSet.readwrite)]);
+}
+
 function genericAgentTaskRunnerSpec(options = {}) {
   const config = options.config || options.executor_config;
   return agentTaskRunnerSpec({
@@ -46,6 +62,7 @@ function genericAgentTaskRequest(options = {}) {
     inputs: options.inputs,
     source_refs: sourceRefs === undefined ? undefined : normalizeArray(sourceRefs),
     policy: options.policy,
+    output_declarations: options.output_declarations,
     limits: runnerRequest.limits,
     artifact_declarations: runnerRequest.artifact_declarations,
     expected_artifacts: runnerRequest.expected_artifacts,
@@ -178,6 +195,10 @@ function normalizeArray(value) {
   return Array.isArray(value) ? value.filter(Boolean) : [];
 }
 
+function uniqueStrings(values) {
+  return [...new Set(values.filter((value) => typeof value === 'string' && value !== ''))];
+}
+
 function requiredString(value, name) {
   if (typeof value !== 'string' || value.trim() === '') {
     throw new Error(`${name} is required.`);
@@ -198,6 +219,7 @@ module.exports = {
   GENERIC_AGENT_TASK_PLAN_SCHEMA,
   GENERIC_AGENT_TASK_REQUEST_SCHEMA,
   GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
+  agentTaskPolicyToolPermissions,
   genericAgentTaskPlan,
   genericAgentTaskRequest,
   genericAgentTaskRunnerSpec,


### PR DESCRIPTION
## Summary
Project generic agent-task write policy into the OpenCode runtime tool surface.

## What changed
- Read-only requests receive inspection tools and structured declared outputs, while patch-writing requests retain edit and command tools.

## How to test
1. Run `npm --prefix agent-runtimes/opencode run test:opencode-agent-task-executor-boundary`; expect Read-only and patch-writing tool surfaces pass exact boundary assertions..
2. Run `npm --prefix agent-runtimes/opencode run check:runtime-manifest`; expect Generated OpenCode runtime manifest remains synchronized..
3. Run `npm --prefix agent-task-contracts run generate:check`; expect Generic provider contract remains synchronized..

## Compatibility
No compatibility impact was recorded by this legacy finalization invocation.

## Evidence
**Declared public contracts**
- `opencode-agent-task-policy`: AgentTaskPolicy.write now selects read-only or patch-writing OpenCode tool capabilities.

**Compatibility impact:** Patch-writing requests retain their existing edit, command, and workspace capabilities; read-only requests gain enforced capability isolation while preserving repository inspection and declared structured outputs.

**External-consumer impact:** Homeboy review-form recovery can rely on policy.write=none as an enforced runtime boundary.

**External usage:** completed; source: Extra-Chill/homeboy#10762 defines the consuming review-form recovery workflow.; limitations: Homeboy #10762 must ship its policy projection before the integrated workflow uses this capability.; evidence: https://github.com/Extra-Chill/homeboy/issues/10762

- Base unchanged since verification: main remains at 424e819064a9533ecfdeeb0e5ebcb979b6adbeac.
- OpenCode boundary: passed (Passed)
- Reviewer-resolvable evidence from artifact\_refs\[0\]: https://github.com/Extra-Chill/homeboy-extensions/issues/2477
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy-extensions/issues/2477
- Verified finalization base: main at 424e819064a9533ecfdeeb0e5ebcb979b6adbeac
- contract generation: passed (Passed)
- runtime manifest: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode via Homeboy)
- **Model:** openai/gpt-5.6-terra
- **Used for:** Traced generic agent-task policy through OpenCode permissions, implemented the runtime projection, and reviewed the generated candidate for owning-layer boundaries.

## Source relationships
- Closes #2477
- Relates to Extra-Chill/homeboy#10762
