### PR TITLE
fix: harvest declared CLI artifacts

### DIFF
--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -85,6 +85,7 @@ try {
 	assert.equal(fs.existsSync(scriptPath), true, `provider command target should exist: ${scriptPath}`);
 
 	const mockCliPath = path.join(root, 'mock-codex.cjs');
+	const declaredArtifactCliPath = path.join(root, 'mock-codex-declared-artifacts.cjs');
 	const omittedModelCliPath = path.join(root, 'mock-codex-without-model.cjs');
 	fs.writeFileSync(omittedModelCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
@@ -100,6 +101,13 @@ assert.equal(process.argv.at(-1), 'Prove the Codex runtime boundary without leak
 assert.equal(process.env.UNDECLARED_SECRET, undefined);
 process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
 process.stderr.write(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN || 'missing secret');
+process.exit(0);
+`);
+	fs.writeFileSync(declaredArtifactCliPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.mkdirSync('screenshots', { recursive: true });
+fs.writeFileSync('report.md', '# Captured report\\n');
+fs.writeFileSync('screenshots/image.bin', Buffer.from([0, 255, 1]));
 process.exit(0);
 `);
 
@@ -138,6 +146,51 @@ process.exit(0);
 		instructions: 'Run without selecting a model.',
 	});
 	assert.equal(omittedModelResult.status, 'succeeded', JSON.stringify(omittedModelResult.diagnostics));
+	const declaredWorkspace = path.join(root, 'declared-workspace');
+	fs.mkdirSync(declaredWorkspace);
+	const declaredResult = executeCodexAgentTask({
+		...request,
+		task_id: 'codex-declared-artifacts',
+		executor: {
+			...request.executor,
+			config: {
+				provider: 'codex',
+				command: process.execPath,
+				command_args: [declaredArtifactCliPath, 'exec'],
+				cwd: declaredWorkspace,
+				artifacts_path: path.join(root, 'declared-artifacts'),
+			},
+		},
+		artifact_declarations: [
+			{ name: 'report', path: 'report.md', kind: 'markdown', required: true },
+			{ name: 'screenshots', path: 'screenshots', kind: 'screenshot-directory', required: true },
+		],
+	});
+	assert.equal(declaredResult.status, 'succeeded', JSON.stringify(declaredResult.diagnostics));
+	const declaredReport = declaredResult.artifacts.find((artifact) => artifact.name === 'report');
+	const declaredScreenshots = declaredResult.artifacts.find((artifact) => artifact.name === 'screenshots');
+	assert.equal(fs.readFileSync(declaredReport.path, 'utf8'), '# Captured report\n');
+	assert.deepEqual(fs.readFileSync(path.join(declaredScreenshots.path, 'image.bin')), Buffer.from([0, 255, 1]));
+	assert.equal(declaredScreenshots.file_count, 1);
+	const missingDeclaredResult = executeCodexAgentTask({
+		...request,
+		task_id: 'codex-missing-declared-artifact',
+		executor: {
+			...request.executor,
+			config: {
+				provider: 'codex',
+				command: process.execPath,
+				command_args: [omittedModelCliPath, 'exec'],
+				cwd: declaredWorkspace,
+				artifacts_path: path.join(root, 'missing-declared-artifacts'),
+			},
+		},
+		instructions: 'Run without selecting a model.',
+		artifact_declarations: [{ name: 'required-report', path: 'missing.md', required: true }],
+	});
+	assert.equal(missingDeclaredResult.status, 'failed');
+	assert.equal(missingDeclaredResult.failure_code, 'agent_task.declared_artifact_harvest_failed');
+	assert.equal(missingDeclaredResult.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.required_declared_artifact_missing'), true);
 	const runResult = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
 		env: {

--- a/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
+++ b/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { harvestDeclaredArtifacts } = require('../../lib/declared-artifact-harvester');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-declared-artifacts-'));
+const workspace = path.join(root, 'workspace');
+const artifacts = path.join(root, 'scheduler-artifacts');
+fs.mkdirSync(path.join(workspace, 'screenshots'), { recursive: true });
+fs.writeFileSync(path.join(workspace, 'report.md'), '# Report\n');
+const binary = Buffer.from([0, 255, 1, 254, 2]);
+fs.writeFileSync(path.join(workspace, 'screenshots', 'image.bin'), binary);
+fs.writeFileSync(path.join(workspace, 'screenshots', 'caption.txt'), 'Screenshot caption\n');
+
+try {
+	const result = harvestDeclaredArtifacts({
+		request: {
+			task_id: 'declared-artifacts',
+			artifact_declarations: [
+				{ name: 'report', path: 'report.md', kind: 'markdown', artifact_type: 'report', artifact_schema: 'example/report/v1', required: true, metadata: { source: 'agent' } },
+				{ name: 'screenshots', path: 'screenshots', kind: 'screenshot-directory', required: true },
+				{ name: 'optional-video', path: 'video.webm', required: false },
+			],
+		},
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.deepEqual(result.errors, []);
+	assert.deepEqual(result.missing.required, []);
+	assert.deepEqual(result.missing.optional, [{ name: 'optional-video', path: 'video.webm', required: false }]);
+	assert.equal(result.artifacts.length, 2);
+	const report = result.artifacts.find((artifact) => artifact.name === 'report');
+	const screenshots = result.artifacts.find((artifact) => artifact.name === 'screenshots');
+	assert.equal(report.artifact_schema, 'example/report/v1');
+	assert.equal(report.artifact_type, 'report');
+	assert.equal(report.required, true);
+	assert.equal(report.sha256, crypto.createHash('sha256').update('# Report\n').digest('hex'));
+	assert.deepEqual(report.metadata, { source: 'agent' });
+	assert.equal(fs.readFileSync(report.path, 'utf8'), '# Report\n');
+	assert.equal(screenshots.file_count, 2);
+	assert.deepEqual(fs.readFileSync(path.join(screenshots.path, 'image.bin')), binary);
+	assert.equal(screenshots.sha256, '831c9f2aacaee843fd4a84b4ae13732902470e83baed13fc52fb08c901cbde6f');
+
+	const rejected = harvestDeclaredArtifacts({
+		request: { artifact_declarations: [{ name: 'escape', path: '../outside.txt', required: true }] },
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.equal(rejected.errors[0].code, 'unsafe_path');
+	assert.equal(rejected.artifacts.length, 0);
+
+	fs.writeFileSync(path.join(root, 'outside.txt'), 'outside workspace\n');
+	fs.symlinkSync(path.join(root, 'outside.txt'), path.join(workspace, 'escaped-link'));
+	const symlink = harvestDeclaredArtifacts({
+		request: { artifact_declarations: [{ name: 'link', path: 'escaped-link', required: true }] },
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.equal(symlink.errors[0].code, 'capture_failed');
+} finally {
+	fs.rmSync(root, { recursive: true, force: true });
+}
+
+process.stdout.write('Declared artifact harvester passed\n');

--- a/agent-runtimes/lib/cli-agent-task-executor.js
+++ b/agent-runtimes/lib/cli-agent-task-executor.js
@@ -16,6 +16,7 @@ const {
 const {
 	normalizeAgentTaskOutcome,
 } = require('../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
+const { harvestDeclaredArtifacts } = require('./declared-artifact-harvester');
 
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
 const DEFAULT_PROCESS_ENV_ALLOWLIST = [
@@ -233,22 +234,24 @@ function createCliAgentTaskExecutor(spec) {
 		});
 
 		const processEvidence = collectArtifacts ? processArtifacts(request, config, spawnResult) : {};
+		const declaredEvidence = harvestDeclaredArtifacts({ request, config, cwd, artifactDir: artifactDirectory(request, config) });
+		const evidence = mergeEvidence(processEvidence, declaredEvidence);
 		const context = { request, config, commandSpec, cwd, spawnResult, spawnExtra };
 
 		if (spawnResult.error?.code === 'ENOENT') {
-			return outcome(request, buildNotFound(context));
+			return outcome(request, applyDeclaredArtifactResult({ ...buildNotFound(context), ...evidence }, declaredEvidence));
 		}
 
 		if (spawnResult.error) {
 			const timedOut = spawnResult.error.code === 'ETIMEDOUT';
-			return outcome(request, buildSpawnError(context, timedOut));
+			return outcome(request, applyDeclaredArtifactResult({ ...buildSpawnError(context, timedOut), ...evidence }, declaredEvidence));
 		}
 
 		if (spawnResult.status === 0) {
-			return outcome(request, { ...buildSuccess(context), ...processEvidence });
+			return outcome(request, applyDeclaredArtifactResult({ ...buildSuccess(context), ...evidence }, declaredEvidence));
 		}
 
-		return outcome(request, { ...buildFailure(context), ...processEvidence });
+		return outcome(request, applyDeclaredArtifactResult({ ...buildFailure(context), ...evidence }, declaredEvidence));
 	}
 
 	return { execute, outcome, validationFailure };
@@ -263,6 +266,40 @@ function timeoutSecondsFromLimits(limits = {}, fallbackSeconds = 0) {
 
 function resolveCwd(request = {}, config = {}) {
 	return config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
+}
+
+function artifactDirectory(request = {}, config = {}) {
+	return config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
+}
+
+function mergeEvidence(primary = {}, secondary = {}) {
+	return {
+		artifacts: [...arrayValue(primary.artifacts), ...arrayValue(secondary.artifacts)],
+		evidence_refs: [...arrayValue(primary.evidence_refs), ...arrayValue(secondary.evidence_refs)],
+	};
+}
+
+function applyDeclaredArtifactResult(terminal = {}, harvested = {}) {
+	const errors = arrayValue(harvested.errors);
+	const missingRequired = arrayValue(harvested.missing?.required);
+	const missingOptional = arrayValue(harvested.missing?.optional);
+	const diagnostics = [
+		...arrayValue(terminal.diagnostics),
+		...missingOptional.map((artifact) => ({ classification: 'artifact', code: 'agent_task.optional_declared_artifact_missing', message: `Optional declared artifact is absent: ${artifact.name}.`, data: artifact })),
+	];
+	if (errors.length === 0 && missingRequired.length === 0) {
+		return { ...terminal, diagnostics };
+	}
+	const details = [...missingRequired.map((artifact) => artifact.name), ...errors.map((error) => error.artifact)].join(', ');
+	return {
+		...terminal,
+		status: terminal.status === 'succeeded' ? 'failed' : terminal.status,
+		failure_classification: terminal.status === 'succeeded' ? 'execution_failed' : terminal.failure_classification,
+		failure_code: terminal.status === 'succeeded' ? 'agent_task.declared_artifact_harvest_failed' : terminal.failure_code,
+		summary: terminal.status === 'succeeded' ? `Declared artifact harvesting failed: ${details}.` : terminal.summary,
+		diagnostics: [...diagnostics, ...(missingRequired.length ? [{ classification: 'artifact', code: 'agent_task.required_declared_artifact_missing', message: `Required declared artifact is absent: ${missingRequired.map((artifact) => artifact.name).join(', ')}.`, data: { missing_artifacts: missingRequired } }] : []), ...errors.map((error) => ({ classification: 'artifact', code: `agent_task.declared_artifact_${error.code}`, message: error.message, data: error }))],
+		metadata: { ...(terminal.metadata || {}), declared_artifact_missing: harvested.missing, declared_artifact_errors: errors },
+	};
 }
 
 function safeFileSegment(value) {
@@ -317,6 +354,9 @@ module.exports = {
 	DEFAULT_PROCESS_ENV_ALLOWLIST,
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
+	applyDeclaredArtifactResult,
+	artifactDirectory,
+	mergeEvidence,
 	timeoutSecondsFromLimits,
 	resolveCwd,
 	safeFileSegment,

--- a/agent-runtimes/lib/declared-artifact-harvester.js
+++ b/agent-runtimes/lib/declared-artifact-harvester.js
@@ -1,0 +1,191 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_BUDGET = {
+	maxBytes: 50 * 1024 * 1024,
+	maxFiles: 1_000,
+	maxDepth: 32,
+};
+
+function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifactDir = '' } = {}) {
+	const declarations = declaredArtifacts(request);
+	if (declarations.length === 0) {
+		return emptyResult();
+	}
+	if (!artifactDir) {
+		return captureFailure(declarations, 'artifact_root', 'The scheduler-owned artifact root is required for declared artifacts.');
+	}
+	const workspaceRoot = realDirectory(cwd);
+	if (!workspaceRoot) {
+		return captureFailure(declarations, 'workspace_root', 'The declared artifact workspace root does not exist.');
+	}
+	const root = path.resolve(artifactDir);
+	const budget = artifactBudget(request, config);
+	const result = emptyResult();
+	for (const declaration of declarations) {
+		const source = resolveSource(workspaceRoot, declaration.path);
+		if (source.error) {
+			result.errors.push({ artifact: declaration.name, code: 'unsafe_path', message: source.error });
+			continue;
+		}
+		if (!fs.existsSync(source.path)) {
+			const missing = { name: declaration.name, path: declaration.path, required: declaration.required === true };
+			(result.missing[missing.required ? 'required' : 'optional']).push(missing);
+			continue;
+		}
+		try {
+			if (root === source.path || root.startsWith(`${source.path}${path.sep}`)) {
+				throw new Error('Declared artifact source must not contain the scheduler artifact root.');
+			}
+			const collected = collectSource(source.path, workspaceRoot, budget);
+			const destination = path.join(root, 'declared', safeFileSegment(request.task_id), safeFileSegment(declaration.name));
+			copyEntries(collected.entries, source.path, destination, collected.directory);
+			const digest = collected.directory
+				? digestTree(collected.entries, source.path)
+				: collected.entries[0].digest;
+			const artifact = {
+				id: declaration.id || declaration.name,
+				name: declaration.name,
+				kind: declaration.kind || declaration.artifact_type || declaration.type || (collected.directory ? 'directory' : 'file'),
+				...(declaration.artifact_type ? { artifact_type: declaration.artifact_type } : {}),
+				...(declaration.artifact_schema || declaration.schema ? { artifact_schema: declaration.artifact_schema || declaration.schema } : {}),
+				path: destination,
+				required: declaration.required === true,
+				bytes: collected.bytes,
+				sha256: digest,
+				file_count: collected.entries.length,
+				provenance: { source_path: declaration.path, workspace_root: workspaceRoot },
+				...(declaration.description ? { description: declaration.description } : {}),
+				...(declaration.metadata && typeof declaration.metadata === 'object' && !Array.isArray(declaration.metadata) ? { metadata: declaration.metadata } : {}),
+			};
+			result.artifacts.push(artifact);
+			result.evidence_refs.push({ kind: artifact.kind, label: artifact.name, uri: `file://${destination}`, sha256: digest });
+		} catch (error) {
+			result.errors.push({ artifact: declaration.name, code: 'capture_failed', message: error.message });
+		}
+	}
+	return result;
+}
+
+function declaredArtifacts(request = {}) {
+	const source = Array.isArray(request.artifact_declarations)
+		? request.artifact_declarations
+		: (Array.isArray(request.executor?.artifact_declarations) ? request.executor.artifact_declarations : []);
+	return source.filter((artifact) => artifact && typeof artifact === 'object' && typeof artifact.path === 'string' && artifact.path && (artifact.name || artifact.id))
+		.map((artifact) => ({ ...artifact, name: String(artifact.name || artifact.id) }));
+}
+
+function artifactBudget(request, config) {
+	const limits = request.limits || {};
+	return {
+		maxBytes: positiveInteger(config.declared_artifact_max_bytes || config.declaredArtifactMaxBytes || limits.declared_artifact_max_bytes || limits.declaredArtifactMaxBytes, DEFAULT_BUDGET.maxBytes),
+		maxFiles: positiveInteger(config.declared_artifact_max_files || config.declaredArtifactMaxFiles || limits.declared_artifact_max_files || limits.declaredArtifactMaxFiles, DEFAULT_BUDGET.maxFiles),
+		maxDepth: positiveInteger(config.declared_artifact_max_depth || config.declaredArtifactMaxDepth || limits.declared_artifact_max_depth || limits.declaredArtifactMaxDepth, DEFAULT_BUDGET.maxDepth),
+	};
+}
+
+function resolveSource(workspaceRoot, declaredPath) {
+	if (path.isAbsolute(declaredPath) || declaredPath.includes('\0') || declaredPath.split(/[\\/]+/).includes('..')) {
+		return { error: 'Declared artifact paths must be workspace-relative.' };
+	}
+	const candidate = path.resolve(workspaceRoot, declaredPath);
+	if (candidate !== workspaceRoot && !candidate.startsWith(`${workspaceRoot}${path.sep}`)) {
+		return { error: 'Declared artifact path escapes the workspace root.' };
+	}
+	return { path: candidate };
+}
+
+function collectSource(source, workspaceRoot, budget) {
+	const rootStat = fs.lstatSync(source);
+	if (rootStat.isSymbolicLink() || !rootStat.isFile() && !rootStat.isDirectory()) {
+		throw new Error('Declared artifact source must be a regular file or directory.');
+	}
+	const entries = [];
+	const visit = (current, depth) => {
+		if (depth > budget.maxDepth) {
+			throw new Error(`Declared artifact exceeds the ${budget.maxDepth}-level traversal budget.`);
+		}
+		const stat = fs.lstatSync(current);
+		if (stat.isSymbolicLink() || !stat.isFile() && !stat.isDirectory()) {
+			throw new Error('Declared artifact tree contains a symlink or unsafe file type.');
+		}
+		const real = fs.realpathSync(current);
+		if (real !== workspaceRoot && !real.startsWith(`${workspaceRoot}${path.sep}`)) {
+			throw new Error('Declared artifact source resolves outside the workspace root.');
+		}
+		if (stat.isDirectory()) {
+			for (const name of fs.readdirSync(current).sort()) {
+				visit(path.join(current, name), depth + 1);
+			}
+			return;
+		}
+		if (entries.length >= budget.maxFiles) {
+			throw new Error(`Declared artifact exceeds the ${budget.maxFiles}-file budget.`);
+		}
+		const bytes = stat.size;
+		if (entries.reduce((total, entry) => total + entry.bytes, 0) + bytes > budget.maxBytes) {
+			throw new Error(`Declared artifact exceeds the ${budget.maxBytes}-byte budget.`);
+		}
+		entries.push({ path: current, bytes, digest: sha256File(current) });
+	};
+	visit(source, 0);
+	return { entries, bytes: entries.reduce((total, entry) => total + entry.bytes, 0), directory: rootStat.isDirectory() };
+}
+
+function copyEntries(entries, source, destination, directory) {
+	if (directory) {
+		fs.mkdirSync(destination, { recursive: true });
+	}
+	for (const entry of entries) {
+		const relative = path.relative(source, entry.path);
+		const target = relative ? path.join(destination, relative) : destination;
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.copyFileSync(entry.path, target);
+	}
+}
+
+function digestTree(entries, source) {
+	const digest = crypto.createHash('sha256');
+	for (const entry of entries) {
+		digest.update(`${path.relative(source, entry.path)}\0${entry.digest}\n`);
+	}
+	return digest.digest('hex');
+}
+
+function sha256File(filePath) {
+	return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function realDirectory(value) {
+	try {
+		return fs.statSync(value).isDirectory() ? fs.realpathSync(value) : '';
+	} catch {
+		return '';
+	}
+}
+
+function positiveInteger(value, fallback) {
+	return Number.isSafeInteger(Number(value)) && Number(value) > 0 ? Number(value) : fallback;
+}
+
+function safeFileSegment(value) {
+	return String(value || 'artifact').replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'artifact';
+}
+
+function emptyResult() {
+	return { artifacts: [], evidence_refs: [], errors: [], missing: { required: [], optional: [] } };
+}
+
+function captureFailure(declarations, code, message) {
+	const result = emptyResult();
+	result.errors = declarations.map((declaration) => ({ artifact: declaration.name, code, message }));
+	return result;
+}
+
+module.exports = { harvestDeclaredArtifacts };

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -13,8 +13,11 @@ const {
 const {
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
+	applyDeclaredArtifactResult,
+	artifactDirectory,
 	timeoutSecondsFromLimits,
 } = require('../../lib/cli-agent-task-executor');
+const { harvestDeclaredArtifacts } = require('../../lib/declared-artifact-harvester');
 const {
 	createOpenCodeProgressAdapter,
 } = require('./opencode-progress-events');
@@ -1231,7 +1234,10 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 		});
 	}
 
-	const terminal = withArtifactCaptureFailure(spawnResult.status === 0 ? opencodeSuccessOutcome(context) : opencodeFailureOutcome(context));
+	const declaredEvidence = harvestDeclaredArtifacts({ request, config, cwd, artifactDir: artifactDirectory(request, config) || resolveArtifactDir(context) });
+	const providerEvidence = spawnResult.status === 0 ? opencodeSuccessOutcome(context) : opencodeFailureOutcome(context);
+	const collected = { ...providerEvidence, ...mergeEvidence(providerEvidence, declaredEvidence) };
+	const terminal = applyDeclaredArtifactResult(withArtifactCaptureFailure(collected), declaredEvidence);
 	return outcome(request, { ...terminal, ...mergeEvidence(terminal, runtimeLogs) });
 }
 


### PR DESCRIPTION
Closes #2540.\n\nAdds shared, bounded declared artifact harvesting for CLI agent runtimes, including OpenCode integration and deterministic binary/directory/path-safety coverage.\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode general coding subagent; used to implement and verify declared artifact harvesting. Chris Huber remains responsible for every line.