### PR TITLE
Register dependency classes lacking a Composer autoloader

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -174,6 +174,7 @@
     "test:dependency-plugin-preflight": "bash tests/dependency-plugin-preflight-smoke.sh",
     "test:validation-dependency-resolution-regressions": "bash tests/validation-dependency-resolution-regressions-smoke.sh",
     "test:phpstan-dependency-signature-shadowing": "bash tests/phpstan-dependency-signature-shadowing-smoke.sh",
+    "test:phpstan-dependency-class-registration": "bash tests/phpstan-dependency-class-registration-smoke.sh",
     "test:build-before-production-prune": "bash scripts/build/build-before-production-prune-smoke.sh",
     "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",
     "test:wp-codebox-bench-prepare-steps": "node tests/wp-codebox-bench-prepare-steps-smoke.js",

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -685,6 +685,82 @@ if [ -f "$COMPONENT_BASELINE" ] && [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
 fi
 
 # Include component/dependency autoloaders if they exist
+# Class map for dependencies that ship no Composer autoloader.
+#
+# `scanFiles:` and `scanDirectories:` make declarations available for signature
+# resolution, but neither registers a class for member access — PHPStan reports
+# `unknown class` and every property/method access on it. Only an autoloader (or
+# pulling the dependency into `paths:`, which would also report findings inside
+# the dependency) registers classes.
+#
+# WordPress plugins commonly load classes with `require_once` from a bootstrap
+# file instead of Composer, so those dependencies contribute no autoloader at
+# all. Their file names also follow WordPress conventions
+# (`class-wp-agent-materialized-identity.php`) rather than PSR-4, so no path
+# convention can derive the mapping — the declarations have to be indexed.
+#
+# Emits `<fqcn> => <file>` pairs by tokenizing each dependency source once.
+# Tokenizing is used rather than a regex so commented-out or string-literal
+# occurrences of `class Foo` cannot poison the map.
+homeboy_emit_dependency_class_map_entries() {
+    local dependency_path="$1"
+
+    homeboy_resolve_phpstan_dependency_signature_files "$dependency_path" \
+        | "${HOMEBOY_PHP_BIN:-php}" -r '
+            $stdin = fopen("php://stdin", "r");
+            while (false !== ($file = fgets($stdin))) {
+                $file = trim($file);
+                if ($file === "" || !is_readable($file)) {
+                    continue;
+                }
+                $source = @file_get_contents($file);
+                if (!is_string($source) || strpos($source, "<?php") === false) {
+                    continue;
+                }
+                $tokens = @token_get_all($source);
+                if (!is_array($tokens)) {
+                    continue;
+                }
+                $namespace = "";
+                $count = count($tokens);
+                for ($i = 0; $i < $count; $i++) {
+                    $token = $tokens[$i];
+                    if (!is_array($token)) {
+                        continue;
+                    }
+                    if ($token[0] === T_NAMESPACE) {
+                        $namespace = "";
+                        for ($j = $i + 1; $j < $count; $j++) {
+                            if (is_array($tokens[$j]) && in_array($tokens[$j][0], array(T_STRING, T_NAME_QUALIFIED), true)) {
+                                $namespace .= $tokens[$j][1];
+                            } elseif ($tokens[$j] === ";" || $tokens[$j] === "{") {
+                                break;
+                            }
+                        }
+                        continue;
+                    }
+                    if (!in_array($token[0], array(T_CLASS, T_INTERFACE, T_TRAIT), true)) {
+                        continue;
+                    }
+                    // Skip anonymous classes and `::class` constant fetches.
+                    if ($i > 0 && is_array($tokens[$i - 1]) && $tokens[$i - 1][0] === T_DOUBLE_COLON) {
+                        continue;
+                    }
+                    for ($j = $i + 1; $j < $count; $j++) {
+                        if (is_array($tokens[$j]) && $tokens[$j][0] === T_STRING) {
+                            $fqcn = ($namespace !== "" ? $namespace . "\\" : "") . $tokens[$j][1];
+                            echo $fqcn . "\t" . $file . "\n";
+                            break;
+                        }
+                        if ($tokens[$j] === "(" || $tokens[$j] === "{") {
+                            break;
+                        }
+                    }
+                }
+            }
+        ' 2>/dev/null
+}
+
 generate_composite_autoload() {
     local tmpfile
     local component_autoload="${PLUGIN_PATH}/vendor/autoload.php"
@@ -696,6 +772,7 @@ generate_composite_autoload() {
         printf '%s\n' '<?php'
         printf '%s\n' '$autoloadFiles = ['
 
+        local autoloaderless_dependencies=""
         while IFS= read -r dependency_path; do
             [ -z "$dependency_path" ] && continue
             local dependency_autoload="${dependency_path}/vendor/autoload.php"
@@ -705,6 +782,9 @@ generate_composite_autoload() {
             fi
             if [ -f "$dependency_prefixed_autoload" ]; then
                 printf '    %s,\n' "$(printf '%s' "$dependency_prefixed_autoload" | jq -Rsa .)"
+            fi
+            if [ ! -f "$dependency_autoload" ] && [ ! -f "$dependency_prefixed_autoload" ]; then
+                autoloaderless_dependencies+="${dependency_path}"$'\n'
             fi
         done < <(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH")
 
@@ -722,6 +802,34 @@ generate_composite_autoload() {
         printf '%s\n' '        require_once $autoloadFile;'
         printf '%s\n' '    }'
         printf '%s\n' '}'
+
+        # Dependencies without a Composer autoloader still have to register
+        # their classes, otherwise member access on them reports `unknown
+        # class`. See homeboy_emit_dependency_class_map_entries().
+        printf '%s\n' '$homeboyDependencyClassMap = ['
+        local class_map_entries=0
+        while IFS= read -r dependency_path; do
+            [ -z "$dependency_path" ] && continue
+            while IFS=$'\t' read -r fqcn class_file; do
+                [ -z "$fqcn" ] || [ -z "$class_file" ] && continue
+                printf '    %s => %s,\n' \
+                    "$(printf '%s' "$fqcn" | jq -Rsa .)" \
+                    "$(printf '%s' "$class_file" | jq -Rsa .)"
+                class_map_entries=$((class_map_entries + 1))
+            done < <(homeboy_emit_dependency_class_map_entries "$dependency_path")
+        done <<< "$autoloaderless_dependencies"
+        printf '%s\n' '];'
+        printf '%s\n' 'if ($homeboyDependencyClassMap !== []) {'
+        printf '%s\n' '    spl_autoload_register(static function ($class) use ($homeboyDependencyClassMap) {'
+        printf '%s\n' '        if (isset($homeboyDependencyClassMap[$class])) {'
+        printf '%s\n' '            require_once $homeboyDependencyClassMap[$class];'
+        printf '%s\n' '        }'
+        printf '%s\n' '    });'
+        printf '%s\n' '}'
+
+        if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+            echo "DEBUG: dependency class map entries: ${class_map_entries}" >&2
+        fi
     } > "$tmpfile"
 
     printf '%s\n' "$tmpfile"

--- a/wordpress/tests/phpstan-dependency-class-registration-smoke.sh
+++ b/wordpress/tests/phpstan-dependency-class-registration-smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression: dependency classes must be registered for analysis even when the
+# dependency ships no Composer autoloader.
+#
+# `scanFiles:` and `scanDirectories:` make declarations available for signature
+# resolution but do not register a class for member access — PHPStan reports
+# `unknown class` plus every property and method access on it. Only an
+# autoloader registers classes.
+#
+# WordPress plugins commonly load classes with `require_once` from a bootstrap
+# file rather than Composer, so such dependencies contribute no autoloader.
+# Their file names also follow WordPress conventions rather than PSR-4, so the
+# mapping has to be indexed from the declarations themselves.
+#
+# This asserts the generated composite autoloader carries a class map covering
+# those dependencies, and that the indexer resolves fully-qualified names.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="${ROOT_DIR}/scripts/lint/phpstan-runner.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+DEPENDENCY_DIR="${TMP_ROOT}/fixture-dependency"
+mkdir -p "${DEPENDENCY_DIR}/src/Identity" "${DEPENDENCY_DIR}/vendor/acme" "${DEPENDENCY_DIR}/tests"
+
+cat > "${DEPENDENCY_DIR}/fixture-dependency.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Fixture Dependency
+ */
+require_once __DIR__ . '/src/Identity/class-fixture-identity.php';
+PHP
+
+# WordPress file naming, PSR-4-incompatible: no path convention derives the FQCN.
+cat > "${DEPENDENCY_DIR}/src/Identity/class-fixture-identity.php" <<'PHP'
+<?php
+namespace FixtureAPI\Core\Identity;
+
+final class Fixture_Materialized_Identity {
+    public function __construct(
+        public readonly int $id,
+        public readonly string $scope,
+    ) {}
+}
+PHP
+
+# Declarations that must never enter the map.
+cat > "${DEPENDENCY_DIR}/vendor/acme/vendored.php" <<'PHP'
+<?php
+namespace Acme;
+class Vendored {}
+PHP
+
+cat > "${DEPENDENCY_DIR}/tests/dependency-own-smoke.php" <<'PHP'
+<?php
+namespace FixtureAPI\Core\Identity;
+class Fixture_Materialized_Identity {}
+PHP
+
+# The runner is an executable script, so extract the helpers under test rather
+# than sourcing it.
+eval "$(awk '/^homeboy_resolve_phpstan_dependency_signature_files\(\)/,/^}/' "$RUNNER")"
+eval "$(awk '/^homeboy_emit_dependency_class_map_entries\(\)/,/^}/' "$RUNNER")"
+
+for helper in homeboy_resolve_phpstan_dependency_signature_files homeboy_emit_dependency_class_map_entries; do
+    if ! declare -F "$helper" >/dev/null 2>&1; then
+        echo "FAIL: ${helper}() is not defined" >&2
+        exit 1
+    fi
+done
+
+entries="$(homeboy_emit_dependency_class_map_entries "$DEPENDENCY_DIR")"
+
+if ! grep -qP '^FixtureAPI\\Core\\Identity\\Fixture_Materialized_Identity\t' <<< "$entries"; then
+    echo "FAIL: namespaced dependency class must be indexed with its fully-qualified name" >&2
+    printf '%s\n' "$entries" >&2
+    exit 1
+fi
+
+mapped_file="$(grep -P '^FixtureAPI\\Core\\Identity\\Fixture_Materialized_Identity\t' <<< "$entries" | head -1 | cut -f2)"
+if [ "$mapped_file" != "${DEPENDENCY_DIR}/src/Identity/class-fixture-identity.php" ]; then
+    echo "FAIL: class must map to its declaring file, got: ${mapped_file}" >&2
+    exit 1
+fi
+
+if grep -q 'Acme\\Vendored' <<< "$entries"; then
+    echo "FAIL: vendored dependency classes must not be indexed" >&2
+    exit 1
+fi
+
+if grep -qF "${DEPENDENCY_DIR}/tests/" <<< "$entries"; then
+    echo "FAIL: the dependency's own tests must not be indexed" >&2
+    exit 1
+fi
+
+# The generated autoloader must register the map for autoloader-less
+# dependencies.
+if ! grep -qF 'homeboy_emit_dependency_class_map_entries "$dependency_path"' "$RUNNER"; then
+    echo "FAIL: generate_composite_autoload() must build a dependency class map" >&2
+    exit 1
+fi
+
+if ! grep -qF 'spl_autoload_register' "$RUNNER"; then
+    echo "FAIL: generate_composite_autoload() must register the class map" >&2
+    exit 1
+fi
+
+echo "PHPStan dependency class registration smoke passed"


### PR DESCRIPTION
Fixes #2490

Third and final variant of the dependency-analysis gap, after #2488 (signature shadowing) and #2489 (depth bound). Those fixed **function** resolution; this fixes **class** resolution.

## Problem

`scanFiles:` and `scanDirectories:` make declarations available for signature resolution but do **not** register a class for member access. PHPStan reports `unknown class` plus every property and method access on it.

`generate_composite_autoload()` only collected `vendor/autoload.php` and `vendor_prefixed/autoload.php` per dependency. WordPress plugins commonly load classes with `require_once` from a bootstrap file instead of Composer, so those dependencies contributed no autoloader at all.

`agents-api` is exactly this shape, which is why `extrachill-roadie` reported:

```
inc/venue-agent-instances.php:191  Class AgentsAPI\Core\Identity\WP_Agent_Materialized_Identity not found.
inc/venue-agent-instances.php:196  Access to property $id on an unknown class ...
```

The class exists with `$id`/`$scope` as promoted readonly properties.

## Why a path convention won't work

The file is `src/Identity/class-wp-agent-materialized-identity.php` declaring `AgentsAPI\Core\Identity\WP_Agent_Materialized_Identity`. WordPress file naming is not PSR-4-derivable — the directory says `Identity`, the namespace says `Core\Identity`, and the basename is kebab-cased with a `class-` prefix. No path rule recovers the FQCN, so declarations have to be **indexed**.

## Fix

Tokenize each dependency source once, emit `<fqcn> => <file>` pairs, and register them via `spl_autoload_register` — only for dependencies that ship no Composer autoloader, so existing Composer-based resolution is untouched.

Tokenizing rather than pattern matching means commented-out or string-literal occurrences of `class Foo` cannot poison the map, and `::class` fetches are skipped. Vendored code and the dependency's own `tests/` are already excluded by the shared file resolver from #2488.

Isolated confirmation that no other mechanism suffices:

| config | result |
|---|---|
| `scanDirectories` only | `unknown class` |
| `scanFiles` only | `unknown class` |
| both | `unknown class` |
| **autoloader registering the class** | **clean** |

## Verification

`extrachill-roadie` (on top of Extra-Chill/extrachill-roadie#100): **6 → 0**, with `HOMEBOY_DEBUG=1` reporting 847 indexed classes from `agents-api`.

No regression elsewhere — `extrachill-community` and `extrachill-events` both still pass.

New `tests/phpstan-dependency-class-registration-smoke.sh` asserts the FQCN is indexed from a WordPress-named file, that it maps to its declaring file, and that vendored code and the dependency's own tests stay out. Confirmed it fails when the wiring is removed:

```
FAIL: generate_composite_autoload() must build a dependency class map
```

All six dependency/PHPStan suites pass: class-registration, signature-shadowing, relative-dependency-path, validation-dependencies, resolution-regressions, plugin-preflight.

## Net effect across the three PRs

`extrachill-roadie` went 28 → 0 findings, and none of the original 28 were real defects in that component.