### PR TITLE
Rust runner: add deterministic test inventory and shard replay

### DIFF
--- a/rust/homeboy.json
+++ b/rust/homeboy.json
@@ -12,7 +12,8 @@
       "bash tests/env-provider-smoke.sh",
       "bash tests/fingerprint-policy-flow-smoke.sh",
       "bash tests/zero-test-scope-fallback-smoke.sh",
-   "bash ../tests/lint-findings-clean-pass-contract-smoke.sh"
+      "bash tests/test-shard-inventory-smoke.sh",
+      "bash ../tests/lint-findings-clean-pass-contract-smoke.sh"
     ]
   }
 }

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -82,6 +82,13 @@
   },
   "test": {
     "extension_script": "scripts/test-runner.sh",
+    "portable_env": {
+      "keys": [
+        "HOMEBOY_TEST_INVENTORY_ONLY",
+        "HOMEBOY_TEST_INVENTORY_FILE",
+        "HOMEBOY_TEST_SHARD_MANIFEST"
+      ]
+    },
     "passthrough_filter": {
       "strategy": "runner_positional"
     },

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -32,6 +32,12 @@ homeboy_runner_harness_source_command_capture
 # shellcheck source=../../scripts/lib/settings.sh
 source "${SETTINGS_HELPER}"
 
+WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
+if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
+    # shellcheck source=/dev/null
+    source "$WRITE_TEST_RESULTS_HELPER"
+fi
+
 rust_test_runner() {
     case "${HOMEBOY_RUST_TEST_RUNNER:-$(homeboy_setting rust_test_runner '.rust_test_runner // .test_runner' cargo)}" in
         nextest|cargo-nextest|cargo_nextest)
@@ -135,12 +141,113 @@ record = {
     "status": status,
     "exit_code": int(exit_code or 0),
 }
+
 with open(target, "w", encoding="utf-8") as handle:
     json.dump([record], handle, indent=2)
     handle.write("\n")
 PY
     homeboy_merge_annotations rust-test-plan "$plan_tmp" || true
     rm -f "$plan_tmp"
+}
+
+rust_emit_shard_result() {
+    local status="$1" total="$2" executed="$3" passed="$4" failed="$5" skipped="$6" duration_ms="$7"
+    local result_tmp
+    if type homeboy_write_test_results >/dev/null 2>&1; then
+        homeboy_write_test_results "$executed" "$passed" "$failed" "$skipped" "rust-shard"
+    fi
+    type homeboy_merge_annotations >/dev/null 2>&1 || return 0
+    result_tmp="$(mktemp)"
+    python3 - "$status" "$total" "$executed" "$passed" "$failed" "$skipped" "$duration_ms" "$result_tmp" <<'PY'
+import json
+import sys
+status, total, executed, passed, failed, skipped, duration, target = sys.argv[1:]
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump([{"type": "rust-test-shard", "status": status, "total": int(total), "executed": int(executed), "passed": int(passed), "failed": int(failed), "skipped": int(skipped), "duration_ms": int(duration)}], handle)
+    handle.write("\n")
+PY
+    homeboy_merge_annotations rust-test-shard "$result_tmp" || true
+    rm -f "$result_tmp"
+}
+
+rust_shard_cargo_counts() {
+    python3 - "$1" <<'PY'
+import re
+import sys
+
+passed = failed = skipped = 0
+for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    if not line.startswith("test result:"):
+        continue
+    for name, target in (("passed", "passed"), ("failed", "failed"), ("ignored", "skipped")):
+        match = re.search(rf"(\d+) {name}", line)
+        if match:
+            if target == "passed": passed += int(match.group(1))
+            elif target == "failed": failed += int(match.group(1))
+            else: skipped += int(match.group(1))
+print(f"{passed}\t{failed}\t{skipped}")
+PY
+}
+
+rust_nextest_filter() {
+    jq -r '[.selected[] | "package(=\(.package)) and kind(=\(.target_kind)) and binary(=\(.target)) and test(=\(.name))"] | join(" + ")' "$1"
+}
+
+rust_validate_nextest_membership() {
+    local list_file="$1" shard_file="$2"
+    python3 - "$list_file" "$shard_file" <<'PY'
+import json
+import sys
+
+listed = json.load(open(sys.argv[1], encoding="utf-8"))
+expected = {item["id"] for item in json.load(open(sys.argv[2], encoding="utf-8"))["selected"]}
+actual = set()
+for suite in listed.get("rust-suites", {}).values():
+    for name, testcase in suite.get("testcases", {}).items():
+        if testcase.get("filter-match", {}).get("status") == "matches":
+            actual.add(f'{suite["package-name"]}::{suite["kind"]}::{suite["binary-name"]}::{name}')
+if actual != expected:
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    raise SystemExit(f"Rust test shard error: nextest exact filter membership mismatch (missing={missing[:1]}, extra={extra[:1]})")
+PY
+}
+
+rust_nextest_counts() {
+    python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+expected = json.load(open(sys.argv[2], encoding="utf-8"))["selected"]
+names = {}
+for item in expected:
+    key = f'{item["package"]}::{item["target"]}${item["name"]}'
+    if key in names:
+        raise SystemExit(f"Rust test shard error: nextest output identity is ambiguous: {key}")
+    names[key] = item["id"]
+passed = failed = skipped = 0
+actual = set()
+for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if event.get("type") != "test":
+        continue
+    status = event.get("event")
+    if status not in {"ok", "passed", "failed", "fail", "ignored", "skipped"}:
+        continue
+    name = event.get("name")
+    if name not in names or names[name] in actual:
+        raise SystemExit(f"Rust test shard error: nextest emitted an unexpected or duplicate test identity: {name}")
+    actual.add(names[name])
+    if status in {"ok", "passed"}: passed += 1
+    elif status in {"failed", "fail"}: failed += 1
+    else: skipped += 1
+if actual != set(names.values()):
+    raise SystemExit(f"Rust test shard error: nextest executed membership does not match the shard manifest (missing={sorted(set(names.values()) - actual)[:1]})")
+print(f"{passed}\t{failed}\t{skipped}")
+PY
 }
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -163,7 +270,9 @@ fi
 echo "Running Rust tests..."
 
 # ── Step 1: Pre-test lint (unless skipped) ──
-if should_run_step "lint" && [ "${HOMEBOY_SKIP_LINT:-}" != "1" ]; then
+if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = "1" ]; then
+    echo "Skipping lint (test inventory only)"
+elif should_run_step "lint" && [ "${HOMEBOY_SKIP_LINT:-}" != "1" ]; then
     LINT_RUNNER="${EXTENSION_PATH}/scripts/lint-runner.sh"
     if [ -f "$LINT_RUNNER" ]; then
         echo ""
@@ -184,7 +293,7 @@ if ! should_run_step "test"; then
 fi
 
 # Coverage mode: use cargo-tarpaulin if HOMEBOY_COVERAGE=1
-if [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then
+if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" != "1" ] && [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then
     if command -v cargo-tarpaulin &>/dev/null; then
         echo "Running cargo tarpaulin (test + coverage)..."
 
@@ -322,6 +431,96 @@ if [ "$SELECTED_RUNNER" = "nextest" ]; then
     fi
 else
     echo "Running cargo test..."
+fi
+
+# Shard manifests are Rust-owned because Cargo target identities and their
+# resolution are runner-specific. Normal and changed-scope paths do not enter
+# this branch.
+if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEBOY_TEST_INVENTORY_ONLY:-}" ]; then
+    if [ "$#" -gt 0 ]; then
+        echo "Error: test shard inventory and replay do not support passthrough arguments." >&2
+        echo "Remove arguments after -- and encode selection in HOMEBOY_TEST_SHARD_MANIFEST." >&2
+        exit 2
+    fi
+    SHARD_TOOL="${EXTENSION_PATH}/scripts/test-shard-inventory.py"
+    SHARD_DATA="$(mktemp)"
+    SHARD_ARGS=(--project "$PROJECT_PATH" --runner "$SELECTED_RUNNER" --output "$SHARD_DATA")
+    if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ]; then
+        SHARD_ARGS+=(--manifest "$HOMEBOY_TEST_SHARD_MANIFEST")
+    fi
+    if ! python3 "$SHARD_TOOL" "${SHARD_ARGS[@]}"; then
+        rm -f "$SHARD_DATA"
+        exit 1
+    fi
+    if [ -n "${HOMEBOY_TEST_INVENTORY_FILE:-}" ]; then
+        cp "$SHARD_DATA" "$HOMEBOY_TEST_INVENTORY_FILE"
+    fi
+    if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = "1" ]; then
+        cat "$SHARD_DATA"
+        rm -f "$SHARD_DATA"
+        exit 0
+    fi
+    if [ -z "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ]; then
+        rm -f "$SHARD_DATA"
+        exit 0
+    fi
+    SHARD_STARTED="$(date +%s)"
+    SHARD_TOTAL="$(jq '.selected | length' "$SHARD_DATA")"
+    SHARD_PASSED=0
+    SHARD_FAILED=0
+    SHARD_SKIPPED=0
+    if [ "$SELECTED_RUNNER" = "nextest" ]; then
+        NEXTEST_FILTER="$(rust_nextest_filter "$SHARD_DATA")"
+        NEXTEST_LIST="$(mktemp)"
+        homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
+        if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_OUTPUT" "$SHARD_DATA"; then
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+            rm -f "$NEXTEST_LIST_OUTPUT" "$NEXTEST_LIST"
+            exit 1
+        fi
+        rm -f "$NEXTEST_LIST_OUTPUT" "$NEXTEST_LIST"
+        echo "Replaying Rust nextest shard: ${SHARD_TOTAL} exact identities"
+        homeboy_run_step_capture SHARD_OUTPUT SHARD_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --manifest-path "${PROJECT_PATH}/Cargo.toml" --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
+        if ! NEXTEST_COUNTS="$(rust_nextest_counts "$SHARD_OUTPUT" "$SHARD_DATA")"; then
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+            rm -f "$SHARD_OUTPUT" "$SHARD_DATA"
+            exit 1
+        fi
+        IFS=$'\t' read -r SHARD_PASSED SHARD_FAILED SHARD_SKIPPED <<< "$NEXTEST_COUNTS"
+        rm -f "$SHARD_OUTPUT"
+    else
+        while IFS=$'\t' read -r package target target_kind name; do
+            case "$target_kind" in
+                lib) TARGET_ARGS=(--lib) ;;
+                bin) TARGET_ARGS=(--bin "$target") ;;
+                doc) TARGET_ARGS=(--doc) ;;
+                example) TARGET_ARGS=(--example "$target") ;;
+                bench) TARGET_ARGS=(--bench "$target") ;;
+                *) TARGET_ARGS=(--test "$target") ;;
+            esac
+            echo "Replaying Rust shard test: ${package}::${target}::${name}"
+            homeboy_run_step_capture SHARD_OUTPUT SHARD_EXIT "cargo test" -- cargo test --manifest-path "${PROJECT_PATH}/Cargo.toml" -p "$package" "${TARGET_ARGS[@]}" -- "$name" --exact --test-threads=1 || true
+            IFS=$'\t' read -r PASSED FAILED SKIPPED < <(rust_shard_cargo_counts "$SHARD_OUTPUT")
+            rm -f "$SHARD_OUTPUT"
+            SHARD_PASSED=$((SHARD_PASSED + PASSED))
+            SHARD_FAILED=$((SHARD_FAILED + FAILED))
+            SHARD_SKIPPED=$((SHARD_SKIPPED + SKIPPED))
+        done < <(jq -r '.selected[] | [.package, .target, .target_kind, .name] | @tsv' "$SHARD_DATA")
+    fi
+    SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+    SHARD_EXECUTED=$((SHARD_PASSED + SHARD_FAILED + SHARD_SKIPPED))
+    if [ "$SHARD_EXECUTED" -ne "$SHARD_TOTAL" ] || [ "$SHARD_FAILED" -ne 0 ] || [ "${SHARD_EXIT:-0}" -ne 0 ]; then
+        echo "Rust shard result: total=${SHARD_TOTAL} executed=${SHARD_EXECUTED} passed=${SHARD_PASSED} failed=${SHARD_FAILED} skipped=${SHARD_SKIPPED}" >&2
+        rust_emit_shard_result failed "$SHARD_TOTAL" "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED" "$((SHARD_ELAPSED*1000))"
+        rm -f "$SHARD_DATA"
+        exit 1
+    fi
+    echo "Rust shard result: total=${SHARD_TOTAL} passed=${SHARD_PASSED} failed=${SHARD_FAILED} skipped=${SHARD_SKIPPED} duration_ms=$((SHARD_ELAPSED*1000))"
+    rust_emit_shard_result completed "$SHARD_TOTAL" "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED" "$((SHARD_ELAPSED*1000))"
+    rm -f "$SHARD_DATA"
+    exit 0
 fi
 
 TEST_ARGS=(

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Build and validate Rust test shard inventories without adding core contracts."""
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+SCHEMA = "homeboy/test-inventory/v1"
+MANIFEST_SCHEMA = "homeboy/test-shard-manifest/v1"
+
+
+def fail(message):
+    raise SystemExit(f"Rust test shard error: {message}")
+
+
+def digest(value):
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def run(command, cwd):
+    return subprocess.run(command, cwd=cwd, text=True, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, check=False)
+
+
+def workspace_fingerprint(root):
+    root = Path(root).resolve()
+    files = sorted(
+        path for path in root.rglob("*")
+        if path.is_file()
+        and ".git" not in path.parts
+        and "target" not in path.parts
+        and (path.name in {"Cargo.toml", "Cargo.lock"} or path.suffix == ".rs")
+    )
+    content = "".join(f"{path.relative_to(root)}\0{path.read_text()}\0" for path in files)
+    return digest(content)
+
+
+def runner_fingerprint(cwd, runner):
+    result = run(["cargo", "nextest", "--version"] if runner == "nextest" else ["cargo", "--version"], cwd)
+    if result.returncode:
+        fail(f"could not fingerprint {runner} runner: {result.stderr.strip()}")
+    return digest(f"{runner}\0{result.stdout.strip()}")
+
+
+def cargo_inventory(workspace_root, packages):
+    tests = []
+    command = ["cargo", "test", "--workspace", "--no-run", "--message-format=json"]
+    result = run(command, workspace_root)
+    if result.returncode:
+        fail(f"could not enumerate test executables: {result.stderr.strip()}")
+    for line in result.stdout.splitlines():
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("reason") != "compiler-artifact" or not message.get("executable"):
+            continue
+        target = message.get("target", {})
+        kinds = target.get("kind", [])
+        if not set(kinds).intersection({"lib", "bin", "test", "bench", "example"}):
+            continue
+        listed = run([message["executable"], "--list"], workspace_root)
+        if listed.returncode:
+            fail(f"could not list tests for {target.get('name', 'unknown target')}: {listed.stderr.strip()}")
+        package = packages.get(message.get("package_id"))
+        if not package:
+            fail("cargo emitted a test executable without a resolvable package")
+        target_kind = next(kind for kind in kinds if kind in {"lib", "bin", "test", "bench", "example"})
+        for test_line in listed.stdout.splitlines():
+            name, separator, _kind = test_line.partition(": ")
+            if separator and name:
+                tests.append({"id": f"{package}::{target_kind}::{target['name']}::{name}", "package": package, "target": target["name"], "target_kind": target_kind, "name": name})
+    return tests
+
+
+def nextest_inventory(workspace_root):
+    result = run(["cargo", "nextest", "list", "--workspace", "--message-format", "json"], workspace_root)
+    if result.returncode:
+        fail(f"could not enumerate nextest tests: {result.stderr.strip()}")
+    try:
+        listed = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        fail(f"nextest emitted invalid test list JSON: {error}")
+    tests = []
+    for suite in listed.get("rust-suites", {}).values():
+        package = suite.get("package-name")
+        target = suite.get("binary-name")
+        target_kind = suite.get("kind")
+        if not all(isinstance(value, str) and value for value in (package, target, target_kind)):
+            fail("nextest emitted a suite without package, binary, or kind identity")
+        for name, testcase in suite.get("testcases", {}).items():
+            if not isinstance(name, str) or not isinstance(testcase, dict):
+                fail("nextest emitted an invalid testcase identity")
+            if testcase.get("filter-match", {}).get("status") != "matches":
+                continue
+            tests.append({"id": f"{package}::{target_kind}::{target}::{name}", "package": package, "target": target, "target_kind": target_kind, "name": name})
+    return tests
+
+
+def inventory(project, runner):
+    metadata_result = run(["cargo", "metadata", "--no-deps", "--format-version=1"], project)
+    if metadata_result.returncode:
+        fail(f"cargo metadata failed: {metadata_result.stderr.strip()}")
+    metadata = json.loads(metadata_result.stdout)
+    workspace_root = Path(metadata["workspace_root"]).resolve()
+    packages = {package["id"]: package["name"] for package in metadata["packages"]}
+    tests = nextest_inventory(workspace_root) if runner == "nextest" else cargo_inventory(workspace_root, packages)
+    # cargo-nextest does not execute doctests, so its inventory contains only
+    # targets that its exact replay command can run.
+    if runner == "cargo":
+        # Doctests do not produce compiler-artifact executables. Cargo's stable
+        # list output still identifies the package in its Doc-tests heading.
+        docs = run(["cargo", "test", "--workspace", "--doc", "--", "--list"], workspace_root)
+        if docs.returncode:
+            fail(f"could not list doctests: {docs.stderr.strip()}")
+        doc_package = None
+        package_names = set(packages.values())
+        for line in docs.stdout.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("Doc-tests "):
+                candidate = stripped.removeprefix("Doc-tests ").strip()
+                doc_package = candidate if candidate in package_names else None
+                continue
+            name, separator, _kind = stripped.partition(": ")
+            if not separator or not name or not doc_package:
+                continue
+            tests.append({
+                "id": f"{doc_package}::doc::doc::{name}",
+                "package": doc_package,
+                "target": "doc",
+                "target_kind": "doc",
+                "name": name,
+            })
+    tests.sort(key=lambda item: item["id"])
+    if len({item["id"] for item in tests}) != len(tests):
+        fail("cargo produced duplicate fully qualified test identities")
+    record = {
+        "schema": SCHEMA,
+        "runner": runner,
+        "runner_fingerprint": runner_fingerprint(workspace_root, runner),
+        "workspace_fingerprint": workspace_fingerprint(workspace_root),
+        "tests": tests,
+    }
+    record["inventory_fingerprint"] = digest(json.dumps(record, sort_keys=True, separators=(",", ":")))
+    return record
+
+
+def validate(manifest_path, current):
+    try:
+        manifest = json.loads(Path(manifest_path).read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"invalid shard manifest: {error}")
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        fail("unsupported shard manifest schema")
+    if manifest.get("runner") != current.get("runner"):
+        fail("shard manifest runner does not match the selected runner")
+    for key in ("inventory_fingerprint", "runner_fingerprint", "workspace_fingerprint"):
+        if manifest.get(key) != current.get(key):
+            fail(f"stale shard manifest: {key} does not match the current inventory")
+    selected = manifest.get("tests")
+    if not isinstance(selected, list) or not selected:
+        fail("shard manifest must contain a non-empty tests array")
+    if any(not isinstance(identity, str) for identity in selected):
+        fail("shard manifest tests must be strings")
+    if len(set(selected)) != len(selected):
+        fail("shard manifest contains duplicate test identities")
+    known = {test["id"]: test for test in current["tests"]}
+    missing = [identity for identity in selected if identity not in known]
+    if missing:
+        fail(f"shard manifest contains unresolvable test identity: {missing[0]}")
+    return [known[identity] for identity in selected]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--runner", choices=("cargo", "nextest"), required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--manifest")
+    args = parser.parse_args()
+    current = inventory(args.project, args.runner)
+    output = current
+    if args.manifest:
+        output = {"inventory": current, "selected": validate(args.manifest, current)}
+    Path(args.output).write_text(json.dumps(output, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORK_DIR="$(mktemp -d -t homeboy-rust-shards.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+PROJECT_DIR="$WORK_DIR/project"
+BIN_DIR="$WORK_DIR/bin"
+mkdir -p "$PROJECT_DIR/src" "$BIN_DIR" "$WORK_DIR/annotations"
+printf '[package]\nname = "shard-smoke"\nversion = "0.1.0"\nedition = "2021"\n' > "$PROJECT_DIR/Cargo.toml"
+printf 'pub fn fixture() {}\n' > "$PROJECT_DIR/src/lib.rs"
+
+cat > "$BIN_DIR/test-lib" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'unit::alpha: test' 'unit::beta: test' 'unit::ignored: test'
+EOF
+cat > "$BIN_DIR/test-api" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'api::works: test'
+EOF
+chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api"
+
+cat > "$BIN_DIR/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = '--version' ]; then printf 'cargo 1.80.0\n'; exit 0; fi
+if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = '--version' ]; then printf 'cargo-nextest 0.9.0\n'; exit 0; fi
+if [ "${1:-}" = 'metadata' ]; then
+  printf '{"packages":[{"id":"shard-smoke 0.1.0 (path+file:///fixture)","name":"shard-smoke"}],"workspace_root":"%s"}\n' "$PWD"
+  exit 0
+fi
+if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'list' ]; then
+  printf '%s\n' '{"rust-suites":{"shard-smoke":{"package-name":"shard-smoke","binary-name":"shard_smoke","kind":"lib","testcases":{"unit::alpha":{"ignored":false,"filter-match":{"status":"matches"}},"unit::beta":{"ignored":false,"filter-match":{"status":"matches"}},"unit::ignored":{"ignored":true,"filter-match":{"status":"matches"}},"profile::excluded":{"ignored":false,"filter-match":{"status":"mismatch"}}}},"shard-smoke::api":{"package-name":"shard-smoke","binary-name":"api","kind":"test","testcases":{"api::works":{"ignored":false,"filter-match":{"status":"matches"}}}}}}'
+  exit 0
+fi
+if [[ " $* " == *' --workspace '* && " $* " == *' --no-run '* ]]; then
+  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"shard_smoke","kind":["lib"]},"executable":"%s/test-lib"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"api","kind":["test"]},"executable":"%s/test-api"}\n' "$(dirname "$0")"
+  exit 0
+fi
+if [[ " $* " == *' --doc '* && " $* " == *' --list '* ]]; then
+  exit 0
+fi
+if [ -n "${HOMEBOY_FAKE_CARGO_LOG:-}" ]; then printf '%s\n' "$*" >> "${HOMEBOY_FAKE_CARGO_LOG}"; fi
+if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'run' ]; then
+  case "${HOMEBOY_NEXTEST_MODE:-pass}" in
+    zero) exit 0 ;;
+    failure) printf '%s\n' '{"type":"test","name":"shard-smoke::shard_smoke$unit::alpha","event":"ok"}' '{"type":"test","name":"shard-smoke::shard_smoke$unit::beta","event":"failed"}' '{"type":"test","name":"shard-smoke::shard_smoke$unit::ignored","event":"ignored"}' '{"type":"test","name":"shard-smoke::api$api::works","event":"ok"}'; exit 1 ;;
+    *) printf '%s\n' '{"type":"test","name":"shard-smoke::shard_smoke$unit::alpha","event":"ok"}' '{"type":"test","name":"shard-smoke::shard_smoke$unit::beta","event":"ok"}' '{"type":"test","name":"shard-smoke::shard_smoke$unit::ignored","event":"ignored"}' '{"type":"test","name":"shard-smoke::api$api::works","event":"ok"}'; exit 0 ;;
+  esac
+fi
+if [ -n "${HOMEBOY_FAIL_TEST:-}" ] && [[ " $* " == *" ${HOMEBOY_FAIL_TEST} "* ]]; then
+  printf 'test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out\n'
+  exit 1
+fi
+if [[ " $* " == *' unit::ignored '* ]]; then
+  printf 'test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out\n'
+  exit 0
+fi
+printf 'test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n'
+EOF
+chmod +x "$BIN_DIR/cargo"
+
+cat > "$WORK_DIR/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+  PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+  EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+  [ -z "${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}" ] || source "$HOMEBOY_RUNTIME_SIDECAR_WRITER"
+}
+should_run_step() { return 0; }
+EOF
+cat > "$WORK_DIR/command-capture.sh" <<'EOF'
+homeboy_run_step_capture() { local output_var="$1" exit_var="$2"; shift 3; [ "$1" = -- ] && shift; local output status=0; output="$(mktemp)"; "$@" >"$output" 2>&1 || status=$?; printf -v "$output_var" '%s' "$output"; printf -v "$exit_var" '%s' "$status"; return "$status"; }
+homeboy_cleanup_step_capture() { rm -f "$1"; }
+EOF
+cat > "$WORK_DIR/write-test-results.sh" <<'EOF'
+homeboy_write_test_results() {
+  python3 - "$HOMEBOY_TEST_RESULTS_FILE" "$@" <<'PY'
+import json
+import sys
+path, total, passed, failed, skipped, partial = sys.argv[1:]
+with open(path, "w") as handle:
+    json.dump({"total": int(total), "passed": int(passed), "failed": int(failed), "skipped": int(skipped), "partial": partial}, handle)
+PY
+}
+EOF
+cat > "$WORK_DIR/sidecar-writer.sh" <<'EOF'
+homeboy_merge_annotations() { cp "$2" "${HOMEBOY_ANNOTATIONS_DIR}/$1.json"; }
+EOF
+
+INVENTORY_A="$WORK_DIR/inventory-a.json"
+INVENTORY_B="$WORK_DIR/inventory-b.json"
+INVENTORY_NEXTEST="$WORK_DIR/inventory-nextest.json"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_TEST_INVENTORY_ONLY=1 \
+HOMEBOY_TEST_INVENTORY_FILE="$INVENTORY_A" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/inventory-a.out"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_TEST_INVENTORY_ONLY=1 \
+HOMEBOY_TEST_INVENTORY_FILE="$INVENTORY_B" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/inventory-b.out"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_TEST_INVENTORY_ONLY=1 \
+HOMEBOY_TEST_INVENTORY_FILE="$INVENTORY_NEXTEST" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/inventory-nextest.out"
+
+python3 - "$INVENTORY_A" "$INVENTORY_B" "$INVENTORY_NEXTEST" "$WORK_DIR/manifest.json" "$WORK_DIR/nextest-manifest.json" <<'PY'
+import json
+import sys
+
+first = json.load(open(sys.argv[1]))
+second = json.load(open(sys.argv[2]))
+nextest = json.load(open(sys.argv[3]))
+assert first == second, "inventory must be deterministic"
+assert set(first) == {"schema", "runner", "runner_fingerprint", "workspace_fingerprint", "inventory_fingerprint", "tests"}, first
+assert first["schema"] == "homeboy/test-inventory/v1", first
+assert nextest["schema"] == "homeboy/test-inventory/v1", nextest
+assert all(set(test) == {"id", "package", "target", "target_kind", "name"} for test in first["tests"]), first
+assert [test["id"] for test in first["tests"]] == [
+    "shard-smoke::lib::shard_smoke::unit::alpha",
+    "shard-smoke::lib::shard_smoke::unit::beta",
+    "shard-smoke::lib::shard_smoke::unit::ignored",
+    "shard-smoke::test::api::api::works",
+], first
+assert nextest["runner"] == "nextest", nextest
+assert nextest["runner_fingerprint"] != first["runner_fingerprint"], nextest
+assert all("profile::excluded" not in test["id"] for test in nextest["tests"]), nextest
+manifest = {
+    "schema": "homeboy/test-shard-manifest/v1",
+    "runner": first["runner"],
+    "inventory_fingerprint": first["inventory_fingerprint"],
+    "runner_fingerprint": first["runner_fingerprint"],
+    "workspace_fingerprint": first["workspace_fingerprint"],
+    "tests": [test["id"] for test in first["tests"]],
+}
+assert set(manifest) == {"schema", "runner", "inventory_fingerprint", "runner_fingerprint", "workspace_fingerprint", "tests"}, manifest
+assert all(isinstance(test_id, str) for test_id in manifest["tests"]), manifest
+json.dump(manifest, open(sys.argv[4], "w"))
+nextest_manifest = dict(manifest, runner=nextest["runner"], inventory_fingerprint=nextest["inventory_fingerprint"], runner_fingerprint=nextest["runner_fingerprint"], workspace_fingerprint=nextest["workspace_fingerprint"], tests=[test["id"] for test in nextest["tests"]])
+json.dump(nextest_manifest, open(sys.argv[5], "w"))
+PY
+
+if grep -q 'Running pre-test lint checks' "$WORK_DIR/inventory-a.out" || ! grep -q 'Skipping lint (test inventory only)' "$WORK_DIR/inventory-a.out"; then
+  printf 'Expected inventory-only run to bypass pre-test lint\n' >&2
+  exit 1
+fi
+
+# The runner's sharded branch deliberately uses one exact Cargo invocation per
+# identity, even when Cargo's own default test parallelism is configured.
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/manifest.json" \
+HOMEBOY_FAKE_CARGO_LOG="$WORK_DIR/cargo.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/test-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/runner.out"
+
+python3 - "$WORK_DIR/cargo.log" <<'PY'
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+assert len(lines) == 4, lines
+assert all(" --exact --test-threads=1" in line for line in lines), lines
+assert sum("unit::alpha" in line for line in lines) == 1, lines
+assert sum("unit::beta" in line for line in lines) == 1, lines
+assert sum("unit::ignored" in line for line in lines) == 1, lines
+assert sum("api::works" in line for line in lines) == 1, lines
+PY
+
+python3 - "$WORK_DIR/test-results.json" "$WORK_DIR/annotations/rust-test-shard.json" <<'PY'
+import json
+import sys
+
+results = json.load(open(sys.argv[1]))
+assert results == {"total": 4, "passed": 3, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
+record = json.load(open(sys.argv[2]))[0]
+assert (record["executed"], record["passed"], record["failed"], record["skipped"]) == (4, 3, 0, 1), record
+assert record["duration_ms"] >= 0, record
+PY
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_CARGO_LOG="$WORK_DIR/cargo.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/nextest-test-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/nextest-runner.out"
+
+python3 - "$WORK_DIR/cargo.log" <<'PY'
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+nextest = lines[4:]
+assert len(nextest) == 1, lines
+assert "nextest run" in nextest[0] and " --test-threads 1 " in nextest[0], nextest
+assert "test(=unit::alpha)" in nextest[0] and "test(=unit::beta)" in nextest[0] and "test(=api::works)" in nextest[0], nextest
+PY
+
+python3 - "$WORK_DIR/nextest-test-results.json" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1])) == {"total": 4, "passed": 3, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_MODE=zero \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/nextest-zero.out" 2>&1
+ZERO_EXIT=$?
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/manifest.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" -- unsupported > "$WORK_DIR/passthrough.out" 2>&1
+PASSTHROUGH_EXIT=$?
+set -e
+if [ "$ZERO_EXIT" -eq 0 ] || ! grep -q 'nextest executed membership does not match the shard manifest' "$WORK_DIR/nextest-zero.out"; then
+  printf 'Expected nextest zero-selection shard replay to fail closed\n' >&2
+  exit 1
+fi
+if [ "$PASSTHROUGH_EXIT" -eq 0 ] || ! grep -q 'do not support passthrough arguments' "$WORK_DIR/passthrough.out"; then
+  printf 'Expected shard replay passthrough rejection\n' >&2
+  exit 1
+fi
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/manifest.json" \
+HOMEBOY_FAIL_TEST='unit::beta' \
+HOMEBOY_FAKE_CARGO_LOG="$WORK_DIR/failing-cargo.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/failing-test-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/failing-runner.out" 2>&1
+FAIL_EXIT=$?
+set -e
+if [ "$FAIL_EXIT" -eq 0 ]; then
+  printf 'Expected shard replay to fail at unit::beta\n' >&2
+  exit 1
+fi
+
+python3 - "$WORK_DIR/failing-test-results.json" "$WORK_DIR/annotations/rust-test-shard.json" <<'PY'
+import json
+import sys
+
+results = json.load(open(sys.argv[1]))
+assert results == {"total": 4, "passed": 2, "failed": 1, "skipped": 1, "partial": "rust-shard"}, results
+record = json.load(open(sys.argv[2]))[0]
+assert record["status"] == "failed", record
+assert (record["total"], record["executed"], record["passed"], record["failed"], record["skipped"]) == (4, 4, 2, 1, 1), record
+assert record["duration_ms"] >= 0, record
+PY
+
+for invalid in duplicate stale missing runner; do
+  python3 - "$WORK_DIR/manifest.json" "$WORK_DIR/$invalid.json" "$invalid" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1]))
+if sys.argv[3] == "duplicate": manifest["tests"].append(manifest["tests"][0])
+if sys.argv[3] == "stale": manifest["workspace_fingerprint"] = "stale"
+if sys.argv[3] == "missing": manifest["tests"].append("shard-smoke::missing::nope")
+if sys.argv[3] == "runner": manifest["runner"] = "nextest"
+json.dump(manifest, open(sys.argv[2], "w"))
+PY
+  if PATH="$BIN_DIR:$PATH" python3 "$EXTENSION_DIR/scripts/test-shard-inventory.py" --project "$PROJECT_DIR" --runner cargo --output "$WORK_DIR/invalid.out" --manifest "$WORK_DIR/$invalid.json" >/dev/null 2>&1; then
+    printf 'Expected %s manifest rejection\n' "$invalid" >&2
+    exit 1
+  fi
+done
+
+printf 'pub fn changed_fixture() {}\n' >> "$PROJECT_DIR/src/lib.rs"
+if PATH="$BIN_DIR:$PATH" python3 "$EXTENSION_DIR/scripts/test-shard-inventory.py" --project "$PROJECT_DIR" --runner cargo --output "$WORK_DIR/stale-workspace.out" --manifest "$WORK_DIR/manifest.json" >/dev/null 2>&1; then
+  printf 'Expected workspace change to reject the stale manifest\n' >&2
+  exit 1
+fi
+
+printf 'rust test shard inventory smoke ok\n'


### PR DESCRIPTION
## Summary
- emit canonical provenance-bound Rust test inventories through the generic Homeboy test inventory contract
- replay exact Cargo or nextest shard manifests serially and fail closed on stale, duplicate, missing, or zero-selection identities
- publish truthful passed, failed, and skipped counts for complete shard aggregation

Closes #2528.
Supports https://github.com/Extra-Chill/homeboy/issues/11399.

## Verification
- `bash rust/tests/test-shard-inventory-smoke.sh`
- `bash rust/tests/workspace-member-test-scope-smoke.sh`
- `bash rust/tests/zero-test-scope-fallback-smoke.sh`
- `bash rust/tests/env-provider-smoke.sh`
- Rust result/failure parser and fingerprint policy-flow smoke tests
- shell/Python syntax checks and `git diff --check`

The shard smoke covers deterministic inventory, Cargo and nextest exact replay, ignored tests, failed tests, zero selection, unsupported passthrough arguments, and stale/invalid manifests.

## AI assistance
OpenAI gpt-5.6-sol and gpt-5.6-terra via OpenCode and Homeboy Cook implemented, reviewed, and verified the inventory/replay contract. Chris Huber reviewed and remains responsible for every line.