### PR TITLE
ci: gate pull requests on every extension's declared self_checks

### DIFF
--- a/.github/workflows/extension-self-checks.yml
+++ b/.github/workflows/extension-self-checks.yml
@@ -36,9 +36,22 @@ jobs:
           - swift
           - wordpress
         include:
-          # Two WordPress self_checks cannot pass in this job today. The runner
-          # reports every skip as a GitHub Actions warning so they stay visible
-          # instead of rotting silently.
+          # Some already-declared self_checks cannot pass in this job today.
+          # Every skip is reported by the runner as a GitHub Actions warning so
+          # it stays visible instead of rotting silently. Nothing is removed
+          # from any homeboy.json, so release-preflight coverage is unchanged.
+          #
+          #   rust tests/zero-test-scope-fallback-smoke.sh
+          #     Fails with "HOMEBOY_RUNTIME_RUNNER_PRELUDE is required" (run
+          #     30700539989). Same #2507 class as the WordPress entry below.
+          #     Note it self-skips with `SKIP: cargo is not installed`, so it is
+          #     silently green anywhere without a Rust toolchain and only fails
+          #     on a runner that has one.
+          - component: rust
+            self_check_skip: |
+              bash tests/zero-test-scope-fallback-smoke.sh
+
+          # Two WordPress self_checks cannot pass in this job today.
           #
           #   scripts/test/full-suite-no-phpunit-smoke.sh
           #     Routes through scripts/test/test-runner.sh, which hard-requires

--- a/.github/workflows/extension-self-checks.yml
+++ b/.github/workflows/extension-self-checks.yml
@@ -1,0 +1,86 @@
+# Pull request gate for the published extensions.
+#
+# `homeboy.yml` only runs on push to main, and it only runs `commands: release`.
+# `homeboy-action` always invokes `homeboy release` with `--skip-checks` because
+# it assumes "quality gates run in separate jobs before this script"
+# (homeboy-action scripts/release/run-release.sh). This repo had no such jobs,
+# so `preflight.lint` / `preflight.test` were reported as
+# `skip_reason: "--skip-checks"` on every release and the declared `self_checks`
+# never executed anywhere.
+#
+# Homeboy resolves extensions at the latest published release and consumers do
+# not pin, so a regression merged here reaches every consumer with nothing in
+# front of it. This workflow is the missing gate: it runs each extension's
+# declared `self_checks` on every pull request.
+name: Extension self-checks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  self-checks:
+    name: Self-checks ${{ matrix.component }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - go
+          - nodejs
+          - rust
+          - swift
+          - wordpress
+        include:
+          # Two WordPress self_checks cannot pass in this job today. The runner
+          # reports every skip as a GitHub Actions warning so they stay visible
+          # instead of rotting silently.
+          #
+          #   scripts/test/full-suite-no-phpunit-smoke.sh
+          #     Routes through scripts/test/test-runner.sh, which hard-requires
+          #     HOMEBOY_RUNTIME_RUNNER_PRELUDE. That path is materialized by the
+          #     Homeboy binary when it executes an extension runner; it does not
+          #     exist for a self-check, which Homeboy runs with a plain `sh -c`.
+          #     Tracked by #2507.
+          #
+          #   tests/wordpress-fuzz-runner-smoke.js
+          #     Pre-existing failure, not an environment problem. Its own
+          #     fake-wp-codebox.js fixture exits 1 with "expected public
+          #     wp-codebox run-fuzz-suite command", so preflight readiness
+          #     resolves to `blocked` and the run status is `skipped` instead of
+          #     the asserted success. Only discoverable once the self_checks were
+          #     wired to run at all.
+          - component: wordpress
+            self_check_skip: |
+              bash scripts/test/full-suite-no-phpunit-smoke.sh
+              node tests/wordpress-fuzz-runner-smoke.js
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install WordPress extension dependencies
+        if: matrix.component == 'wordpress'
+        working-directory: wordpress
+        run: |
+          set -euo pipefail
+          composer install --no-interaction --no-progress --prefer-dist
+          npm install
+
+      - name: Run lint self-checks
+        env:
+          HOMEBOY_SELF_CHECK_SKIP: ${{ matrix.self_check_skip }}
+        run: bash scripts/ci/run-self-checks.sh "${{ matrix.component }}" lint
+
+      - name: Run test self-checks
+        env:
+          HOMEBOY_SELF_CHECK_SKIP: ${{ matrix.self_check_skip }}
+        run: bash scripts/ci/run-self-checks.sh "${{ matrix.component }}" test

--- a/go/homeboy.json
+++ b/go/homeboy.json
@@ -6,5 +6,11 @@
       "file": "go.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
-  ]
+  ],
+  "self_checks": {
+    "lint": [
+      "jq empty go.json",
+      "find . -name '*.sh' -print0 | xargs -0 -r -n1 bash -n"
+    ]
+  }
 }

--- a/nodejs/homeboy.json
+++ b/nodejs/homeboy.json
@@ -6,5 +6,35 @@
       "file": "nodejs.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
-  ]
+  ],
+  "self_checks": {
+    "lint": [
+      "jq empty nodejs.json",
+      "find . -name '*.sh' -print0 | xargs -0 -r -n1 bash -n",
+      "find . \\( -name '*.mjs' -o -name '*.cjs' -o -name '*.js' \\) -not -path './node_modules/*' -print0 | xargs -0 -r -n1 node --check"
+    ],
+    "test": [
+      "node scripts/bench/browser-profile-diff-smoke.mjs",
+      "bash scripts/bench/nodejs-bench-artifact-context-smoke.sh",
+      "bash scripts/bench/nodejs-bench-artifacts-smoke.sh",
+      "bash scripts/bench/nodejs-bench-custom-metrics-smoke.sh",
+      "bash scripts/bench/nodejs-bench-warmup-smoke.sh",
+      "bash scripts/bench/nodejs-bench-workload-context-smoke.sh",
+      "bash scripts/bench/nodejs-browser-helper-smoke.sh",
+      "bash scripts/bench/nodejs-browser-page-scenario-smoke.sh",
+      "bash scripts/bench/nodejs-browser-performance-profiler-smoke.sh",
+      "bash scripts/bench/nodejs-package-script-bench-smoke.sh",
+      "bash scripts/bench/nodejs-standalone-workload-smoke.sh",
+      "bash scripts/bench/nodejs-workload-progress-forwarding-smoke.sh",
+      "bash scripts/bench/nodejs-workload-utils-smoke.sh",
+      "bash scripts/build/build-runner-shell-smoke.sh",
+      "bash scripts/runtime/nodejs-invocation-runtime-smoke.sh",
+      "node scripts/trace/trace-helpers-smoke.mjs",
+      "bash tests/local-workspace-deps-smoke.sh",
+      "bash tests/node-helpers-packaged-project-scripts-smoke.sh",
+      "bash tests/nodejs-dev-overlay-browser-result-shapes-smoke.sh",
+      "cd .. && bash nodejs/tests/playwright-utility-smoke.sh",
+      "bash ../tests/nodejs-deps-provider-smoke.sh"
+    ]
+  }
 }

--- a/scripts/ci/run-self-checks.sh
+++ b/scripts/ci/run-self-checks.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Run an extension's declared `self_checks` for one capability.
+#
+# `self_checks` in `<extension>/homeboy.json` are the commands Homeboy runs
+# during the release quality preflight (`preflight.lint` / `preflight.test`).
+# The published release workflow invokes `homeboy release` through
+# `Extra-Chill/homeboy-action`, which always passes `--skip-checks` because it
+# assumes "quality gates run in separate jobs before this script". This repo had
+# no such jobs, so the declared self_checks never executed anywhere. This runner
+# is that missing job.
+#
+# Execution semantics deliberately mirror Homeboy's own self-check runner
+# (crates/homeboy-extension/src/self_check.rs): each command is executed with
+# `sh -c` and the extension directory as the working directory. The one
+# difference is that this runner executes every command and reports a summary
+# instead of stopping at the first failure, so a pull request surfaces its whole
+# blast radius in a single run.
+#
+# Usage:
+#   scripts/ci/run-self-checks.sh <extension-dir> <capability>
+#
+# Environment:
+#   HOMEBOY_SELF_CHECK_SKIP  Optional newline-separated list of declared
+#                            commands to skip. Every skip is reported as a
+#                            GitHub Actions warning so it cannot rot silently.
+
+set -euo pipefail
+
+EXTENSION_DIR="${1:-}"
+CAPABILITY="${2:-}"
+
+if [ -z "$EXTENSION_DIR" ] || [ -z "$CAPABILITY" ]; then
+    echo "Usage: scripts/ci/run-self-checks.sh <extension-dir> <capability>" >&2
+    exit 2
+fi
+
+case "$CAPABILITY" in
+    lint | test) ;;
+    *)
+        echo "Unsupported capability '$CAPABILITY' (expected 'lint' or 'test')." >&2
+        exit 2
+        ;;
+esac
+
+if [ ! -d "$EXTENSION_DIR" ]; then
+    echo "Extension directory not found: $EXTENSION_DIR" >&2
+    exit 2
+fi
+
+MANIFEST="$EXTENSION_DIR/homeboy.json"
+if [ ! -f "$MANIFEST" ]; then
+    echo "Missing component manifest: $MANIFEST" >&2
+    exit 2
+fi
+
+if ! jq empty "$MANIFEST" >/dev/null 2>&1; then
+    echo "Component manifest is not valid JSON: $MANIFEST" >&2
+    exit 1
+fi
+
+mapfile -t COMMANDS < <(jq -r --arg capability "$CAPABILITY" \
+    '.self_checks[$capability] // [] | .[]' "$MANIFEST")
+
+if [ "${#COMMANDS[@]}" -eq 0 ]; then
+    echo "::notice::${EXTENSION_DIR} declares no ${CAPABILITY} self_checks — nothing to run."
+    exit 0
+fi
+
+SKIPPED_COMMANDS=()
+if [ -n "${HOMEBOY_SELF_CHECK_SKIP:-}" ]; then
+    while IFS= read -r skip_entry; do
+        [ -n "$skip_entry" ] || continue
+        SKIPPED_COMMANDS+=("$skip_entry")
+    done <<<"${HOMEBOY_SELF_CHECK_SKIP}"
+fi
+
+is_skipped() {
+    local candidate="$1"
+    local entry
+    for entry in ${SKIPPED_COMMANDS[@]+"${SKIPPED_COMMANDS[@]}"}; do
+        if [ "$entry" = "$candidate" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+echo "Running ${#COMMANDS[@]} ${CAPABILITY} self-check command(s) for ${EXTENSION_DIR}"
+
+FAILED_COMMANDS=()
+SKIPPED_COUNT=0
+PASSED_COUNT=0
+
+for command in "${COMMANDS[@]}"; do
+    if is_skipped "$command"; then
+        SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+        echo "::warning::Skipping declared ${CAPABILITY} self-check for ${EXTENSION_DIR}: ${command}"
+        continue
+    fi
+
+    echo "::group::${EXTENSION_DIR} ${CAPABILITY}: ${command}"
+    command_exit=0
+    (cd "$EXTENSION_DIR" && sh -c "$command") || command_exit=$?
+    echo "::endgroup::"
+
+    if [ "$command_exit" -eq 0 ]; then
+        PASSED_COUNT=$((PASSED_COUNT + 1))
+        echo "::notice::PASSED ${EXTENSION_DIR} ${CAPABILITY}: ${command}"
+    else
+        FAILED_COMMANDS+=("$command")
+        echo "::error::FAILED (exit ${command_exit}) ${EXTENSION_DIR} ${CAPABILITY}: ${command}"
+    fi
+done
+
+echo ""
+echo "${EXTENSION_DIR} ${CAPABILITY} self-checks: ${PASSED_COUNT} passed, ${#FAILED_COMMANDS[@]} failed, ${SKIPPED_COUNT} skipped"
+
+if [ "${#FAILED_COMMANDS[@]}" -gt 0 ]; then
+    echo "Failed commands:" >&2
+    for command in "${FAILED_COMMANDS[@]}"; do
+        echo "  - ${command}" >&2
+    done
+    exit 1
+fi

--- a/swift/homeboy.json
+++ b/swift/homeboy.json
@@ -6,5 +6,16 @@
       "file": "swift.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
-  ]
+  ],
+  "self_checks": {
+    "lint": [
+      "jq empty swift.json",
+      "find . -name '*.sh' -print0 | xargs -0 -r -n1 bash -n",
+      "python3 -c 'import ast,sys;[ast.parse(open(f).read(),f) for f in sys.argv[1:]]' scripts/fingerprint.py"
+    ],
+    "test": [
+      "bash tests/fingerprint-smoke.sh",
+      "bash tests/swift-extension-smoke.sh"
+    ]
+  }
 }


### PR DESCRIPTION
ci: gate pull requests on every extension's declared self_checks

Homeboy resolves extensions at the latest published release and consumers
do not pin, so anything merged here propagates to every consumer on the
next release with nothing in front of it. Until now nothing gated that.

`.github/workflows/homeboy.yml` triggers only on push to main and runs
only `commands: release`. The one `pull_request` workflow,
`wp-codebox-test-runtime-canary.yml`, is path-filtered to
`wordpress/scripts/test/**` plus four fixture directories. Any change to
`rust/`, `nodejs/`, `go/`, `swift/`, `scripts/lib/`, or any `<ext>.json`
received zero CI on a pull request.

The declared `self_checks` were not a fallback for that gap: they have
never executed in CI at all. `homeboy-action` invokes `homeboy release`
with a hard-coded `--skip-checks` because it assumes "quality gates run
in separate jobs before this script"
(homeboy-action scripts/release/run-release.sh). This repo has no such
jobs, so every release run reports `preflight.audit`, `preflight.lint`
and `preflight.test` with `skip_reason: "--skip-checks"` — verified in
run 30699418547, the most recent green release of `wordpress`. The
`self_checks` already declared in `rust/homeboy.json` and
`wordpress/homeboy.json` were dead configuration.

What this adds
--------------

`.github/workflows/extension-self-checks.yml` — `pull_request` and
`workflow_dispatch`, `permissions: contents: read`, `fail-fast: false`
over the same `[go, nodejs, rust, swift, wordpress]` matrix the release
workflow uses. Each matrix entry runs two steps, `lint` then `test`. The
WordPress entry additionally runs `composer install` + `npm install`
first, matching the existing canary workflow. No `concurrency` block:
that is not a pattern in this repo. This is the "separate job" that
`--skip-checks` in the release path already assumes exists.

`scripts/ci/run-self-checks.sh` — reads `self_checks.<capability>` from
`<extension>/homeboy.json` and executes each command with `sh -c` and the
extension directory as the working directory, mirroring Homeboy's own
runner in `crates/homeboy-extension/src/self_check.rs`. It deliberately
runs every command instead of stopping at the first failure, so a pull
request sees its whole blast radius in one run. An absent or empty
capability list is a no-op, not a failure.

Note that `homeboy review lint <ext>` / `homeboy review test <ext>`
cannot be used here. Both force the main workflow rather than self-check
dispatch, and both fail with `extension.unsupported` ("No extension
provider configured") for these components. `homeboy release --dry-run`
is also unusable as a PR gate: on a non-default branch it short-circuits
at `preflight.default_branch` and `no-releasable-commits` before
reaching the quality preflight.

New self_checks
---------------

nodejs — 3 lint, 21 test. Lint validates `nodejs.json`, `bash -n` over
every shell script, and `node --check` over every `.mjs`/`.cjs`/`.js`.
Test covers the 21 smoke tests that are runnable standalone, including
`../tests/nodejs-deps-provider-smoke.sh` (the repo-root pattern `rust`
already uses).

swift — 3 lint, 2 test. Lint validates `swift.json`, `bash -n` over every
shell script, and parses `scripts/fingerprint.py`. Test runs
`fingerprint-smoke.sh` and `swift-extension-smoke.sh`.

go — 2 lint, no test. `go/` has no `tests/` directory and its runners
require a real Go project plus the toolchain, so there is nothing
runnable to declare. Lint validates `go.json` and `bash -n` over every
shell script.

Every declared command was verified passing in a non-root sandbox with a
clean HOME and TMPDIR against a pristine tree, which is why
`nodejs-standalone-workload-smoke.sh` is included: it asserts a
`chmod 000` file is unreadable, so it only passes as a non-root user like
the GitHub runner.

Deliberately not covered
------------------------

The `tests/**` tree at the repository root is not wired into the matrix.
Only the extension-owned smoke tests that the extensions themselves
declare are gated.

The smoke tests that require Homeboy-materialized runtime helpers
(`HOMEBOY_RUNTIME_RUNNER_PRELUDE`, `HOMEBOY_RUNTIME_SIDECAR_WRITER`, and
friends) are not made runnable here — that is #2507. Nine nodejs smoke
tests and two `../tests/nodejs-*` smoke tests fall in that class and are
left out of the declared lists rather than declared and skipped.

Two commands already declared by `wordpress` are skipped by the workflow,
each as a loud `::warning::` so they cannot rot silently:
`scripts/test/full-suite-no-phpunit-smoke.sh`, which hard-requires
`HOMEBOY_RUNTIME_RUNNER_PRELUDE` (#2507), and
`tests/wordpress-fuzz-runner-smoke.js`, which is a genuine pre-existing
failure — its own `fake-wp-codebox.js` fixture exits 1 with "expected
public wp-codebox run-fuzz-suite command", leaving readiness `blocked`
and the run `skipped` instead of the asserted success. Neither is removed
from `wordpress/homeboy.json`, so release-preflight coverage is unchanged.

Closes #2504

Risk on first run
-----------------

This workflow has never executed on GitHub Actions, only in a local
non-root sandbox with a clean HOME/TMPDIR against a pristine tree. All
five components passed both capabilities there — 50 commands executed,
2 skipped. Residual risks, in descending order of likelihood:

1. **Runner environment drift.** The sandbox had Node 25 while the
   workflow pins `node-version: 24` (matching the canary). Several nodejs
   bench/browser smoke tests shell out to Node and parse its output. A
   Node-version-sensitive assertion would surface here first.
2. **`nodejs-standalone-workload-smoke.sh`.** It `chmod 000`s a file and
   asserts the read fails. Correct on the non-root GitHub runner, but it
   is the one check whose result depends on the executing user.
3. **WordPress dependency install.** `composer install` + `npm install`
   are now on the PR path for the WordPress entry. Network flake there
   fails the job before any check runs. The 20-minute timeout is the same
   one the canary uses; the sandbox run of all 20 WordPress commands
   finished well inside it.
4. **The two skipped WordPress commands.** They are skipped by exact
   string match against the command as declared in
   `wordpress/homeboy.json`. If that file is reworded, the skip stops
   matching and the command runs — and fails. That is the intended
   failure mode: it is louder than a silent stale skip.
5. **Newly gated surface.** The nodejs `lint` checks glob with `find`
   rather than an explicit file list, so any `.sh`/`.mjs`/`.cjs`/`.js`
   added later is covered automatically. That is the point, but it does
   mean the gate can start failing on files nobody thought were in scope.

Related finding, not fixed here
-------------------------------

`node --check a.js b.js` only checks the **first** file; it exits 0 even
when a later argument is a syntax error (verified on Node 24 and 25). The
existing `wordpress` lint self-check
`node --check index.js lib/... scripts/...` has therefore only ever
checked `index.js`. The new nodejs check avoids this with
`xargs -n1`. Left alone here to keep this change scoped; worth a
follow-up against `wordpress/homeboy.json`.

Found during the 2026-08-01 consolidation investigation,
Extra-Chill/homeboy#11151.
