### PR TITLE
fix(wordpress): stop the test runner owning Composer preparation

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -19,6 +19,7 @@
       "node tests/wp-codebox-phpunit-aggregate-smoke.mjs",
       "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
       "node tests/wp-codebox-phpunit-target-activation-smoke.mjs",
+      "bash scripts/test/wp-codebox-mount-translation-smoke.sh",
       "node tests/wp-codebox-database-service-smoke.mjs",
       "node tests/wp-codebox-native-database-canary.mjs",
       "bash scripts/test/full-suite-no-phpunit-smoke.sh",

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -16,6 +16,7 @@ ARTIFACTS_DIR="${TMPDIR}/artifacts"
 WRITABLE_DIR="${TMPDIR}/writable"
 STUBS_DIR="${TMPDIR}/stubs"
 COMPOSER_LOG="${TMPDIR}/composer.log"
+: > "$COMPOSER_LOG"
 RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context-helper.sh"
 WRITE_RESULTS_HELPER="${TMPDIR}/write-test-results-helper.sh"
 RESULTS_FILE="${TMPDIR}/parsed-results.json"
@@ -78,7 +79,7 @@ if (args[0] === 'recipe' && args[1] === 'build' && args[2] === 'phpunit') {
   const recipe = {
     schema: 'wp-codebox/workspace-recipe/v1',
     runtime: { wp: options.wordpressVersion, blueprint: { steps: [] } },
-    inputs: { mounts: options.mounts || [] },
+    inputs: { mounts: options.mounts || [], extra_plugins: options.extra_plugins || [] },
     workflow: {
       steps: [{
         command: 'wordpress.phpunit',
@@ -90,7 +91,6 @@ if (args[0] === 'recipe' && args[1] === 'build' && args[2] === 'phpunit') {
           `env-json=${JSON.stringify(options.env || {})}`,
           `wp-config-defines-json=${JSON.stringify(options.wpConfigDefines || {})}`,
           `autoload-file=${options.autoloadFile}`,
-          `tests-dir=${options.testsDir}`,
           `dependency-mounts=${(options.dependencyMounts || []).filter(Boolean).join(',')}`,
           `multisite=${options.multisite ? '1' : '0'}`,
         ],
@@ -138,14 +138,13 @@ if (step?.command !== 'wordpress.phpunit') {
 const mounts = recipe.inputs?.mounts || []
 for (const expected of [
   'plugin-slug=example',
-  'test-file=OnlyTest.php',
+  'test-file=tests/OnlyTest.php',
   'changed-tests-json=["tests/OnlyTest.php"]',
-  'phpunit-args-json=["--filter","OnlyTest"]',
-  'env-json={}',
+  'phpunit-args-json=["tests/OnlyTest.php","--filter","OnlyTest"]',
+  'env-json={"HOMEBOY_FLAG":"yes"}',
   'wp-config-defines-json={"WP_DEBUG":true,"CUSTOM_NUMBER":7}',
   'autoload-file=/wp-codebox-vendor/autoload.php',
-  'tests-dir=/wp-codebox-vendor/wp-phpunit/wp-phpunit',
-  'dependency-mounts=/wordpress/wp-content/plugins/dep-plugin',
+  'dependency-mounts=/wordpress/wp-content/plugins/example,/wordpress/wp-content/plugins/dep-plugin',
   'multisite=1',
 ]) {
   if (!(step.args || []).includes(expected)) {
@@ -162,14 +161,16 @@ for (const mount of requiredMounts) {
   }
 }
 
-const componentMountSuffix = ':/wordpress/wp-content/plugins/example:readonly'
-const componentMount = mountStrings.find((mount) => mount.endsWith(componentMountSuffix))
-if (!componentMount) {
-  throw new Error('component mount missing')
+const pluginSources = (recipe.inputs?.extra_plugins || []).map((plugin) => plugin.source)
+const requiredPluginSources = JSON.parse(process.env.REQUIRED_PLUGIN_SOURCES_JSON)
+if (JSON.stringify(pluginSources) !== JSON.stringify(requiredPluginSources)) {
+  throw new Error(`unexpected recipe plugin sources:\nexpected:\n${requiredPluginSources.join('\n')}\nactual:\n${pluginSources.join('\n')}`)
 }
-const componentPath = componentMount.slice(0, -componentMountSuffix.length)
-if (!fs.existsSync(path.join(componentPath, 'vendor/autoload.php'))) {
-  throw new Error(`component Composer autoload was not prepared before mount: ${componentPath}`)
+// Dependency materialization is the runtime substrate's concern: WP Codebox
+// prepares Composer autoload for every recipe plugin itself, so this runner must
+// not be shelling out to composer on the way.
+if ((recipe.inputs?.extra_plugins || []).some((plugin) => 'composer' in plugin)) {
+  throw new Error('recipe extra plugins must not carry Composer preparation instructions')
 }
 
 const artifactRoot = argValue('--artifacts') || path.join(path.dirname(process.env.FAKE_WP_CODEBOX_ARGS_FILE), 'artifacts')
@@ -227,24 +228,24 @@ SETTINGS_JSON=$(jq -nc \
         bench_env: $benchEnv,
         wp_codebox_phpunit_mounts: [
             {source: $writable, target: "/tmp/writable-workspace", mode: "readwrite"}
-        ],
-        wp_codebox_file_mounts: [
-            {from: "config/component-extra.php", to: "/wordpress/wp-content/component-extra.php"},
-            {from_dependency: "dep-plugin", from: "fixtures/dep-extra.php", to: "/wordpress/wp-content/dep-extra.php"}
         ]
     }')
 
 REQUIRED_MOUNTS_JSON=$(jq -nc \
-    --arg component "${PLUGIN_PATH}:/wordpress/wp-content/plugins/example:readonly" \
-    --arg dep "${REMOTE_DEP_PATH}:/wordpress/wp-content/plugins/dep-plugin:readonly" \
-    --arg dropin "${PLUGIN_PATH}/db.php:/wordpress/wp-content/db.php:readonly" \
-    --arg componentExtra "${PLUGIN_PATH}/config/component-extra.php:/wordpress/wp-content/component-extra.php:readonly" \
-    --arg depExtra "${REMOTE_DEP_PATH}/fixtures/dep-extra.php:/wordpress/wp-content/dep-extra.php:readonly" \
     --arg writableWorkspace "${WRITABLE_DIR}:/tmp/writable-workspace" \
     --arg vendor "${EXTENSION_PATH}/vendor:/wp-codebox-vendor:readonly" \
-    --arg extension "${EXTENSION_PATH}:/homeboy-extension:readonly" \
-    '[$component, $dep, $dropin, $componentExtra, $depExtra, $writableWorkspace, $vendor, $extension]')
+    '[$writableWorkspace, $vendor]')
 export REQUIRED_MOUNTS_JSON
+
+# Declared settings mounts and the PHPUnit harness are what this runner still
+# translates. The component and its dependencies are carried as extra_plugins,
+# and Lab offload must have rewritten the dependency's local workspace path to
+# its remote path before the recipe is built.
+REQUIRED_PLUGIN_SOURCES_JSON=$(jq -nc \
+    --arg component "$PLUGIN_PATH" \
+    --arg dep "$REMOTE_DEP_PATH" \
+    '[$dep, $component]')
+export REQUIRED_PLUGIN_SOURCES_JSON
 
 LAB_OFFLOAD_JSON=$(jq -nc \
     --arg depLocal "$DEP_PATH" \
@@ -261,6 +262,7 @@ run_runner() {
         HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
         HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
         HOMEBOY_COMPONENT_ID="example" \
+        COMPONENT_ID="example" \
         HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
         HOMEBOY_RUNTIME_RUNNER_STEPS="${TMPDIR}/missing-runner-steps.sh" \
         HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_RESULTS_HELPER" \
@@ -270,6 +272,7 @@ run_runner() {
         HOMEBOY_LAB_OFFLOAD_JSON="$LAB_OFFLOAD_JSON" \
         HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
         HOMEBOY_CHANGED_TEST_FILES="tests/OnlyTest.php" \
+        HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE="tests/OnlyTest.php" \
         HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="$ARTIFACTS_DIR" \
         bash "$RUNNER" tests/OnlyTest.php --filter OnlyTest
 }
@@ -295,8 +298,11 @@ if [ ! -f "$FAILURES_FILE" ] || grep -q 'stale-caller-sidecar' "$FAILURES_FILE";
     exit 1
 fi
 
-if ! grep -q -- 'install --no-dev --no-interaction --no-progress --prefer-dist' "$COMPOSER_LOG"; then
-    echo "Expected WP Codebox runner to prepare missing component Composer autoload" >&2
+# The runner must not perform dependency materialization. WP Codebox prepares
+# Composer autoload for every recipe plugin itself, so a `composer` invocation
+# from this runner is a layering regression.
+if [ -s "$COMPOSER_LOG" ]; then
+    echo "WP Codebox runner must not invoke composer; dependency materialization is not its concern" >&2
     cat "$COMPOSER_LOG" >&2 || true
     exit 1
 fi
@@ -332,55 +338,10 @@ if [ -e "${PLUGIN_PATH}/.pg-test-result.txt" ]; then
     exit 1
 fi
 
-mkdir -p "${ARTIFACTS_DIR}/files/phpunit"
-printf 'NO_TEST_FILES\n' > "${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"
-printf '{"schema":"stale-caller-sidecar"}\n' > "${ARTIFACTS_DIR}/files/test-results.json"
-printf '{"source":"stale-caller-sidecar"}\n' > "$RESULTS_FILE"
-printf '{"source":"stale-caller-sidecar"}\n' > "$FAILURES_FILE"
-printf 'fail-before-diagnostic\n' > "${ARTIFACTS_DIR}/runtime-smoke-result-mode"
-set +e
-stale_output=$(run_runner 2>&1)
-stale_status=$?
-set -e
-if [ "$stale_status" -eq 0 ]; then
-    echo "Expected a runtime failure without a current diagnostic to fail the runner" >&2
-    exit 1
-fi
-if [[ "$stale_output" == *"Skipping PHPUnit tests"* ]]; then
-    echo "Runner consumed a stale no-test diagnostic from a previous invocation" >&2
-    echo "$stale_output" >&2
-    exit 1
-fi
-if ! grep -q '^NO_TEST_FILES' "${ARTIFACTS_DIR}/files/phpunit/.pg-test-result.txt"; then
-    echo "Runner must preserve unrelated caller artifacts" >&2
-    exit 1
-fi
-if ! grep -q 'stale-caller-sidecar' "${ARTIFACTS_DIR}/files/test-results.json"; then
-    echo "Runner must not consume or replace stale caller test-result sidecars" >&2
-    exit 1
-fi
-if ! grep -q 'stale-caller-sidecar' "$RESULTS_FILE"; then
-    echo "Runner must not overwrite exported results from stale caller sidecars" >&2
-    exit 1
-fi
-if ! grep -q 'stale-caller-sidecar' "$FAILURES_FILE"; then
-    echo "Runner must not overwrite exported failures from stale caller sidecars" >&2
-    exit 1
-fi
-
-printf 'invalid-pointer\n' > "${ARTIFACTS_DIR}/runtime-smoke-result-mode"
-set +e
-pointer_output=$(run_runner 2>&1)
-pointer_status=$?
-set -e
-if [ "$pointer_status" -eq 0 ]; then
-    echo "Expected malformed runtime artifact pointer to fail the runner" >&2
-    exit 1
-fi
-if [[ "$pointer_output" != *"Invalid runtime directory"* ]]; then
-    echo "Expected actionable malformed runtime pointer diagnostic" >&2
-    echo "$pointer_output" >&2
-    exit 1
-fi
+# Runtime-artifact pointer handling (crashed runtime, malformed pointer, stale
+# caller sidecars) is owned by tests/wp-codebox-phpunit-aggregate-smoke.mjs,
+# which asserts the current contract: preserve and parse the captured aggregate
+# at the stable artifact root rather than report a zero-test run. Those
+# scenarios previously lived here asserting the pre-hardening behaviour.
 
 echo "WP Codebox mount translation smoke passed"

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -166,11 +166,15 @@ const requiredPluginSources = JSON.parse(process.env.REQUIRED_PLUGIN_SOURCES_JSO
 if (JSON.stringify(pluginSources) !== JSON.stringify(requiredPluginSources)) {
   throw new Error(`unexpected recipe plugin sources:\nexpected:\n${requiredPluginSources.join('\n')}\nactual:\n${pluginSources.join('\n')}`)
 }
-// Dependency materialization is the runtime substrate's concern: WP Codebox
-// prepares Composer autoload for every recipe plugin itself, so this runner must
-// not be shelling out to composer on the way.
-if ((recipe.inputs?.extra_plugins || []).some((plugin) => 'composer' in plugin)) {
-  throw new Error('recipe extra plugins must not carry Composer preparation instructions')
+// The recipe may declare that a validation dependency needs Composer
+// preparation, but the component under review never carries that instruction:
+// its vendor/ comes from the declared dependency-materialization phase.
+const target = (recipe.inputs?.extra_plugins || []).at(-1)
+if (target?.composer !== undefined) {
+  throw new Error(`component under review must not carry a Composer preparation instruction: ${JSON.stringify(target)}`)
+}
+if ((recipe.inputs?.extra_plugins || []).slice(0, -1).some((plugin) => plugin.composer !== 'install')) {
+  throw new Error('validation dependencies must declare Composer preparation for the substrate to own')
 }
 
 const artifactRoot = argValue('--artifacts') || path.join(path.dirname(process.env.FAKE_WP_CODEBOX_ARGS_FILE), 'artifacts')

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -33,13 +33,18 @@ const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
 const artifacts = process.env.HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR || path.join(directory, 'artifacts');
 const runArtifacts = path.join(artifacts, `wp-codebox-phpunit.${process.pid}`);
-// Dependency materialization is not this runner's concern. The WordPress
-// extension owns PHP knowledge, but preparing a mounted plugin's Composer
-// autoload belongs to the runtime substrate that mounts it, and WP Codebox
-// already does that for every recipe plugin.
+// Validation dependencies are external checkouts nobody built, so the recipe
+// declares that they may need Composer preparation. It does not decide whether
+// they do: WP Codebox owns the detection (no composer.json, or an existing
+// vendor/autoload.php, are both no-ops) and owns running composer. This runner
+// never inspects a dependency's vendor state and never shells out to composer.
+//
+// The component under review is deliberately absent from this: its vendor/ is
+// produced by the declared dependency-materialization phase before the runner
+// is ever invoked.
 const dependencies = (await dependencyPaths(settings, [componentPath, pluginSourceDirectory])).map((source) => {
   const dependencySlug = path.basename(source).replace(/@[^/]+$/, '');
-  return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug) };
+  return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug), composer: 'install' };
 });
 const selectedTestFile = (process.env.HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE || '').trim();
 const changedTestFiles = phpunitChangedTestFiles();
@@ -49,7 +54,7 @@ const changedTestFiles = phpunitChangedTestFiles();
 // Codebox's activation phase and from Composer autoloader preloading, which
 // yields a sandbox that reports zero executed tests.
 const activationPlan = [
-  ...dependencies.map(({ source, slug: dependencySlug }) => ({ role: 'validation-dependency', source, slug: dependencySlug })),
+  ...dependencies.map(({ source, slug: dependencySlug, composer }) => ({ role: 'validation-dependency', source, slug: dependencySlug, composer })),
   { role: 'target', source: root, sourceSubpath: subpath, slug },
 ];
 await requireHarness(harnessSource);

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -33,10 +33,14 @@ const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
 const artifacts = process.env.HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR || path.join(directory, 'artifacts');
 const runArtifacts = path.join(artifacts, `wp-codebox-phpunit.${process.pid}`);
-const dependencies = await Promise.all((await dependencyPaths(settings, [componentPath, pluginSourceDirectory])).map(async (source) => {
+// Dependency materialization is not this runner's concern. The WordPress
+// extension owns PHP knowledge, but preparing a mounted plugin's Composer
+// autoload belongs to the runtime substrate that mounts it, and WP Codebox
+// already does that for every recipe plugin.
+const dependencies = (await dependencyPaths(settings, [componentPath, pluginSourceDirectory])).map((source) => {
   const dependencySlug = path.basename(source).replace(/@[^/]+$/, '');
-  return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug), composer: await composerPreparation(source) };
-}));
+  return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug) };
+});
 const selectedTestFile = (process.env.HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE || '').trim();
 const changedTestFiles = phpunitChangedTestFiles();
 // Validation dependencies activate before the plugin under review so the
@@ -45,7 +49,7 @@ const changedTestFiles = phpunitChangedTestFiles();
 // Codebox's activation phase and from Composer autoloader preloading, which
 // yields a sandbox that reports zero executed tests.
 const activationPlan = [
-  ...dependencies.map(({ source, slug: dependencySlug, composer }) => ({ role: 'validation-dependency', source, slug: dependencySlug, composer })),
+  ...dependencies.map(({ source, slug: dependencySlug }) => ({ role: 'validation-dependency', source, slug: dependencySlug })),
   { role: 'target', source: root, sourceSubpath: subpath, slug },
 ];
 await requireHarness(harnessSource);
@@ -276,19 +280,6 @@ async function dependencyPaths(configuration, primarySources) {
   return resolved
     .filter(({ canonicalSource }) => !primary.has(canonicalSource) && !seen.has(canonicalSource) && Boolean(seen.add(canonicalSource)))
     .map(({ source }) => source);
-}
-async function composerPreparation(source) {
-  try {
-    await access(path.join(source, 'composer.json'));
-  } catch {
-    return undefined;
-  }
-  try {
-    await access(path.join(source, 'vendor/autoload.php'));
-    return undefined;
-  } catch {
-    return 'install';
-  }
 }
 function sandboxPluginDirectory(pluginSlug) {
   return `/wordpress/wp-content/plugins/${pluginSlug}`;
@@ -830,6 +821,15 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     await writeFile(managedRuntimeServicesPath, `${JSON.stringify(managedRuntimeServices, null, 2)}\n`);
   }
 
+  // A failed bootstrap stage means PHPUnit never got to run. Trust that over an
+  // optimistic structured sidecar: reporting a pass because the sidecar claims
+  // one is exactly how a red run shows up green.
+  const stageLog = await readPhpunitStageLog(artifactDirectory);
+  const stageFailure = (stageLog || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => /^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE):/.test(line)) || '';
+
   const aggregate = phpunitAggregate(output);
   let results;
   try { results = json(await readFile(testResultsPath, 'utf8'), null); } catch { results = null; }
@@ -842,7 +842,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     if (aggregate) {
       results.summary = { ...summary, ...aggregate };
     }
-    results.status = normalizedTestStatus(results, aggregate, execution.status, validResults);
+    results.status = stageFailure ? 'failed' : normalizedTestStatus(results, aggregate, execution.status, validResults);
     const references = Array.isArray(results.rawLogReferences) ? results.rawLogReferences : [];
     results.rawLogReferences = [
       ...references.filter((reference) => reference?.path !== 'files/phpunit-output.log'),
@@ -862,12 +862,15 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     await writeFile(testResultsPath, `${JSON.stringify(results, null, 2)}\n`);
   }
 
-  const diagnosis = await phpunitExecutionDiagnosis(artifactDirectory, results, execution);
+  const diagnosis = await phpunitExecutionDiagnosis(artifactDirectory, results, execution, stageLog);
   await writeFile(path.join(filesDirectory, 'phpunit-execution-diagnosis.json'), `${JSON.stringify(diagnosis, null, 2)}\n`);
 
   process.stdout.write('Structured PHPUnit evidence: artifact://files/test-results.json\n');
   process.stdout.write('Full PHPUnit output: artifact://files/phpunit-output.log\n');
   process.stdout.write('PHPUnit execution diagnosis: artifact://files/phpunit-execution-diagnosis.json\n');
+  if (stageFailure) {
+    process.stdout.write(`BOOTSTRAP FAILURE: ${stageFailure.replace(/^STAGE_(FAIL|FATAL|DIE):/, '')}\n`);
+  }
   if (diagnosis.executed_tests === 0) {
     process.stdout.write(`PHPUNIT_ZERO_TESTS cause=${diagnosis.cause}\n`);
     process.stdout.write(`  ${diagnosis.detail}\n`);
@@ -881,10 +884,9 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
 // A selected test set must either execute or say why it did not. The sandbox
 // bootstrap logs stage markers to a diagnostic file; classify them so a zero
 // count names the failing seam instead of reporting an empty pass.
-async function phpunitExecutionDiagnosis(artifactDirectory, results, execution) {
+async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, stageLog) {
   const summary = isObject(results?.summary) ? results.summary : {};
   const executed = Number.isInteger(summary.total) ? summary.total : 0;
-  const stageLog = await readPhpunitStageLog(artifactDirectory);
   const markers = stageLog === null
     ? []
     : stageLog.split('\n').filter((line) => /^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE|NO_TEST_FILES|DISCOVERY:|SCOPED_TEST_FILES|PLUGIN_DETECTED|THEME_DETECTED|PLUGIN_ACTIVATE|NOTICE:no plugin entry file)/.test(line.trim()));
@@ -904,6 +906,22 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution) 
   };
 
   const classification = (() => {
+    if (has(/^STAGE_FAIL:activation/)) {
+      return {
+        cause: 'activation_failed',
+        detail: 'Plugin activation raised a throwable before PHPUnit discovery.',
+        remediation: 'Read the STAGE_FAIL:activation trace in the stage log; a validation dependency may be missing from validation_dependencies.',
+      };
+    }
+    if (has(/^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE)/)) {
+      const marker = markers.find((line) => /^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE)/.test(line)) || '';
+      const stage = marker.split(':')[1] || 'unknown';
+      return {
+        cause: 'bootstrap_failed',
+        detail: `The sandbox bootstrap failed at stage '${stage}': ${marker}`,
+        remediation: 'Read the failing stage trace in the stage log excerpt below and in artifact://files/phpunit-output.log.',
+      };
+    }
     if (executed > 0) {
       return { cause: 'tests_executed', detail: `PHPUnit executed ${executed} test(s).`, remediation: 'No execution diagnosis is required.' };
     }
@@ -919,21 +937,6 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution) 
         cause: 'target_component_not_mounted',
         detail: `The sandbox never loaded an entry file for the component under review (${slug}); its mount or plugin header is missing.`,
         remediation: 'Confirm wp_codebox_source_root/wp_codebox_source_subpath resolve to a directory containing the plugin entry file.',
-      };
-    }
-    if (has(/^STAGE_FAIL:activation/)) {
-      return {
-        cause: 'activation_failed',
-        detail: 'Plugin activation raised a throwable before PHPUnit discovery.',
-        remediation: 'Read the STAGE_FAIL:activation trace in the stage log; a validation dependency may be missing from validation_dependencies.',
-      };
-    }
-    if (has(/^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE)/)) {
-      const stage = (markers.find((line) => /^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE)/.test(line)) || '').split(':')[1] || 'unknown';
-      return {
-        cause: 'bootstrap_failed',
-        detail: `The sandbox bootstrap failed at stage '${stage}' before any test executed.`,
-        remediation: 'Read the failing stage trace in the stage log excerpt below and in artifact://files/phpunit-output.log.',
       };
     }
     if (scoped && Number(scoped[1]) > 0 && Number(scoped[2]) === 0) {

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -74,7 +74,7 @@ try {
   // excluded from WP Codebox's activation phase and Composer autoloader
   // preloading, which produces a sandbox where nothing can execute.
   assert.deepEqual(options[1].extra_plugins, [
-    { source: dependency, slug: 'db-touching-dependency', activate: true },
+    { source: dependency, slug: 'db-touching-dependency', activate: true, composer: 'install' },
     { source: '/workspace/monorepo', sourceSubpath: 'plugins/canonical-plugin', slug: 'canonical-plugin', activate: true },
   ]);
   assert.deepEqual(options[1].dependencyMounts, [

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -208,7 +208,10 @@ try {
   }, 'recipe build receives administrative names without host values');
   assert.equal(options.databaseType, 'mysql');
   assert.equal(options.multisite, true, 'external MySQL remains compatible with multisite PHPUnit');
-  assert.equal(options.extra_plugins[0].composer, 'install', 'source-form validation dependencies explicitly request staged Composer preparation');
+  // Dependency materialization is the runtime substrate's concern, not this
+  // runner's. WP Codebox prepares Composer autoload for every recipe plugin,
+  // and its recipe normalizer drops any `composer` field the caller sets.
+  assert.equal('composer' in options.extra_plugins[0], false, 'the test recipe does not carry Composer preparation instructions');
   assert.equal('secretEnv' in options, false, 'administrative credentials are not forwarded into the sandbox runtime');
   assert.deepEqual(options.services, [{
     id: 'wordpress-database',

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -208,10 +208,11 @@ try {
   }, 'recipe build receives administrative names without host values');
   assert.equal(options.databaseType, 'mysql');
   assert.equal(options.multisite, true, 'external MySQL remains compatible with multisite PHPUnit');
-  // Dependency materialization is the runtime substrate's concern, not this
-  // runner's. WP Codebox prepares Composer autoload for every recipe plugin,
-  // and its recipe normalizer drops any `composer` field the caller sets.
-  assert.equal('composer' in options.extra_plugins[0], false, 'the test recipe does not carry Composer preparation instructions');
+  // The recipe declares that a validation dependency may need Composer
+  // preparation; WP Codebox owns detecting whether it does and running it. This
+  // runner never inspects vendor state, so the declaration is unconditional.
+  assert.equal(options.extra_plugins[0].composer, 'install', 'validation dependencies declare Composer preparation for the substrate to own');
+  assert.equal('composer' in options.extra_plugins.at(-1), false, 'the component under review carries no Composer preparation instruction');
   assert.equal('secretEnv' in options, false, 'administrative credentials are not forwarded into the sandbox runtime');
   assert.deepEqual(options.services, [{
     id: 'wordpress-database',

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -185,7 +185,7 @@ printf '%s\\n' '${JSON.stringify({ data: { entity: { local_path: conflictingData
   const metadataOptions = JSON.parse(await readFile(path.join(metadataRunArtifact, 'wp-codebox-phpunit-recipe-options.json'), 'utf8'));
   const metadataProvenance = JSON.parse(await readFile(path.join(metadataRunArtifact, 'wp-codebox-phpunit-provenance.json'), 'utf8'));
   assert.deepEqual(metadataOptions.extra_plugins, [
-    { source: dataMachine, slug: 'data-machine', activate: true },
+    { source: dataMachine, slug: 'data-machine', activate: true, composer: 'install' },
     { source: component, slug: 'component', activate: true },
   ]);
   assert.deepEqual(metadataProvenance.source_refs.slice(1), [{ slug: 'data-machine', source: dataMachine }]);


### PR DESCRIPTION
Addresses the layering item in #2532.

## The rule

The test runner does not own Composer, and homeboy core does not either — core
is ecosystem-agnostic. Verified: every `composer` occurrence under `crates/` is
an opaque string in a test fixture, a component-declared harvest exclude, or a
`package_manager` setting passed through as an opaque token.

The WordPress extension legitimately owns PHP knowledge. But deciding whether a
mounted plugin needs its Composer autoload built, and building it, belongs to
the runtime substrate that mounts it.

## What was wrong

`wp-codebox-phpunit-adapter.mjs` stat'd `composer.json` and
`vendor/autoload.php` on every validation dependency to decide whether to set
`composer: 'install'`. **That detection is the violation** — a test runner
reading dependency vendor state and making materialization policy from it.

WP Codebox already performs exactly that detection inside
`prepareComposerAutoloadForPlugin`: absent `composer.json` is a no-op, an
existing `vendor/autoload.php` is a no-op, otherwise it stages a copy and runs
composer under a managed host command. The adapter was duplicating it from the
wrong side of the boundary.

The adapter now declares `composer: 'install'` unconditionally for validation
dependencies and lets the substrate own both the detection and the execution.
It no longer inspects vendor state and never shells out to composer.

**The component under review carries no instruction at all** — its `vendor/` is
produced by the declared dependency-materialization phase
(`wordpress-php-package-dependencies`) before this runner is invoked. That
asymmetry is the point: the component is built, validation dependencies are
external checkouts nobody built.

## A correction I owe this PR

My first commit deleted the field outright, claiming it was dead code — that
`normalizeExtraPlugins` dropped it and `prepareComposerAutoloadForPlugin` ran
unconditionally.

That was analysed against a `wp-codebox` checkout **169 commits and 10 days
stale**. On current `main` the field is carried through the normalizer, and
preparation early-returns unless the recipe declares `"install"`. The substrate
moved from always-prepare to opt-in.

CI caught it: `playground-managed-dependency-order-smoke.sh` failed with
`bootstrap_evidence_unavailable`, a dependency whose autoload was never built.
The DB-activation smoke passed, so only the dependency-ordering case exposed it.

The layering conclusion survived; the mechanism claim did not.

## Bootstrap-failure classification, restored

Repairing the smoke surfaced a real regression: `BOOTSTRAP FAILURE:`
classification survived the CLI delegation only in
`test-runner-core-dev-wp-codebox.sh`. The plugin PHPUnit path lost it.

A `STAGE_FAIL` / `STAGE_FATAL` / `STAGE_DIE` marker in the sandbox stage log now
forces `status: failed` and prints `BOOTSTRAP FAILURE: <stage line>`
**regardless of what the structured sidecar claims**. A bootstrap that never
reached PHPUnit cannot have produced passing tests, so trusting an optimistic
sidecar there is precisely how a red run reports green. `activation_failed`
still outranks the generic classification.

## Smoke repaired and registered

`scripts/test/wp-codebox-mount-translation-smoke.sh` has been orphaned since the
CLI delegation. Now green and registered, covering what is still unique to it:

- settings mount translation and the PHPUnit harness mount
- recipe plugin ordering, with Lab offload having rewritten the dependency's
  local workspace path to its remote path
- the readonly component source
- VFS diagnostic persistence under the artifact root
- bootstrap-failure classification
- **that the runner never invokes `composer`**, and that the component under
  review carries no Composer instruction while dependencies declare one — the
  boundary above, enforced rather than described

Stale expectations removed, each with a reason:

- `composer install ... --prefer-dist` invoked by the runner for the component —
  the pre-refactor design this PR is undoing
- `wp_codebox_file_mounts` and the `db.php` drop-in mount — exist nowhere in the
  tree (see #2532)
- `tests-dir=` — wp-codebox owns that default
- runtime-artifact pointer, crash, and stale-sidecar scenarios — superseded by
  `tests/wp-codebox-phpunit-aggregate-smoke.mjs`, whose `crash` and
  `pointer: 'malformed'` cases assert the current contract

It also caught that the adapter's slug contract is `COMPONENT_ID`; the fixture
set only `HOMEBOY_COMPONENT_ID`, so the slug silently fell back to the directory
basename with no error. Fixture corrected; the silent fallback is noted in #2532.

## Verification

The smoke fails against the pre-fix adapter and passes after. Full suite run
with the sibling `homeboy` checkout moved aside, to reproduce CI's environment:

```
wordpress lint self-checks: 3 passed, 0 failed, 0 skipped
wordpress test self-checks: 56 passed, 0 failed, 2 skipped
```

Plus the real-`wp-codebox` canary job, which is what caught the first attempt.