### PR TITLE
fix(wordpress): stabilize phpstan scoped smoke

### DIFF
--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -4,13 +4,20 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR}/crates/homeboy-extension/src/runtime"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${CORE_RUNTIME_DIR}/sidecar-writer.sh}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${CORE_RUNTIME_DIR}/resolve-context.sh}"
 RUNNER="${SCRIPT_DIR}/phpstan-runner.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
     echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
+
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve context helper: $RESOLVE_CONTEXT_HELPER" >&2
     exit 1
 fi
 
@@ -49,16 +56,20 @@ cat > "${EXTENSION_DIR}/vendor/bin/phpstan" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" > "${PHPSTAN_ARGS_FILE}"
+count=0
+[ -f "${PHPSTAN_CALLS_FILE}" ] && count=$(cat "${PHPSTAN_CALLS_FILE}")
+count=$((count + 1))
+printf '%s\n' "$count" > "${PHPSTAN_CALLS_FILE}"
+if [ "${1:-}" = "--version" ]; then
+    printf '%s\n' 'PHPStan - PHP Static Analysis Tool 2.0.0'
+    exit 0
+fi
 for arg in "$@"; do
     case "$arg" in
         --configuration=*) cp "${arg#--configuration=}" "${PHPSTAN_CONFIG_CAPTURE}" ;;
         --autoload-file=*) cp "${arg#--autoload-file=}" "${PHPSTAN_AUTOLOAD_CAPTURE}" ;;
     esac
 done
-count=0
-[ -f "${PHPSTAN_CALLS_FILE}" ] && count=$(cat "${PHPSTAN_CALLS_FILE}")
-count=$((count + 1))
-printf '%s\n' "$count" > "${PHPSTAN_CALLS_FILE}"
 if [ "${PHPSTAN_EMIT_ERROR:-}" = "1" ]; then
     printf '{"totals":{"errors":1,"file_errors":1},"files":{"%s/main.php":{"errors":1,"messages":[{"message":"Call to an undefined function missing_function().","line":1,"identifier":"function.notFound"}]}}}\n' "${HOMEBOY_COMPONENT_PATH}"
     exit 1
@@ -75,6 +86,8 @@ run_phpstan() {
     HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
     HOMEBOY_COMPONENT_ID="phpstan-smoke" \
     HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+    HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
     PHPSTAN_ARGS_FILE="$ARGS_FILE" \
     PHPSTAN_CALLS_FILE="$CALLS_FILE" \
     PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \
@@ -223,18 +236,24 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="phpstan-smoke" \
 HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 PHPSTAN_ARGS_FILE="$ARGS_FILE" \
 PHPSTAN_CALLS_FILE="$CALLS_FILE" \
 PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \
 PHPSTAN_AUTOLOAD_CAPTURE="$AUTOLOAD_CAPTURE" \
 HOMEBOY_SUMMARY_MODE=1 \
 HOMEBOY_LINT_FILE="assets/app.js" \
-"$RUNNER" >/dev/null
+"$RUNNER" >"$OUTPUT_FILE"
 
-if [ "$(cat "$CALLS_FILE")" != "0" ]; then
-    echo "FAIL: non-PHP single-file scope should skip PHPStan" >&2
+if [ "$(cat "$CALLS_FILE")" != "1" ]; then
+    echo "FAIL: non-PHP single-file scope should only run the PHPStan integrity probe" >&2
     exit 1
 fi
+
+assert_contains "--version" "non-PHP single-file scope runs the PHPStan integrity probe"
+assert_not_contains "analyse" "non-PHP single-file scope skips PHPStan analysis"
+assert_file_contains "$OUTPUT_FILE" "no PHP files in requested scope, skipping static analysis" "non-PHP single-file scope reports that PHPStan analysis was skipped"
 
 : > "$ARGS_FILE"
 printf '0\n' > "$CALLS_FILE"
@@ -243,6 +262,7 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="phpstan-smoke" \
 HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
 PHPSTAN_ARGS_FILE="$ARGS_FILE" \
 PHPSTAN_CALLS_FILE="$CALLS_FILE" \
 PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \


### PR DESCRIPTION
Fixes #2519

## Summary
- Use the current Homeboy runtime helper layout for the PHPStan scoped smoke.
- Distinguish the required PHPStan integrity probe from a PHPStan `analyse` invocation.
- Keep the fake PHPStan probe healthy when the analysis-error fixture is enabled.

## Verification
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash wordpress/tests/phpstan-integrity-guard-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash -n wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode reproduced the smoke failure, identified the integrity-probe assertion mismatch, and implemented deterministic focused coverage. Chris Huber remains responsible for every line.