### PR TITLE
fix(wordpress): activate the target plugin and scope changed PHPUnit files

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -170,6 +170,40 @@ If your plugin depends on other local plugins at runtime, declare them:
 Dependencies are mounted alongside the plugin under test and their entry
 files are loaded during the `load_deps` bootstrap stage.
 
+Declared validation dependencies are activated first, in declaration order,
+and the plugin under review is activated last. Both appear in the recipe's
+setup and activation evidence
+(`wp-codebox-phpunit-recipe-options.json`, `wp-codebox-phpunit-provenance.json`)
+so a run can be checked against the topology it claims to have booted. Leaving
+the target inactive excludes it from Composer autoloader preloading and from
+the activation phase, which produces a sandbox where no test can execute.
+
+## Changed-file PHPUnit scope and zero-test diagnosis
+
+`--changed-since` selection forwards the PHPUnit-shaped subset of the changed
+files to the sandbox as an explicit scope, so a narrowed review runs the
+selection instead of silently widening to the full suite. `--file` selection
+forwards the single requested file the same way.
+
+Every run writes `files/phpunit-execution-diagnosis.json`
+(`homeboy/wordpress-phpunit-execution-diagnosis/v1`), registered as a run
+artifact alongside the raw `files/phpunit-output.log`. When a run reports zero
+executed tests the diagnosis names the seam rather than reporting an empty
+pass:
+
+| `cause` | Meaning |
+| --- | --- |
+| `target_component_not_mounted` | No entry file for the plugin under review was loaded |
+| `activation_failed` | Activation raised a throwable before discovery |
+| `bootstrap_failed` | A bootstrap stage failed before any test ran |
+| `changed_file_filter_mismatch` | The changed-file scope matched no discovered test file |
+| `phpunit_discovery_empty` | Discovery found no test files under the test root |
+| `suite_reported_no_tests` | Files were discovered but declared no runnable cases |
+| `bootstrap_evidence_unavailable` | No stage log was produced at all |
+
+The same classification prints to the runner transcript as
+`PHPUNIT_ZERO_TESTS cause=<cause>` with the detail and remediation lines.
+
 Bench and trace scenarios preflight dependency plugin packages before WP
 Codebox dispatch. The dependency path must be the runnable WordPress plugin
 package root with a root `Plugin Name:` main file. Monorepo source checkouts,

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -18,6 +18,7 @@
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
       "node tests/wp-codebox-phpunit-aggregate-smoke.mjs",
       "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
+      "node tests/wp-codebox-phpunit-target-activation-smoke.mjs",
       "node tests/wp-codebox-database-service-smoke.mjs",
       "node tests/wp-codebox-native-database-canary.mjs",
       "bash scripts/test/full-suite-no-phpunit-smoke.sh",

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -729,10 +729,22 @@ if [ -z "$TARGET_FILE" ] && [ "${HOMEBOY_TEST_SCOPE_KIND:-}" = "exclusive_env" ]
     fi
 fi
 
+homeboy_wordpress_is_phpunit_test_file() {
+    case "$(basename "$1")" in
+        *Test.php|test-*.php)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     changed_js_smoke_files=""
     changed_shell_smoke_files=""
     changed_node_test_files=""
+    changed_phpunit_files=""
     changed_non_host_smoke_files=0
     while IFS= read -r changed_test_file; do
         [ -n "$changed_test_file" ] || continue
@@ -755,10 +767,23 @@ if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
                 changed_node_test_files+=$'\n'
             fi
             changed_node_test_files+="$changed_test_rel"
+        elif homeboy_wordpress_is_phpunit_test_file "$changed_test_rel"; then
+            if [ -n "$changed_phpunit_files" ]; then
+                changed_phpunit_files+=$'\n'
+            fi
+            changed_phpunit_files+="$changed_test_rel"
+            changed_non_host_smoke_files=1
         else
             changed_non_host_smoke_files=1
         fi
     done <<< "$HOMEBOY_CHANGED_TEST_FILES"
+
+    # Selected PHPUnit files must reach the WordPress runtime backend as an
+    # explicit scope. Without it a changed-file review silently widens to the
+    # full suite, and the backend cannot report whether the selection ran.
+    if [ -n "$changed_phpunit_files" ]; then
+        export HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES="$changed_phpunit_files"
+    fi
 
     if [ -n "$changed_js_smoke_files" ] && [ -z "$changed_shell_smoke_files" ] && [ -z "$changed_node_test_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
         homeboy_wordpress_run_js_smoke_files "$changed_js_smoke_files"

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -37,6 +37,17 @@ const dependencies = await Promise.all((await dependencyPaths(settings, [compone
   const dependencySlug = path.basename(source).replace(/@[^/]+$/, '');
   return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug), composer: await composerPreparation(source) };
 }));
+const selectedTestFile = (process.env.HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE || '').trim();
+const changedTestFiles = phpunitChangedTestFiles();
+// Validation dependencies activate before the plugin under review so the
+// target's own activation hooks observe the topology it declares. The target
+// is activated last and never omitted: an inactive target is excluded from WP
+// Codebox's activation phase and from Composer autoloader preloading, which
+// yields a sandbox that reports zero executed tests.
+const activationPlan = [
+  ...dependencies.map(({ source, slug: dependencySlug, composer }) => ({ role: 'validation-dependency', source, slug: dependencySlug, composer })),
+  { role: 'target', source: root, sourceSubpath: subpath, slug },
+];
 await requireHarness(harnessSource);
 const options = clean({
   wordpressVersion: settings.wordpress_runtime_version,
@@ -44,11 +55,10 @@ const options = clean({
   databaseType: settings.database_type,
   services: databaseService ? [databaseService.service] : undefined,
   pluginSlug: slug,
-  extra_plugins: [
-    { source: root, sourceSubpath: subpath, slug, activate: false },
-    ...dependencies.map(({ source, slug: dependencySlug, composer }) => clean({ source, slug: dependencySlug, activate: true, composer })),
-  ],
+  extra_plugins: activationPlan.map(({ role, ...plugin }) => clean({ ...plugin, activate: true })),
   dependencyMounts: [...new Set([sandboxPluginDirectory(slug), ...dependencies.map(({ sandboxDirectory }) => sandboxDirectory)])],
+  selectedTestFile,
+  changedTestFiles,
   testRoot: phpunitProfile.testRoot,
   phpunitXml: phpunitProfile.config,
   cwd: phpunitProfile.cwd,
@@ -283,6 +293,18 @@ async function composerPreparation(source) {
 function sandboxPluginDirectory(pluginSlug) {
   return `/wordpress/wp-content/plugins/${pluginSlug}`;
 }
+// The router publishes the PHPUnit-shaped subset of the changed-file scope.
+// Fall back to filtering the raw scope so a directly invoked adapter still
+// narrows to the selection instead of silently widening to the full suite.
+function phpunitChangedTestFiles() {
+  const scoped = process.env.HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES;
+  const raw = scoped === undefined || scoped === '' ? process.env.HOMEBOY_CHANGED_TEST_FILES || '' : scoped;
+  const entries = raw.split('\n').map((entry) => entry.trim()).filter(Boolean);
+  const selected = scoped === undefined || scoped === ''
+    ? entries.filter((entry) => /(?:Test\.php|\/test-[^/]*\.php)$/.test(`/${entry}`))
+    : entries;
+  return [...new Set(selected)];
+}
 function canonicalMounts(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -513,14 +535,15 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
   const publishedDirectory = path.join(invocationArtifacts, 'wp-codebox-phpunit');
   const publishedFilesDirectory = path.join(publishedDirectory, 'files');
   const files = [
-    { name: 'test-results.json', kind: 'test-results', role: 'structured-test-results', semantic_key: 'test_results', content_type: 'application/json' },
-    { name: 'phpunit-output.log', kind: 'phpunit-output', role: 'raw-test-output', semantic_key: 'phpunit_output', content_type: 'text/plain' },
+    { name: 'test-results.json', kind: 'test-results', role: 'structured-test-results', semantic_key: 'test_results', content_type: 'application/json', copy: true },
+    { name: 'phpunit-output.log', kind: 'phpunit-output', role: 'raw-test-output', semantic_key: 'phpunit_output', content_type: 'text/plain', copy: true },
+    { name: 'phpunit-execution-diagnosis.json', kind: 'phpunit-execution-diagnosis', role: 'test-execution-diagnosis', semantic_key: 'phpunit_execution_diagnosis', content_type: 'application/json', copy: true },
     { name: 'test-failures.json', kind: 'test-failures', role: 'structured-test-failures', semantic_key: 'test_failures', content_type: 'application/json' },
   ];
   await withInvocationArtifactLock(invocationArtifacts, async () => {
     await assertDirectoryTree(invocationArtifacts, ['wp-codebox-phpunit', 'files']);
     await assertDirectoryTree(artifactDirectory, ['files']);
-    for (const file of files.slice(0, 2)) {
+    for (const file of files.filter((entry) => entry.copy)) {
       await atomicCopy(path.join(artifactDirectory, 'files', file.name), path.join(publishedFilesDirectory, file.name));
     }
     // The parser replaces this valid fallback atomically. Its registration and
@@ -529,7 +552,7 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
       path.join(publishedFilesDirectory, 'test-failures.json'),
       await fallbackTestFailures(publishedFilesDirectory),
     );
-    await registerInvocationArtifacts(invocationArtifacts, files.map((file) => ({
+    await registerInvocationArtifacts(invocationArtifacts, files.map(({ copy, ...file }) => ({
       ...file,
       path: path.join('wp-codebox-phpunit', 'files', file.name).replaceAll(path.sep, '/'),
     })));
@@ -830,6 +853,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     const evidenceReferences = [
       { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
       { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
+      { kind: 'test-execution-diagnosis', uri: 'artifact://files/phpunit-execution-diagnosis.json' },
     ];
     if (managedRuntimeServices.length > 0) {
       evidenceReferences.push({ kind: 'managed-runtime-services', uri: 'artifact://files/managed-runtime-services.json' });
@@ -838,12 +862,139 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     await writeFile(testResultsPath, `${JSON.stringify(results, null, 2)}\n`);
   }
 
+  const diagnosis = await phpunitExecutionDiagnosis(artifactDirectory, results, execution);
+  await writeFile(path.join(filesDirectory, 'phpunit-execution-diagnosis.json'), `${JSON.stringify(diagnosis, null, 2)}\n`);
+
   process.stdout.write('Structured PHPUnit evidence: artifact://files/test-results.json\n');
   process.stdout.write('Full PHPUnit output: artifact://files/phpunit-output.log\n');
+  process.stdout.write('PHPUnit execution diagnosis: artifact://files/phpunit-execution-diagnosis.json\n');
+  if (diagnosis.executed_tests === 0) {
+    process.stdout.write(`PHPUNIT_ZERO_TESTS cause=${diagnosis.cause}\n`);
+    process.stdout.write(`  ${diagnosis.detail}\n`);
+    process.stdout.write(`  ${diagnosis.remediation}\n`);
+  }
   if (managedRuntimeServices.length > 0) {
     process.stdout.write('Managed runtime service evidence: artifact://files/managed-runtime-services.json\n');
   }
   return results.status;
+}
+// A selected test set must either execute or say why it did not. The sandbox
+// bootstrap logs stage markers to a diagnostic file; classify them so a zero
+// count names the failing seam instead of reporting an empty pass.
+async function phpunitExecutionDiagnosis(artifactDirectory, results, execution) {
+  const summary = isObject(results?.summary) ? results.summary : {};
+  const executed = Number.isInteger(summary.total) ? summary.total : 0;
+  const stageLog = await readPhpunitStageLog(artifactDirectory);
+  const markers = stageLog === null
+    ? []
+    : stageLog.split('\n').filter((line) => /^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE|NO_TEST_FILES|DISCOVERY:|SCOPED_TEST_FILES|PLUGIN_DETECTED|THEME_DETECTED|PLUGIN_ACTIVATE|NOTICE:no plugin entry file)/.test(line.trim()));
+  const has = (pattern) => markers.some((line) => pattern.test(line));
+  const scoped = markers.map((line) => line.match(/^SCOPED_TEST_FILES requested=(\d+) matched=(\d+)/)).find(Boolean);
+  const discovery = markers.map((line) => line.match(/^DISCOVERY:.*\bfound=(\d+)/)).find(Boolean);
+
+  const activation = {
+    target: { slug, source: root, source_subpath: subpath || null, activate: true, activated: has(new RegExp(`^PLUGIN_ACTIVATE(_OK)? ${escapeRegExp(slug)}/`)) },
+    validation_dependencies: dependencies.map(({ slug: dependencySlug, source }) => ({
+      slug: dependencySlug,
+      source,
+      activate: true,
+      activated: has(new RegExp(`^PLUGIN_ACTIVATE(_OK)? ${escapeRegExp(dependencySlug)}/`)),
+    })),
+    order: activationPlan.map(({ role, slug: planSlug }) => ({ role, slug: planSlug })),
+  };
+
+  const classification = (() => {
+    if (executed > 0) {
+      return { cause: 'tests_executed', detail: `PHPUnit executed ${executed} test(s).`, remediation: 'No execution diagnosis is required.' };
+    }
+    if (stageLog === null) {
+      return {
+        cause: 'bootstrap_evidence_unavailable',
+        detail: 'The sandbox produced no PHPUnit stage log, so the run did not reach the bootstrap that records stage markers.',
+        remediation: 'Inspect artifact://files/phpunit-output.log and logs/recipe-run.stderr.log for a runtime or recipe-level failure.',
+      };
+    }
+    if (has(/^NOTICE:no plugin entry file/) || !has(/^(PLUGIN_DETECTED|THEME_DETECTED)/)) {
+      return {
+        cause: 'target_component_not_mounted',
+        detail: `The sandbox never loaded an entry file for the component under review (${slug}); its mount or plugin header is missing.`,
+        remediation: 'Confirm wp_codebox_source_root/wp_codebox_source_subpath resolve to a directory containing the plugin entry file.',
+      };
+    }
+    if (has(/^STAGE_FAIL:activation/)) {
+      return {
+        cause: 'activation_failed',
+        detail: 'Plugin activation raised a throwable before PHPUnit discovery.',
+        remediation: 'Read the STAGE_FAIL:activation trace in the stage log; a validation dependency may be missing from validation_dependencies.',
+      };
+    }
+    if (has(/^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE)/)) {
+      const stage = (markers.find((line) => /^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE)/.test(line)) || '').split(':')[1] || 'unknown';
+      return {
+        cause: 'bootstrap_failed',
+        detail: `The sandbox bootstrap failed at stage '${stage}' before any test executed.`,
+        remediation: 'Read the failing stage trace in the stage log excerpt below and in artifact://files/phpunit-output.log.',
+      };
+    }
+    if (scoped && Number(scoped[1]) > 0 && Number(scoped[2]) === 0) {
+      return {
+        cause: 'changed_file_filter_mismatch',
+        detail: `The changed-file scope requested ${scoped[1]} file(s) and matched 0 discovered test files.`,
+        remediation: 'Confirm the selected paths sit under the configured PHPUnit test root and match the suite\'s discovery suffixes/prefixes.',
+      };
+    }
+    if (has(/^NO_TEST_FILES/) || (discovery && Number(discovery[1]) === 0)) {
+      return {
+        cause: 'phpunit_discovery_empty',
+        detail: 'PHPUnit discovery found no test files under the configured test root.',
+        remediation: 'Check wp_codebox_phpunit_test_root and the phpunit.xml testsuite directories against the mounted component.',
+      };
+    }
+    return {
+      cause: 'suite_reported_no_tests',
+      detail: 'The sandbox mounted, activated, and discovered the component but the assembled suite contained no test cases.',
+      remediation: 'Confirm the discovered files declare concrete PHPUnit\\Framework\\TestCase subclasses with runnable test methods.',
+    };
+  })();
+
+  return {
+    schema: 'homeboy/wordpress-phpunit-execution-diagnosis/v1',
+    executed_tests: executed,
+    recipe_run_exit_code: execution.status,
+    scope: {
+      selected_test_file: selectedTestFile || null,
+      changed_test_files: changedTestFiles,
+      test_root: phpunitProfile.testRoot,
+      phpunit_config: phpunitProfile.config || null,
+    },
+    activation,
+    ...classification,
+    evidence: [
+      { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
+      { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
+      { kind: 'recipe-options', uri: 'artifact://wp-codebox-phpunit-recipe-options.json' },
+      { kind: 'recipe-provenance', uri: 'artifact://wp-codebox-phpunit-provenance.json' },
+    ],
+    stage_markers: markers.slice(0, 60),
+  };
+}
+async function readPhpunitStageLog(artifactDirectory) {
+  const stageRoot = path.join(artifactDirectory, 'files', 'phpunit');
+  const candidates = [path.join(stageRoot, '.pg-test-result.txt')];
+  try {
+    for (const entry of await readdir(stageRoot, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        candidates.push(path.join(stageRoot, entry.name, '.pg-test-result.txt'));
+      }
+    }
+  } catch {}
+  for (const candidate of candidates) {
+    try { return await readFile(candidate, 'utf8'); } catch {}
+  }
+  return null;
+}
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 function validTestResults(results) {
   if (!isObject(results) || results.schema !== 'wp-codebox/test-results/v1' || !['passed', 'failed', 'skipped', 'unknown'].includes(results.status) || !isObject(results.summary)) {
@@ -951,7 +1102,7 @@ async function persistRecipeEvidence(artifactDirectory, recipeOptions, generated
     copyFile(generatedRecipePath, path.join(artifactDirectory, 'wp-codebox-phpunit-recipe.json')),
     writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-recipe-options.json'), `${JSON.stringify(recipeOptions, null, 2)}\n`),
     writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-profile.json'), `${JSON.stringify({ wordpress: { topology }, phpunit: { config: profile.config, cwd: profile.cwd, test_root: profile.testRoot, environment: profile.environment, bootstrap_mode: recipeOptions.bootstrapMode, project_bootstrap: recipeOptions.projectBootstrap || null, passthrough_args: recipeOptions.phpunitArgs, extra_mounts: recipeOptions.mounts } }, null, 2)}\n`),
-    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-provenance.json'), `${JSON.stringify({ source_refs: sourceRefs, wp_codebox: { cli_bin: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', resolved_cli_path: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', command: [process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'] } }, null, 2)}\n`),
+    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-provenance.json'), `${JSON.stringify({ source_refs: sourceRefs, activation: { order: activationPlan.map(({ role, slug: planSlug }) => ({ role, slug: planSlug, activate: true })) }, scope: { selected_test_file: selectedTestFile || null, changed_test_files: changedTestFiles }, wp_codebox: { cli_bin: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', resolved_cli_path: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', command: [process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'] } }, null, 2)}\n`),
   ]);
 }
 function runScript(script, args) {

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -66,12 +66,16 @@ try {
     ['recipe', 'build'], ['recipe-run', '--recipe'], ['recipe', 'build'], ['recipe-run', '--recipe'],
   ]);
   const options = entries.filter((entry) => entry.options).map((entry) => entry.options);
-  assert.deepEqual(options.map((entry) => entry.extra_plugins[0]), [
-    { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
+  assert.deepEqual(options[0].extra_plugins, [
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: false },
   ]);
-  assert.deepEqual(options[1].extra_plugins.slice(1), [
+  // The PHPUnit recipe activates declared validation dependencies first and
+  // never leaves the plugin under review inactive: an inactive target is
+  // excluded from WP Codebox's activation phase and Composer autoloader
+  // preloading, which produces a sandbox where nothing can execute.
+  assert.deepEqual(options[1].extra_plugins, [
     { source: dependency, slug: 'db-touching-dependency', activate: true },
+    { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: true },
   ]);
   assert.deepEqual(options[1].dependencyMounts, [
     '/wordpress/wp-content/plugins/canonical-plugin',

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -208,7 +208,7 @@ try {
   }, 'recipe build receives administrative names without host values');
   assert.equal(options.databaseType, 'mysql');
   assert.equal(options.multisite, true, 'external MySQL remains compatible with multisite PHPUnit');
-  assert.equal(options.extra_plugins[1].composer, 'install', 'source-form validation dependencies explicitly request staged Composer preparation');
+  assert.equal(options.extra_plugins[0].composer, 'install', 'source-form validation dependencies explicitly request staged Composer preparation');
   assert.equal('secretEnv' in options, false, 'administrative credentials are not forwarded into the sandbox runtime');
   assert.deepEqual(options.services, [{
     id: 'wordpress-database',

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -122,6 +122,7 @@ try {
     assert.deepEqual(manifest.artifacts.map(({ path: artifactPath }) => artifactPath), [
       'wp-codebox-phpunit/files/test-results.json',
       'wp-codebox-phpunit/files/phpunit-output.log',
+      'wp-codebox-phpunit/files/phpunit-execution-diagnosis.json',
       'wp-codebox-phpunit/files/test-failures.json',
     ], testCase.name);
     const durableSummary = JSON.parse(await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/test-results.json'), 'utf8')).summary;
@@ -133,7 +134,10 @@ try {
     const options = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
     const profile = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-profile.json'), 'utf8'));
     const provenance = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));
-    assert.equal(options.extra_plugins[1].activate, true);
+    assert.deepEqual(options.extra_plugins.map(({ slug, activate }) => [slug, activate]), [
+      ['dependency', true],
+      ['component', true],
+    ], `${testCase.name}: validation dependencies activate before the plugin under review`);
     assert.equal(options.phpunitXml, '/wordpress/wp-content/plugins/component/phpunit.xml.dist');
     assert.equal(options.autoloadFile, '/wp-codebox-vendor/autoload.php');
     assert.equal(options.bootstrapMode, testCase.bootstrapMode || (testCase.settings?.wp_codebox_phpunit_bootstrap_mode === 'managed' ? 'managed' : 'project'));
@@ -180,7 +184,10 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
   const metadataRunArtifact = path.join(metadataArtifacts, (await readdir(metadataArtifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.')));
   const metadataOptions = JSON.parse(await readFile(path.join(metadataRunArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
   const metadataProvenance = JSON.parse(await readFile(path.join(metadataRunArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));
-  assert.deepEqual(metadataOptions.extra_plugins.slice(1), [{ source: dataMachine, slug: 'data-machine', activate: true }]);
+  assert.deepEqual(metadataOptions.extra_plugins, [
+    { source: dataMachine, slug: 'data-machine', activate: true },
+    { source: component, slug: 'component', activate: true },
+  ]);
   assert.deepEqual(metadataProvenance.source_refs.slice(1), [{ slug: 'data-machine', source: dataMachine }]);
 
   const malformedManifestArtifacts = path.join(root, 'malformed-manifest-artifacts');

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -122,12 +122,14 @@ try {
   assert.deepEqual(artifactResults.evidenceReferences, [
     { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
     { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
+    { kind: 'test-execution-diagnosis', uri: 'artifact://files/phpunit-execution-diagnosis.json' },
   ]);
   assert.deepEqual(JSON.parse(await readFile(resultsFile, 'utf8')), { total: 3, passed: 0, failed: 2, skipped: 1 });
   const invocationManifest = JSON.parse(await readFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), 'utf8'));
   assert.deepEqual(invocationManifest.artifacts.map(({ path: artifactPath }) => artifactPath), [
     'wp-codebox-phpunit/files/test-results.json',
     'wp-codebox-phpunit/files/phpunit-output.log',
+    'wp-codebox-phpunit/files/phpunit-execution-diagnosis.json',
     'wp-codebox-phpunit/files/test-failures.json',
   ]);
   const publishedDirectory = path.join(invocationArtifacts, 'wp-codebox-phpunit/files');

--- a/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
@@ -103,7 +103,7 @@ try {
   const defaultDatabase = singleSite;
   assert.equal('databaseType' in defaultDatabase, false, 'omitted database_type preserves WP Codebox defaults');
   assert.equal(defaultDatabase.extra_plugins.length, 1, 'no dependencies only emits the primary plugin');
-  assert.equal(defaultDatabase.extra_plugins[0].activate, false, 'primary plugin remains inactive for the managed PHPUnit bootstrap');
+  assert.equal(defaultDatabase.extra_plugins[0].activate, true, 'the plugin under review is activated alongside its validation dependencies');
 
   const mysqlDatabase = await resolvedOptions({ fixture: 'single-site', settings: { database_type: 'mysql' } });
   assert.equal(mysqlDatabase.databaseType, 'mysql', 'database_type maps to the WP Codebox databaseType contract');

--- a/wordpress/tests/wp-codebox-phpunit-target-activation-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-target-activation-smoke.mjs
@@ -1,0 +1,148 @@
+/**
+ * Regression: the plugin under review must be mounted, bootstrapped, and
+ * activated alongside its declared validation dependencies, the selected
+ * changed PHPUnit files must reach the sandbox, and a zero-test result must
+ * name the seam that produced it.
+ *
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner.sh');
+const codeboxRunner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-target-activation-'));
+
+const component = path.join(root, 'data-machine-socials');
+const dependency = path.join(root, 'data-machine');
+const cli = path.join(root, 'wp-codebox');
+const recipeOptionsCapture = path.join(root, 'recipe-options.json');
+const invocationArtifacts = path.join(root, 'invocation-artifacts');
+const artifacts = path.join(root, 'artifacts');
+const runnerPrelude = path.join(root, 'runner-prelude.sh');
+
+await mkdir(path.join(component, 'tests/Unit/Abilities'), { recursive: true });
+await mkdir(dependency, { recursive: true });
+await mkdir(invocationArtifacts, { recursive: true });
+await writeFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
+await writeFile(path.join(component, 'data-machine-socials.php'), '<?php\n/* Plugin Name: Data Machine Socials */\n');
+await writeFile(path.join(dependency, 'data-machine.php'), '<?php\n/* Plugin Name: Data Machine */\n');
+await writeFile(path.join(component, 'tests/Unit/Abilities/SocialCommentsAbilityTest.php'), '<?php\n// selected changed test\n');
+await writeFile(path.join(component, 'tests/Unit/RestApiRecentCommentsTest.php'), '<?php\n// selected changed test\n');
+await writeFile(path.join(component, 'tests/Unit/UnselectedTest.php'), '<?php\n// not part of the changed scope\n');
+await writeFile(runnerPrelude, `homeboy_runner_init() {
+    COMPONENT_PATH="\${HOMEBOY_COMPONENT_PATH:?HOMEBOY_COMPONENT_PATH is required}"
+    PLUGIN_PATH="$COMPONENT_PATH"
+    EXTENSION_PATH="\${HOMEBOY_EXTENSION_PATH:?HOMEBOY_EXTENSION_PATH is required}"
+}
+`);
+
+// The stub stands in for WP Codebox: it records the recipe options the adapter
+// produced and replays a sandbox that discovered nothing, which is the shape
+// the zero-test diagnosis has to classify.
+await writeFile(cli, `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+const args = process.argv.slice(2);
+if (args[0] === 'recipe' && args[1] === 'build') {
+  fs.copyFileSync(args[args.indexOf('--options') + 1], ${JSON.stringify(recipeOptionsCapture)});
+  fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
+  process.exit(0);
+}
+const artifactRoot = args[args.indexOf('--artifacts') + 1];
+const runtime = path.join(artifactRoot, 'runtime-fixture');
+fs.mkdirSync(path.join(runtime, 'files', 'phpunit'), { recursive: true });
+fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+fs.writeFileSync(path.join(runtime, 'files', 'phpunit', '.pg-test-result.txt'), [
+  'STAGE_BEGIN:load_component',
+  'PLUGIN_DETECTED data-machine-socials.php',
+  'STAGE_OK:load_component',
+  'PLUGIN_ACTIVATE data-machine/data-machine.php',
+  'PLUGIN_ACTIVATE_OK data-machine/data-machine.php stage=activation',
+  'PLUGIN_ACTIVATE data-machine-socials/data-machine-socials.php',
+  'PLUGIN_ACTIVATE_OK data-machine-socials/data-machine-socials.php stage=activation',
+  'SCOPED_TEST_FILES requested=2 matched=0',
+  'DISCOVERY: dirs=/wordpress/wp-content/plugins/data-machine-socials/tests files=0 suffixes=Test.php prefixes=test- excludes=0 found=0',
+  '',
+].join('\\n'));
+fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify({
+  schema: 'wp-codebox/test-results/v1',
+  status: 'skipped',
+  summary: { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 },
+  suites: [],
+}));
+process.stdout.write(JSON.stringify({ success: true, executions: [{ stdout: 'Tests: 0, Assertions: 0.\\n', stderr: '' }] }));
+`);
+await chmod(cli, 0o755);
+
+const run = spawnSync('bash', [runner], {
+  env: {
+    ...process.env,
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE: runnerPrelude,
+    HOMEBOY_EXTENSION_PATH: extension,
+    HOMEBOY_COMPONENT_PATH: component,
+    HOMEBOY_COMPONENT_ID: 'data-machine-socials',
+    COMPONENT_ID: 'data-machine-socials',
+    HOMEBOY_COMPONENT_SHAPE: 'plugin',
+    HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX: codeboxRunner,
+    HOMEBOY_WP_CODEBOX_BIN: cli,
+    HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
+    HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts,
+    HOMEBOY_WORDPRESS_DEPENDENCY_PATHS: dependency,
+    HOMEBOY_CHANGED_TEST_FILES: 'tests/Unit/Abilities/SocialCommentsAbilityTest.php\ntests/Unit/RestApiRecentCommentsTest.php',
+  },
+  encoding: 'utf8',
+});
+
+const transcript = `${run.stdout || ''}${run.stderr || ''}`;
+
+try {
+  const options = JSON.parse(await readFile(recipeOptionsCapture, 'utf8'));
+
+  // The target must be present in the plugins WP Codebox activates, and it
+  // must activate after the validation dependencies it declares.
+  const activated = options.extra_plugins.filter((plugin) => plugin.activate !== false).map((plugin) => plugin.slug);
+  assert.deepEqual(activated, ['data-machine', 'data-machine-socials'], `unexpected activation set: ${JSON.stringify(options.extra_plugins)}`);
+  assert.equal(options.extra_plugins.every((plugin) => plugin.activate === true), true, 'every recipe plugin must be activated');
+
+  // The selected changed PHPUnit files must reach the sandbox as a scope.
+  assert.deepEqual(options.changedTestFiles, [
+    'tests/Unit/Abilities/SocialCommentsAbilityTest.php',
+    'tests/Unit/RestApiRecentCommentsTest.php',
+  ], `unexpected changed test scope: ${JSON.stringify(options.changedTestFiles)}`);
+
+  const publishedFiles = path.join(invocationArtifacts, 'wp-codebox-phpunit', 'files');
+  const diagnosis = JSON.parse(await readFile(path.join(publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.equal(diagnosis.schema, 'homeboy/wordpress-phpunit-execution-diagnosis/v1');
+  assert.equal(diagnosis.executed_tests, 0);
+  assert.equal(diagnosis.cause, 'changed_file_filter_mismatch', `unexpected zero-test cause: ${diagnosis.cause}`);
+  assert.equal(diagnosis.activation.target.slug, 'data-machine-socials');
+  assert.equal(diagnosis.activation.target.activated, true);
+  assert.deepEqual(diagnosis.activation.validation_dependencies.map((entry) => [entry.slug, entry.activated]), [['data-machine', true]]);
+  assert.deepEqual(diagnosis.activation.order, [
+    { role: 'validation-dependency', slug: 'data-machine' },
+    { role: 'target', slug: 'data-machine-socials' },
+  ]);
+  assert.deepEqual(diagnosis.scope.changed_test_files, options.changedTestFiles);
+
+  // Raw PHPUnit output stays directly retrievable from the run evidence.
+  const manifest = JSON.parse(await readFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), 'utf8'));
+  const registered = manifest.artifacts.map((artifact) => artifact.path);
+  assert.equal(registered.includes('wp-codebox-phpunit/files/phpunit-output.log'), true, `raw output not registered: ${registered.join(', ')}`);
+  assert.equal(registered.includes('wp-codebox-phpunit/files/phpunit-execution-diagnosis.json'), true, `diagnosis not registered: ${registered.join(', ')}`);
+  await readFile(path.join(publishedFiles, 'phpunit-output.log'), 'utf8');
+
+  assert.match(transcript, /PHPUNIT_ZERO_TESTS cause=changed_file_filter_mismatch/);
+  assert.match(transcript, /PHPUnit execution diagnosis: artifact:\/\/files\/phpunit-execution-diagnosis\.json/);
+} catch (error) {
+  process.stderr.write(`${transcript}\n`);
+  throw error;
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+process.stdout.write('WP Codebox PHPUnit target activation smoke passed\n');


### PR DESCRIPTION
Fixes Extra-Chill/homeboy#11406.

A changed-file WordPress PHPUnit review could select 12 test files, build a
Codebox sandbox, and still report `Total: 0, Passed: 0, Failed: 0, Skipped: 0`
with setup evidence that listed only the validation dependency. Three seams in
this extension produced that, none of them in `homeboy` core.

## 1. The plugin under review was never activated

`wp-codebox-phpunit-adapter.mjs` passed the target as
`{ ..., activate: false }`. WP Codebox filters on that flag in two places:

- `installPluginComposerAutoloadersCode` — only activated plugins get their
  `vendor/autoload_packages.php` / `vendor/autoload.php` preloaded via the
  generated mu-plugin
- the `activate_plugins` setup phase, whose `activePlugins` result *is* the
  setup evidence quoted in the issue

So the target was mounted but excluded from both, which is exactly why the
artifact showed `"plugins": ["data-machine/data-machine.php"]` and nothing else.

`activate: false` was inherited default behavior, not a requirement:
#2390 only changed the dependency entries. It is safe to activate the target
because both consumers of the flag run outside the PHPUnit bootstrap —
setup `wordpress.run-php` calls pass `recipe-active-plugins=none`, and
`wordpress.phpunit` runs with `bootstrap=runtime-only`.

Validation dependencies now activate first, in declaration order, and the
target activates last, so the target's activation hooks observe the topology it
declares.

## 2. Selected changed PHPUnit files never reached the sandbox

The July 18 "delegate wordpress runners to codebox cli" refactor dropped
`selectedTestFile` and `changedTestFiles` from the adapter's recipe options and
they were never restored — the runner still exported
`HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE`, and nothing read it. A `--changed-since`
or `--file` review silently widened to the full suite.

`test-runner.sh` now collects the PHPUnit-shaped subset of the changed scope
and exports `HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES`; the adapter
forwards both `selectedTestFile` and `changedTestFiles` into the recipe, which
WP Codebox already accepts.

## 3. A zero-test result could not be told apart from an empty pass

Every run now writes `files/phpunit-execution-diagnosis.json`
(`homeboy/wordpress-phpunit-execution-diagnosis/v1`), registered as a run
artifact alongside the raw `files/phpunit-output.log`, and classifies zero-test
runs from the sandbox stage log:

| `cause` | Meaning |
| --- | --- |
| `target_component_not_mounted` | No entry file for the plugin under review was loaded |
| `activation_failed` | `STAGE_FAIL:activation` |
| `bootstrap_failed` | A bootstrap stage failed before any test ran |
| `changed_file_filter_mismatch` | `SCOPED_TEST_FILES requested=N matched=0` |
| `phpunit_discovery_empty` | `NO_TEST_FILES` / `DISCOVERY: ... found=0` |
| `suite_reported_no_tests` | Files discovered, no runnable cases |
| `bootstrap_evidence_unavailable` | No stage log produced at all |

The diagnosis also records the resolved activation order and whether each
plugin actually activated, plus the changed-file scope that was requested. The
same classification prints to the transcript as `PHPUNIT_ZERO_TESTS cause=...`
with detail and remediation lines.

## Verification

New `wordpress/tests/wp-codebox-phpunit-target-activation-smoke.mjs`,
registered in `self_checks.test`, uses a target plugin with one validation
dependency and changed tests under `tests/Unit/`. It asserts the recipe
activates `[dependency, target]` in that order with `activate: true` on both,
that the two changed `tests/Unit/**` files are forwarded as the scope, and that
a sandbox which discovers nothing yields
`cause: changed_file_filter_mismatch` with the raw PHPUnit output still
registered as a retrievable run artifact.

Against the pre-fix adapter it fails with exactly the shape from the issue:

```
unexpected activation set: [
  {"slug":"data-machine-socials","activate":false},
  {"slug":"data-machine","activate":true}
]
```

Existing smokes updated for the new contract:
`wp-codebox-canonical-cli-adapters`, `wp-codebox-phpunit-multisite`,
`wp-codebox-phpunit-evidence`, `wp-codebox-database-service`. All pass locally.
(`wp-codebox-phpunit-aggregate` needs a real `composer install`; it fails
identically on `main` in this checkout.)