### PR TITLE
Fix line-sensitive WordPress lint fingerprints

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -25,6 +25,7 @@
       "node tests/wp-codebox-artifacts-isolated-snapshot-smoke.js",
       "node tests/wordpress-manifest-settings-smoke.js",
       "node tests/wordpress-artifact-cleanup-declarations-smoke.js",
+      "bash scripts/lint/stable-fingerprint-smoke.sh",
       "bash scripts/lint/eslint-dependency-tree-scope-smoke.sh"
     ]
   }

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # flows go through `homeboy refactor --from lint --write` (#1145).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STABLE_FINGERPRINT_HELPER="${SCRIPT_DIR}/stable-fingerprint.php"
 SHARED_LIB_DIR="${HOMEBOY_SHARED_LIB_DIR:-}"
 if [ -z "$SHARED_LIB_DIR" ] && [ -n "${HOMEBOY_EXTENSION_PATH:-}" ] && [ -d "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" ]; then
     SHARED_LIB_DIR="$(cd "${HOMEBOY_EXTENSION_PATH}/../scripts/lib" && pwd)"
@@ -861,6 +862,7 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
         _PHPCS_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpcs-findings.XXXXXX')
         echo "$json_output" | php -r '
             ini_set("memory_limit", "-1");
+            require $argv[3];
             $json = json_decode(file_get_contents("php://stdin"), true);
             if (!$json || empty($json["files"])) {
                 file_put_contents($argv[2], "[]\n");
@@ -927,13 +929,13 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
                         "category" => $category,
                         "message" => $message,
                         "fixable" => (bool) ($msg["fixable"] ?? false),
-                        "fingerprint" => sha1($id),
                         "excerpt" => $readExcerpt($filePath, $line),
                     ];
                 }
             }
+            $findings = homeboy_assign_stable_lint_fingerprints($findings);
             file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");
-        ' "$PLUGIN_PATH" "$_PHPCS_FINDINGS_TMPFILE" 2>/dev/null || true
+        ' "$PLUGIN_PATH" "$_PHPCS_FINDINGS_TMPFILE" "$STABLE_FINGERPRINT_HELPER" 2>/dev/null || true
         # Writing the findings sidecar is best-effort observability; never let a
         # sidecar-writer failure fail the lint gate (homeboy-extensions#1402).
         merge_findings_into_sidecar "$_PHPCS_FINDINGS_TMPFILE" || true

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STABLE_FINGERPRINT_HELPER="${SCRIPT_DIR}/stable-fingerprint.php"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
@@ -1234,6 +1235,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     if [ -n "${_HOMEBOY_PHPSTAN_FINDINGS_FILE:-}" ] && [ -n "$json_output" ]; then
         _PHPSTAN_FINDINGS_OUTPUT_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
         echo "$json_output" | php -r '
+            require $argv[3];
             $json = json_decode(file_get_contents("php://stdin"), true);
             if (!$json || empty($json["files"])) {
                 file_put_contents($argv[2], "[]");
@@ -1272,13 +1274,13 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
                         "category" => "phpstan",
                         "message" => $message,
                         "fixable" => false,
-                        "fingerprint" => sha1($id),
                         "excerpt" => $readExcerpt($filePath, $line),
                     ];
                 }
             }
+            $findings = homeboy_assign_stable_lint_fingerprints($findings);
             file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");
-        ' "$PLUGIN_PATH" "${_PHPSTAN_FINDINGS_OUTPUT_TMPFILE}" 2>/dev/null || true
+        ' "$PLUGIN_PATH" "${_PHPSTAN_FINDINGS_OUTPUT_TMPFILE}" "$STABLE_FINGERPRINT_HELPER" 2>/dev/null || true
         # Best-effort observability; never fail the gate on a sidecar write.
         write_phpstan_findings_sidecar "${_HOMEBOY_PHPSTAN_FINDINGS_FILE}" "${_PHPSTAN_FINDINGS_OUTPUT_TMPFILE}" || true
         rm -f "${_PHPSTAN_FINDINGS_OUTPUT_TMPFILE}"

--- a/wordpress/scripts/lint/stable-fingerprint-smoke.sh
+++ b/wordpress/scripts/lint/stable-fingerprint-smoke.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FINGERPRINT_HELPER="${SCRIPT_DIR}/stable-fingerprint.php"
+
+php -r '
+require $argv[1];
+
+function make_findings(string $tool, int $lineOffset): array
+{
+    $codePrefix = $tool === "phpcs" ? "WordPress.Security" : "phpstan";
+    $column = $tool === "phpcs" ? 9 : null;
+
+    return [
+        [
+            "id" => "src/example.php::{$codePrefix}.unsafeCall::" . (10 + $lineOffset),
+            "tool" => $tool,
+            "file" => "src/example.php",
+            "line" => 10 + $lineOffset,
+            "column" => $column,
+            "code" => "{$codePrefix}.unsafeCall",
+            "rule" => "{$codePrefix}.unsafeCall",
+            "message" => "Unsafe call ({$codePrefix}.unsafeCall)",
+            "excerpt" => "dangerous_call();",
+        ],
+        [
+            "id" => "src/example.php::{$codePrefix}.unsafeCall::" . (20 + $lineOffset),
+            "tool" => $tool,
+            "file" => "src/example.php",
+            "line" => 20 + $lineOffset,
+            "column" => $column,
+            "code" => "{$codePrefix}.unsafeCall",
+            "rule" => "{$codePrefix}.unsafeCall",
+            "message" => "Unsafe call ({$codePrefix}.unsafeCall)",
+            "excerpt" => "dangerous_call();",
+        ],
+        [
+            "id" => "src/example.php::{$codePrefix}.unsafeCall::" . (30 + $lineOffset),
+            "tool" => $tool,
+            "file" => "src/example.php",
+            "line" => 30 + $lineOffset,
+            "column" => $column,
+            "code" => "{$codePrefix}.unsafeCall",
+            "rule" => "{$codePrefix}.unsafeCall",
+            "message" => "Different unsafe call ({$codePrefix}.unsafeCall)",
+            "excerpt" => "other_dangerous_call();",
+        ],
+    ];
+}
+
+foreach (["phpcs", "phpstan"] as $tool) {
+    $original = homeboy_assign_stable_lint_fingerprints(make_findings($tool, 0));
+    $shifted = homeboy_assign_stable_lint_fingerprints(make_findings($tool, 12));
+    $originalFingerprints = array_column($original, "fingerprint");
+    $shiftedFingerprints = array_column($shifted, "fingerprint");
+
+    if ($originalFingerprints !== $shiftedFingerprints) {
+        fwrite(STDERR, "FAIL: {$tool} fingerprints changed after insertion-only line movement\n");
+        exit(1);
+    }
+    if (count(array_unique($originalFingerprints)) !== count($originalFingerprints)) {
+        fwrite(STDERR, "FAIL: {$tool} distinct or repeated findings collapsed\n");
+        exit(1);
+    }
+    if ($original[0]["id"] === $shifted[0]["id"] || $original[0]["line"] === $shifted[0]["line"]) {
+        fwrite(STDERR, "FAIL: {$tool} fixture did not exercise line-based movement\n");
+        exit(1);
+    }
+}
+' "$FINGERPRINT_HELPER"
+
+echo "stable lint fingerprint smoke passed"

--- a/wordpress/scripts/lint/stable-fingerprint.php
+++ b/wordpress/scripts/lint/stable-fingerprint.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Assign line-independent fingerprints while preserving duplicate findings.
+ *
+ * Findings are expected in source order. The occurrence index distinguishes
+ * otherwise identical diagnostics without making line numbers part of identity.
+ *
+ * @param array<int, array<string, mixed>> $findings
+ * @return array<int, array<string, mixed>>
+ */
+function homeboy_assign_stable_lint_fingerprints(array $findings): array
+{
+	$occurrences = [];
+
+	foreach ($findings as &$finding) {
+		$identity = [
+			'tool' => $finding['tool'] ?? null,
+			'file' => $finding['file'] ?? null,
+			'rule' => $finding['rule'] ?? ($finding['code'] ?? null),
+			'message' => $finding['message'] ?? null,
+			'column' => $finding['column'] ?? null,
+			'excerpt' => $finding['excerpt'] ?? null,
+		];
+		$anchor = json_encode($identity, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+		if ($anchor === false) {
+			$anchor = serialize($identity);
+		}
+
+		$occurrence = $occurrences[$anchor] ?? 0;
+		$occurrences[$anchor] = $occurrence + 1;
+		$finding['fingerprint'] = sha1($anchor . "\0" . $occurrence);
+	}
+	unset($finding);
+
+	return $findings;
+}


### PR DESCRIPTION
## Summary

- derive PHPCS and PHPStan baseline fingerprints from semantic finding anchors instead of source line numbers
- preserve distinct repeated diagnostics with a deterministic occurrence index
- add a shared helper and regression coverage for insertion-only line movement

Fixes #2516.

## Verification

- `bash wordpress/scripts/lint/stable-fingerprint-smoke.sh`
- `HOMEBOY_RUNTIME_SIDECAR_WRITER=/Users/chubes/Developer/homeboy/crates/homeboy-extension/src/runtime/sidecar-writer.sh bash wordpress/scripts/lint/autofixable-exit-smoke.sh`
- `php -l wordpress/scripts/lint/stable-fingerprint.php`
- `bash -n wordpress/scripts/lint/lint-runner.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh`
- `git diff --check`

`phpstan-scoped-smoke.sh` still fails at its non-PHP single-file skip assertion; the same assertion fails on untouched base `9c2ce14f`, so it is not introduced by this change.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode produced the initial patch, then reviewed, corrected, and verified the PHPCS/PHPStan integration. Chris Huber is responsible for every line.