### PR TITLE
Fix OpenCode terminal result classification

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -483,9 +483,23 @@ function opencodeSuccessOutcome(context) {
 	const structured = structuredOpenCodeOutputs(context);
 	const evidence = collectOpenCodeArtifacts(context, structured);
 	const emptyPatch = evidence.artifacts?.some((artifact) => artifact.name === 'patch' && artifact.bytes === 0);
+	const missingRequiredOutputs = structured.missingRequiredOutputs || [];
+	const intentionalNoChange = structured.outputs && missingRequiredOutputs.length === 0 && emptyPatch && context.initialRevision?.revision
+		? {
+			schema: 'homeboy/intentional-no-change/v1',
+			verdict: 'no_change',
+			inspected_revision: context.initialRevision.revision,
+		}
+		: null;
 	return withPolicyDeniedOutcome(context, {
-		status: structured.outputs && emptyPatch ? 'no_op' : 'succeeded',
-		summary: structured.outputs && emptyPatch
+		status: missingRequiredOutputs.length > 0 ? 'failed' : 'succeeded',
+		...(missingRequiredOutputs.length > 0 ? {
+			failure_classification: 'provider',
+			failure_code: 'agent_task.opencode_required_outputs_missing',
+		} : {}),
+		summary: missingRequiredOutputs.length > 0
+			? `OpenCode completed without required structured output(s): ${missingRequiredOutputs.join(', ')}.`
+			: intentionalNoChange
 			? 'OpenCode completed without workspace changes.'
 			: 'OpenCode completed successfully.',
 		diagnostics: [
@@ -497,7 +511,17 @@ function opencodeSuccessOutcome(context) {
 			opencode_session: sessionMetadata(context),
 			opencode_progress: progressMetadata(context),
 		},
-		...(structured.outputs ? { outputs: structured.outputs } : {}),
+		...(structured.outputs || intentionalNoChange ? {
+			outputs: {
+				...(structured.outputs || {}),
+				...(intentionalNoChange ? {
+					opencode_run_result: {
+						status: 'succeeded',
+						intentional_no_change: intentionalNoChange,
+					},
+				} : {}),
+			},
+		} : {}),
 		...evidence,
 	});
 }
@@ -533,10 +557,15 @@ function structuredOpenCodeOutputs(context = {}) {
 		const missing = declarations.filter((declaration) => declaration.required && !Object.hasOwn(outputs, declaration.name));
 		return {
 			...(Object.keys(outputs).length > 0 ? { outputs } : {}),
+			missingRequiredOutputs: missing.map((declaration) => declaration.name),
 			diagnostics: outputDiagnostics(missing, oversized),
 		};
 	}
-	return { diagnostics: outputDiagnostics(declarations.filter((declaration) => declaration.required), []) };
+	const missing = declarations.filter((declaration) => declaration.required);
+	return {
+		missingRequiredOutputs: missing.map((declaration) => declaration.name),
+		diagnostics: outputDiagnostics(missing, []),
+	};
 }
 
 function declaredOutputValues(envelope, declarations) {
@@ -650,9 +679,6 @@ function opencodeFailureOutcome(context) {
 }
 
 function withPolicyDeniedOutcome(context = {}, terminal = {}) {
-	if (terminal.status === 'succeeded') {
-		return terminal;
-	}
 	const denial = detectOpenCodePolicyDenial(context);
 	if (!denial) {
 		return terminal;
@@ -693,7 +719,25 @@ function detectOpenCodePolicyDenial(context = {}) {
 	if (!OPENCODE_PERMISSION_DENIED_PATTERN.test(text)) {
 		return null;
 	}
+	if (spawnResult.status === 0 && openCodeCompletedAfterPolicyDenial(text)) {
+		return null;
+	}
 	return sanitizeDeniedToolCall(extractDeniedToolCall(text));
+}
+
+function openCodeCompletedAfterPolicyDenial(text = '') {
+	const lines = String(text).split(/\r?\n/).filter((line) => line.trim() !== '');
+	const deniedIndex = lines.findLastIndex((line) => OPENCODE_PERMISSION_DENIED_PATTERN.test(line));
+	return lines.slice(deniedIndex + 1).some((line) => {
+		try {
+			const value = JSON.parse(line);
+			return openCodeTextParts(value).some((event) => (
+				event.text !== '' && !OPENCODE_PERMISSION_DENIED_PATTERN.test(event.text)
+			));
+		} catch {
+			return false;
+		}
+	});
 }
 
 function extractDeniedToolCall(text = '') {
@@ -818,10 +862,18 @@ function collectOpenCodeArtifacts(context = {}, structured = {}) {
 		captureErrors.push({ artifact: 'patch', message: patchCapture.error });
 	}
 	const patch = patchCapture.content;
-	const policyDenial = spawnResult.status === 0 ? null : detectOpenCodePolicyDenial(context);
+	const policyDenial = detectOpenCodePolicyDenial(context);
+	const missingRequiredOutputs = structured.missingRequiredOutputs || [];
+	const intentionalNoChange = structured.outputs && missingRequiredOutputs.length === 0 && patch === '' && context.initialRevision?.revision
+		? {
+			schema: 'homeboy/intentional-no-change/v1',
+			verdict: 'no_change',
+			inspected_revision: context.initialRevision.revision,
+		}
+		: null;
 	const resultStatus = policyDenial
 		? 'failed'
-		: (spawnResult.status === 0 ? (structured.outputs && patch === '' ? 'no_op' : 'succeeded') : 'failed');
+		: (spawnResult.status === 0 && missingRequiredOutputs.length === 0 ? 'succeeded' : 'failed');
 	const resultEnvelope = JSON.stringify({
 		schema: 'homeboy/opencode-agent-result/v1',
 		task_id: request.task_id,
@@ -831,6 +883,11 @@ function collectOpenCodeArtifacts(context = {}, structured = {}) {
 			failure_code: 'agent_task.opencode_policy_denied',
 			denied_tool_call: policyDenial,
 		} : {}),
+		...(!policyDenial && missingRequiredOutputs.length > 0 ? {
+			failure_classification: 'provider',
+			failure_code: 'agent_task.opencode_required_outputs_missing',
+		} : {}),
+		...(intentionalNoChange ? { intentional_no_change: intentionalNoChange } : {}),
 		exit_code: spawnResult.status,
 		command: context.commandSpec?.command,
 		args: Array.isArray(context.commandSpec?.args) ? context.commandSpec.args : [],
@@ -838,7 +895,17 @@ function collectOpenCodeArtifacts(context = {}, structured = {}) {
 			patch: patch !== '',
 			transcript: transcript !== '',
 		},
-		...(structured.outputs ? { outputs: structured.outputs } : {}),
+		...(structured.outputs || intentionalNoChange ? {
+			outputs: {
+				...(structured.outputs || {}),
+				...(intentionalNoChange ? {
+					opencode_run_result: {
+						status: 'succeeded',
+						intentional_no_change: intentionalNoChange,
+					},
+				} : {}),
+			},
+		} : {}),
 		opencode_session: sessionMetadata(context),
 		opencode_progress: progressMetadata(context),
 	}, null, 2);

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -760,7 +760,10 @@ process.stdout.write(JSON.stringify({
     state: { error: 'The user rejected permission to use this specific tool call.' }
   }]
 }) + '\\n');
-process.stdout.write(JSON.stringify({ type: 'message', text: 'Completed after the denied tool call.' }) + '\\n');
+process.stdout.write(JSON.stringify({
+  type: 'text',
+  part: { type: 'text', text: 'Completed after the denied tool call.', metadata: { openai: { phase: 'final_answer' } } }
+}) + '\\n');
 process.exit(0);
 `);
 	const recoveredResult = await executeOpenCodeAgentTask({
@@ -838,6 +841,22 @@ process.exit(1);
 	assert.equal(deniedAgentResult.status, 'failed');
 	assert.equal(deniedAgentResult.failure_classification, 'policy_denied');
 	assert.deepEqual(deniedAgentResult.denied_tool_call, deniedResult.metadata.denied_tool_call);
+
+	const deniedZeroCliPath = path.join(root, 'mock-opencode-policy-denied-zero.cjs');
+	fs.writeFileSync(deniedZeroCliPath, fs.readFileSync(deniedCliPath, 'utf8').replace('process.exit(1);', 'process.exit(0);'));
+	const deniedZeroResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-policy-denied-zero',
+		workspace_path: deniedWorkspace,
+		artifacts_path: deniedArtifactDir,
+		executor: {
+			...request.executor,
+			config: { ...request.executor.config, command_args: [deniedZeroCliPath] },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(deniedZeroResult.status, 'failed');
+	assert.equal(deniedZeroResult.failure_classification, 'policy_denied');
+	assert.equal(deniedZeroResult.retryable, false);
 
 	const inheritedPipeCliPath = path.join(root, 'mock-opencode-inherited-pipe.cjs');
 	fs.writeFileSync(inheritedPipeCliPath, `#!/usr/bin/env node
@@ -1069,15 +1088,16 @@ process.stdout.write(JSON.stringify({
 		},
 	}, { env: fixtureEnv });
 
-	assert.equal(reviewResult.status, 'no_op', JSON.stringify(reviewResult.diagnostics));
-	assert.deepEqual(reviewResult.outputs, {
-		review_form: {
+	assert.equal(reviewResult.status, 'succeeded', JSON.stringify(reviewResult.diagnostics));
+	assert.deepEqual(reviewResult.outputs.review_form, {
 			summary: 'Reviewed candidate; no changes required.',
 			what_changed: [],
 			compatibility: 'No compatibility impact.',
 			used_for: 'Pull request review.',
-		},
 	});
+	assert.equal(reviewResult.outputs.opencode_run_result.intentional_no_change.schema, 'homeboy/intentional-no-change/v1');
+	assert.equal(reviewResult.outputs.opencode_run_result.intentional_no_change.verdict, 'no_change');
+	assert.match(reviewResult.outputs.opencode_run_result.intentional_no_change.inspected_revision, /^[0-9a-f]{40}$/);
 	const reviewConfig = JSON.parse(fs.readFileSync(reviewCapturePath, 'utf8'));
 	// Read-only inspection is permitted within the workspace...
 	assert.equal(reviewConfig.permission.read['*'], 'allow');
@@ -1138,12 +1158,14 @@ process.stdout.write(JSON.stringify({
 		},
 	};
 	const structuredOutputResult = await executeOpenCodeAgentTask(structuredOutputRequest, { env: fixtureEnv });
-	assert.equal(structuredOutputResult.status, 'no_op', JSON.stringify(structuredOutputResult.diagnostics));
-	assert.deepEqual(structuredOutputResult.outputs, { release_notes: ['Added generic output handling.'], verification: { passed: true } });
+	assert.equal(structuredOutputResult.status, 'succeeded', JSON.stringify(structuredOutputResult.diagnostics));
+	assert.deepEqual(structuredOutputResult.outputs.release_notes, ['Added generic output handling.']);
+	assert.deepEqual(structuredOutputResult.outputs.verification, { passed: true });
+	assert.equal(structuredOutputResult.outputs.opencode_run_result.intentional_no_change.schema, 'homeboy/intentional-no-change/v1');
 	assert.equal(structuredOutputResult.metadata.opencode_session.status, 'not_discovered');
 	const structuredAgentResult = structuredOutputResult.artifacts.find((artifact) => artifact.name === 'agent_result');
 	const structuredAgentResultPayload = JSON.parse(fs.readFileSync(structuredAgentResult.path, 'utf8'));
-	assert.equal(structuredAgentResultPayload.status, 'no_op');
+	assert.equal(structuredAgentResultPayload.status, 'succeeded');
 	assert.deepEqual(structuredAgentResultPayload.outputs, structuredOutputResult.outputs);
 
 	for (const [mode, outputs, diagnosticClass] of [
@@ -1162,8 +1184,10 @@ process.stdout.write(JSON.stringify({
 				},
 			},
 		}, { env: fixtureEnv });
-		assert.equal(incompleteOutputResult.status, mode === 'malformed' ? 'no_op' : 'succeeded');
-		assert.deepEqual(incompleteOutputResult.outputs, outputs);
+		assert.equal(incompleteOutputResult.status, mode === 'malformed' ? 'succeeded' : 'failed');
+		assert.deepEqual(Object.fromEntries(
+			Object.entries(incompleteOutputResult.outputs).filter(([name]) => name !== 'opencode_run_result')
+		), outputs);
 		assert.equal(incompleteOutputResult.diagnostics.some((diagnostic) => diagnostic.class === diagnosticClass), diagnosticClass !== undefined);
 	}
 
@@ -1175,8 +1199,8 @@ process.stdout.write(JSON.stringify({
 			config: { ...structuredOutputRequest.executor.config, runtime_env: { OUTPUT_MODE: 'optional-absent' } },
 		},
 	}, { env: fixtureEnv });
-	assert.equal(optionalAbsentResult.status, 'no_op');
-	assert.deepEqual(optionalAbsentResult.outputs, { release_notes: ['Optional output omitted'] });
+	assert.equal(optionalAbsentResult.status, 'succeeded');
+	assert.deepEqual(optionalAbsentResult.outputs.release_notes, ['Optional output omitted']);
 	assert.equal(optionalAbsentResult.diagnostics.some((diagnostic) => diagnostic.class === 'opencode.required_outputs_missing'), false);
 
 	const legacyOutputResult = await executeOpenCodeAgentTask({
@@ -1187,7 +1211,7 @@ process.stdout.write(JSON.stringify({
 			config: { ...structuredOutputRequest.executor.config, runtime_env: { OUTPUT_MODE: 'legacy' } },
 		},
 	}, { env: fixtureEnv });
-	assert.deepEqual(legacyOutputResult.outputs, { release_notes: ['Legacy declaration mapping'] });
+	assert.deepEqual(legacyOutputResult.outputs.release_notes, ['Legacy declaration mapping']);
 	assert.equal(legacyOutputResult.outputs.ignored, undefined);
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- classify terminal OpenCode permission denials even when the process exits 0
- fail completions missing required structured outputs
- emit revision-bound intentional no-change evidence for verified clean completions

## Verification
- `npm run test:opencode-agent-task-executor-boundary`
- `npm run test:opencode-progress-events`
- `git diff --check`

Closes #2510

## AI assistance
OpenAI gpt-5.6-sol via OpenCode implemented the result-contract repair and regression coverage. Chris Huber reviewed the result and remains responsible for every line.