### PR TITLE
Exclude generated artifacts from default WordPress lint

### DIFF
--- a/scripts/lib/repository-file-discovery.sh
+++ b/scripts/lib/repository-file-discovery.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Print default lint candidates relative to a repository root. Explicit lint
+# targets intentionally bypass this helper so operators can inspect any file.
+homeboy_discover_repository_files() {
+    local root="$1"
+    shift
+    local path
+    local pattern="${1:-*}"
+
+    if git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        while IFS= read -r -d '' path; do
+            case "${path#./}" in
+                artifacts/*|*/artifacts/*)
+                    ;;
+                *)
+                    printf '%s\0' "$path"
+                    ;;
+            esac
+        done < <(git -C "$root" ls-files --cached --others --exclude-standard -z -- "$@")
+        return
+    fi
+
+    find "$root" -type f -name "$pattern" -print0
+}

--- a/wordpress/scripts/lint/lint-gitignore-discovery-smoke.sh
+++ b/wordpress/scripts/lint/lint-gitignore-discovery-smoke.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/lint-runner.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+EXTENSION_DIR="${TMP_DIR}/extension"
+COMPONENT_DIR="${TMP_DIR}/component"
+PHPCS_ARGS_FILE="${TMP_DIR}/phpcs-args.txt"
+
+mkdir -p "${EXTENSION_DIR}/vendor/bin" "${EXTENSION_DIR}/scripts/lint" "${COMPONENT_DIR}/src" "${COMPONENT_DIR}/artifacts/generated"
+touch "${EXTENSION_DIR}/phpcs.xml.dist"
+
+cat > "${COMPONENT_DIR}/plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Git Discovery Fixture
+ * Text Domain: git-discovery-fixture
+ */
+PHP
+cat > "${COMPONENT_DIR}/src/tracked-violation.php" <<'PHP'
+<?php
+echo $_GET['tracked'];
+PHP
+cat > "${COMPONENT_DIR}/artifacts/generated/ignored-violation.php" <<'PHP'
+<?php
+echo $_GET['ignored'];
+PHP
+printf '%s\n' 'artifacts/' > "${COMPONENT_DIR}/.gitignore"
+git -C "$COMPONENT_DIR" init -q
+git -C "$COMPONENT_DIR" add .gitignore plugin.php src/tracked-violation.php
+git -C "$COMPONENT_DIR" -c user.name=fixture -c user.email=fixture@example.test commit -qm fixture
+
+cat > "${EXTENSION_DIR}/vendor/bin/phpcs" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$PHPCS_ARGS_FILE"
+if [[ " $* " == *' --report=json '* ]]; then
+    printf '%s\n' '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{}}'
+fi
+SH
+chmod +x "${EXTENSION_DIR}/vendor/bin/phpcs"
+
+run_lint() {
+    : > "$PHPCS_ARGS_FILE"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+    HOMEBOY_COMPONENT_ID="git-discovery-fixture" \
+    HOMEBOY_SUMMARY_MODE=1 \
+    HOMEBOY_STEP="phpcs" \
+    PHPCS_ARGS_FILE="$PHPCS_ARGS_FILE" \
+        bash "$RUNNER" >/dev/null
+}
+
+assert_contains() {
+    local expected="$1"
+    if ! grep -Fqx -- "$expected" "$PHPCS_ARGS_FILE"; then
+        echo "Expected PHPCS target: $expected" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local unexpected="$1"
+    if grep -Fqx -- "$unexpected" "$PHPCS_ARGS_FILE"; then
+        echo "Unexpected PHPCS target: $unexpected" >&2
+        exit 1
+    fi
+}
+
+run_lint
+assert_contains "${COMPONENT_DIR}/src/tracked-violation.php"
+assert_not_contains "${COMPONENT_DIR}/artifacts/generated/ignored-violation.php"
+
+: > "$PHPCS_ARGS_FILE"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="git-discovery-fixture" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_STEP="phpcs" \
+HOMEBOY_LINT_FILE="artifacts/generated/ignored-violation.php" \
+PHPCS_ARGS_FILE="$PHPCS_ARGS_FILE" \
+    bash "$RUNNER" >/dev/null
+assert_contains "${COMPONENT_DIR}/artifacts/generated/ignored-violation.php"
+
+: > "$PHPCS_ARGS_FILE"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="git-discovery-fixture" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_STEP="phpcs" \
+HOMEBOY_LINT_GLOB="artifacts/generated/ignored-violation.php" \
+PHPCS_ARGS_FILE="$PHPCS_ARGS_FILE" \
+    bash "$RUNNER" >/dev/null
+assert_contains "artifacts/generated/ignored-violation.php"
+
+echo "WordPress Git-ignored lint discovery smoke passed"

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -21,6 +21,8 @@ SHARED_LIB_DIR="${SHARED_LIB_DIR:-$(cd "${SCRIPT_DIR}/../../../scripts/lib" && p
 source "${SHARED_LIB_DIR}/runner-harness.sh"
 # shellcheck source=/dev/null
 source "${SHARED_LIB_DIR}/lint-findings-adapter.sh"
+# shellcheck source=/dev/null
+source "${SHARED_LIB_DIR}/repository-file-discovery.sh"
 homeboy_runner_harness_init --bash 4 --steps --sidecar-writer --component-alias PLUGIN_PATH
 homeboy_lint_findings_init
 
@@ -178,9 +180,10 @@ except Exception:
 PYEOF
 }
 
-# Determine lint target (file, glob, or full component)
-# Use array to properly handle paths with spaces
-LINT_FILES=("$PLUGIN_PATH")
+# Determine lint target (file, glob, or full component).
+# Explicit targets may intentionally include generated or Git-ignored files.
+# Use an array to properly handle paths with spaces.
+LINT_FILES=()
 
 if [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
     LINT_FILES=("${PLUGIN_PATH}/${HOMEBOY_LINT_FILE}")
@@ -207,6 +210,14 @@ elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     cd - > /dev/null
 else
     echo "Running PHP linting..."
+    while IFS= read -r -d '' lint_file; do
+        LINT_FILES+=("${PLUGIN_PATH}/${lint_file#./}")
+    done < <(homeboy_discover_repository_files "$PLUGIN_PATH" '*.php')
+
+    if [ "${#LINT_FILES[@]}" -eq 0 ]; then
+        echo "No PHP files found, skipping PHPCS."
+        exit 0
+    fi
 fi
 
 WORDPRESS_LINT_ROLE="production"


### PR DESCRIPTION
## Summary

- discover default PHP lint candidates through tracked and non-ignored Git files
- exclude generated artifact trees from repository lint
- preserve explicit file/glob inspection of ignored files

Closes #2524.

## Verification

- Git-ignored lint discovery smoke passes
- shell syntax and `git diff --check`
- extension shape lint passes
- existing `wordpress-lint-role-smoke.sh` fixture/runtime-helper failure remains unrelated

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode traced WordPress lint discovery, implemented the reusable repair, reviewed the diff, and ran targeted verification. Chris Huber remains responsible for every line.