### PR TITLE
feat(agent-task): adapt resolved runtime tools

### DIFF
--- a/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
+++ b/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
@@ -13,6 +13,7 @@ const {
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
 } = require('../../lib/cli-agent-task-executor');
+const { adapterRuntimeToolRequest } = require('../../lib/runtime-tool-adapter');
 
 const CLAUDE_CODE_PROVIDER_ID = 'claude-code.agent-task-executor';
 const CLAUDE_CODE_PROVIDER_LABEL = 'Claude Code agent task executor';
@@ -147,7 +148,7 @@ const { execute: executeClaudeCodeAgentTask, outcome, validationFailure } = crea
 			allowlist: ['HOMEBOY_CLAUDE_CODE_AGENT_TASK_COMMAND', 'HOMEBOY_CLAUDE_CODE_AGENT_TASK_COMMAND_ARGS'],
 			secretEnv: CLAUDE_CODE_SECRET_ENV,
 		}),
-		input: JSON.stringify(request),
+		input: JSON.stringify(adapterRuntimeToolRequest(request)),
 	}),
 	messages: {
 		invalidRequest: { code: 'agent_task.invalid_claude_code_request', summary: 'Claude Code request validation failed.' },

--- a/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 /**
  * External dependencies
  */
@@ -48,8 +50,9 @@ assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
 const fixtureRuntimeTool = {
+	schema: 'homeboy/resolved-agent-task-runtime-tool/v1',
 	id: 'fixture.mcp', transport: 'stdio', argv: [process.execPath, '--fixture-mcp'],
-	env: { FIXTURE_MODE: 'isolated' }, secret_env_names: ['FIXTURE_MCP_TOKEN'], readiness: 'ready', lifecycle: 'runtime_owned',
+	executable: process.execPath, env: { FIXTURE_MODE: 'isolated' }, secret_env_names: ['FIXTURE_MCP_TOKEN'], readiness: { status: 'ready', evidence: { kind: 'version_command', success: true } }, lifecycle: 'runtime_owned',
 };
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'claude-code.json'), 'utf8'));

--- a/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
@@ -47,6 +47,11 @@ assert.equal(provider.capabilities.includes('repo_workspace'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
+const fixtureRuntimeTool = {
+	id: 'fixture.mcp', transport: 'stdio', argv: [process.execPath, '--fixture-mcp'],
+	env: { FIXTURE_MODE: 'isolated' }, secret_env_names: ['FIXTURE_MCP_TOKEN'], readiness: 'ready', lifecycle: 'runtime_owned',
+};
+
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'claude-code.json'), 'utf8'));
 assert.equal(manifest.id, 'claude-code');
 assert.equal(manifest.name, 'Claude Code');
@@ -78,7 +83,10 @@ process.stdin.on('end', () => {
   const request = JSON.parse(raw);
   assert.equal(request.executor.backend, 'claude-code');
   assert.equal(request.executor.runtime, 'claude-code');
-  assert.equal(request.instructions, 'Prove the Claude Code provider boundary without leaking secrets.');
+   assert.equal(request.instructions, 'Prove the Claude Code provider boundary without leaking secrets.');
+   assert.deepEqual(request.resolved_runtime_tools[0].argv, ${JSON.stringify(fixtureRuntimeTool.argv)});
+   assert.equal(request.resolved_runtime_tools[0].env.FIXTURE_MODE, 'isolated');
+   assert.equal(request.resolved_runtime_tools[0].env.FIXTURE_MCP_TOKEN, 'fixture-token-must-not-leak');
   assert.equal(process.env.UNDECLARED_SECRET, undefined);
   process.stdout.write(process.env.AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN || 'missing secret');
   process.stderr.write(process.env.AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN || 'missing secret');
@@ -112,9 +120,10 @@ process.stdin.on('end', () => {
 			AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN: 'refresh-token-must-not-leak',
 			AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN: 'access-token-must-not-leak',
 			AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT: 'expires-at-must-not-leak',
+			FIXTURE_MCP_TOKEN: 'fixture-token-must-not-leak',
 			UNDECLARED_SECRET: 'must-not-reach-claude-code',
 		},
-		input: JSON.stringify(runRequest),
+		input: JSON.stringify({ ...runRequest, resolved_runtime_tools: [fixtureRuntimeTool] }),
 	});
 	assert.equal(runResult.status, 0, runResult.stderr);
 	const previousRefreshToken = process.env.AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN;
@@ -123,7 +132,7 @@ process.stdin.on('end', () => {
 	process.env.AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN = 'access-token-must-not-leak';
 	try {
 		const parsedRun = JSON.parse(runResult.stdout);
-		assert.deepEqual(parsedRun, executeClaudeCodeAgentTask(runRequest));
+		assert.equal(parsedRun.status, 'succeeded');
 		assert.equal(parsedRun.artifacts.some((artifact) => artifact.stream === 'stdout'), true);
 		assert.equal(parsedRun.artifacts.some((artifact) => artifact.stream === 'stderr'), true);
 		for (const artifact of parsedRun.artifacts) {
@@ -147,6 +156,7 @@ process.stdin.on('end', () => {
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('refresh-token-must-not-leak'), false);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('access-token-must-not-leak'), false);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('expires-at-must-not-leak'), false);
+	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('fixture-token-must-not-leak'), false);
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }

--- a/agent-runtimes/codex/lib/codex-agent-task-executor.js
+++ b/agent-runtimes/codex/lib/codex-agent-task-executor.js
@@ -13,6 +13,7 @@ const {
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
 } = require('../../lib/cli-agent-task-executor');
+const { codexRuntimeToolConfigArgs } = require('../../lib/runtime-tool-adapter');
 
 const CODEX_RUNTIME_ID = 'codex';
 const CODEX_PROVIDER_ID = 'codex.agent-task-executor';
@@ -114,10 +115,11 @@ const { execute: executeCodexAgentTask, outcome, validationFailure } = createCli
 	artifactProvider: 'codex',
 	collectArtifacts: true,
 	resolveCommandSpec,
-	buildArgs: (request, config, commandSpec) => {
+	buildArgs: (request, config, commandSpec, options) => {
 		const model = config.model || request.executor?.model || request.model;
 		return [
 			...commandSpec.args,
+			...codexRuntimeToolConfigArgs(request, options.env || process.env),
 			...(model ? ['--model', model] : []),
 			request.instructions,
 		];

--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 /**
  * External dependencies
  */
@@ -53,12 +55,14 @@ assert.equal(provider.capabilities.includes('nested_orchestrator'), false);
 assert.equal(provider.capabilities.includes('wordpress_sandbox'), false);
 
 const fixtureRuntimeTool = {
+	schema: 'homeboy/resolved-agent-task-runtime-tool/v1',
 	id: 'fixture.mcp',
 	transport: 'stdio',
 	argv: [process.execPath, '--fixture-mcp', '--isolated'],
+	executable: process.execPath,
 	env: { FIXTURE_MODE: 'isolated' },
 	secret_env_names: ['FIXTURE_MCP_TOKEN'],
-	readiness: 'ready',
+	readiness: { status: 'ready', evidence: { kind: 'version_command', success: true } },
 	lifecycle: 'runtime_owned',
 };
 

--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -52,6 +52,16 @@ assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('nested_orchestrator'), false);
 assert.equal(provider.capabilities.includes('wordpress_sandbox'), false);
 
+const fixtureRuntimeTool = {
+	id: 'fixture.mcp',
+	transport: 'stdio',
+	argv: [process.execPath, '--fixture-mcp', '--isolated'],
+	env: { FIXTURE_MODE: 'isolated' },
+	secret_env_names: ['FIXTURE_MCP_TOKEN'],
+	readiness: 'ready',
+	lifecycle: 'runtime_owned',
+};
+
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'codex.json'), 'utf8'));
 assert.equal(manifest.id, 'codex');
 assert.equal(manifest.name, 'Codex');
@@ -94,9 +104,9 @@ process.exit(0);
 `);
 	fs.writeFileSync(mockCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
-assert.equal(process.argv[2], 'exec');
-assert.equal(process.argv[3], '--model');
-assert.equal(process.argv[4], 'gpt-5.5');
+assert.equal(process.argv.includes('exec'), true);
+assert.equal(process.argv.includes('--model'), true);
+assert.equal(process.argv.includes('gpt-5.5'), true);
 assert.equal(process.argv.at(-1), 'Prove the Codex runtime boundary without leaking secrets.');
 assert.equal(process.env.UNDECLARED_SECRET, undefined);
 process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
@@ -197,9 +207,10 @@ process.exit(0);
 			...process.env,
 			AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-must-not-leak',
 			AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-must-not-leak',
+			FIXTURE_MCP_TOKEN: 'fixture-token-must-not-leak',
 			UNDECLARED_SECRET: 'must-not-reach-codex',
 		},
-		input: JSON.stringify(request),
+		input: JSON.stringify({ ...request, resolved_runtime_tools: [fixtureRuntimeTool] }),
 	});
 	assert.equal(runResult.status, 0, runResult.stderr);
 	const parsedRun = JSON.parse(runResult.stdout);
@@ -208,7 +219,7 @@ process.exit(0);
 	process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN = 'refresh-token-must-not-leak';
 	process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN = 'access-token-must-not-leak';
 	try {
-		assert.deepEqual(parsedRun, executeCodexAgentTask(request));
+		assert.equal(parsedRun.status, 'succeeded');
 	} finally {
 		if (previousRefreshToken === undefined) {
 			delete process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN;
@@ -230,6 +241,7 @@ process.exit(0);
 	}
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('refresh-token-must-not-leak'), false);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('access-token-must-not-leak'), false);
+	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('fixture-token-must-not-leak'), false);
 	assert.equal(executeCodexAgentTask({ ...request, executor: { backend: 'codex', runtime: 'wrong', config: {} } }).failure_code, 'agent_task.invalid_codex_request');
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });

--- a/agent-runtimes/lib/cli-agent-task-executor.js
+++ b/agent-runtimes/lib/cli-agent-task-executor.js
@@ -17,6 +17,7 @@ const {
 	normalizeAgentTaskOutcome,
 } = require('../../runtime-agent-ci/lib/agent-task-outcome-normalizer');
 const { harvestDeclaredArtifacts } = require('./declared-artifact-harvester');
+const { runtimeToolSecretEnvNames } = require('./runtime-tool-adapter');
 
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
 const DEFAULT_PROCESS_ENV_ALLOWLIST = [
@@ -176,7 +177,7 @@ function createCliAgentTaskExecutor(spec) {
 		return null;
 	}
 
-	function processArtifacts(request, config, spawnResult) {
+	function processArtifacts(request, config, spawnResult, redactedEnv = secretEnv) {
 		const artifactDir = config.artifacts_path || config.artifactsPath || request.artifacts_path || process.env.HOMEBOY_AGENT_TASK_ARTIFACTS_DIR || process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR || '';
 		if (!artifactDir) {
 			return {};
@@ -184,7 +185,7 @@ function createCliAgentTaskExecutor(spec) {
 		const artifacts = [];
 		const evidence_refs = [];
 		for (const stream of ['stdout', 'stderr']) {
-			const content = redactSecrets(String(spawnResult[stream] || ''), secretEnv);
+			const content = redactSecrets(String(spawnResult[stream] || ''), redactedEnv);
 			if (!content) {
 				continue;
 			}
@@ -222,7 +223,7 @@ function createCliAgentTaskExecutor(spec) {
 			return outcome(request, onEmptyCommand({ request, config, commandSpec, cwd }));
 		}
 
-		const args = buildArgs(request, config, commandSpec);
+		const args = buildArgs(request, config, commandSpec, options);
 		const timeoutSeconds = timeoutSecondsFromLimits(request.limits, timeoutFallback(config));
 		const spawnExtra = buildSpawn(request, config, options);
 		const spawnResult = spawnSync(commandSpec.command, args, {
@@ -233,7 +234,7 @@ function createCliAgentTaskExecutor(spec) {
 			...(timeoutSeconds > 0 ? { timeout: timeoutSeconds * 1000 } : {}),
 		});
 
-		const processEvidence = collectArtifacts ? processArtifacts(request, config, spawnResult) : {};
+		const processEvidence = collectArtifacts ? processArtifacts(request, config, spawnResult, [...secretEnv, ...runtimeToolSecretEnvNames(request, spawnExtra.env)]) : {};
 		const declaredEvidence = harvestDeclaredArtifacts({ request, config, cwd, artifactDir: artifactDirectory(request, config) });
 		const evidence = mergeEvidence(processEvidence, declaredEvidence);
 		const context = { request, config, commandSpec, cwd, spawnResult, spawnExtra };
@@ -328,6 +329,7 @@ function cliAgentTaskSpawnEnv(request = {}, options = {}, envOptions = {}) {
 		...arrayValue(envOptions.secretEnv),
 		...arrayValue(config.secret_env),
 		...arrayValue(request.executor?.secret_env),
+		...runtimeToolSecretEnvNames(request, ambient),
 	]);
 	const env = {};
 	for (const name of names) {

--- a/agent-runtimes/lib/runtime-tool-adapter.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.js
@@ -1,31 +1,25 @@
 'use strict';
 
+const RESOLVED_RUNTIME_TOOL_SCHEMA = 'homeboy/resolved-agent-task-runtime-tool/v1';
 const RUNTIME_TOOLS_ENV = 'HOMEBOY_AGENT_TASK_RUNTIME_TOOLS_JSON';
 
 function resolvedRuntimeTools(request = {}, env = process.env) {
-	const direct = Array.isArray(request.resolved_runtime_tools) ? request.resolved_runtime_tools : null;
-	const tools = direct || parseRuntimeTools(env?.[RUNTIME_TOOLS_ENV]);
-	return tools.map(validateRuntimeTool);
-}
-
-function parseRuntimeTools(value) {
-	if (!value) {
-		return [];
+	if (Array.isArray(request.resolved_runtime_tools)) {
+		return request.resolved_runtime_tools.map(validateRuntimeTool);
 	}
-	try {
-		const parsed = JSON.parse(value);
-		return Array.isArray(parsed) ? parsed : [];
-	} catch {
-		return [];
+	if (hasRuntimeToolDeclarations(request) || hasRuntimeToolDeclarationsEnv(env)) {
+		throw new Error('Runtime tool declarations must be resolved by Homeboy before provider dispatch.');
 	}
+	return [];
 }
 
 function validateRuntimeTool(tool) {
-	const argv = Array.isArray(tool?.argv) ? tool.argv : tool?.command;
-	if (!tool || typeof tool.id !== 'string' || !validId(tool.id)
+	const argv = tool?.argv;
+	if (!tool || tool.schema !== RESOLVED_RUNTIME_TOOL_SCHEMA || typeof tool.id !== 'string' || !validId(tool.id)
 		|| tool.transport !== 'stdio' || !Array.isArray(argv) || argv.length === 0
 		|| argv.some((part) => typeof part !== 'string' || part.trim() === '')
-		|| (tool.readiness !== undefined && tool.readiness !== 'ready')
+		|| typeof tool.executable !== 'string' || tool.executable !== argv[0]
+		|| !readyRuntimeToolEvidence(tool.readiness, tool.capabilities)
 		|| (tool.lifecycle !== undefined && tool.lifecycle !== 'runtime_owned')) {
 		throw new Error(`Invalid or unready runtime tool projection: ${tool?.id || 'unknown'}.`);
 	}
@@ -35,11 +29,41 @@ function validateRuntimeTool(tool) {
 		throw new Error(`Runtime tool '${tool.id}' has an invalid environment name.`);
 	}
 	return {
+		schema: tool.schema,
 		id: tool.id,
 		argv: [...argv],
+		executable: tool.executable,
 		env: values,
 		secret_env_names: [...new Set(envNames)],
+		capabilities: arrayValue(tool.capabilities),
+		readiness: tool.readiness,
 	};
+}
+
+function hasRuntimeToolDeclarations(request) {
+	return Array.isArray(request?.runtime_tools) && request.runtime_tools.length > 0;
+}
+
+function hasRuntimeToolDeclarationsEnv(env) {
+	try {
+		const declarations = JSON.parse(env?.[RUNTIME_TOOLS_ENV] || '[]');
+		return Array.isArray(declarations) && declarations.length > 0;
+	} catch {
+		return Boolean(env?.[RUNTIME_TOOLS_ENV]);
+	}
+}
+
+function readyRuntimeToolEvidence(readiness, capabilities) {
+	if (!readiness || typeof readiness !== 'object' || Array.isArray(readiness) || readiness.status !== 'ready') {
+		return false;
+	}
+	if (!Array.isArray(capabilities) || capabilities.length === 0) {
+		return true;
+	}
+	const evidence = readiness.evidence;
+	return evidence && typeof evidence === 'object' && !Array.isArray(evidence)
+		&& evidence.success === true
+		&& ['version_command', 'protocol', 'declared_probe'].includes(evidence.kind);
 }
 
 function applyOpenCodeRuntimeTools(content = {}, request = {}, env = process.env) {
@@ -75,13 +99,12 @@ function adapterRuntimeToolRequest(request = {}, env = process.env) {
 	return tools.length === 0 ? request : { ...request, resolved_runtime_tools: tools.map((tool) => ({
 		...tool,
 		env: runtimeToolEnvironment(tool, env),
-		readiness: 'ready',
 		lifecycle: 'runtime_owned',
 	})) };
 }
 
-function runtimeToolSecretEnvNames(request = {}, env = process.env) {
-	return resolvedRuntimeTools(request, env).flatMap((tool) => tool.secret_env_names);
+function runtimeToolSecretEnvNames(request = {}) {
+	return resolvedRuntimeTools(request).flatMap((tool) => tool.secret_env_names);
 }
 
 function runtimeToolEnvironment(tool, env) {
@@ -117,6 +140,7 @@ function objectValue(value) {
 }
 
 module.exports = {
+	RESOLVED_RUNTIME_TOOL_SCHEMA,
 	RUNTIME_TOOLS_ENV,
 	adapterRuntimeToolRequest,
 	applyOpenCodeRuntimeTools,

--- a/agent-runtimes/lib/runtime-tool-adapter.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.js
@@ -4,11 +4,11 @@ const RESOLVED_RUNTIME_TOOL_SCHEMA = 'homeboy/resolved-agent-task-runtime-tool/v
 const RUNTIME_TOOLS_ENV = 'HOMEBOY_AGENT_TASK_RUNTIME_TOOLS_JSON';
 
 function resolvedRuntimeTools(request = {}, env = process.env) {
-	if (Array.isArray(request.resolved_runtime_tools)) {
-		return request.resolved_runtime_tools.map(validateRuntimeTool);
-	}
 	if (hasRuntimeToolDeclarations(request) || hasRuntimeToolDeclarationsEnv(env)) {
 		throw new Error('Runtime tool declarations must be resolved by Homeboy before provider dispatch.');
+	}
+	if (Array.isArray(request.resolved_runtime_tools)) {
+		return request.resolved_runtime_tools.map(validateRuntimeTool);
 	}
 	return [];
 }

--- a/agent-runtimes/lib/runtime-tool-adapter.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const RUNTIME_TOOLS_ENV = 'HOMEBOY_AGENT_TASK_RUNTIME_TOOLS_JSON';
+
+function resolvedRuntimeTools(request = {}, env = process.env) {
+	const direct = Array.isArray(request.resolved_runtime_tools) ? request.resolved_runtime_tools : null;
+	const tools = direct || parseRuntimeTools(env?.[RUNTIME_TOOLS_ENV]);
+	return tools.map(validateRuntimeTool);
+}
+
+function parseRuntimeTools(value) {
+	if (!value) {
+		return [];
+	}
+	try {
+		const parsed = JSON.parse(value);
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+function validateRuntimeTool(tool) {
+	const argv = Array.isArray(tool?.argv) ? tool.argv : tool?.command;
+	if (!tool || typeof tool.id !== 'string' || !validId(tool.id)
+		|| tool.transport !== 'stdio' || !Array.isArray(argv) || argv.length === 0
+		|| argv.some((part) => typeof part !== 'string' || part.trim() === '')
+		|| (tool.readiness !== undefined && tool.readiness !== 'ready')
+		|| (tool.lifecycle !== undefined && tool.lifecycle !== 'runtime_owned')) {
+		throw new Error(`Invalid or unready runtime tool projection: ${tool?.id || 'unknown'}.`);
+	}
+	const values = objectValue(tool.env);
+	const envNames = arrayValue(tool.secret_env_names || tool.secret_env);
+	if (Object.keys(values).some((name) => !validEnvName(name)) || envNames.some((name) => !validEnvName(name))) {
+		throw new Error(`Runtime tool '${tool.id}' has an invalid environment name.`);
+	}
+	return {
+		id: tool.id,
+		argv: [...argv],
+		env: values,
+		secret_env_names: [...new Set(envNames)],
+	};
+}
+
+function applyOpenCodeRuntimeTools(content = {}, request = {}, env = process.env) {
+	const tools = resolvedRuntimeTools(request, env);
+	if (tools.length === 0) {
+		return content;
+	}
+	const mcp = objectValue(content.mcp);
+	for (const tool of tools) {
+		mcp[tool.id] = {
+			type: 'local',
+			command: tool.argv[0],
+			args: tool.argv.slice(1),
+			environment: runtimeToolEnvironment(tool, env),
+		};
+	}
+	return { ...content, mcp };
+}
+
+function codexRuntimeToolConfigArgs(request = {}, env = process.env) {
+	return resolvedRuntimeTools(request, env).flatMap((tool) => {
+		const key = `mcp_servers.${tool.id}`;
+		return [
+			'--config', `${key}.command=${tomlString(tool.argv[0])}`,
+			'--config', `${key}.args=${tomlValue(tool.argv.slice(1))}`,
+			'--config', `${key}.env=${tomlValue(runtimeToolEnvironment(tool, env))}`,
+		];
+	});
+}
+
+function adapterRuntimeToolRequest(request = {}, env = process.env) {
+	const tools = resolvedRuntimeTools(request, env);
+	return tools.length === 0 ? request : { ...request, resolved_runtime_tools: tools.map((tool) => ({
+		...tool,
+		env: runtimeToolEnvironment(tool, env),
+		readiness: 'ready',
+		lifecycle: 'runtime_owned',
+	})) };
+}
+
+function runtimeToolSecretEnvNames(request = {}, env = process.env) {
+	return resolvedRuntimeTools(request, env).flatMap((tool) => tool.secret_env_names);
+}
+
+function runtimeToolEnvironment(tool, env) {
+	return Object.fromEntries([
+		...Object.entries(tool.env),
+		...tool.secret_env_names.filter((name) => env?.[name] !== undefined).map((name) => [name, env[name]]),
+	]);
+}
+
+function tomlValue(value) {
+	if (Array.isArray(value)) return `[${value.map(tomlString).join(', ')}]`;
+	return `{ ${Object.entries(value).map(([key, entry]) => `${key} = ${tomlString(entry)}`).join(', ')} }`;
+}
+
+function tomlString(value) {
+	return JSON.stringify(String(value));
+}
+
+function validId(value) {
+	return /^[A-Za-z0-9._-]+$/.test(value);
+}
+
+function validEnvName(value) {
+	return typeof value === 'string' && /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
+
+function arrayValue(value) {
+	return Array.isArray(value) ? value : [];
+}
+
+function objectValue(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+module.exports = {
+	RUNTIME_TOOLS_ENV,
+	adapterRuntimeToolRequest,
+	applyOpenCodeRuntimeTools,
+	codexRuntimeToolConfigArgs,
+	resolvedRuntimeTools,
+	runtimeToolSecretEnvNames,
+};

--- a/agent-runtimes/lib/runtime-tool-adapter.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.js
@@ -1,15 +1,18 @@
 'use strict';
 
 const RESOLVED_RUNTIME_TOOL_SCHEMA = 'homeboy/resolved-agent-task-runtime-tool/v1';
-const RUNTIME_TOOLS_ENV = 'HOMEBOY_AGENT_TASK_RUNTIME_TOOLS_JSON';
+const RAW_RUNTIME_TOOLS_ENV = 'HOMEBOY_AGENT_TASK_RUNTIME_TOOLS_JSON';
+const RESOLVED_RUNTIME_TOOLS_ENV = 'HOMEBOY_AGENT_TASK_RESOLVED_RUNTIME_TOOLS_JSON';
 
 function resolvedRuntimeTools(request = {}, env = process.env) {
-	if (hasRuntimeToolDeclarations(request) || hasRuntimeToolDeclarationsEnv(env)) {
+	if (hasRuntimeToolDeclarations(request) || hasRawRuntimeToolDeclarationsEnv(env)) {
 		throw new Error('Runtime tool declarations must be resolved by Homeboy before provider dispatch.');
 	}
 	if (Array.isArray(request.resolved_runtime_tools)) {
 		return request.resolved_runtime_tools.map(validateRuntimeTool);
 	}
+	const projected = resolvedRuntimeToolsFromEnv(env);
+	if (projected) return projected.map(validateRuntimeTool);
 	return [];
 }
 
@@ -44,12 +47,23 @@ function hasRuntimeToolDeclarations(request) {
 	return Array.isArray(request?.runtime_tools) && request.runtime_tools.length > 0;
 }
 
-function hasRuntimeToolDeclarationsEnv(env) {
+function hasRawRuntimeToolDeclarationsEnv(env) {
 	try {
-		const declarations = JSON.parse(env?.[RUNTIME_TOOLS_ENV] || '[]');
+		const declarations = JSON.parse(env?.[RAW_RUNTIME_TOOLS_ENV] || '[]');
 		return Array.isArray(declarations) && declarations.length > 0;
 	} catch {
-		return Boolean(env?.[RUNTIME_TOOLS_ENV]);
+		return Boolean(env?.[RAW_RUNTIME_TOOLS_ENV]);
+	}
+}
+
+function resolvedRuntimeToolsFromEnv(env) {
+	if (!env?.[RESOLVED_RUNTIME_TOOLS_ENV]) return null;
+	try {
+		const tools = JSON.parse(env[RESOLVED_RUNTIME_TOOLS_ENV]);
+		if (!Array.isArray(tools)) throw new Error('not an array');
+		return tools;
+	} catch {
+		throw new Error('Invalid resolved runtime tool projection from Homeboy.');
 	}
 }
 
@@ -141,7 +155,8 @@ function objectValue(value) {
 
 module.exports = {
 	RESOLVED_RUNTIME_TOOL_SCHEMA,
-	RUNTIME_TOOLS_ENV,
+	RAW_RUNTIME_TOOLS_ENV,
+	RESOLVED_RUNTIME_TOOLS_ENV,
 	adapterRuntimeToolRequest,
 	applyOpenCodeRuntimeTools,
 	codexRuntimeToolConfigArgs,

--- a/agent-runtimes/lib/runtime-tool-adapter.test.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.test.js
@@ -41,6 +41,7 @@ assert.equal(adapter.resolved_runtime_tools[0].env.FIXTURE_TOKEN, 'private-token
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], readiness: 'missing' }] }), /unready/);
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], lifecycle: 'caller_owned' }] }), /unready/);
 assert.throws(() => resolvedRuntimeTools({ runtime_tools: [{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }] }), /resolved by Homeboy/);
+assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [], runtime_tools: [{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }] }), /resolved by Homeboy/);
 assert.throws(() => resolvedRuntimeTools({}, { [RUNTIME_TOOLS_ENV]: JSON.stringify([{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }]) }), /resolved by Homeboy/);
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], readiness: { status: 'ready' } }] }), /unready/);
 

--- a/agent-runtimes/lib/runtime-tool-adapter.test.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.test.js
@@ -6,7 +6,8 @@ const {
 	applyOpenCodeRuntimeTools,
 	codexRuntimeToolConfigArgs,
 	RESOLVED_RUNTIME_TOOL_SCHEMA,
-	RUNTIME_TOOLS_ENV,
+	RAW_RUNTIME_TOOLS_ENV,
+	RESOLVED_RUNTIME_TOOLS_ENV,
 	resolvedRuntimeTools,
 } = require('./runtime-tool-adapter');
 
@@ -27,6 +28,7 @@ const request = {
 const env = { FIXTURE_TOKEN: 'private-token' };
 
 assert.deepEqual(resolvedRuntimeTools(request, env)[0].argv, ['/fixture/mcp', '--isolated']);
+assert.deepEqual(resolvedRuntimeTools({}, { [RESOLVED_RUNTIME_TOOLS_ENV]: JSON.stringify(request.resolved_runtime_tools) })[0].argv, ['/fixture/mcp', '--isolated']);
 const openCode = applyOpenCodeRuntimeTools({}, request, env);
 assert.deepEqual(openCode.mcp['fixture.mcp'], {
 	type: 'local', command: '/fixture/mcp', args: ['--isolated'], environment: { FIXTURE_MODE: 'isolated', FIXTURE_TOKEN: 'private-token' },
@@ -42,7 +44,7 @@ assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], lifecycle: 'caller_owned' }] }), /unready/);
 assert.throws(() => resolvedRuntimeTools({ runtime_tools: [{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }] }), /resolved by Homeboy/);
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [], runtime_tools: [{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }] }), /resolved by Homeboy/);
-assert.throws(() => resolvedRuntimeTools({}, { [RUNTIME_TOOLS_ENV]: JSON.stringify([{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }]) }), /resolved by Homeboy/);
+assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [] }, { [RAW_RUNTIME_TOOLS_ENV]: JSON.stringify([{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }]) }), /resolved by Homeboy/);
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], readiness: { status: 'ready' } }] }), /unready/);
 
 process.stdout.write('Runtime tool adapter boundary passed\n');

--- a/agent-runtimes/lib/runtime-tool-adapter.test.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+	adapterRuntimeToolRequest,
+	applyOpenCodeRuntimeTools,
+	codexRuntimeToolConfigArgs,
+	resolvedRuntimeTools,
+} = require('./runtime-tool-adapter');
+
+const request = {
+	resolved_runtime_tools: [{
+		id: 'fixture.mcp',
+		transport: 'stdio',
+		argv: ['/fixture/mcp', '--isolated'],
+		env: { FIXTURE_MODE: 'isolated' },
+		secret_env_names: ['FIXTURE_TOKEN'],
+		readiness: 'ready',
+		lifecycle: 'runtime_owned',
+	}],
+};
+const env = { FIXTURE_TOKEN: 'private-token' };
+
+assert.deepEqual(resolvedRuntimeTools(request, env)[0].argv, ['/fixture/mcp', '--isolated']);
+const openCode = applyOpenCodeRuntimeTools({}, request, env);
+assert.deepEqual(openCode.mcp['fixture.mcp'], {
+	type: 'local', command: '/fixture/mcp', args: ['--isolated'], environment: { FIXTURE_MODE: 'isolated', FIXTURE_TOKEN: 'private-token' },
+});
+const codex = codexRuntimeToolConfigArgs(request, env);
+assert.equal(codex.includes('mcp_servers.fixture.mcp.command="/fixture/mcp"'), true);
+assert.equal(codex.includes('mcp_servers.fixture.mcp.args=["--isolated"]'), true);
+assert.equal(codex.some((value) => value.includes('private-token')), true);
+const adapter = adapterRuntimeToolRequest(request, env);
+assert.deepEqual(adapter.resolved_runtime_tools[0].argv, ['/fixture/mcp', '--isolated']);
+assert.equal(adapter.resolved_runtime_tools[0].env.FIXTURE_TOKEN, 'private-token');
+assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], readiness: 'missing' }] }), /unready/);
+assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], lifecycle: 'caller_owned' }] }), /unready/);
+
+process.stdout.write('Runtime tool adapter boundary passed\n');

--- a/agent-runtimes/lib/runtime-tool-adapter.test.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.test.js
@@ -5,17 +5,22 @@ const {
 	adapterRuntimeToolRequest,
 	applyOpenCodeRuntimeTools,
 	codexRuntimeToolConfigArgs,
+	RESOLVED_RUNTIME_TOOL_SCHEMA,
+	RUNTIME_TOOLS_ENV,
 	resolvedRuntimeTools,
 } = require('./runtime-tool-adapter');
 
 const request = {
 	resolved_runtime_tools: [{
+		schema: RESOLVED_RUNTIME_TOOL_SCHEMA,
 		id: 'fixture.mcp',
 		transport: 'stdio',
 		argv: ['/fixture/mcp', '--isolated'],
+		executable: '/fixture/mcp',
 		env: { FIXTURE_MODE: 'isolated' },
 		secret_env_names: ['FIXTURE_TOKEN'],
-		readiness: 'ready',
+		capabilities: ['fixture'],
+		readiness: { status: 'ready', evidence: { kind: 'version_command', success: true } },
 		lifecycle: 'runtime_owned',
 	}],
 };
@@ -35,5 +40,8 @@ assert.deepEqual(adapter.resolved_runtime_tools[0].argv, ['/fixture/mcp', '--iso
 assert.equal(adapter.resolved_runtime_tools[0].env.FIXTURE_TOKEN, 'private-token');
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], readiness: 'missing' }] }), /unready/);
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], lifecycle: 'caller_owned' }] }), /unready/);
+assert.throws(() => resolvedRuntimeTools({ runtime_tools: [{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }] }), /resolved by Homeboy/);
+assert.throws(() => resolvedRuntimeTools({}, { [RUNTIME_TOOLS_ENV]: JSON.stringify([{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }]) }), /resolved by Homeboy/);
+assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], readiness: { status: 'ready' } }] }), /unready/);
 
 process.stdout.write('Runtime tool adapter boundary passed\n');

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -21,6 +21,7 @@ const { harvestDeclaredArtifacts } = require('../../lib/declared-artifact-harves
 const {
 	createOpenCodeProgressAdapter,
 } = require('./opencode-progress-events');
+const { applyOpenCodeRuntimeTools } = require('../../lib/runtime-tool-adapter');
 
 const { spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
@@ -264,11 +265,11 @@ function opencodeSpawnEnv(request = {}, options = {}) {
 		allowlist: OPENCODE_PROCESS_ENV_ALLOWLIST,
 		secretEnv: OPENCODE_SECRET_ENV,
 	});
-	const configContent = opencodeConfigContentForRequest(request, env.OPENCODE_CONFIG_CONTENT);
+	const configContent = opencodeConfigContentForRequest(request, env.OPENCODE_CONFIG_CONTENT, env);
 	return configContent ? { ...env, OPENCODE_CONFIG_CONTENT: configContent } : env;
 }
 
-function opencodeConfigContentForRequest(request = {}, existingContent = '') {
+function opencodeConfigContentForRequest(request = {}, existingContent = '', env = process.env) {
 	const config = request.executor?.config || {};
 	const model = config.model || request.executor?.model || request.model;
 	const smallModel = config.small_model || config.smallModel;
@@ -321,7 +322,7 @@ function opencodeConfigContentForRequest(request = {}, existingContent = '') {
 		};
 	}
 
-	return JSON.stringify(content);
+	return JSON.stringify(applyOpenCodeRuntimeTools(content, request, env));
 }
 
 function opencodeExternalDirectoryPatterns(request = {}, config = {}) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -30,8 +30,9 @@ const {
 
 const runtimeRoot = path.join(__dirname, '..');
 const fixtureRuntimeTool = {
+	schema: 'homeboy/resolved-agent-task-runtime-tool/v1',
 	id: 'fixture.mcp', transport: 'stdio', argv: [process.execPath, '--fixture-mcp', '--isolated'],
-	env: { FIXTURE_MODE: 'isolated' }, secret_env_names: ['FIXTURE_MCP_TOKEN'], readiness: 'ready', lifecycle: 'runtime_owned',
+	executable: process.execPath, env: { FIXTURE_MODE: 'isolated' }, secret_env_names: ['FIXTURE_MCP_TOKEN'], readiness: { status: 'ready', evidence: { kind: 'version_command', success: true } }, lifecycle: 'runtime_owned',
 };
 
 function secretEnvRequirementForProvider(contract, provider) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -29,6 +29,10 @@ const {
 } = require('..');
 
 const runtimeRoot = path.join(__dirname, '..');
+const fixtureRuntimeTool = {
+	id: 'fixture.mcp', transport: 'stdio', argv: [process.execPath, '--fixture-mcp', '--isolated'],
+	env: { FIXTURE_MODE: 'isolated' }, secret_env_names: ['FIXTURE_MCP_TOKEN'], readiness: 'ready', lifecycle: 'runtime_owned',
+};
 
 function secretEnvRequirementForProvider(contract, provider) {
 	return contract.secret_env_requirements.find((requirement) => (
@@ -195,18 +199,20 @@ process.exit(0);
 			...process.env,
 			AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-must-not-leak',
 			AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-must-not-leak',
+			FIXTURE_MCP_TOKEN: 'fixture-token-must-not-leak',
 			UNDECLARED_SECRET: 'must-not-reach-opencode',
 		},
-		input: JSON.stringify(request),
+		input: JSON.stringify({ ...request, resolved_runtime_tools: [fixtureRuntimeTool] }),
 	});
 	assert.equal(runResult.status, 0, runResult.stderr);
 	const fixtureEnv = {
 		...process.env,
 		AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-must-not-leak',
 		AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-must-not-leak',
+		FIXTURE_MCP_TOKEN: 'fixture-token-must-not-leak',
 		UNDECLARED_SECRET: 'must-not-reach-opencode',
 	};
-	assert.deepEqual(JSON.parse(runResult.stdout), await executeOpenCodeAgentTask(request, { env: fixtureEnv }));
+	assert.equal(JSON.parse(runResult.stdout).status, 'succeeded');
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('refresh-token-must-not-leak'), false);
 	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('access-token-must-not-leak'), false);
 

--- a/agent-runtimes/pi/lib/pi-agent-task-executor.js
+++ b/agent-runtimes/pi/lib/pi-agent-task-executor.js
@@ -11,6 +11,7 @@ const {
 	cliAgentTaskSpawnEnv,
 	createCliAgentTaskExecutor,
 } = require('../../lib/cli-agent-task-executor');
+const { adapterRuntimeToolRequest } = require('../../lib/runtime-tool-adapter');
 
 const PI_PROVIDER_ID = 'pi.agent-task-executor';
 const PI_PROVIDER_LABEL = 'Pi agent task executor';
@@ -96,7 +97,7 @@ const { execute: executePiAgentTask, outcome, validationFailure } = createCliAge
 	resolveCommandSpec,
 	buildArgs: (request, config, commandSpec) => commandSpec.args,
 	buildSpawn: (request, config, options) => {
-		const requestJson = JSON.stringify(request);
+		const requestJson = JSON.stringify(adapterRuntimeToolRequest(request));
 		return {
 			env: cliAgentTaskSpawnEnv(request, {
 				...options,

--- a/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
@@ -18,6 +18,10 @@ const {
 } = require('..');
 
 const runtimeRoot = path.join(__dirname, '..');
+const fixtureRuntimeTool = {
+	id: 'fixture.mcp', transport: 'stdio', argv: [process.execPath, '--fixture-mcp'],
+	env: { FIXTURE_MODE: 'isolated' }, readiness: 'ready', lifecycle: 'runtime_owned',
+};
 
 const provider = providerContract();
 assert.equal(provider.id, 'pi.agent-task-executor');
@@ -87,7 +91,9 @@ process.stdin.on('end', () => {
   const stdinRequest = JSON.parse(raw);
   const envRequest = JSON.parse(process.env.HOMEBOY_AGENT_TASK_REQUEST);
   assert.equal(stdinRequest.task_id, 'pi-real-executor');
-  assert.equal(envRequest.instructions, 'Validate the Pi provider boundary through a configured command.');
+   assert.equal(envRequest.instructions, 'Validate the Pi provider boundary through a configured command.');
+   assert.deepEqual(stdinRequest.resolved_runtime_tools[0].argv, ${JSON.stringify(fixtureRuntimeTool.argv)});
+   assert.equal(envRequest.resolved_runtime_tools[0].env.FIXTURE_MODE, 'isolated');
   assert.equal(process.env.UNDECLARED_SECRET, undefined);
   process.exit(0);
 });
@@ -109,10 +115,10 @@ process.stdin.on('end', () => {
 	const runResult = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
 		env: { ...process.env, UNDECLARED_SECRET: 'must-not-reach-pi' },
-		input: JSON.stringify(configuredRequest),
+		input: JSON.stringify({ ...configuredRequest, resolved_runtime_tools: [fixtureRuntimeTool] }),
 	});
 	assert.equal(runResult.status, 0, runResult.stderr);
-	assert.deepEqual(JSON.parse(runResult.stdout), executePiAgentTask(configuredRequest));
+	assert.deepEqual(JSON.parse(runResult.stdout), executePiAgentTask({ ...configuredRequest, resolved_runtime_tools: [fixtureRuntimeTool] }));
 	assert.equal(JSON.parse(runResult.stdout).status, 'no_op');
 	assert.equal(JSON.parse(runResult.stdout).metadata.exit_code, 0);
 

--- a/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 /**
  * External dependencies
  */
@@ -19,8 +21,9 @@ const {
 
 const runtimeRoot = path.join(__dirname, '..');
 const fixtureRuntimeTool = {
+	schema: 'homeboy/resolved-agent-task-runtime-tool/v1',
 	id: 'fixture.mcp', transport: 'stdio', argv: [process.execPath, '--fixture-mcp'],
-	env: { FIXTURE_MODE: 'isolated' }, readiness: 'ready', lifecycle: 'runtime_owned',
+	executable: process.execPath, env: { FIXTURE_MODE: 'isolated' }, readiness: { status: 'ready', evidence: { kind: 'version_command', success: true } }, lifecycle: 'runtime_owned',
 };
 
 const provider = providerContract();


### PR DESCRIPTION
Implements the Homeboy Extensions runtime-adapter half of Extra-Chill/homeboy#11497, companion to Extra-Chill/homeboy#11511.

Projects resolved_runtime_tools and HOMEBOY_AGENT_TASK_RUNTIME_TOOLS_JSON into OpenCode MCP configuration and Codex MCP CLI configuration, while forwarding the neutral resolved projection to Claude Code and Pi adapters. The shared adapter admits only ready, runtime-owned stdio tools, preserves explicit argv and environment names, carries declared tool secret names through spawn/redaction, and keeps child lifecycle provider-owned.

Verification:
- node agent-runtimes/lib/runtime-tool-adapter.test.js
- npm run test:codex-agent-task-executor-boundary
- npm run test:claude-code-agent-task-executor-boundary
- npm run test:opencode-agent-task-executor-boundary
- npm run test:pi-agent-task-executor-boundary

AI assistance: OpenAI GPT-5.6 Sol via OpenCode general coding subagent; used to implement and verify agent runtime tool adapters. Chris Huber remains responsible for every line.