### PR TITLE
Raise dependency signature pin depth to clear real plugin layouts

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -398,11 +398,19 @@ homeboy_resolve_phpstan_context_files() {
 # dependency's real signature governs analysis. Both mechanisms are emitted:
 # `scanDirectories:` keeps whole-tree discovery for autoloaded classes, and
 # `scanFiles:` pins the function signatures that shadowing would otherwise
-# corrupt. Depth is bounded so large dependency trees stay affordable — the
-# shadowed symbols in practice are top-level plugin API surface.
+# corrupt.
+#
+# Depth is bounded so pathological trees stay affordable, but the bound must
+# clear real plugin layouts. PSR-4 sources routinely nest further than the
+# top-level API surface: `inc/Core/Database/Agents/Agents.php` is depth 5, and
+# measured dependency trees reach depth 8. A shallower bound silently omits
+# those files, which reintroduces the shadowing this function exists to
+# prevent — as unresolved-method findings rather than arity ones. Vendored
+# code, node_modules, build output, and the dependency's own tests are excluded
+# above, so the remaining tree is first-party source.
 homeboy_resolve_phpstan_dependency_signature_files() {
     local dependency_path="$1"
-    local depth="${HOMEBOY_PHPSTAN_DEPENDENCY_SIGNATURE_DEPTH:-4}"
+    local depth="${HOMEBOY_PHPSTAN_DEPENDENCY_SIGNATURE_DEPTH:-10}"
 
     [ -d "$dependency_path" ] || return 0
 

--- a/wordpress/tests/phpstan-dependency-signature-shadowing-smoke.sh
+++ b/wordpress/tests/phpstan-dependency-signature-shadowing-smoke.sh
@@ -24,7 +24,11 @@ TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 DEPENDENCY_DIR="${TMP_ROOT}/fixture-dependency"
-mkdir -p "${DEPENDENCY_DIR}/includes/core" "${DEPENDENCY_DIR}/vendor/acme" "${DEPENDENCY_DIR}/tests"
+mkdir -p \
+    "${DEPENDENCY_DIR}/includes/core" \
+    "${DEPENDENCY_DIR}/inc/Core/Database/Agents" \
+    "${DEPENDENCY_DIR}/vendor/acme" \
+    "${DEPENDENCY_DIR}/tests"
 
 cat > "${DEPENDENCY_DIR}/fixture-dependency.php" <<'PHP'
 <?php
@@ -37,6 +41,20 @@ cat > "${DEPENDENCY_DIR}/includes/core/template-functions.php" <<'PHP'
 <?php
 function fixture_dep_template_part( $slug, $name = null ) {
     return $slug . (string) $name;
+}
+PHP
+
+# Deeply nested PSR-4 source. Real dependency trees reach this depth, and a
+# shallow bound would silently omit it — reintroducing shadowing as
+# unresolved-method findings.
+cat > "${DEPENDENCY_DIR}/inc/Core/Database/Agents/Agents.php" <<'PHP'
+<?php
+namespace Fixture\Core\Database\Agents;
+
+class Agents {
+    public function get_agent( int $agent_id ): ?array {
+        return null;
+    }
 }
 PHP
 
@@ -70,6 +88,13 @@ fi
 
 if ! grep -F "${DEPENDENCY_DIR}/fixture-dependency.php" <<< "$signature_files" >/dev/null; then
     echo "FAIL: dependency root plugin file must be pinned" >&2
+    printf '%s\n' "$signature_files" >&2
+    exit 1
+fi
+
+# Depth bound must clear real PSR-4 layouts, not just top-level API surface.
+if ! grep -F "${DEPENDENCY_DIR}/inc/Core/Database/Agents/Agents.php" <<< "$signature_files" >/dev/null; then
+    echo "FAIL: deeply nested dependency sources must be pinned; the depth bound is too shallow" >&2
     printf '%s\n' "$signature_files" >&2
     exit 1
 fi


### PR DESCRIPTION
Follow-up to #2488. That PR fixed the shadowing mechanism but shipped a depth bound that is too shallow, so the fix under-covered real dependency trees.

## Problem

`homeboy_resolve_phpstan_dependency_signature_files()` defaulted to depth 4. Real PSR-4 layouts nest further:

| dependency | max first-party PHP depth |
|---|---|
| `agents-api` | 3 |
| `extrachill` | 4 |
| `extrachill-users` | 5 |
| `data-machine` | **8** |

`data-machine`'s `inc/Core/Database/Agents/Agents.php` is depth 5 — outside the bound — so it was never pinned and stayed shadowable.

## Why it survived review

The symptom differs from the arity findings #2488 targeted. An omitted *function* file produces `invoked with N parameters, 0 required`; an omitted *class* file produces:

```
Call to an undefined method DataMachine\Core\Database\Agents\Agents::get_agent().
Call to an undefined method DataMachine\Core\Database\Agents\Agents::update_agent().
```

Both methods demonstrably exist (`Agents.php:232` and `:469`). I read that as genuine consumer breakage in `extrachill-roadie` rather than residual under-coverage from my own fix, and only caught it when checking whether those methods were real.

## Fix

Default depth 4 → 10, and cover a depth-5 PSR-4 source in the smoke test so a future narrowing fails loudly rather than silently under-covering.

Exclusions are unchanged — vendored code, `node_modules`, build output, and the dependency's own `tests/` are still filtered, so the scanned tree remains first-party source.

## Verification

`extrachill-roadie` scoped lint: **21 → 19**. Both `Agents::` findings clear, and the result now matches an explicit `HOMEBOY_PHPSTAN_DEPENDENCY_SIGNATURE_DEPTH=8` run, confirming depth was the only variable.

`extrachill-community` stays clean (0 PHPStan findings), so the wider scan introduces no regression.

Smoke test asserts the deep file is pinned; confirmed it fails under `HOMEBOY_PHPSTAN_DEPENDENCY_SIGNATURE_DEPTH=4`:

```
FAIL: deeply nested dependency sources must be pinned; the depth bound is too shallow
```

Existing suites pass: `phpstan-relative-dependency-path`, `validation-dependencies`, `validation-dependency-resolution-regressions`.

## Remaining Roadie findings

The other 19 are genuine issues in Roadie's own source — redundant `is_array()` checks PHPStan proves always-true, a non-nullable `??` left operand, and `WP_Agent_Execution_Principal::user_session()` / `$scope` property access that needs checking against the current agents-api API. Those belong to that component, not here.