### PR TITLE
Fix WordPress smoke runtime helper resolution

### DIFF
--- a/scripts/lib/runtime-helper-resolver.sh
+++ b/scripts/lib/runtime-helper-resolver.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Resolve Homeboy runtime helpers from supported local checkout layouts.
+
+homeboy_runtime_helper() {
+    local extensions_root="$1"
+    local override_variable="$2"
+    local helper_name="$3"
+    local override="${!override_variable:-}"
+    local core_dir="${HOMEBOY_CORE_DIR:-${extensions_root%/}/../homeboy}"
+    local candidate="${core_dir%/}/crates/homeboy-extension/src/runtime/${helper_name}"
+
+    if [ -n "$override" ]; then
+        if [ -f "$override" ]; then
+            printf '%s\n' "$override"
+            return 0
+        fi
+
+        echo "Unable to resolve Homeboy runtime helper '${helper_name}'." >&2
+        echo "Explicit override ${override_variable} is not a file: ${override}" >&2
+        echo "Set ${override_variable}=/path/to/${helper_name}" >&2
+        return 1
+    fi
+
+    if [ -f "$candidate" ]; then
+        printf '%s/%s\n' "$(cd "$(dirname "$candidate")" && pwd)" "$helper_name"
+        return 0
+    fi
+
+    echo "Unable to resolve Homeboy runtime helper '${helper_name}'." >&2
+    echo "Probed: ${candidate}" >&2
+    echo "Set ${override_variable}=/path/to/${helper_name}" >&2
+    return 1
+}

--- a/tests/wordpress-runtime-helper-resolver-smoke.sh
+++ b/tests/wordpress-runtime-helper-resolver-smoke.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-runtime-helper-resolver.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+EXTENSIONS_ROOT="${TMP_DIR}/homeboy-extensions"
+CORE_ROOT="${TMP_DIR}/homeboy"
+HELPER="${CORE_ROOT}/crates/homeboy-extension/src/runtime/sidecar-writer.sh"
+mkdir -p "$(dirname "$HELPER")" "$EXTENSIONS_ROOT"
+touch "$HELPER"
+HELPER="$(cd "$(dirname "$HELPER")" && pwd)/sidecar-writer.sh"
+
+resolved="$(HOMEBOY_CORE_DIR="$CORE_ROOT" homeboy_runtime_helper "$EXTENSIONS_ROOT" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
+[ "$resolved" = "$HELPER" ] || { echo "Expected current checkout helper path, got: $resolved" >&2; exit 1; }
+
+resolved="$(unset HOMEBOY_CORE_DIR; homeboy_runtime_helper "$EXTENSIONS_ROOT" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
+[ "$resolved" = "$HELPER" ] || { echo "Expected sibling checkout helper path, got: $resolved" >&2; exit 1; }
+
+OVERRIDE="${TMP_DIR}/override.sh"
+touch "$OVERRIDE"
+resolved="$(HOMEBOY_RUNTIME_SIDECAR_WRITER="$OVERRIDE" homeboy_runtime_helper "$EXTENSIONS_ROOT" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
+[ "$resolved" = "$OVERRIDE" ] || { echo "Expected explicit override, got: $resolved" >&2; exit 1; }
+
+set +e
+diagnostic="$(HOMEBOY_CORE_DIR="${TMP_DIR}/missing" homeboy_runtime_helper "$EXTENSIONS_ROOT" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh 2>&1)"
+status=$?
+set -e
+[ "$status" -ne 0 ] || { echo "Expected missing helper resolution to fail" >&2; exit 1; }
+case "$diagnostic" in
+    *"Probed: ${TMP_DIR}/missing/crates/homeboy-extension/src/runtime/sidecar-writer.sh"*"Set HOMEBOY_RUNTIME_SIDECAR_WRITER=/path/to/sidecar-writer.sh"*) ;;
+    *) echo "Expected actionable missing-helper diagnostic, got: $diagnostic" >&2; exit 1 ;;
+esac
+
+echo "WordPress runtime helper resolver smoke passed"

--- a/wordpress/scripts/bench/wp-codebox-bench-crawl-helper-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-crawl-helper-smoke.sh
@@ -6,8 +6,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
-BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+ROOT_DIR="$(cd "${EXTENSION_PATH}/.." && pwd)"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+BASH_PREFLIGHT_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_BASH_PREFLIGHT bash-preflight.sh)"
 FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-crawl-helper"
 
 if [ ! -d "$FIXTURE_DIR" ]; then

--- a/wordpress/scripts/bench/wp-codebox-bench-custom-metrics-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-custom-metrics-smoke.sh
@@ -11,8 +11,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
-BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+ROOT_DIR="$(cd "${EXTENSION_PATH}/.." && pwd)"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+BASH_PREFLIGHT_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_BASH_PREFLIGHT bash-preflight.sh)"
 FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-custom-metrics"
 
 if [ ! -d "$FIXTURE_DIR" ]; then

--- a/wordpress/scripts/bench/wp-codebox-bench-query-profiler-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-query-profiler-smoke.sh
@@ -6,8 +6,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
-BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+ROOT_DIR="$(cd "${EXTENSION_PATH}/.." && pwd)"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+BASH_PREFLIGHT_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_BASH_PREFLIGHT bash-preflight.sh)"
 FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-query-profiler"
 
 if [ ! -d "$FIXTURE_DIR" ]; then

--- a/wordpress/scripts/bench/wp-codebox-bench-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-smoke.sh
@@ -21,8 +21,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
-BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+ROOT_DIR="$(cd "${EXTENSION_PATH}/.." && pwd)"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+BASH_PREFLIGHT_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_BASH_PREFLIGHT bash-preflight.sh)"
 FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-noop"
 
 if [ ! -d "$FIXTURE_DIR" ]; then

--- a/wordpress/scripts/build/build-clean-vendor-smoke.sh
+++ b/wordpress/scripts/build/build-clean-vendor-smoke.sh
@@ -21,8 +21,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_DIR="$(cd "${EXTENSION_DIR}/.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-RESOLVE_CONTEXT_CORE_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+RESOLVE_CONTEXT_CORE_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_RESOLVE_CONTEXT resolve-context.sh)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-build-clean-vendor.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
 

--- a/wordpress/scripts/build/build-helper-smoke.sh
+++ b/wordpress/scripts/build/build-helper-smoke.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_DIR="$(cd "${EXTENSION_DIR}/.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-RESOLVE_CONTEXT_CORE_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+RESOLVE_CONTEXT_CORE_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_RESOLVE_CONTEXT resolve-context.sh)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-build-helper.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
 

--- a/wordpress/scripts/build/build-package-artifacts-smoke.sh
+++ b/wordpress/scripts/build/build-package-artifacts-smoke.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_DIR="$(cd "${EXTENSION_DIR}/.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-RESOLVE_CONTEXT_CORE_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+RESOLVE_CONTEXT_CORE_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_RESOLVE_CONTEXT resolve-context.sh)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-package-artifacts.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
 

--- a/wordpress/scripts/build/local-workspace-dep-build-smoke.sh
+++ b/wordpress/scripts/build/local-workspace-dep-build-smoke.sh
@@ -13,8 +13,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_DIR="$(cd "${EXTENSION_DIR}/.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-RESOLVE_CONTEXT_CORE_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+RESOLVE_CONTEXT_CORE_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_RESOLVE_CONTEXT resolve-context.sh)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-lwd.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
 

--- a/wordpress/scripts/lint/autofixable-exit-smoke.sh
+++ b/wordpress/scripts/lint/autofixable-exit-smoke.sh
@@ -3,12 +3,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+SIDECAR_WRITER_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
 RUNNER="${SCRIPT_DIR}/lint-runner.sh"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 

--- a/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
+++ b/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REAL_EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+SIDECAR_WRITER_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 EXTENSION_PATH="${TMPDIR}/extension"

--- a/wordpress/scripts/lint/fix-results-smoke.sh
+++ b/wordpress/scripts/lint/fix-results-smoke.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+SIDECAR_WRITER_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
 FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${ROOT_DIR}/scripts/lib/fix-results.sh}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT

--- a/wordpress/scripts/lint/lint-producers-smoke.sh
+++ b/wordpress/scripts/lint/lint-producers-smoke.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_DIR="$(cd "${EXTENSION_DIR}/.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+SIDECAR_WRITER_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -4,14 +4,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STABLE_FINGERPRINT_HELPER="${SCRIPT_DIR}/stable-fingerprint.php"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 # shellcheck source=../lib/validation-dependencies.sh
 source "${DEPENDENCY_HELPER}"
 # Standalone `homeboy lint` runs do not export HOMEBOY_RUNTIME_SIDECAR_WRITER;
 # fall back to the co-located direct-invocation copy so the sidecar writer is
 # available outside a release run (homeboy-extensions#1415).
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+SIDECAR_WRITER_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
 # shellcheck source=/dev/null
 if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
     source "$SIDECAR_WRITER_HELPER"
@@ -99,8 +100,8 @@ if [[ "${HOMEBOY_SKIP_PHPSTAN:-}" == "1" ]]; then
 fi
 
 # Resolve execution context (shared helper)
-RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/resolve-context.sh}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+RESOLVE_CONTEXT_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_RESOLVE_CONTEXT resolve-context.sh)"
+SIDECAR_WRITER_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
 # shellcheck source=/dev/null
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context --component-alias PLUGIN_PATH

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
+SIDECAR_WRITER_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_SIDECAR_WRITER sidecar-writer.sh)"
 RUNNER="${SCRIPT_DIR}/phpstan-runner.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/wordpress/scripts/lint/sidecar-writer-missing-exit-smoke.sh
+++ b/wordpress/scripts/lint/sidecar-writer-missing-exit-smoke.sh
@@ -17,19 +17,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR}/src/core/extension/runtime"
+# shellcheck source=../../../scripts/lib/runtime-helper-resolver.sh
+source "${ROOT_DIR}/scripts/lib/runtime-helper-resolver.sh"
 RUNNER="${SCRIPT_DIR}/lint-runner.sh"
 
 # The runner sources its prelude/steps/resolve-context helpers via `:?` (they
 # are hard preconditions provided by homeboy core), so provide working copies.
-for helper in runner-prelude.sh runner-steps.sh resolve-context.sh; do
-    if [ ! -f "${CORE_RUNTIME_DIR}/${helper}" ]; then
-        echo "Missing required runtime helper: ${CORE_RUNTIME_DIR}/${helper}" >&2
-        echo "Set HOMEBOY_CORE_DIR to a homeboy checkout to run this smoke." >&2
-        exit 1
-    fi
-done
+RUNNER_PRELUDE_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_RUNNER_PRELUDE runner-prelude.sh)"
+RUNNER_STEPS_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_RUNNER_STEPS runner-steps.sh)"
+RESOLVE_CONTEXT_HELPER="$(homeboy_runtime_helper "$ROOT_DIR" HOMEBOY_RUNTIME_RESOLVE_CONTEXT resolve-context.sh)"
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -43,9 +39,9 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # sidecar-writer.sh, so the prelude's runtime_dir fallback finds nothing.
 RUNTIME_DIR="${TMPDIR}/runtime-no-sidecar"
 mkdir -p "$RUNTIME_DIR"
-cp "${CORE_RUNTIME_DIR}/runner-prelude.sh" \
-   "${CORE_RUNTIME_DIR}/runner-steps.sh" \
-   "${CORE_RUNTIME_DIR}/resolve-context.sh" \
+cp "$RUNNER_PRELUDE_HELPER" \
+   "$RUNNER_STEPS_HELPER" \
+   "$RESOLVE_CONTEXT_HELPER" \
    "$RUNTIME_DIR/"
 # Deliberately do NOT copy sidecar-writer.sh into $RUNTIME_DIR.
 


### PR DESCRIPTION
Fixes #2520

## Summary
- Resolve WordPress smoke runtime helpers from the current Homeboy crate layout through one shared resolver.
- Preserve explicit `HOMEBOY_RUNTIME_*` overrides and provide probed-path diagnostics with a copyable override.
- Migrate every WordPress smoke with the retired helper path.

## Verification
- `bash tests/wordpress-runtime-helper-resolver-smoke.sh`
- `bash wordpress/scripts/lint/autofixable-exit-smoke.sh`
- `bash wordpress/scripts/lint/sidecar-writer-missing-exit-smoke.sh`
- `bash wordpress/scripts/build/build-helper-smoke.sh`
- `bash wordpress/scripts/build/build-clean-vendor-smoke.sh`
- `bash wordpress/scripts/build/local-workspace-dep-build-smoke.sh`
- `bash wordpress/scripts/build/build-package-artifacts-smoke.sh`
- `bash -n` across the migrated resolver and callers
- Repository inventory: no remaining `wordpress/**/*.sh` references to `src/core/extension/runtime`.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and verified this change. Chris Huber is responsible for every line.