### PR TITLE
fix(rust): structure toolchain readiness probes

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -16,6 +16,7 @@
       "node tests/runtime-workflow-input-renderer-smoke.mjs",
       "bash tests/rust-release-prepare-smoke.sh",
       "node tests/secret-env-plan-smoke.mjs",
+      "node tests/extension-shape-lint-toolchain-probes.test.mjs",
       "bash tests/settings-helper-smoke.sh",
       "bash tests/wordpress-install-command-smoke.sh",
       "bash tests/wordpress-release-artifact-version-smoke.sh",

--- a/rust/docs/dev-loop.md
+++ b/rust/docs/dev-loop.md
@@ -4,6 +4,15 @@ The Rust extension owns Rust/Cargo toolchain acceleration. Homeboy core should
 only receive generic command environment and benchmark metadata; it should not
 grow Rust, Cargo, sccache, linker, or nextest behavior.
 
+## Portable Toolchain Readiness
+
+Before a portable lint operation, the extension declares separate structured
+probes for `cargo --version` and `cargo fmt --version`. Each probe uses a
+`program` plus literal `args` array, so the runner invokes Cargo directly
+rather than interpreting a compound shell command. The extension shape check
+rejects legacy `command` probe fields; repair guidance remains diagnostic
+metadata for the operator.
+
 ## Shared Cargo Target Directory
 
 The Rust env provider sets a stable `CARGO_TARGET_DIR` per component identity:

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.32.1",
+  "version": "1.32.0",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
@@ -72,7 +72,16 @@
     {
       "id": "cargo-lint-toolchain",
       "capabilities": ["lint"],
-      "command": "cargo --version && cargo fmt --version",
+      "program": "cargo",
+      "args": ["--version"],
+      "repair_command": "rustup default stable",
+      "diagnostic_env": ["PATH", "CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"]
+    },
+    {
+      "id": "cargo-fmt-lint-toolchain",
+      "capabilities": ["lint"],
+      "program": "cargo",
+      "args": ["fmt", "--version"],
       "repair_command": "rustup default stable",
       "diagnostic_env": ["PATH", "CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"]
     }

--- a/tests/extension-shape-lint-toolchain-probes.test.mjs
+++ b/tests/extension-shape-lint-toolchain-probes.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const rootDir = resolve(new URL('..', import.meta.url).pathname);
+const fixtureDir = mkdtempSync(resolve(tmpdir(), 'homeboy-extension-probe-'));
+const sideEffect = resolve(fixtureDir, 'legacy-command-executed');
+
+try {
+  cpSync(rootDir, fixtureDir, { recursive: true, filter: (source) => !source.includes('/.git') });
+  const manifestPath = resolve(fixtureDir, 'rust/rust.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.toolchain_readiness[0] = {
+    id: 'legacy-shell-command',
+    capabilities: ['lint'],
+    command: `cargo --version; touch ${sideEffect}`,
+  };
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  const result = spawnSync(process.execPath, [resolve(rootDir, 'tests/extension-shape-lint.mjs')], {
+    encoding: 'utf8',
+    env: { ...process.env, HOMEBOY_EXTENSION_ROOT: fixtureDir },
+  });
+
+  assert.notEqual(result.status, 0, 'legacy command probe must fail validation');
+  assert.match(result.stderr, /toolchain_readiness\.0\.command is unsupported/);
+  assert.equal(existsSync(sideEffect), false, 'probe text must never execute during validation');
+} finally {
+  rmSync(fixtureDir, { recursive: true, force: true });
+}
+
+console.log('Structured toolchain probe validation rejects legacy shell commands without execution.');

--- a/tests/extension-shape-lint.mjs
+++ b/tests/extension-shape-lint.mjs
@@ -2,7 +2,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const rootDir = process.env.HOMEBOY_EXTENSION_ROOT
+  ? path.resolve(process.env.HOMEBOY_EXTENSION_ROOT)
+  : path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
 const extensionIds = new Set([
   'cloudflare-workers',
@@ -159,11 +161,67 @@ function validateComposition(extensionId, composition) {
   }
 }
 
+function validateToolchainReadiness(extensionId, probes) {
+  if (probes === undefined) {
+    return;
+  }
+
+  if (!Array.isArray(probes)) {
+    fail(`${extensionId}: toolchain_readiness must be an array`);
+    return;
+  }
+
+  const ids = new Set();
+  for (const [index, probe] of probes.entries()) {
+    const source = `${extensionId}: toolchain_readiness.${index}`;
+    if (!probe || typeof probe !== 'object' || Array.isArray(probe)) {
+      fail(`${source} must be an object`);
+      continue;
+    }
+    const allowed = new Set(['id', 'capabilities', 'program', 'args', 'repair_command', 'diagnostic_env']);
+    for (const key of Object.keys(probe)) {
+      if (!allowed.has(key)) {
+        fail(`${source}.${key} is unsupported; readiness probes use program and args, not shell command strings`);
+      }
+    }
+    if (typeof probe.id !== 'string' || probe.id.length === 0) {
+      fail(`${source}.id must be a non-empty string`);
+    } else if (ids.has(probe.id)) {
+      fail(`${source}.id must be unique`);
+    } else {
+      ids.add(probe.id);
+    }
+    if (typeof probe.program !== 'string' || probe.program.length === 0) {
+      fail(`${source}.program must be a non-empty executable name or path`);
+    }
+    if (probe.args !== undefined && !isStringArray(probe.args)) {
+      fail(`${source}.args must be an array of non-empty literal arguments`);
+    }
+    if (probe.capabilities !== undefined && (!isStringArray(probe.capabilities) || hasDuplicates(probe.capabilities))) {
+      fail(`${source}.capabilities must be unique non-empty strings`);
+    }
+    if (probe.repair_command !== undefined && (typeof probe.repair_command !== 'string' || probe.repair_command.length === 0)) {
+      fail(`${source}.repair_command must be a non-empty diagnostic string`);
+    }
+    if (probe.diagnostic_env !== undefined && (!isStringArray(probe.diagnostic_env) || probe.diagnostic_env.some((name) => !/^[A-Z_][A-Z0-9_]*$/.test(name)))) {
+      fail(`${source}.diagnostic_env must contain environment variable names`);
+    }
+  }
+}
+
 function validateRustToolchainReadiness(manifest) {
   const expected = [{
     id: 'cargo-lint-toolchain',
     capabilities: ['lint'],
-    command: 'cargo --version && cargo fmt --version',
+    program: 'cargo',
+    args: ['--version'],
+    repair_command: 'rustup default stable',
+    diagnostic_env: ['PATH', 'CARGO_HOME', 'RUSTUP_HOME', 'RUSTUP_TOOLCHAIN'],
+  }, {
+    id: 'cargo-fmt-lint-toolchain',
+    capabilities: ['lint'],
+    program: 'cargo',
+    args: ['fmt', '--version'],
     repair_command: 'rustup default stable',
     diagnostic_env: ['PATH', 'CARGO_HOME', 'RUSTUP_HOME', 'RUSTUP_TOOLCHAIN'],
   }];
@@ -213,6 +271,8 @@ function validateExtension(extensionId) {
   if (Object.hasOwn(standardDiscoveryMarkers, extensionId)) {
     validateComposition(extensionId, manifest.composition);
   }
+
+  validateToolchainReadiness(extensionId, manifest.toolchain_readiness);
 
   if (extensionId === 'rust') {
     validateRustToolchainReadiness(manifest);


### PR DESCRIPTION
## Summary

Migrates Rust portable-lint readiness from the legacy compound shell command to two extension-owned structured probes: `cargo --version` and `cargo fmt --version`.

The repository-wide extension shape validation now accepts only `program` plus literal `args` readiness probes, rejects legacy `command` fields and unknown probe fields, and audits every shipped extension manifest. The focused regression injects `cargo --version; touch <temp-file>` into an isolated manifest copy, verifies rejection, and proves validation never executes the text.

## Compatibility

- Rust manifest version remains `1.32.0`; extension version and release mutation remain Homeboy release-owned.
- Legacy toolchain `command` fields fail closed. The migration requires Homeboy #11473 structured `program` and `args` support, while preserving the extension-owned probe IDs, lint capability, repair guidance, and diagnostic environment metadata.
- Cargo and Cargo fmt are now independently reported, so a missing formatter is explicit without interpreting a compound shell command.

References Extra-Chill/homeboy#11429, Extra-Chill/homeboy#11350, and Extra-Chill/homeboy#11473.

## Verification

Passed after the compatibility correction:

- `node tests/extension-shape-lint.mjs`
- `node tests/extension-shape-lint-toolchain-probes.test.mjs`
- `bash rust/tests/env-provider-smoke.sh`
- `bash rust/tests/fingerprint-policy-flow-smoke.sh`
- JSON parsing for every tracked `*.json` manifest
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the Homeboy contract and architecture issue, migrated the extension manifests and validation, added the fail-closed regression, removed the release-owned version mutation, and ran the listed verification. Chris Huber remains responsible for every line.