### PR TITLE
Pin validation dependency signatures against test-stub shadowing

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -173,6 +173,7 @@
     "test:wp-codebox-prepared-dependency-cache": "bash tests/prepared-bench-dependency-cache-smoke.sh",
     "test:dependency-plugin-preflight": "bash tests/dependency-plugin-preflight-smoke.sh",
     "test:validation-dependency-resolution-regressions": "bash tests/validation-dependency-resolution-regressions-smoke.sh",
+    "test:phpstan-dependency-signature-shadowing": "bash tests/phpstan-dependency-signature-shadowing-smoke.sh",
     "test:build-before-production-prune": "bash scripts/build/build-before-production-prune-smoke.sh",
     "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",
     "test:wp-codebox-bench-prepare-steps": "node tests/wp-codebox-bench-prepare-steps-smoke.js",

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -295,9 +295,11 @@ generate_dependency_config() {
         fi
         printf '%s\n' '    scanDirectories:'
 
+        local dependency_paths=""
         while IFS= read -r dependency_path; do
             [ -z "$dependency_path" ] && continue
             has_dependencies=1
+            dependency_paths+="${dependency_path}"$'\n'
             printf '        - %s\n' "$dependency_path"
         done < <(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH")
 
@@ -318,6 +320,21 @@ generate_dependency_config() {
                 printf '        - %s\n' "$context_path"
             done < <(homeboy_resolve_phpstan_context_files "$PLUGIN_PATH")
         fi
+
+        # Pin dependency function signatures so test scaffolding in the
+        # component cannot shadow them. See
+        # homeboy_resolve_phpstan_dependency_signature_files().
+        while IFS= read -r dependency_path; do
+            [ -z "$dependency_path" ] && continue
+            while IFS= read -r signature_file; do
+                [ -z "$signature_file" ] && continue
+                if [ "$scan_file_count" -eq 0 ]; then
+                    printf '%s\n' '    scanFiles:'
+                fi
+                scan_file_count=$((scan_file_count + 1))
+                printf '        - %s\n' "$signature_file"
+            done < <(homeboy_resolve_phpstan_dependency_signature_files "$dependency_path")
+        done <<< "$dependency_paths"
 
         if [ -f "$wordpress_api_overrides" ]; then
             if [ "$scan_file_count" -eq 0 ]; then
@@ -363,6 +380,41 @@ homeboy_resolve_phpstan_context_files() {
     local component_path="$1"
 
     find "$component_path" -mindepth 1 -maxdepth 1 -type f -name '*.php' -print 2>/dev/null
+}
+
+# Dependency PHP sources registered as `scanFiles:` rather than only through
+# `scanDirectories:`.
+#
+# `scanDirectories:` declarations lose to project-source declarations during
+# signature resolution, exactly like the `bootstrapFiles:` case documented in
+# phpstan.neon.dist. A test file that defines `function bbp_get_template_part()
+# {}` for an isolated standalone run therefore shadows the dependency's real
+# `bbp_get_template_part( $slug, $name = null )`, and every genuine two-argument
+# call in component source is reported as `invoked with 2 parameters, 0
+# required`. The findings look like component defects but are artifacts of test
+# scaffolding winning the symbol graph.
+#
+# `scanFiles:` entries are scanned alongside project source and win, so the
+# dependency's real signature governs analysis. Both mechanisms are emitted:
+# `scanDirectories:` keeps whole-tree discovery for autoloaded classes, and
+# `scanFiles:` pins the function signatures that shadowing would otherwise
+# corrupt. Depth is bounded so large dependency trees stay affordable — the
+# shadowed symbols in practice are top-level plugin API surface.
+homeboy_resolve_phpstan_dependency_signature_files() {
+    local dependency_path="$1"
+    local depth="${HOMEBOY_PHPSTAN_DEPENDENCY_SIGNATURE_DEPTH:-4}"
+
+    [ -d "$dependency_path" ] || return 0
+
+    find "$dependency_path" -mindepth 1 -maxdepth "$depth" -type f -name '*.php' \
+        -not -path '*/vendor/*' \
+        -not -path '*/vendor_prefixed/*' \
+        -not -path '*/node_modules/*' \
+        -not -path '*/build/*' \
+        -not -path '*/dist/*' \
+        -not -path '*/tests/*' \
+        -not -path '*/tools/*' \
+        -print 2>/dev/null
 }
 
 cleanup_dependency_config() {

--- a/wordpress/tests/phpstan-dependency-signature-shadowing-smoke.sh
+++ b/wordpress/tests/phpstan-dependency-signature-shadowing-smoke.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression: a validation dependency's PHP sources must be registered as
+# `scanFiles:`, not only through `scanDirectories:`.
+#
+# `scanDirectories:` declarations lose to project-source declarations during
+# signature resolution, the same precedence trap phpstan.neon.dist documents for
+# `bootstrapFiles:`. Standalone test files idiomatically declare bare stubs
+# (`function bbp_get_template_part() {}`) so they can run under plain `php`.
+# When such a file is inside the analysed scope, its stub outranks the
+# dependency's real `bbp_get_template_part( $slug, $name = null )`, and every
+# genuine two-argument call in component source is reported as `invoked with 2
+# parameters, 0 required`. Those findings look like component defects but are
+# artifacts of test scaffolding winning the symbol graph.
+#
+# This asserts the generated dependency config carries both mechanisms:
+# `scanDirectories:` for whole-tree class discovery, and `scanFiles:` entries
+# pinning the dependency's function signatures.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="${ROOT_DIR}/scripts/lint/phpstan-runner.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+DEPENDENCY_DIR="${TMP_ROOT}/fixture-dependency"
+mkdir -p "${DEPENDENCY_DIR}/includes/core" "${DEPENDENCY_DIR}/vendor/acme" "${DEPENDENCY_DIR}/tests"
+
+cat > "${DEPENDENCY_DIR}/fixture-dependency.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Fixture Dependency
+ */
+PHP
+
+cat > "${DEPENDENCY_DIR}/includes/core/template-functions.php" <<'PHP'
+<?php
+function fixture_dep_template_part( $slug, $name = null ) {
+    return $slug . (string) $name;
+}
+PHP
+
+# Must never be pinned: vendored code and the dependency's own tests.
+cat > "${DEPENDENCY_DIR}/vendor/acme/vendored.php" <<'PHP'
+<?php
+function fixture_vendored_helper() {}
+PHP
+
+cat > "${DEPENDENCY_DIR}/tests/dependency-own-smoke.php" <<'PHP'
+<?php
+function fixture_dep_template_part() {}
+PHP
+
+# The runner is an executable script, not a sourceable library, so extract the
+# helper for a focused unit check instead of running a full analysis.
+eval "$(awk '/^homeboy_resolve_phpstan_dependency_signature_files\(\)/,/^}/' "$RUNNER")"
+
+if ! declare -F homeboy_resolve_phpstan_dependency_signature_files >/dev/null 2>&1; then
+    echo "FAIL: homeboy_resolve_phpstan_dependency_signature_files() is not defined" >&2
+    exit 1
+fi
+
+signature_files="$(homeboy_resolve_phpstan_dependency_signature_files "$DEPENDENCY_DIR")"
+
+if ! grep -F "${DEPENDENCY_DIR}/includes/core/template-functions.php" <<< "$signature_files" >/dev/null; then
+    echo "FAIL: dependency function signatures must be pinned as scanFiles entries" >&2
+    printf '%s\n' "$signature_files" >&2
+    exit 1
+fi
+
+if ! grep -F "${DEPENDENCY_DIR}/fixture-dependency.php" <<< "$signature_files" >/dev/null; then
+    echo "FAIL: dependency root plugin file must be pinned" >&2
+    printf '%s\n' "$signature_files" >&2
+    exit 1
+fi
+
+if grep -F "${DEPENDENCY_DIR}/vendor/acme/vendored.php" <<< "$signature_files" >/dev/null; then
+    echo "FAIL: vendored dependency code must not be pinned" >&2
+    exit 1
+fi
+
+if grep -F "${DEPENDENCY_DIR}/tests/dependency-own-smoke.php" <<< "$signature_files" >/dev/null; then
+    echo "FAIL: the dependency's own tests must not be pinned" >&2
+    exit 1
+fi
+
+# The generated dependency config must emit both mechanisms for the dependency.
+if ! grep -qF 'homeboy_resolve_phpstan_dependency_signature_files "$dependency_path"' "$RUNNER"; then
+    echo "FAIL: generate_dependency_config() must pin dependency signature files" >&2
+    exit 1
+fi
+
+if ! grep -q 'scanDirectories:' "$RUNNER"; then
+    echo "FAIL: generate_dependency_config() must still emit scanDirectories" >&2
+    exit 1
+fi
+
+echo "PHPStan dependency signature shadowing smoke passed"


### PR DESCRIPTION
## Problem

Validation dependencies are registered only through `scanDirectories:`. Those declarations **lose** to project-source declarations during PHPStan signature resolution — the exact precedence trap `phpstan.neon.dist` already documents for `bootstrapFiles:` and solves for `wordpress-stubs` by also listing it under `scanFiles:`:

> `bootstrapFiles:` declarations lose to project-source declarations. […] `scanFiles:` declarations are scanned alongside project source and win during signature resolution.

Dependencies never got the same treatment.

Standalone test files idiomatically declare bare stubs so they can run under plain `php`:

```php
function bbp_get_template_part() {
    echo '<form id="new-post"></form>';
}
```

When such a file is inside the analysed scope, that zero-argument stub outranks bbPress's real `bbp_get_template_part( $slug, $name = null )`. Every correct two-argument call in component source is then reported as:

```
bbpress/form-topic.php:23  Function bbp_get_template_part invoked with 2 parameters, 0 required.
```

The finding names a component file, so it reads as a component defect. It is an artifact of test scaffolding winning the symbol graph.

## Why it surfaced now

Unscoped runs exclude `tests/`, so shadowing cannot occur. Scoped (`--changed-since`) runs analyse changed test files, which pulls the stubs into the graph. `extrachill-community` hit this once its test files entered the changed set.

## Fix

Emit **both** mechanisms for each dependency: `scanDirectories:` keeps whole-tree discovery for autoloaded classes, and new `scanFiles:` entries pin the dependency's function signatures so they stay authoritative.

`homeboy_resolve_phpstan_dependency_signature_files()` excludes vendored code and the dependency's own `tests/`, and bounds depth (override: `HOMEBOY_PHPSTAN_DEPENDENCY_SIGNATURE_DEPTH`, default 4) since the shadowed symbols in practice are top-level plugin API surface.

## Verification

Isolated PHPStan reproduction confirming the precedence rule:

| config | result |
|---|---|
| `scanDirectories` only | `Function probe_func invoked with 2 parameters, 0 required.` |
| `scanFiles` only | clean |
| both (this fix) | clean |

Against the real case, `extrachill-community` scoped lint:

- **before:** 12 findings
- **after:** 4 findings

All 8 arity findings cleared. The remaining 4 are genuinely undeclared dependencies (`ec_icon`, `extrachill_pagination`, `extrachill_cross_site_link_button` from the parent theme; `ec_users_auto_subscribe_enabled` from `extrachill-users`) — a real config gap in that component, not shadowing. Toggling only the installed runner between patched and unpatched reproduces 12 ↔ 4 deterministically.

New `tests/phpstan-dependency-signature-shadowing-smoke.sh` asserts signature files are pinned, that vendored code and the dependency's own tests are not, and that `scanDirectories` is still emitted. Confirmed it fails when the wiring is removed.

Existing suites pass: `phpstan-relative-dependency-path`, `validation-dependencies`, `validation-dependency-resolution-regressions`, `dependency-plugin-preflight`.

`scripts/lint/phpstan-scoped-smoke.sh` fails in my environment on a missing `homeboy` sidecar-writer helper path — **identically on clean `main`**, so it is environmental and unrelated.

## Honest note on the test

My first attempt tried to reproduce shadowing end-to-end through the runner with a two-file fixture. It passed with the fix reverted — the fixture was too small to flip precedence — so it would have been a test that proved nothing. Rather than ship it, the committed test asserts the config contract directly, which is what actually regressed.