### PR TITLE
Install and verify WP Codebox native runtime dependencies

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -805,6 +805,14 @@ The script resolves `runtime_bin` first, then legacy `HOMEBOY_WP_CODEBOX_BIN` or
 WP Codebox owns the health output, including JSON mode, binary/source checks,
 stale `recipe-run` process checks, and archive cache cleanup behavior.
 
+### Source hydration
+
+Source installs require the checked-out WP Codebox source to provide an npm
+lockfile (`package-lock.json` or `npm-shrinkwrap.json`). Homeboy hydrates it with
+`npm ci --include=optional`, which removes stale dependencies and installs the
+current platform's optional native packages before checking both the CLI and the
+`sharp` native runtime.
+
 ## Environment variables
 
 | Variable | Purpose |

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -5,11 +5,13 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/build/install-composer-dependencies.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
+      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
       "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs"
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
+      "bash scripts/build/setup-wp-codebox-smoke.sh",
+      "bash scripts/build/update-wp-codebox-cache-smoke.sh",
       "bash scripts/test/wp-codebox-doctor-smoke.sh",
       "bash tests/installed-test-helper-resolution-smoke.sh",
       "bash tests/extension-composer-vendor-integrity-smoke.sh",

--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -95,9 +95,13 @@ while [ "$#" -gt 0 ]; do
             prefix="$2"
             shift 2
             ;;
-        install)
-            if [[ " $* " != *" --omit=optional "* ]]; then
-                printf 'expected wp-codebox source install to omit optional dependencies: %s\n' "$*" >&2
+        ci)
+            if [[ " $* " != *" --include=optional "* ]]; then
+                printf 'expected wp-codebox source install to include optional dependencies: %s\n' "$*" >&2
+                exit 1
+            fi
+            if [[ " $* " == *" --omit=optional "* ]]; then
+                printf 'wp-codebox source install must not omit optional dependencies: %s\n' "$*" >&2
                 exit 1
             fi
             exit 0
@@ -195,13 +199,9 @@ if ! grep -q '^WP_CODEBOX_SOURCE_SHA=0123456789abcdef0123456789abcdef01234567$' 
     exit 1
 fi
 
-# Cold-cache regression: a later CI step picks up a cached wp-codebox CLI via
-# HOMEBOY_WP_CODEBOX_BIN, but HOMEBOY_WP_CODEBOX_CORE_MODULE did not survive the
-# step/process boundary. The runtime-core module is still on disk from the
-# earlier install. Setup must re-derive the core package module from the known install
-# locations instead of leaving it unset (which made the recipe loader hard-fail
-# with "@automattic/wp-codebox-core not found" and "No tests ran"). The CLI bin
-# is already present, so this path must NOT trigger a network install.
+# Cached native-runtime regression: a later CI step finds a CLI and core module
+# on disk, but its platform optional dependency is unavailable. Setup must probe
+# the CLI and rebuild from the source lockfile instead of trusting node_modules.
 COLD_HOME="${TMPDIR}/cold-home"
 COLD_INSTALL_DIR="${TMPDIR}/cold-install"
 COLD_GITHUB_ENV_FILE="${TMPDIR}/cold-github-env"
@@ -213,20 +213,15 @@ mkdir -p \
 
 cat > "${COLD_BIN}" <<'SH'
 #!/usr/bin/env bash
+if [ "${1:-}" = "commands" ]; then
+    printf '%s\n' 'Could not load native optional runtime dependency' >&2
+    exit 1
+fi
 printf '%s\n' 'wp-codebox cached stub'
 SH
 chmod +x "${COLD_BIN}"
 printf '%s\n' 'module.exports = { fixture: true };' > "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/index.js"
 printf '%s\n' 'module.exports = { runtimeContractManifest() { return {}; } };' > "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/contracts.js"
-
-# A network would be a hard failure here: the bin already exists, so no curl/git
-# install should run. Point curl/git at stubs that fail loudly if invoked.
-cat > "${FAKE_BIN}/curl-fail" <<'SH'
-#!/usr/bin/env bash
-printf 'cold-cache path must not download via curl: %s\n' "$*" >&2
-exit 1
-SH
-chmod +x "${FAKE_BIN}/curl-fail"
 
 (
     cd "${EXTENSION_DIR}"
@@ -235,6 +230,7 @@ chmod +x "${FAKE_BIN}/curl-fail"
     GITHUB_ENV="${COLD_GITHUB_ENV_FILE}" \
     HOMEBOY_WP_CODEBOX_BIN="${COLD_BIN}" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COLD_INSTALL_DIR}" \
+    FAKE_WP_CODEBOX_RELEASE_MISSING="1" \
     bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/cold-setup.out"
 )
 
@@ -246,12 +242,12 @@ fi
 
 cold_core_module="$(grep '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${COLD_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
 if [ "${cold_core_module}" != "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/contracts.js" ]; then
-    echo "Expected cold-cache setup to resolve the on-disk core package module, got: ${cold_core_module}" >&2
+    echo "Expected cold-cache setup to rebuild and export the runtime core module, got: ${cold_core_module}" >&2
     exit 1
 fi
 
-if grep -qi 'Installing WP Codebox CLI' "${TMPDIR}/cold-setup.out"; then
-    echo "Cold-cache path must not reinstall the CLI when a cached bin and module exist" >&2
+if ! grep -q 'Installing WP Codebox CLI' "${TMPDIR}/cold-setup.out"; then
+    echo "Broken cached runtime must be rebuilt instead of reused" >&2
     cat "${TMPDIR}/cold-setup.out" >&2
     exit 1
 fi

--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -16,7 +16,7 @@ OVERRIDE_GITHUB_ENV_FILE="${TMPDIR}/override-github-env"
 ARTIFACT_ROOT="${TMPDIR}/artifact-root"
 ARTIFACT_PATH="${TMPDIR}/wp-codebox-cli-linux-x64.tar.gz"
 
-mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}/scripts/build" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist"
+mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}/scripts/build" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/sharp"
 
 cat > "${EXTENSION_DIR}/scripts/build/persist-wp-codebox-overrides.mjs" <<'NODE'
 #!/usr/bin/env node
@@ -31,6 +31,8 @@ SH
 chmod +x "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox"
 printf '%s\n' 'module.exports = { fixture: true };' > "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"
 printf '%s\n' 'module.exports = { runtimeContractManifest() { return {}; } };' > "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/contracts.js"
+printf '%s\n' 'module.exports = require("./native.js");' > "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/sharp/index.js"
+printf '%s\n' 'module.exports = { native: true };' > "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/sharp/native.js"
 tar -czf "${ARTIFACT_PATH}" -C "${ARTIFACT_ROOT}" wp-codebox-cli
 
 cat > "${FAKE_BIN}/curl" <<SH
@@ -69,6 +71,9 @@ case "$1" in
     clone)
         dest="${@: -1}"
         mkdir -p "${dest}/.git"
+        if [ "${FAKE_WP_CODEBOX_NO_LOCKFILE:-}" != "1" ]; then
+            printf '%s\n' '{}' > "${dest}/package-lock.json"
+        fi
         ;;
     -C)
         if [ "${3:-}" = "rev-parse" ] && [ "${4:-}" = "HEAD" ]; then
@@ -104,6 +109,9 @@ while [ "$#" -gt 0 ]; do
                 printf 'wp-codebox source install must not omit optional dependencies: %s\n' "$*" >&2
                 exit 1
             fi
+            mkdir -p "${prefix}/node_modules/sharp"
+            printf '%s\n' 'module.exports = require("./native.js");' > "${prefix}/node_modules/sharp/index.js"
+            printf '%s\n' 'module.exports = { native: true };' > "${prefix}/node_modules/sharp/native.js"
             exit 0
             ;;
         run)
@@ -199,9 +207,9 @@ if ! grep -q '^WP_CODEBOX_SOURCE_SHA=0123456789abcdef0123456789abcdef01234567$' 
     exit 1
 fi
 
-# Cached native-runtime regression: a later CI step finds a CLI and core module
-# on disk, but its platform optional dependency is unavailable. Setup must probe
-# the CLI and rebuild from the source lockfile instead of trusting node_modules.
+# Cached native-runtime regression: `commands` can succeed while a lazy native
+# dependency is unavailable. Setup must probe sharp and rebuild from the source
+# lockfile instead of trusting the cached node_modules tree.
 COLD_HOME="${TMPDIR}/cold-home"
 COLD_INSTALL_DIR="${TMPDIR}/cold-install"
 COLD_GITHUB_ENV_FILE="${TMPDIR}/cold-github-env"
@@ -213,15 +221,13 @@ mkdir -p \
 
 cat > "${COLD_BIN}" <<'SH'
 #!/usr/bin/env bash
-if [ "${1:-}" = "commands" ]; then
-    printf '%s\n' 'Could not load native optional runtime dependency' >&2
-    exit 1
-fi
 printf '%s\n' 'wp-codebox cached stub'
 SH
 chmod +x "${COLD_BIN}"
 printf '%s\n' 'module.exports = { fixture: true };' > "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/index.js"
 printf '%s\n' 'module.exports = { runtimeContractManifest() { return {}; } };' > "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/contracts.js"
+mkdir -p "${COLD_INSTALL_DIR}/source/node_modules/sharp"
+printf '%s\n' 'module.exports = require("./native.js");' > "${COLD_INSTALL_DIR}/source/node_modules/sharp/index.js"
 
 (
     cd "${EXTENSION_DIR}"
@@ -252,13 +258,42 @@ if ! grep -q 'Installing WP Codebox CLI' "${TMPDIR}/cold-setup.out"; then
     exit 1
 fi
 
+if ! node -e 'require(require.resolve("sharp", { paths: [ process.argv[1] ] }));' "${COLD_INSTALL_DIR}/source"; then
+    echo "Expected source hydration to restore the cached native runtime dependency" >&2
+    exit 1
+fi
+
+NO_LOCKFILE_OUTPUT="${TMPDIR}/no-lockfile.out"
+NO_LOCKFILE_ERROR="${TMPDIR}/no-lockfile.err"
+if (
+    cd "${EXTENSION_DIR}"
+    HOME="${TMPDIR}/no-lockfile-home" \
+    PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GITHUB_ENV="${TMPDIR}/no-lockfile-github-env" \
+    HOMEBOY_WP_CODEBOX_INSTALL_MODE="source" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMPDIR}/no-lockfile-install" \
+    HOMEBOY_WP_CODEBOX_SOURCE="https://example.test/custom-wp-codebox.git" \
+    FAKE_WP_CODEBOX_NO_LOCKFILE="1" \
+    bash "${ROOT_DIR}/scripts/build/setup.sh" > "${NO_LOCKFILE_OUTPUT}" 2> "${NO_LOCKFILE_ERROR}"
+); then
+    echo "Source setup without a lockfile must fail" >&2
+    exit 1
+fi
+
+if ! grep -q 'WP Codebox source install requires an npm lockfile (package-lock.json or npm-shrinkwrap.json) for deterministic npm ci: https://example.test/custom-wp-codebox.git' "${NO_LOCKFILE_ERROR}"; then
+    echo "Expected a deterministic lockfile diagnostic for custom WP Codebox sources" >&2
+    cat "${NO_LOCKFILE_ERROR}" >&2
+    exit 1
+fi
+
 STALE_ROOT="${TMPDIR}/stale-wp-codebox"
 CURRENT_ROOT="${TMPDIR}/wp-codebox-main-current"
 mkdir -p \
     "${STALE_ROOT}/packages/cli/dist" \
     "${STALE_ROOT}/packages/runtime-core/dist" \
     "${CURRENT_ROOT}/packages/cli/dist" \
-    "${CURRENT_ROOT}/packages/runtime-core/dist"
+    "${CURRENT_ROOT}/packages/runtime-core/dist" \
+    "${CURRENT_ROOT}/node_modules/sharp"
 
 cat > "${STALE_ROOT}/packages/cli/dist/index.js" <<'NODE'
 #!/usr/bin/env node
@@ -273,6 +308,8 @@ console.log('current wp-codebox');
 NODE
 chmod +x "${CURRENT_ROOT}/packages/cli/dist/index.js"
 printf '%s\n' 'module.exports = { runtimeContractManifest() { return { fixture: "current" }; } };' > "${CURRENT_ROOT}/packages/runtime-core/dist/index.js"
+printf '%s\n' 'module.exports = require("./native.js");' > "${CURRENT_ROOT}/node_modules/sharp/index.js"
+printf '%s\n' 'module.exports = { native: true };' > "${CURRENT_ROOT}/node_modules/sharp/native.js"
 
 (
     cd "${EXTENSION_DIR}"

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -38,6 +38,19 @@ install_wp_codebox() {
         return 0
     }
 
+    probe_wp_codebox_runtime() {
+        local bin_path="$1"
+
+        # `commands` initializes the CLI runtime, including native optional
+        # dependencies, without starting a WordPress workload.
+        if ! "${bin_path}" commands >/dev/null 2>&1; then
+            echo "WP Codebox CLI runtime probe failed: ${bin_path}" >&2
+            return 1
+        fi
+
+        return 0
+    }
+
     first_non_empty_env() {
         local name
         for name in "$@"; do
@@ -76,7 +89,7 @@ install_wp_codebox() {
             configured_core_module=1
         fi
 
-        if [ "${configured_bin}" -eq 1 ] && { [ "${configured_core_module}" -eq 1 ] || resolve_core_module_from_known_locations; }; then
+        if [ "${configured_bin}" -eq 1 ] && { [ "${configured_core_module}" -eq 1 ] || resolve_core_module_from_known_locations; } && probe_wp_codebox_runtime "${HOMEBOY_WP_CODEBOX_BIN}"; then
             node "${EXTENSION_PATH}/scripts/build/persist-wp-codebox-overrides.mjs" "${EXTENSION_PATH}/wordpress.json"
             return 0
         fi
@@ -120,10 +133,10 @@ install_wp_codebox() {
 
     if [ "${source_install_requested}" -eq 0 ] && [ -n "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && [ -x "${HOMEBOY_WP_CODEBOX_BIN}" ]; then
         echo "WP Codebox already configured: ${HOMEBOY_WP_CODEBOX_BIN}"
-        if resolve_core_module_from_known_locations; then
+        if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${HOMEBOY_WP_CODEBOX_BIN}"; then
             return 0
         fi
-        echo "WP Codebox CLI is configured without a runtime core module; (re)installing source module" >&2
+        echo "WP Codebox CLI is configured without a ready runtime; (re)installing source module" >&2
     fi
 
     if [ "${source_install_requested}" -eq 0 ] && command -v wp-codebox >/dev/null 2>&1; then
@@ -131,10 +144,10 @@ install_wp_codebox() {
         detected_bin="$(command -v wp-codebox)"
         echo "WP Codebox already available: ${detected_bin}"
         write_github_env "HOMEBOY_WP_CODEBOX_BIN" "${detected_bin}"
-        if resolve_core_module_from_known_locations; then
+        if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${detected_bin}"; then
             return 0
         fi
-        echo "WP Codebox CLI is available without a runtime core module; (re)installing source module" >&2
+        echo "WP Codebox CLI is available without a ready runtime; (re)installing source module" >&2
     fi
 
     local install_mode install_root bin_dir bin_path platform arch artifact_name download_url artifact_path extract_dir
@@ -184,11 +197,11 @@ EOF
             write_github_env "PATH" "${bin_dir}:${PATH}"
 
             echo "WP Codebox installed: ${bin_path}"
-            if resolve_core_module_from_known_locations; then
+            if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${bin_path}"; then
                 return 0
             fi
 
-            echo "WP Codebox release artifact did not include a runtime core module; falling back to source install" >&2
+            echo "WP Codebox release artifact did not provide a ready runtime; falling back to source install" >&2
         fi
 
         if [ "${release_artifact_downloaded}" -eq 0 ]; then
@@ -219,7 +232,7 @@ EOF
     write_github_env "WP_CODEBOX_SOURCE_REF" "${ref}"
     write_github_env "WP_CODEBOX_SOURCE_SHA" "${source_sha}"
 
-    npm --prefix "${repo_dir}" install --quiet --no-fund --no-audit --omit=optional
+    npm --prefix "${repo_dir}" ci --quiet --no-fund --no-audit --include=optional
     npm --prefix "${repo_dir}" run build --silent
 
     resolve_core_module_from_known_locations || {
@@ -233,6 +246,11 @@ EOF
         echo "Built WP Codebox source did not contain an executable CLI at ${source_bin_path}" >&2
         exit 1
     fi
+
+    probe_wp_codebox_runtime "${source_bin_path}" || {
+        echo "Built WP Codebox source CLI runtime is not ready" >&2
+        exit 1
+    }
 
     bin_path="${source_bin_path}"
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -41,14 +41,38 @@ install_wp_codebox() {
     probe_wp_codebox_runtime() {
         local bin_path="$1"
 
-        # `commands` initializes the CLI runtime, including native optional
-        # dependencies, without starting a WordPress workload.
+        # `commands` verifies the CLI entrypoint without starting a WordPress workload.
         if ! "${bin_path}" commands >/dev/null 2>&1; then
             echo "WP Codebox CLI runtime probe failed: ${bin_path}" >&2
             return 1
         fi
 
         return 0
+    }
+
+    probe_wp_codebox_native_runtime() {
+        local dependency_root="$1"
+
+        # Resolve from WP Codebox's dependency tree so Homeboy's dependencies
+        # cannot satisfy this check. Requiring sharp loads its platform binary.
+        if ! node -e 'const root=process.argv[1]; require(require.resolve("sharp", { paths: [ root ] }));' "${dependency_root}" >/dev/null 2>&1; then
+            echo "WP Codebox native runtime probe failed to load sharp from: ${dependency_root}" >&2
+            return 1
+        fi
+
+        return 0
+    }
+
+    wp_codebox_dependency_root() {
+        local bin_path="$1"
+        local install_root="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+        local core_module="${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}"
+
+        case "${core_module}" in
+            "${install_root}/source/node_modules/"*) printf '%s' "${install_root}/source" ;;
+            "${install_root}/release/wp-codebox-cli/node_modules/"*) printf '%s' "${install_root}/release/wp-codebox-cli" ;;
+            *) dirname "${bin_path}" ;;
+        esac
     }
 
     first_non_empty_env() {
@@ -89,7 +113,7 @@ install_wp_codebox() {
             configured_core_module=1
         fi
 
-        if [ "${configured_bin}" -eq 1 ] && { [ "${configured_core_module}" -eq 1 ] || resolve_core_module_from_known_locations; } && probe_wp_codebox_runtime "${HOMEBOY_WP_CODEBOX_BIN}"; then
+        if [ "${configured_bin}" -eq 1 ] && { [ "${configured_core_module}" -eq 1 ] || resolve_core_module_from_known_locations; } && probe_wp_codebox_runtime "${HOMEBOY_WP_CODEBOX_BIN}" && probe_wp_codebox_native_runtime "$(wp_codebox_dependency_root "${HOMEBOY_WP_CODEBOX_BIN}")"; then
             node "${EXTENSION_PATH}/scripts/build/persist-wp-codebox-overrides.mjs" "${EXTENSION_PATH}/wordpress.json"
             return 0
         fi
@@ -133,7 +157,7 @@ install_wp_codebox() {
 
     if [ "${source_install_requested}" -eq 0 ] && [ -n "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && [ -x "${HOMEBOY_WP_CODEBOX_BIN}" ]; then
         echo "WP Codebox already configured: ${HOMEBOY_WP_CODEBOX_BIN}"
-        if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${HOMEBOY_WP_CODEBOX_BIN}"; then
+        if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${HOMEBOY_WP_CODEBOX_BIN}" && probe_wp_codebox_native_runtime "$(wp_codebox_dependency_root "${HOMEBOY_WP_CODEBOX_BIN}")"; then
             return 0
         fi
         echo "WP Codebox CLI is configured without a ready runtime; (re)installing source module" >&2
@@ -144,7 +168,7 @@ install_wp_codebox() {
         detected_bin="$(command -v wp-codebox)"
         echo "WP Codebox already available: ${detected_bin}"
         write_github_env "HOMEBOY_WP_CODEBOX_BIN" "${detected_bin}"
-        if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${detected_bin}"; then
+        if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${detected_bin}" && probe_wp_codebox_native_runtime "$(wp_codebox_dependency_root "${detected_bin}")"; then
             return 0
         fi
         echo "WP Codebox CLI is available without a ready runtime; (re)installing source module" >&2
@@ -197,7 +221,7 @@ EOF
             write_github_env "PATH" "${bin_dir}:${PATH}"
 
             echo "WP Codebox installed: ${bin_path}"
-            if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${bin_path}"; then
+            if resolve_core_module_from_known_locations && probe_wp_codebox_runtime "${bin_path}" && probe_wp_codebox_native_runtime "${extract_dir}/wp-codebox-cli"; then
                 return 0
             fi
 
@@ -225,6 +249,11 @@ EOF
     git -C "${repo_dir}" fetch --quiet origin "${ref}"
     git -C "${repo_dir}" checkout --quiet FETCH_HEAD
 
+    if [ ! -f "${repo_dir}/package-lock.json" ] && [ ! -f "${repo_dir}/npm-shrinkwrap.json" ]; then
+        echo "WP Codebox source install requires an npm lockfile (package-lock.json or npm-shrinkwrap.json) for deterministic npm ci: ${source}" >&2
+        exit 1
+    fi
+
     local source_sha
     source_sha="$(git -C "${repo_dir}" rev-parse HEAD)"
     export WP_CODEBOX_SOURCE_REF="${ref}"
@@ -249,6 +278,10 @@ EOF
 
     probe_wp_codebox_runtime "${source_bin_path}" || {
         echo "Built WP Codebox source CLI runtime is not ready" >&2
+        exit 1
+    }
+    probe_wp_codebox_native_runtime "${repo_dir}" || {
+        echo "Built WP Codebox source native runtime is not ready" >&2
         exit 1
     }
 

--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -65,7 +65,8 @@ git clone --quiet "$REMOTE_REPO" "$SOURCE_WORK"
 git -C "$SOURCE_WORK" config user.email smoke@example.com
 git -C "$SOURCE_WORK" config user.name Smoke
 printf '%s\n' '{"scripts":{"build":"node -e 0"}}' > "${SOURCE_WORK}/package.json"
-git -C "$SOURCE_WORK" add package.json
+printf '%s\n' '{"lockfileVersion":3,"packages":{}}' > "${SOURCE_WORK}/package-lock.json"
+git -C "$SOURCE_WORK" add package.json package-lock.json
 git -C "$SOURCE_WORK" commit --quiet -m 'initial wp-codebox fixture'
 INITIAL_SHA="$(git -C "$SOURCE_WORK" rev-parse HEAD)"
 git -C "$SOURCE_WORK" push --quiet origin HEAD:main

--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -38,7 +38,14 @@ while [ "$#" -gt 0 ]; do
 done
 [ -n "$prefix" ] || { echo "missing --prefix" >&2; exit 2; }
 case "${args[*]}" in
-    install*)
+    ci*)
+        case " ${args[*]} " in
+            *" --include=optional "*) ;;
+            *)
+                echo "expected npm ci to include optional dependencies: ${args[*]}" >&2
+                exit 2
+                ;;
+        esac
         touch "${prefix}/npm-install-ran"
         ;;
     "run build")

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -128,6 +128,8 @@ echo "Fetching WP Codebox ref: $REQUESTED_REF"
 git -C "$CACHE_DIR" fetch --quiet --tags origin "$REQUESTED_REF" || fail "failed to fetch ref '$REQUESTED_REF' from $SOURCE"
 git -C "$CACHE_DIR" reset --hard --quiet FETCH_HEAD || fail "failed to reset cache checkout to FETCH_HEAD"
 
+[ -f "$CACHE_DIR/package-lock.json" ] || [ -f "$CACHE_DIR/npm-shrinkwrap.json" ] || fail "WP Codebox source cache requires an npm lockfile (package-lock.json or npm-shrinkwrap.json) for deterministic npm ci: $SOURCE"
+
 echo "Installing WP Codebox dependencies..."
 "$NPM_BIN" --prefix "$CACHE_DIR" ci --include=optional --no-fund --no-audit || fail "npm ci failed in $CACHE_DIR"
 

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -129,7 +129,7 @@ git -C "$CACHE_DIR" fetch --quiet --tags origin "$REQUESTED_REF" || fail "failed
 git -C "$CACHE_DIR" reset --hard --quiet FETCH_HEAD || fail "failed to reset cache checkout to FETCH_HEAD"
 
 echo "Installing WP Codebox dependencies..."
-"$NPM_BIN" --prefix "$CACHE_DIR" install --no-fund --no-audit || fail "npm install failed in $CACHE_DIR"
+"$NPM_BIN" --prefix "$CACHE_DIR" ci --include=optional --no-fund --no-audit || fail "npm ci failed in $CACHE_DIR"
 
 echo "Building WP Codebox packages..."
 "$NPM_BIN" --prefix "$CACHE_DIR" run build || fail "npm run build failed in $CACHE_DIR"


### PR DESCRIPTION
## Summary

- hydrate WP Codebox source/cache installs deterministically with lockfile-based `npm ci --include=optional`
- load `sharp` from the selected target dependency tree before accepting cached, source, or release runtimes
- retain a separate CLI command probe and recover broken warm caches through source hydration
- enforce and document the source lockfile contract
- gate cold-cache and broken-native-runtime regression smokes in required extension self-checks

Closes #2526.

## Verification

- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash wordpress/scripts/build/update-wp-codebox-cache-smoke.sh`
- `bash -n` and `shellcheck` on changed shell scripts
- relevant WordPress extension ESLint checks
- real target-tree recovery: stale Darwin `sharp` load failed, `npm ci --include=optional` rehydrated it, then native load passed
- `git diff --check origin/main...HEAD`

## AI Assistance

GPT-5.6-Sol via OpenCode diagnosed the CI native dependency failure, implemented and reviewed deterministic runtime hydration/readiness checks, and added required regression gates. Chris Huber remains responsible for every line.