### PR TITLE
fix(wordpress): honor the declared JavaScript test runner for changed tests

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -94,6 +94,37 @@ The real-WordPress focused path preserves the machine-readable `HOST_SMOKE_BEGIN
 `HOST_SMOKE_PROGRESS`, `HOST_SMOKE_OK`, `HOST_SMOKE_FAIL`, and
 `HOST_SMOKE_SUMMARY` markers, and fails fast with the selected script name.
 
+## JavaScript unit tests
+
+`*.test.js`, `*.test.jsx`, `*.test.mjs`, `*.test.cjs`, `*.test.ts`, and
+`*.test.tsx` files route to the framework the component declares, not to a
+backend chosen from the file extension. Selection order:
+
+1. `HOMEBOY_WORDPRESS_JS_TEST_SCRIPT`
+2. the `wordpress_js_test_script` (or `js_test_script`) setting
+3. the first declared `package.json` script from
+   `HOMEBOY_WORDPRESS_JS_TEST_SCRIPT_CANDIDATES`, which defaults to
+   `test:unit test:unit:js test:js`
+
+When one of those resolves, the runner delegates to the package manager
+(`npm run <script> -- <selected files>`), which preserves the package's
+config, transforms, setup files, globals, and test environment. Evidence
+reports `Backend: package-script` with the `Contract:` line naming the source
+that selected it, and `JS_TEST_BEGIN` / `JS_TEST_SUMMARY` markers.
+
+```json
+{
+  "scripts": {
+    "test:unit": "wp-scripts test-unit-js"
+  }
+}
+```
+
+Node's built-in runner (`Backend: node-test`) is used only when no script is
+declared and every selected file imports `node:test`. A selected file that
+declares neither is a hard error with actionable guidance rather than a
+`describe is not defined` failure from the wrong runner.
+
 ## Agent Bundle Validator
 
 Agent bundle repositories can run the shared bundle validator as a standalone

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -5,7 +5,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
+      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
       "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs"
     ],
     "test": [
@@ -21,6 +21,7 @@
       "node tests/wp-codebox-database-service-smoke.mjs",
       "node tests/wp-codebox-native-database-canary.mjs",
       "bash scripts/test/full-suite-no-phpunit-smoke.sh",
+      "bash tests/js-test-framework-routing-smoke.sh",
       "node tests/codebox-client-boundary.test.js",
       "node tests/wp-codebox-fuzz-run-smoke.js",
       "node tests/wordpress-fuzz-runner-smoke.js",

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -21,11 +21,16 @@ CORE_WP_CODEBOX_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_CORE_WP_CODEBOX:-${SCRIPT_
 WORDPRESS_TEST_RUNTIME_BACKEND="${HOMEBOY_WORDPRESS_TEST_RUNTIME_BACKEND:-wp-codebox}"
 
 SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SHARED_LIB_DIR}/settings.sh}"
+PROJECT_SCRIPTS_HELPER="${HOMEBOY_RUNTIME_PROJECT_SCRIPTS_HELPER:-${SHARED_LIB_DIR}/project-scripts.sh}"
 # shellcheck source=/dev/null
 source "$RUNNER_PRELUDE"
 homeboy_runner_init --bash 4 --component-alias PLUGIN_PATH
 # shellcheck source=/dev/null
 source "$SETTINGS_HELPER"
+if [ -f "$PROJECT_SCRIPTS_HELPER" ]; then
+    # shellcheck source=/dev/null
+    source "$PROJECT_SCRIPTS_HELPER"
+fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Extension path: $EXTENSION_PATH"
@@ -408,13 +413,181 @@ homeboy_wordpress_is_js_smoke_file() {
 
 homeboy_wordpress_is_node_test_file() {
     case "$1" in
-        *.test.js|*.test.cjs|*.test.mjs)
+        *.test.js|*.test.cjs|*.test.mjs|*.test.jsx|*.test.ts|*.test.tsx)
             return 0
             ;;
         *)
             return 1
             ;;
     esac
+}
+
+# A `*.test.js` suffix says nothing about which framework owns the file. A
+# WordPress package that declares `wp-scripts test-unit-js` runs Jest, whose
+# `describe`/`it`/`expect` globals, transforms, setup files, and test
+# environment come from the package configuration. Narrowing a run to changed
+# files must narrow the declared runner, never replace it.
+#
+# Resolution order, most explicit first:
+#   1. HOMEBOY_WORDPRESS_JS_TEST_SCRIPT
+#   2. settings wordpress_js_test_script / js_test_script
+#   3. the first declared package script from
+#      HOMEBOY_WORDPRESS_JS_TEST_SCRIPT_CANDIDATES
+#
+# Sets JS_TEST_SCRIPT and JS_TEST_SCRIPT_SOURCE. Returns 0 when a repository
+# runner is declared, 1 when none is declared, and 2 when an explicitly
+# declared script is missing from the package manifest.
+JS_TEST_SCRIPT=""
+JS_TEST_SCRIPT_SOURCE=""
+JS_TEST_SCRIPT_RESOLVED=0
+JS_TEST_SCRIPT_STATUS=1
+
+homeboy_wordpress_resolve_js_test_script() {
+    local configured candidate
+
+    if [ "$JS_TEST_SCRIPT_RESOLVED" -eq 1 ]; then
+        return "$JS_TEST_SCRIPT_STATUS"
+    fi
+    JS_TEST_SCRIPT_RESOLVED=1
+    JS_TEST_SCRIPT_STATUS=1
+
+    configured="${HOMEBOY_WORDPRESS_JS_TEST_SCRIPT:-}"
+    if [ -z "$configured" ]; then
+        configured="$(homeboy_setting wordpress_js_test_script '.wordpress_js_test_script // .js_test_script // empty')"
+    fi
+
+    if [ ! -f "${PLUGIN_PATH}/package.json" ] || ! type homeboy_project_init >/dev/null 2>&1; then
+        if [ -n "$configured" ]; then
+            echo "ERROR: declared JavaScript test script '${configured}' requires a package manifest at ${PLUGIN_PATH}/package.json" >&2
+            JS_TEST_SCRIPT_STATUS=2
+        fi
+        return "$JS_TEST_SCRIPT_STATUS"
+    fi
+
+    if ! homeboy_project_init --ecosystem nodejs --path "$PLUGIN_PATH" >/dev/null 2>&1; then
+        if [ -n "$configured" ]; then
+            echo "ERROR: could not resolve the Node.js project contract for ${PLUGIN_PATH}" >&2
+            JS_TEST_SCRIPT_STATUS=2
+        fi
+        return "$JS_TEST_SCRIPT_STATUS"
+    fi
+
+    if [ -n "$configured" ]; then
+        if ! homeboy_project_has_script "$configured"; then
+            echo "ERROR: declared JavaScript test script '${configured}' is not defined in ${PLUGIN_PATH}/package.json" >&2
+            JS_TEST_SCRIPT_STATUS=2
+            return "$JS_TEST_SCRIPT_STATUS"
+        fi
+        JS_TEST_SCRIPT="$configured"
+        JS_TEST_SCRIPT_SOURCE="declared setting wordpress_js_test_script -> package.json scripts.${configured}"
+        JS_TEST_SCRIPT_STATUS=0
+        return 0
+    fi
+
+    for candidate in ${HOMEBOY_WORDPRESS_JS_TEST_SCRIPT_CANDIDATES:-test:unit test:unit:js test:js}; do
+        if homeboy_project_has_script "$candidate"; then
+            JS_TEST_SCRIPT="$candidate"
+            JS_TEST_SCRIPT_SOURCE="package.json scripts.${candidate}"
+            JS_TEST_SCRIPT_STATUS=0
+            return 0
+        fi
+    done
+
+    return "$JS_TEST_SCRIPT_STATUS"
+}
+
+# True when the file itself imports Node's built-in test runner, which is the
+# only extension-independent evidence that `node --test` is the right backend.
+homeboy_wordpress_is_native_node_test_file() {
+    local rel_path="$1"
+    grep -qE "(require\(|from[[:space:]]+|import[[:space:]]*\()[[:space:]]*['\"]node:test['\"]" "${PLUGIN_PATH}/${rel_path}" 2>/dev/null
+}
+
+homeboy_wordpress_run_declared_js_test_files() {
+    local test_files_raw="$1"
+    local test_file rel_path run_command exit_code
+    local selected=()
+
+    while IFS= read -r test_file; do
+        [ -n "$test_file" ] || continue
+        if ! rel_path="$(homeboy_wordpress_rel_test_file "$test_file")"; then
+            echo "ERROR: requested JavaScript test file not found or outside the component: ${test_file}" >&2
+            return 2
+        fi
+        selected+=("$rel_path")
+    done <<< "$test_files_raw"
+
+    if [ "${#selected[@]}" -eq 0 ]; then
+        echo "ERROR: no JavaScript test files were selected" >&2
+        return 2
+    fi
+
+    if ! run_command="$(homeboy_project_run_script_command "$JS_TEST_SCRIPT")"; then
+        echo "ERROR: could not resolve the package runner command for script '${JS_TEST_SCRIPT}'" >&2
+        return 2
+    fi
+
+    homeboy_project_ensure_dependencies
+
+    echo "Running declared JavaScript tests..."
+    echo "  Component: ${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
+    echo "  Backend: package-script"
+    echo "  Contract: ${JS_TEST_SCRIPT_SOURCE}"
+    echo "  Command: ${run_command} -- ${selected[*]}"
+    for rel_path in "${selected[@]}"; do
+        echo "JS_TEST_BEGIN:${rel_path}"
+    done
+
+    exit_code=0
+    # shellcheck disable=SC2086
+    (cd "$PLUGIN_PATH" && $run_command -- "${selected[@]}") || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        echo "JS_TEST_SUMMARY:backend=package-script script=${JS_TEST_SCRIPT} files=${#selected[@]} status=ok"
+    else
+        echo "JS_TEST_SUMMARY:backend=package-script script=${JS_TEST_SCRIPT} files=${#selected[@]} status=failed exit=${exit_code}"
+    fi
+    return "$exit_code"
+}
+
+# Route selected JavaScript test files to the framework that actually owns
+# them: the repository's declared runner when one exists, Node's built-in
+# runner when the files themselves declare it, and an actionable error when
+# neither is knowable.
+homeboy_wordpress_run_js_unit_test_files() {
+    local test_files_raw="$1"
+    local resolve_status=0
+    local test_file rel_path
+    local ambiguous=()
+
+    homeboy_wordpress_resolve_js_test_script || resolve_status=$?
+    if [ "$resolve_status" -eq 2 ]; then
+        return 2
+    fi
+    if [ "$resolve_status" -eq 0 ]; then
+        homeboy_wordpress_run_declared_js_test_files "$test_files_raw"
+        return $?
+    fi
+
+    while IFS= read -r test_file; do
+        [ -n "$test_file" ] || continue
+        if ! rel_path="$(homeboy_wordpress_rel_test_file "$test_file")"; then
+            echo "ERROR: requested JavaScript test file not found or outside the component: ${test_file}" >&2
+            return 2
+        fi
+        if ! homeboy_wordpress_is_native_node_test_file "$rel_path"; then
+            ambiguous+=("$rel_path")
+        fi
+    done <<< "$test_files_raw"
+
+    if [ "${#ambiguous[@]}" -gt 0 ]; then
+        echo "ERROR: cannot select a JavaScript test framework for: ${ambiguous[*]}" >&2
+        echo "  The files do not import Node's built-in 'node:test' runner and the component declares no JavaScript test script." >&2
+        echo "  Add a package.json test script (for example \"test:unit\": \"wp-scripts test-unit-js\"), set the wordpress_js_test_script setting, or import 'node:test' in the tests." >&2
+        return 2
+    fi
+
+    homeboy_wordpress_run_node_test_files "$test_files_raw"
 }
 
 homeboy_wordpress_run_node_test_files() {
@@ -428,6 +601,7 @@ homeboy_wordpress_run_node_test_files() {
     echo "Running Node test files..."
     echo "  Component: ${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
     echo "  Backend: node-test"
+    echo "  Contract: ${JS_TEST_SCRIPT_SOURCE:-native node:test import}"
 
     while IFS= read -r test_file; do
         [ -n "$test_file" ] || continue
@@ -597,12 +771,12 @@ if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     fi
 
     if [ -z "$changed_js_smoke_files" ] && [ -z "$changed_shell_smoke_files" ] && [ -n "$changed_node_test_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
-        homeboy_wordpress_run_node_test_files "$changed_node_test_files"
+        homeboy_wordpress_run_js_unit_test_files "$changed_node_test_files"
         exit $?
     fi
 
     if [ -n "$changed_node_test_files" ]; then
-        homeboy_wordpress_run_node_test_files "$changed_node_test_files" || exit $?
+        homeboy_wordpress_run_js_unit_test_files "$changed_node_test_files" || exit $?
     fi
 fi
 
@@ -614,7 +788,7 @@ if [ -n "$TARGET_FILE" ]; then
 
     target_base="$(basename "$target_rel")"
     if homeboy_wordpress_is_node_test_file "$target_rel"; then
-        homeboy_wordpress_run_node_test_files "$target_rel"
+        homeboy_wordpress_run_js_unit_test_files "$target_rel"
         exit $?
     fi
 

--- a/wordpress/tests/js-test-framework-routing-smoke.sh
+++ b/wordpress/tests/js-test-framework-routing-smoke.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression: a `*.test.js` suffix must not replace the framework the component
+# declares. A WordPress package whose contract is `wp-scripts test-unit-js`
+# runs Jest, whose describe/it/expect globals do not exist under `node --test`.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RUNNER="${EXTENSION_PATH}/scripts/test/test-runner.sh"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq -- "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    if grep -Fq -- "$unexpected" "$file"; then
+        echo "Expected $file not to contain: $unexpected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+runner_prelude="${WORK_DIR}/runner-prelude.sh"
+cat > "$runner_prelude" <<'SH'
+homeboy_runner_init() {
+    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:?HOMEBOY_COMPONENT_PATH is required}"
+    PLUGIN_PATH="$COMPONENT_PATH"
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:?HOMEBOY_EXTENSION_PATH is required}"
+}
+SH
+
+stubs="${WORK_DIR}/stubs"
+mkdir -p "$stubs"
+# Stand in for the package manager so the smoke asserts the delegated contract
+# without installing a real Jest toolchain.
+cat > "${stubs}/npm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'NPM_INVOKED:%s\n' "$*"
+if [ "${1:-}" = "run" ] && [ "${2:-}" = "test:unit" ]; then
+    echo "PASS ${*:4}"
+    echo "Test Suites: 1 passed, 1 total"
+    exit 0
+fi
+echo "Unexpected npm command: $*" >&2
+exit 2
+SH
+chmod +x "${stubs}/npm"
+
+# --- Jest-shaped component: package contract owns the runner ---------------
+jest_component="${WORK_DIR}/jest-component"
+mkdir -p "${jest_component}/src/blocks/studio/tabs" "${jest_component}/node_modules"
+cat > "${jest_component}/package.json" <<'JSON'
+{
+  "name": "studio",
+  "scripts": {
+    "build": "wp-scripts build",
+    "test:unit": "wp-scripts test-unit-js"
+  }
+}
+JSON
+cat > "${jest_component}/src/blocks/studio/tabs/usability-contracts.test.js" <<'JS'
+describe( 'usability contracts', () => {
+	it( 'exposes Jest globals', () => {
+		expect( 2 + 2 ).toBe( 4 );
+	} );
+} );
+JS
+
+PATH="${stubs}:${PATH}" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="studio" \
+HOMEBOY_COMPONENT_PATH="$jest_component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_CHANGED_TEST_FILES="src/blocks/studio/tabs/usability-contracts.test.js" \
+    bash "$RUNNER" > "${WORK_DIR}/jest.out" 2>&1
+
+assert_contains "${WORK_DIR}/jest.out" "Backend: package-script"
+assert_contains "${WORK_DIR}/jest.out" "Contract: package.json scripts.test:unit"
+assert_contains "${WORK_DIR}/jest.out" "JS_TEST_BEGIN:src/blocks/studio/tabs/usability-contracts.test.js"
+assert_contains "${WORK_DIR}/jest.out" "NPM_INVOKED:run test:unit -- src/blocks/studio/tabs/usability-contracts.test.js"
+assert_contains "${WORK_DIR}/jest.out" "JS_TEST_SUMMARY:backend=package-script script=test:unit files=1 status=ok"
+assert_not_contains "${WORK_DIR}/jest.out" "Backend: node-test"
+assert_not_contains "${WORK_DIR}/jest.out" "describe is not defined"
+
+# The same routing must hold for an explicitly selected file.
+PATH="${stubs}:${PATH}" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="studio" \
+HOMEBOY_COMPONENT_PATH="$jest_component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+    bash "$RUNNER" --file src/blocks/studio/tabs/usability-contracts.test.js > "${WORK_DIR}/jest-file.out" 2>&1
+
+assert_contains "${WORK_DIR}/jest-file.out" "Backend: package-script"
+assert_not_contains "${WORK_DIR}/jest-file.out" "Backend: node-test"
+
+# --- Native node:test component: built-in runner stays selected ------------
+native_component="${WORK_DIR}/native-component"
+mkdir -p "${native_component}/tools"
+cat > "${native_component}/tools/fixture-matrix.test.mjs" <<'JS'
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test( 'composed Node test runs', () => assert.equal( 2 + 2, 4 ) );
+JS
+
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="native" \
+HOMEBOY_COMPONENT_PATH="$native_component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_CHANGED_TEST_FILES="tools/fixture-matrix.test.mjs" \
+    bash "$RUNNER" > "${WORK_DIR}/native.out" 2>&1
+
+assert_contains "${WORK_DIR}/native.out" "Backend: node-test"
+assert_contains "${WORK_DIR}/native.out" "Contract: native node:test import"
+assert_contains "${WORK_DIR}/native.out" "NODE_TEST_OK:tools/fixture-matrix.test.mjs"
+assert_contains "${WORK_DIR}/native.out" "NODE_TEST_SUMMARY:passed=1 failed=0"
+
+# --- Ambiguous file: no declared script and no native import ---------------
+ambiguous_component="${WORK_DIR}/ambiguous-component"
+mkdir -p "${ambiguous_component}/src"
+cat > "${ambiguous_component}/src/widget.test.js" <<'JS'
+describe( 'widget', () => {
+	it( 'has no resolvable runner', () => {
+		expect( true ).toBe( true );
+	} );
+} );
+JS
+
+set +e
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="ambiguous" \
+HOMEBOY_COMPONENT_PATH="$ambiguous_component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_CHANGED_TEST_FILES="src/widget.test.js" \
+    bash "$RUNNER" > "${WORK_DIR}/ambiguous.out" 2>&1
+status=$?
+set -e
+
+if [ "$status" -ne 2 ]; then
+    echo "Expected ambiguous JavaScript test selection to exit 2, got $status" >&2
+    sed 's/^/  /' "${WORK_DIR}/ambiguous.out" >&2
+    exit 1
+fi
+assert_contains "${WORK_DIR}/ambiguous.out" "cannot select a JavaScript test framework for: src/widget.test.js"
+assert_not_contains "${WORK_DIR}/ambiguous.out" "NODE_TEST_BEGIN:src/widget.test.js"
+
+# --- Declared setting overrides the package script candidates --------------
+setting_component="${WORK_DIR}/setting-component"
+mkdir -p "${setting_component}/src" "${setting_component}/node_modules"
+cat > "${setting_component}/package.json" <<'JSON'
+{
+  "name": "setting",
+  "scripts": {
+    "test:unit": "wp-scripts test-unit-js"
+  }
+}
+JSON
+cat > "${setting_component}/src/widget.test.js" <<'JS'
+describe( 'widget', () => {
+	it( 'runs under the declared runner', () => {
+		expect( true ).toBe( true );
+	} );
+} );
+JS
+
+set +e
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="setting" \
+HOMEBOY_COMPONENT_PATH="$setting_component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_SETTINGS_JSON='{"wordpress_js_test_script":"test:missing"}' \
+HOMEBOY_CHANGED_TEST_FILES="src/widget.test.js" \
+    bash "$RUNNER" > "${WORK_DIR}/missing-script.out" 2>&1
+status=$?
+set -e
+
+if [ "$status" -ne 2 ]; then
+    echo "Expected a missing declared script to exit 2, got $status" >&2
+    sed 's/^/  /' "${WORK_DIR}/missing-script.out" >&2
+    exit 1
+fi
+assert_contains "${WORK_DIR}/missing-script.out" "declared JavaScript test script 'test:missing' is not defined"
+
+echo "WordPress JavaScript test framework routing smoke passed"


### PR DESCRIPTION
Fixes Extra-Chill/homeboy#11405.

## Problem

`homeboy review test <component> --changed-since <ref>` ran a changed
`*.test.js` file through Node's built-in test runner based on the file
extension alone. A WordPress package whose contract is
`"test:unit": "wp-scripts test-unit-js"` therefore failed with
`ReferenceError: describe is not defined` on a file that passes cleanly
through its own runner.

The routing lives entirely in this extension — `homeboy` core only hands the
extension a list of changed test files, so nothing WordPress- or
Jest-specific leaks into core.

## Change

`wordpress/scripts/test/test-runner.sh` now resolves the repository-owned
JavaScript runner before choosing a backend:

1. `HOMEBOY_WORDPRESS_JS_TEST_SCRIPT`
2. the `wordpress_js_test_script` / `js_test_script` setting
3. the first declared `package.json` script from
   `HOMEBOY_WORDPRESS_JS_TEST_SCRIPT_CANDIDATES`
   (default `test:unit test:unit:js test:js`)

When one resolves, the runner delegates through the shared
`project-scripts.sh` helper (`npm run <script> -- <selected files>`), which
keeps the package's config, transforms, setup files, globals, and test
environment intact while still narrowing to the changed files.

Node's built-in runner stays selected only when nothing is declared and every
selected file imports `node:test`. A selected file that declares neither is
now a hard error with actionable guidance instead of a bogus failure from the
wrong framework.

Evidence reports both the selected framework and the contract source:

```
  Backend: package-script
  Contract: package.json scripts.test:unit
  Command: npm run test:unit -- src/blocks/studio/tabs/usability-contracts.test.js
JS_TEST_BEGIN:src/blocks/studio/tabs/usability-contracts.test.js
JS_TEST_SUMMARY:backend=package-script script=test:unit files=1 status=ok
```

```
  Backend: node-test
  Contract: native node:test import
```

## Verification

New `wordpress/tests/js-test-framework-routing-smoke.sh`, registered in the
extension's `self_checks` lint and test lists, covers:

- a WordPress package with Jest-style `describe`/`it`/`expect` globals and
  `wp-scripts test-unit-js` — asserts the declared runner receives the changed
  file, for both `--changed-since` and `--file` selection
- a native `node:test` file — asserts `node --test` is still selected
- an ambiguous file with no declared script and no `node:test` import — exits 2
  with guidance
- an explicitly declared but missing script — exits 2

The smoke fails against the pre-fix runner (the Jest case dies in
`node --test`) and passes after.