### PR TITLE
fix(rust): run workspace member tests on every scope kind

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -329,24 +329,46 @@ TEST_ARGS=(
     --manifest-path "${PROJECT_PATH}/Cargo.toml"
 )
 
-# For a full/workspace run, test every workspace member -- not just the root
-# package. At a hybrid root (a Cargo.toml that is both [package] and [workspace]),
-# `cargo test` without `--workspace` only runs the root package's tests, silently
-# skipping every member crate. Only add it for full-scope runs and only when the
-# scope args don't already select specific packages (e.g. a changed-files scope
-# that passes `-p <crate>`).
-if [ "$SCOPE_KIND" = "workspace" ] || [ "$SCOPE_KIND" = "full" ]; then
-    case " $(printf '%s' "$SCOPE_JSON" | jq -r '.args[]?' | tr '\n' ' ') " in
-        *" -p "* | *" --package "* | *" --workspace "* | *" --exclude "*) ;;
-        *) TEST_ARGS+=(--workspace) ;;
-    esac
-fi
+# Test every workspace member -- not just the root package.
+#
+# At a hybrid root (a Cargo.toml that is both [package] and [workspace]),
+# `cargo test` without `--workspace` runs ONLY the root package's targets and
+# silently skips every member crate. Member crates are still compiled as test
+# targets, so nothing looks wrong: the binaries are built and never executed.
+#
+# This used to be added only for `workspace`/`full` scope kinds, which meant
+# every other kind (`args`, `rust_filter`, `rust_integration`) inherited the
+# root-package-only default. On this repository that hid ten genuinely failing
+# member-crate tests from CI indefinitely, including a real release-timeout
+# defect (#10477).
+#
+# `--workspace` is now the default and is withheld only when the scope args
+# already choose packages themselves, so an intentionally narrow scope such as
+# `-p <crate> --lib` stays narrow.
+SCOPE_ARGS_FLAT=" $(printf '%s' "$SCOPE_JSON" | jq -r '.args[]?' | tr '\n' ' ') "
+case "$SCOPE_ARGS_FLAT" in
+    *" -p "* | *" --package "* | *" --workspace "* | *" --exclude "*)
+        WORKSPACE_SELECTION="scope args select packages explicitly"
+        ;;
+    *)
+        TEST_ARGS+=(--workspace)
+        WORKSPACE_SELECTION="--workspace (all members)"
+        ;;
+esac
 
 if [ -n "${HOMEBOY_TEST_SCOPE_MESSAGE:-}" ]; then
     echo "$HOMEBOY_TEST_SCOPE_MESSAGE"
 fi
 
 rust_append_scope_args "$SCOPE_JSON"
+
+# Always state the resolved scope and the exact cargo invocation. "Which targets
+# ran" was previously only recoverable by reverse-engineering `Running
+# deps/<crate>-<hash>` lines out of the log, which is how a root-package-only
+# run went unnoticed across three separate scope fixes (#10477).
+echo "Rust test scope kind: ${SCOPE_KIND}"
+echo "Rust test package selection: ${WORKSPACE_SELECTION}"
+echo "Rust test invocation: cargo ${TEST_ARGS[*]}"
 
 # Builds COMMAND_LABEL/COMMAND_BINARY from the current TEST_ARGS. Shared so a
 # widened re-run reuses the exact runner selection the first attempt used.
@@ -421,6 +443,8 @@ if [ "$TEST_EXIT" -eq 0 ] \
         --workspace
     )
     SCOPE_KIND="full"
+    WORKSPACE_SELECTION="--workspace (all members)"
+    echo "Rust test invocation: cargo ${TEST_ARGS[*]}"
     SCOPE_JSON="$(printf '%s' "$SCOPE_JSON" | jq -c '.kind = "full" | .args = [] | .reason = "Derived scope executed no tests; widened to the full test command."')"
     rust_build_test_command
     rust_execute_test_run "$@"

--- a/rust/tests/workspace-member-test-scope-smoke.sh
+++ b/rust/tests/workspace-member-test-scope-smoke.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Member-crate tests must actually execute on a Cargo workspace component.
+#
+# At a hybrid root (a Cargo.toml that is both [package] and [workspace]),
+# `cargo test` without `--workspace` runs ONLY the root package's targets and
+# silently skips every member crate. Member crates are still compiled as test
+# targets, so nothing looks broken: the binaries are built and never run.
+#
+# `--workspace` used to be added only for `workspace`/`full` scope kinds, so
+# every other kind (`args`, `rust_filter`, `rust_integration`) inherited the
+# root-package-only default. On the homeboy repository that hid ten genuinely
+# failing member-crate tests from CI indefinitely (#10477).
+#
+# Guards: member tests run for each non-full scope kind, an explicitly narrow
+# scope stays narrow, and the resolved selection is always reported.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORK_DIR="$(mktemp -d -t homeboy-rust-ws-scope.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+if ! command -v cargo >/dev/null 2>&1; then
+    printf 'SKIP: cargo is not installed\n'
+    exit 0
+fi
+
+# A hybrid root: the root Cargo.toml is both a [package] and a [workspace], with
+# one member crate whose test is uniquely named so we can prove it executed.
+make_workspace() {
+    local dir="$1"
+    mkdir -p "${dir}/src" "${dir}/crates/member/src"
+
+    cat > "${dir}/Cargo.toml" <<'TOML'
+[package]
+name = "hybrid-root"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["crates/member"]
+
+[dependencies]
+member = { path = "crates/member" }
+TOML
+
+    cat > "${dir}/src/lib.rs" <<'RS'
+pub fn root_value() -> i32 { 1 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn root_package_test_runs() {
+        assert_eq!(super::root_value(), 1);
+    }
+}
+RS
+
+    cat > "${dir}/crates/member/Cargo.toml" <<'TOML'
+[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+TOML
+
+    cat > "${dir}/crates/member/src/lib.rs" <<'RS'
+pub fn member_value() -> i32 { 2 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn member_crate_test_runs() {
+        assert_eq!(super::member_value(), 2);
+    }
+}
+RS
+}
+
+run_runner() {
+    local project="$1" scope_kind="$2" runner_args="$3"
+    set +e
+    HOMEBOY_EXTENSION_PATH="${EXTENSION_DIR}" \
+        HOMEBOY_COMPONENT_PATH="${project}" \
+        HOMEBOY_SKIP_LINT=1 \
+        HOMEBOY_TEST_SCOPE_KIND="${scope_kind}" \
+        HOMEBOY_TEST_RUNNER_ARGS="${runner_args}" \
+        bash "${EXTENSION_DIR}/scripts/test-runner.sh" >"${WORK_DIR}/out.log" 2>&1
+    RUNNER_EXIT=$?
+    set -e
+    RUNNER_OUTPUT="$(cat "${WORK_DIR}/out.log")"
+}
+
+make_workspace "${WORK_DIR}/ws"
+
+# 1-3. Every non-full scope kind must still reach the member crate.
+for kind in args rust_filter rust_integration; do
+    run_runner "${WORK_DIR}/ws" "${kind}" ''
+    if [ "${RUNNER_EXIT}" -ne 0 ]; then
+        printf 'FAIL: scope kind %s exited %s\n' "${kind}" "${RUNNER_EXIT}"
+        printf '%s\n' "${RUNNER_OUTPUT}"
+        exit 1
+    fi
+    if ! printf '%s' "${RUNNER_OUTPUT}" | grep -q 'member_crate_test_runs ... ok'; then
+        printf 'FAIL: scope kind %s did not execute the member crate test\n' "${kind}"
+        printf '%s\n' "${RUNNER_OUTPUT}"
+        exit 1
+    fi
+    if ! printf '%s' "${RUNNER_OUTPUT}" | grep -q 'root_package_test_runs ... ok'; then
+        printf 'FAIL: scope kind %s stopped running the root package test\n' "${kind}"
+        exit 1
+    fi
+    printf 'PASS: scope kind %s executes member crate and root package tests\n' "${kind}"
+done
+
+# 4. An explicitly narrow scope must stay narrow: `-p` selects packages itself,
+#    so `--workspace` must not be forced on top of it.
+run_runner "${WORK_DIR}/ws" 'rust_filter' "$(printf -- '-p\nmember\n--lib')"
+if [ "${RUNNER_EXIT}" -ne 0 ]; then
+    printf 'FAIL: package-scoped run exited %s\n' "${RUNNER_EXIT}"
+    printf '%s\n' "${RUNNER_OUTPUT}"
+    exit 1
+fi
+if printf '%s' "${RUNNER_OUTPUT}" | grep -q 'root_package_test_runs'; then
+    printf 'FAIL: -p member must not widen to the root package\n'
+    printf '%s\n' "${RUNNER_OUTPUT}"
+    exit 1
+fi
+if ! printf '%s' "${RUNNER_OUTPUT}" | grep -q 'member_crate_test_runs ... ok'; then
+    printf 'FAIL: -p member did not run the member crate test\n'
+    exit 1
+fi
+printf 'PASS: an explicitly package-scoped run stays narrow\n'
+
+# 5. The resolved selection must always be auditable from the log.
+run_runner "${WORK_DIR}/ws" 'args' ''
+for needle in 'Rust test scope kind:' 'Rust test package selection:' 'Rust test invocation: cargo test'; do
+    if ! printf '%s' "${RUNNER_OUTPUT}" | grep -q "${needle}"; then
+        printf 'FAIL: runner did not report %s\n' "${needle}"
+        printf '%s\n' "${RUNNER_OUTPUT}"
+        exit 1
+    fi
+done
+if ! printf '%s' "${RUNNER_OUTPUT}" | grep -q 'Rust test invocation: .*--workspace'; then
+    printf 'FAIL: reported invocation did not include --workspace\n'
+    exit 1
+fi
+printf 'PASS: resolved scope kind, package selection, and cargo invocation are reported\n'
+
+printf '\nAll workspace member test scope checks passed.\n'


### PR DESCRIPTION
Fixes Extra-Chill/homeboy#10477.

## The bug

`cargo test` at a **hybrid root** — a `Cargo.toml` that is both `[package]` and `[workspace]` — runs **only the root package's targets** and silently skips every member crate. The member crates are still *compiled* as test targets, so nothing looks wrong: the binaries get built and never executed.

`--workspace` was added only for the `workspace` and `full` scope kinds:

```sh
if [ "$SCOPE_KIND" = "workspace" ] || [ "$SCOPE_KIND" = "full" ]; then
```

So every other kind — `args`, `rust_filter`, `rust_integration` — inherited the root-package-only default.

## Demonstrated on the homeboy repository

`managed_source` tests live in the `homeboy-lab-runner` **member** crate.

| invocation | result |
|---|---|
| `cargo test --manifest-path Cargo.toml -- managed_source` | **0 passed** across every target (all `N filtered out`) |
| `cargo test -p homeboy-lab-runner --lib -- managed_source` | **15 passed** |

The tests exist, compile, and never ran.

## What it cost

This is the outermost reason ten genuinely failing tests in `homeboy-release` were invisible to CI. One of them was **not a test problem** — it was a live production defect in release-timeout reporting: a supervised process-group kill returned `process group N remained alive after SIGKILL` with `timed_out: false` instead of reporting a timeout, because a forked death guard became an unreaped zombie inside the group it had joined. Fixed in Extra-Chill/homeboy#10858.

That defect sat behind five red tests that CI compiled and never executed.

## Fix

Make `--workspace` the default, and withhold it only when the scope args already choose packages themselves — so an intentionally narrow `-p <crate> --lib` scope stays narrow.

Decision table as implemented:

```
kind=workspace,      no args              -> --workspace
kind=args,           no args              -> --workspace
kind=rust_filter,    -- <module>          -> --workspace
kind=rust_filter,    -p X --lib -- <mod>  -> narrow (args select packages)
kind=rust_integration, --test <target>    -> --workspace
args already contain --workspace/--exclude -> narrow
```

Verified `cargo test --workspace --test cook_lab_handoff_test` works when only the root package owns that target (5 passed).

## Auditability

The runner now always prints:

```
Rust test scope kind: args
Rust test package selection: --workspace (all members)
Rust test invocation: cargo test --manifest-path /path/Cargo.toml --workspace
```

"Which targets ran" was previously only recoverable by reverse-engineering `Running deps/<crate>-<hash>` lines out of the job log. That is precisely how a root-package-only run survived **three** separate scope fixes (#10449/#10450, #10465/#10468) — the unit-level selection logic was correct each time, and the executed target set never changed.

## Test

`rust/tests/workspace-member-test-scope-smoke.sh` builds a real hybrid-root workspace with one member crate and asserts:

1. the member crate's test executes under `args`
2. …under `rust_filter`
3. …under `rust_integration`
4. an explicit `-p member --lib` scope stays narrow and does **not** pull in the root package
5. scope kind, package selection, and cargo invocation are all reported

**Verified to fail against the pre-fix logic** — reverting just the selection block produces `FAIL: scope kind args did not execute the member crate test`.

`rust/tests/zero-test-scope-fallback-smoke.sh` still passes all four of its cases, so the widen-on-zero-match behaviour is intact.

## Note

This repository has no PR CI (`homeboy.yml` is `push: main` only), so everything above was verified locally: `bash -n` on both scripts, the new smoke test, the existing fallback smoke test, and a negative control against the reverted logic.

Expect this to surface previously-hidden failures on workspace components the first time it runs. That is the point — but it means the first homeboy run after release will likely go red on the five remaining known-bad `homeboy-release` tests listed in Extra-Chill/homeboy#10858.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via chubes-bot
