### PR TITLE
fix(wordpress): honor project PHPUnit bootstraps

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -23,6 +23,7 @@ const root = settings.wp_codebox_source_root || componentPath;
 const subpath = settings.wp_codebox_source_subpath || undefined;
 const pluginSourceDirectory = subpath ? path.join(root, subpath) : root;
 const phpunitProfile = await resolvePhpunitProfile(settings, pluginSourceDirectory, slug);
+const phpunitBootstrap = resolvePhpunitBootstrap(settings, phpunitProfile);
 const topology = await resolveWordPressTopology(settings, pluginSourceDirectory);
 const databaseService = resolveDatabaseService(settings, process.env);
 requireDatabaseServiceCapability(databaseService);
@@ -54,8 +55,9 @@ const options = clean({
   phpunitArgs: process.argv.slice(2),
   env: settings.bench_env,
   wpConfigDefines: settings.wp_config_defines,
-  bootstrapMode: settings.wp_codebox_phpunit_bootstrap_mode,
-  projectBootstrap: settings.wp_codebox_phpunit_project_bootstrap,
+  autoloadFile: '/wp-codebox-vendor/autoload.php',
+  bootstrapMode: phpunitBootstrap.mode,
+  projectBootstrap: phpunitBootstrap.projectBootstrap,
   multisite: topology.multisite,
   preloadFiles: settings.wp_codebox_phpunit_preload_files,
   mounts: [...canonicalMounts(settings.wp_codebox_phpunit_mounts), { source: harnessSource, target: '/wp-codebox-vendor', mode: 'readonly' }],
@@ -912,10 +914,11 @@ async function resolvePhpunitProfile(configuration, pluginDirectory, pluginSlug)
   const testRoot = configuration.wp_codebox_phpunit_test_root || `${sandboxRoot}/tests`;
   const cwd = configuration.wp_codebox_phpunit_cwd || sandboxRoot;
   let environment = 'wordpress-integration';
+  let bootstrap = '';
   if (hostConfig) {
     try {
       const xml = await readFile(hostConfig, 'utf8');
-      const bootstrap = xml.match(/\bbootstrap\s*=\s*["']([^"']+)["']/i)?.[1];
+      bootstrap = xml.match(/\bbootstrap\s*=\s*["']([^"']+)["']/i)?.[1] || '';
       if (bootstrap) {
         const bootstrapPath = path.resolve(path.dirname(hostConfig), bootstrap);
         const source = await readFile(bootstrapPath, 'utf8').catch(() => '');
@@ -923,14 +926,31 @@ async function resolvePhpunitProfile(configuration, pluginDirectory, pluginSlug)
       }
     } catch {}
   }
-  return { config, testRoot, cwd, environment, hostConfig };
+  return { config, testRoot, cwd, environment, hostConfig, bootstrap };
+}
+function resolvePhpunitBootstrap(configuration, profile) {
+  const requestedMode = configuration.wp_codebox_phpunit_bootstrap_mode || 'auto';
+  if (!['auto', 'managed', 'project'].includes(requestedMode)) {
+    throw new Error(`Unsupported WP Codebox PHPUnit bootstrap mode: ${requestedMode}`);
+  }
+  let mode = requestedMode;
+  if (requestedMode === 'auto') {
+    mode = profile.bootstrap ? 'project' : 'managed';
+  }
+  const override = typeof configuration.wp_codebox_phpunit_project_bootstrap === 'string'
+    ? configuration.wp_codebox_phpunit_project_bootstrap.trim()
+    : '';
+  return {
+    mode,
+    projectBootstrap: mode === 'project' ? override : '',
+  };
 }
 async function persistRecipeEvidence(artifactDirectory, recipeOptions, generatedRecipePath, profile, resolvedDependencies) {
   const sourceRefs = [{ slug, source: root, source_subpath: subpath || null }, ...resolvedDependencies.map((dependency) => ({ slug: dependency.slug, source: dependency.source }))];
   await Promise.all([
     copyFile(generatedRecipePath, path.join(artifactDirectory, 'wp-codebox-phpunit-recipe.json')),
     writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-recipe-options.json'), `${JSON.stringify(recipeOptions, null, 2)}\n`),
-    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-profile.json'), `${JSON.stringify({ wordpress: { topology }, phpunit: { config: profile.config, cwd: profile.cwd, test_root: profile.testRoot, environment: profile.environment, bootstrap_mode: recipeOptions.bootstrapMode, passthrough_args: recipeOptions.phpunitArgs, extra_mounts: recipeOptions.mounts } }, null, 2)}\n`),
+    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-profile.json'), `${JSON.stringify({ wordpress: { topology }, phpunit: { config: profile.config, cwd: profile.cwd, test_root: profile.testRoot, environment: profile.environment, bootstrap_mode: recipeOptions.bootstrapMode, project_bootstrap: recipeOptions.projectBootstrap || null, passthrough_args: recipeOptions.phpunitArgs, extra_mounts: recipeOptions.mounts } }, null, 2)}\n`),
     writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-provenance.json'), `${JSON.stringify({ source_refs: sourceRefs, wp_codebox: { cli_bin: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', resolved_cli_path: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', command: [process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'] } }, null, 2)}\n`),
   ]);
 }

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -21,7 +21,31 @@ await mkdir(dependency);
 await mkdir(dataMachine);
 await mkdir(conflictingDataMachine, { recursive: true });
 await writeFile(path.join(component, 'component.php'), '<?php /* Plugin Name: Component */\n');
-await writeFile(path.join(component, 'tests', 'bootstrap.php'), '<?php require_once __DIR__ . "/../component.php";\n');
+await writeFile(path.join(component, 'tests', 'bootstrap.php'), `<?php
+if (class_exists('WP_Post', false)) {
+    throw new RuntimeException('WordPress was loaded before the project bootstrap');
+}
+if (!class_exists('WP_Post', false)) {
+    class WP_Post {}
+}
+if (!function_exists('add_action')) {
+    function add_action() { return true; }
+}
+`);
+await mkdir(path.join(component, 'tests', 'nested'));
+await writeFile(path.join(component, 'tests', 'FirstTest.php'), `<?php
+use PHPUnit\\Framework\\TestCase;
+final class FirstTest extends TestCase {
+    public function test_project_stub_is_loaded(): void { $this->assertInstanceOf(WP_Post::class, new WP_Post()); }
+}
+`);
+await writeFile(path.join(component, 'tests', 'nested', 'SecondTest.php'), `<?php
+use PHPUnit\\Framework\\TestCase;
+final class SecondTest extends TestCase {
+    public function test_nested_xml_test_is_discovered(): void { $this->assertTrue(add_action()); }
+}
+`);
+await writeFile(path.join(component, 'tests', 'override.php'), '<?php require_once __DIR__ . "/bootstrap.php";\n');
 await writeFile(path.join(component, 'phpunit.xml.dist'), '<phpunit bootstrap="tests/bootstrap.php"><testsuites><testsuite name="suite"><directory>tests</directory></testsuite></testsuites></phpunit>\n');
 await writeFile(path.join(dependency, 'dependency.php'), '<?php /* Plugin Name: Dependency */\n');
 await writeFile(path.join(dataMachine, 'data-machine.php'), '<?php /* Plugin Name: Data Machine */\n');
@@ -50,6 +74,10 @@ process.exitCode = fixture.exitCode || 0;
 await chmod(cli, 0o755);
 
 try {
+  const nativeSuite = spawnSync(path.join(extension, 'vendor', 'bin', 'phpunit'), ['--configuration', path.join(component, 'phpunit.xml.dist')], { encoding: 'utf8' });
+  assert.equal(nativeSuite.status, 0, nativeSuite.stderr || nativeSuite.stdout);
+  assert.match(nativeSuite.stdout, /OK \(2 tests, 2 assertions\)/);
+
   const unknownSidecar = { schema: 'wp-codebox/test-results/v1', status: 'unknown', summary: { total: 0, passed: 0, failed: 0, skipped: 0 } };
   const tenPassingSidecar = { schema: 'wp-codebox/test-results/v1', status: 'passed', summary: { total: 10, passed: 10, failed: 0, skipped: 0 }, suites: [], rawLogReferences: [] };
   const passedSidecar = { schema: 'wp-codebox/test-results/v1', status: 'passed', summary: { total: 3, passed: 3, failed: 0, skipped: 0 }, suites: [], rawLogReferences: [] };
@@ -68,10 +96,16 @@ try {
     { name: 'missing-sidecar', fixture: { output: green }, status: 1, artifactStatus: 'unknown', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
     { name: 'malformed-pointer', fixture: { pointer: 'malformed', output: green }, status: 1, artifactStatus: 'unknown', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
     { name: 'errors-and-failures', fixture: { sidecar: unknownSidecar, output: failures, exitCode: 2 }, status: 2, artifactStatus: 'failed', expected: { total: 281, passed: 135, failed: 146, skipped: 0 } },
-    { name: 'managed-passed', fixture: { sidecar: passedSidecar }, status: 0, artifactStatus: 'passed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'managed-passed', fixture: { sidecar: passedSidecar }, settings: { wp_codebox_phpunit_bootstrap_mode: 'managed' }, status: 0, artifactStatus: 'passed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'project-bootstrap-from-xml', fixture: { sidecar: passedSidecar }, settings: { wp_codebox_phpunit_bootstrap_mode: 'project' }, status: 0, artifactStatus: 'passed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 } },
+    { name: 'project-bootstrap-override', fixture: { sidecar: passedSidecar }, settings: { wp_codebox_phpunit_bootstrap_mode: 'project', wp_codebox_phpunit_project_bootstrap: 'tests/override.php' }, status: 0, artifactStatus: 'passed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 }, projectBootstrap: 'tests/override.php' },
+    { name: 'auto-without-bootstrap', fixture: { sidecar: passedSidecar }, status: 0, artifactStatus: 'passed', expected: { total: 3, passed: 3, failed: 0, skipped: 0 }, noBootstrap: true, bootstrapMode: 'managed' },
     { name: 'crash', fixture: { crash: true, output: failures, exitCode: 2 }, status: 2, artifactStatus: 'failed', expected: { total: 281, passed: 135, failed: 146, skipped: 0 } },
   ];
   for (const testCase of testCases) {
+    await writeFile(path.join(component, 'phpunit.xml.dist'), testCase.noBootstrap
+      ? '<phpunit><testsuites><testsuite name="suite"><directory>tests</directory></testsuite></testsuites></phpunit>\n'
+      : '<phpunit bootstrap="tests/bootstrap.php"><testsuites><testsuite name="suite"><directory>tests</directory></testsuite></testsuites></phpunit>\n');
     const artifacts = path.join(root, `${testCase.name}-artifacts`);
     const results = path.join(root, `${testCase.name}-results.json`);
     const invocationArtifacts = path.join(root, `${testCase.name}-invocation-artifacts`);
@@ -101,7 +135,10 @@ try {
     const provenance = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));
     assert.equal(options.extra_plugins[1].activate, true);
     assert.equal(options.phpunitXml, '/wordpress/wp-content/plugins/component/phpunit.xml.dist');
-    assert.equal(profile.phpunit.environment, 'standalone-php');
+    assert.equal(options.autoloadFile, '/wp-codebox-vendor/autoload.php');
+    assert.equal(options.bootstrapMode, testCase.bootstrapMode || (testCase.settings?.wp_codebox_phpunit_bootstrap_mode === 'managed' ? 'managed' : 'project'));
+    assert.equal(options.projectBootstrap || '', testCase.projectBootstrap || '');
+    assert.equal(profile.phpunit.environment, testCase.noBootstrap ? 'wordpress-integration' : 'standalone-php');
     assert.deepEqual(provenance.source_refs, [
       { slug: 'component', source: component, source_subpath: null },
       { slug: 'dependency', source: dependency },


### PR DESCRIPTION
## Summary
- resolve the WordPress extension's `auto` PHPUnit bootstrap mode from the component's `phpunit.xml(.dist)` instead of forwarding the unsupported value into WP Codebox
- keep the mounted PHPUnit harness autoloader available in project mode without preloading WordPress, while preserving XML-relative bootstrap and testsuite discovery in WP Codebox
- expand the generic smoke fixture to reject preloaded `WP_Post`, execute nested XML-discovered tests, and cover managed, auto, explicit project, and project override modes

## Root cause
Before this fix, the adapter forwarded `wp_codebox_phpunit_bootstrap_mode=auto` verbatim. WP Codebox supports `managed` and `project`, so it treated `auto` as managed and booted real WordPress before standalone project fixtures. Explicit project mode avoided WordPress, but the recipe builder cleared the harness autoload by default; projects whose native bootstrap assumes the PHPUnit executable has already loaded Composer/PHPUnit could not initialize the harness and ended with no usable test execution. The adapter also did not resolve the schema's documented auto behavior.

This belongs in the generic Homeboy WordPress extension adapter: it owns interpretation of the extension setting and mounts the shared PHPUnit harness. WP Codebox already correctly owns project bootstrap execution and PHPUnit XML testsuite discovery, so the fix uses those primitives rather than adding a consumer-specific workaround. No product or vendor special cases were added.

## Behavior after
- `managed` remains the Homeboy/WP Codebox real-WordPress bootstrap for `WP_UnitTestCase` suites.
- `project` does not preload WordPress, keeps PHPUnit's harness autoload available, honors an explicit project bootstrap override, and otherwise lets WP Codebox resolve the bootstrap relative to the selected PHPUnit XML.
- `auto` selects `project` when the selected XML declares `bootstrap`, otherwise `managed`.
- the selected PHPUnit XML remains the source of testsuite directory/file discovery.

## Verification
- `node tests/wp-codebox-phpunit-aggregate-smoke.mjs` - passed; fixture ran 2 tests / 2 assertions from XML, including a nested test, and covered managed, auto with/without XML bootstrap, explicit project with XML fallback, and explicit override
- `node tests/wp-codebox-canonical-cli-adapters-smoke.mjs` - passed
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs` - passed
- `node tests/wp-codebox-phpunit-evidence-smoke.mjs` - passed
- `node tests/wp-codebox-database-service-smoke.mjs` - passed
- `npx eslint scripts/test/wp-codebox-phpunit-adapter.mjs` - passed
- `node --check tests/wp-codebox-phpunit-aggregate-smoke.mjs` - passed
- `git diff --check` - passed
- `HOMEBOY_CORE_DIR=/var/lib/datamachine/workspace/homeboy bash scripts/test/playground-db-activation-smoke.sh` - passed against a real managed `WP_UnitTestCase` suite
- real WP Codebox explicit project mode without an override against the external analytics suite - passed 400 tests / 1,598 assertions
- real WP Codebox `auto` mode against the same external suite - passed 400 tests / 1,598 assertions

Broader repository checks exposed unrelated existing failures: full-tree ESLint reports 52 pre-existing errors outside this change, direct `vendor/bin/phpunit` cannot bootstrap the repository's real-WordPress fixtures, direct `full-suite-no-phpunit-smoke.sh` lacks Homeboy's runner-prelude environment, and `wordpress-fuzz-runner-smoke.js` currently disagrees with its fake WP Codebox runtime-contract fixture. The changed files and all relevant PHPUnit adapter/runtime checks pass.

Closes #2514