### PR TITLE
fix(wordpress): project external database test secrets

### DIFF
--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -23,6 +23,16 @@ for (const legacySettingId of ['wp_codebox_blueprint', 'wp_codebox_workloads', '
 	assert.equal(settingIds.has(legacySettingId), false, `wordpress manifest no longer accepts ${legacySettingId}`);
 }
 
+assert.deepEqual(manifest.test.secret_env_projections, [
+	{
+		when: {
+			path: ['wp_codebox_database_service', 'provider'],
+			equals: 'external',
+		},
+		names_path: ['wp_codebox_database_service', 'secret_env'],
+	},
+], 'external WP Codebox database identity names are projected through Homeboy test secret resolution');
+
 const fuzzEnv = new Set(manifest.fuzz.env);
 for (const envKey of ['HOMEBOY_SETTINGS_JSON', 'HOMEBOY_SETTINGS_WP_CODEBOX_BIN', 'HOMEBOY_WP_CODEBOX_BIN', 'WP_CODEBOX_BIN']) {
 	assert.ok(

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1091,6 +1091,15 @@
       "file_extensions": ["php"],
       "inline_tests": false
     },
+    "secret_env_projections": [
+      {
+        "when": {
+          "path": ["wp_codebox_database_service", "provider"],
+          "equals": "external"
+        },
+        "names_path": ["wp_codebox_database_service", "secret_env"]
+      }
+    ],
     "extension_script": "scripts/test/test-runner.sh"
   },
   "bench": {


### PR DESCRIPTION
## Summary
- project WordPress external database secret identity names through Homeboy's merged `test.secret_env_projections` contract
- keep Docker/default and native database modes free of external credential requirements
- assert the exact WordPress-owned settings predicate and names path in the manifest smoke test

## Root Cause
The WordPress PHPUnit adapter reads external database identity names from `settings.wp_codebox_database_service.secret_env`, but the extension did not declare those conditional identities to Homeboy. Local review/release therefore started the adapter without resolved `WP_CODEBOX_DB_*` values and failed before product PHPUnit at `wp-codebox-phpunit-adapter.mjs`.

## Homeboy Contract
This consumes Homeboy PR #10852 without adding WordPress or WP Codebox knowledge to generic Homeboy:

- predicate: `settings.wp_codebox_database_service.provider == "external"`
- names path: `settings.wp_codebox_database_service.secret_env`
- projected data: identity names only, never resolved values

Homeboy evaluates this after effective settings merge and before child execution. Its existing resolver rejects missing, malformed, duplicate, or conflicting identities, injects resolved values only into the test child, and applies existing stdout, stderr, artifact, supervision, failure, and release-evidence redaction. Static `test.secret_env` declarations continue to compose through the same path.

## Mode Behavior
- omitted/default Docker mode does not match and requests no external identities
- native MariaDB mode does not match and requests no external identities
- external mode projects configured host, optional port, username, and password identity names
- missing external identities fail closed in Homeboy before the adapter child starts, exposing names only

## Verification
Passed:
- `node tests/wordpress-manifest-settings-smoke.js`
- `npm run test:wp-codebox-database-service`
- `npm run test:wp-codebox-phpunit-evidence`
- `npm run test:wp-codebox-phpunit-aggregate`
- `jq empty wordpress.json`
- `node --check tests/wordpress-manifest-settings-smoke.js`
- `node --check scripts/test/wp-codebox-phpunit-adapter.mjs`
- current Homeboy main `cargo build --bin homeboy`
- current Homeboy main installed and parsed this WordPress extension manifest successfully
- `cargo test -p homeboy-extension-contract conditional_secret_projection --lib` (2 passed)
- `cargo test -p homeboy-extension conditional_secret_projection --lib` (3 passed)
- `cargo test -p homeboy-extension review_test_projects_matching_secrets_and_skips_non_matching_mode --lib`
- `cargo test -p homeboy-extension review_test_missing_projected_secret_fails_before_spawn --lib`
- `cargo test -p homeboy-release validate_test_quality_composes_and_redacts_conditional_secrets --lib`
- `git diff --check`

Repository-wide `npm run lint:js` still reports 52 existing errors in untouched files; the changed smoke test and JSON manifest are ignored by the ESLint configuration, while their focused syntax/contract checks pass. The existing recipe-helper timeout suite is independently blocked because its explicit camelCase binary option is not translated to the resolver's canonical key; tracked in #2493. The native canary host binary does not advertise native MariaDB, while the database-service smoke fixture covers native routing and no-secret behavior.

## Release Impact
This unblocks the Extra Chill Events v0.56.3 local `preflight.test` failure by ensuring Homeboy resolves the configured external database identities before WordPress test execution.

Closes #2458