### PR TITLE
fix(wordpress): retain failed PHPUnit artifacts

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -551,7 +551,7 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
     // invocation tree that Homeboy preserves after the extension exits.
     if (controllerRunDirectory) {
       await assertDirectoryTree(controllerRunDirectory, ['files']);
-      for (const file of files.slice(0, 2)) {
+      for (const file of files.filter((entry) => entry.copy)) {
         await atomicCopy(path.join(publishedFilesDirectory, file.name), path.join(controllerRunDirectory, 'files', file.name));
       }
     }

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -532,6 +532,7 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
     return { directory: artifactDirectory, status, failuresPath: '' };
   }
 
+  const controllerRunDirectory = process.env.HOMEBOY_RUN_DIR;
   const publishedDirectory = path.join(invocationArtifacts, 'wp-codebox-phpunit');
   const publishedFilesDirectory = path.join(publishedDirectory, 'files');
   const files = [
@@ -545,6 +546,14 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
     await assertDirectoryTree(artifactDirectory, ['files']);
     for (const file of files.filter((entry) => entry.copy)) {
       await atomicCopy(path.join(artifactDirectory, 'files', file.name), path.join(publishedFilesDirectory, file.name));
+    }
+    // artifact://files locators resolve from HOMEBOY_RUN_DIR, not from the
+    // invocation tree that Homeboy preserves after the extension exits.
+    if (controllerRunDirectory) {
+      await assertDirectoryTree(controllerRunDirectory, ['files']);
+      for (const file of files.slice(0, 2)) {
+        await atomicCopy(path.join(publishedFilesDirectory, file.name), path.join(controllerRunDirectory, 'files', file.name));
+      }
     }
     // The parser replaces this valid fallback atomically. Its registration and
     // aggregate counts survive a parser crash without poisoning Homeboy's sidecar.

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -140,6 +140,11 @@ try {
       await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/phpunit-output.log'), 'utf8'),
       testCase.name,
     );
+    assert.deepEqual(
+      JSON.parse(await readFile(path.join(controllerRun, 'files/phpunit-execution-diagnosis.json'), 'utf8')),
+      JSON.parse(await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/phpunit-execution-diagnosis.json'), 'utf8')),
+      testCase.name,
+    );
     const options = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
     const profile = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-profile.json'), 'utf8'));
     const provenance = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -109,9 +109,11 @@ try {
     const artifacts = path.join(root, `${testCase.name}-artifacts`);
     const results = path.join(root, `${testCase.name}-results.json`);
     const invocationArtifacts = path.join(root, `${testCase.name}-invocation-artifacts`);
+    const controllerRun = path.join(root, `${testCase.name}-controller-run`);
     await mkdir(invocationArtifacts, { recursive: true });
+    await mkdir(controllerRun, { recursive: true });
     await writeFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
-    const run = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify(testCase.fixture), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts, HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: results, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [dependency], ...testCase.settings }) }, encoding: 'utf8' });
+    const run = spawnSync(runner, [], { env: { ...process.env, FIXTURE: JSON.stringify(testCase.fixture), HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts, HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts, HOMEBOY_RUN_DIR: controllerRun, HOMEBOY_RUNTIME_WRITE_TEST_RESULTS: resultsWriter, HOMEBOY_TEST_RESULTS_FILE: results, HOMEBOY_SETTINGS_JSON: JSON.stringify({ validation_dependencies: [dependency], ...testCase.settings }) }, encoding: 'utf8' });
     assert.equal(run.status, testCase.status, `${testCase.name}: ${run.stderr}`);
     assert.deepEqual(JSON.parse(await readFile(results, 'utf8')), testCase.expected, testCase.name);
     const runArtifact = path.join(artifacts, (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.')));
@@ -126,9 +128,16 @@ try {
       'wp-codebox-phpunit/files/test-failures.json',
     ], testCase.name);
     const durableSummary = JSON.parse(await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/test-results.json'), 'utf8')).summary;
+    const controllerResults = JSON.parse(await readFile(path.join(controllerRun, 'files/test-results.json'), 'utf8'));
     assert.deepEqual(
       Object.fromEntries(['total', 'passed', 'failed', 'skipped'].map((key) => [key, durableSummary[key]])),
       testCase.expected,
+      testCase.name,
+    );
+    assert.equal(controllerResults.status, testCase.artifactStatus, testCase.name);
+    assert.equal(
+      await readFile(path.join(controllerRun, 'files/phpunit-output.log'), 'utf8'),
+      await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/phpunit-output.log'), 'utf8'),
       testCase.name,
     );
     const options = JSON.parse(await readFile(path.join(runArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));


### PR DESCRIPTION
## Summary
- mirror provider-produced PHPUnit results, raw output, and execution diagnosis into the controller run's `files/` directory before the invocation artifact tree is reclaimed
- retain the existing invocation-manifest copies used for durable preservation and parsing
- cover controller-local persistence across passing, failed, zero-test, malformed, and crashed provider runs

## Root cause
The WP Codebox producer wrote PHPUnit evidence under its runtime artifact directory, then copied it into `HOMEBOY_INVOCATION_ARTIFACT_DIR/wp-codebox-phpunit/files` and registered those nested paths in the invocation manifest. It also printed `artifact://files/...` locators. Homeboy resolves those locators from `HOMEBOY_RUN_DIR/files`, but the producer did not populate that controller-local location itself. When controller materialization was unavailable or happened after the provider path lifetime ended, collection retained only metadata-only unavailable records and the underlying bootstrap output disappeared.

## Behavior
Before, bootstrap/discovery failures could end with a structured zero-test summary while `test-results.json`, `phpunit-output.log`, and execution diagnosis were unavailable at their declared controller-local locators.

After, the adapter atomically copies every publishable PHPUnit evidence file into `HOMEBOY_RUN_DIR/files` before exit while preserving the invocation-manifest copies. Failed and zero-test status normalization is unchanged, but the original raw/bootstrap diagnostics and structured diagnosis remain collectable.

This belongs in the generic WordPress extension because it owns the WP Codebox PHPUnit producer and its artifact declarations. The fix uses only Homeboy's generic run/invocation directory contracts and adds no consumer-specific names or behavior.

## Validation
- `npm run test:wp-codebox-phpunit-aggregate`
- `npm run test:wp-codebox-phpunit-evidence`
- `npm run lint:js -- --no-warn-ignored scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-aggregate-smoke.mjs`
- `node --check scripts/test/wp-codebox-phpunit-adapter.mjs`
- declared WordPress shell/JSON/Node lint checks from `wordpress/homeboy.json`
- `bash scripts/build/build-package-artifacts-smoke.sh`
- `git diff --check origin/main...HEAD`

The initially stale checkout's package smoke referenced a removed Homeboy helper path; after rebasing onto current `origin/main`, the package-build smoke passed. The registered `homeboy-extensions` component has no linked lint/build provider, so direct extension checks were used.

Closes #2503