### PR TITLE
fix: harden declared artifact harvesting

### DIFF
--- a/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 /**
  * External dependencies
  */

--- a/agent-runtimes/codex/codex.json
+++ b/agent-runtimes/codex/codex.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "codex",
   "name": "Codex",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Standalone Codex agent runtime for repository-scoped agent tasks.",
   "contract_producers": [
     {

--- a/agent-runtimes/codex/package.json
+++ b/agent-runtimes/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeboy-agent-runtime-codex",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "main": "index.js",
   "exports": {
@@ -11,7 +11,8 @@
     "homeboy-codex-agent-task-executor": "./scripts/agent/homeboy-codex-agent-task-executor.cjs"
   },
   "scripts": {
-    "test:codex-agent-task-executor-boundary": "node tests/codex-agent-task-executor-boundary.test.js"
+    "test:declared-artifact-harvester": "node tests/declared-artifact-harvester.test.js",
+    "test:codex-agent-task-executor-boundary": "npm run test:declared-artifact-harvester && node tests/codex-agent-task-executor-boundary.test.js"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -147,7 +147,9 @@ process.exit(0);
 	});
 	assert.equal(omittedModelResult.status, 'succeeded', JSON.stringify(omittedModelResult.diagnostics));
 	const declaredWorkspace = path.join(root, 'declared-workspace');
+	const declaredArtifactRoot = path.join(root, 'declared-artifacts');
 	fs.mkdirSync(declaredWorkspace);
+	fs.mkdirSync(declaredArtifactRoot);
 	const declaredResult = executeCodexAgentTask({
 		...request,
 		task_id: 'codex-declared-artifacts',
@@ -158,7 +160,7 @@ process.exit(0);
 				command: process.execPath,
 				command_args: [declaredArtifactCliPath, 'exec'],
 				cwd: declaredWorkspace,
-				artifacts_path: path.join(root, 'declared-artifacts'),
+				artifacts_path: declaredArtifactRoot,
 			},
 		},
 		artifact_declarations: [
@@ -172,6 +174,8 @@ process.exit(0);
 	assert.equal(fs.readFileSync(declaredReport.path, 'utf8'), '# Captured report\n');
 	assert.deepEqual(fs.readFileSync(path.join(declaredScreenshots.path, 'image.bin')), Buffer.from([0, 255, 1]));
 	assert.equal(declaredScreenshots.file_count, 1);
+	const missingDeclaredArtifactRoot = path.join(root, 'missing-declared-artifacts');
+	fs.mkdirSync(missingDeclaredArtifactRoot);
 	const missingDeclaredResult = executeCodexAgentTask({
 		...request,
 		task_id: 'codex-missing-declared-artifact',
@@ -182,7 +186,7 @@ process.exit(0);
 				command: process.execPath,
 				command_args: [omittedModelCliPath, 'exec'],
 				cwd: declaredWorkspace,
-				artifacts_path: path.join(root, 'missing-declared-artifacts'),
+				artifacts_path: missingDeclaredArtifactRoot,
 			},
 		},
 		instructions: 'Run without selecting a model.',

--- a/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
+++ b/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
@@ -15,6 +15,7 @@ fs.writeFileSync(path.join(workspace, 'report.md'), '# Report\n');
 const binary = Buffer.from([0, 255, 1, 254, 2]);
 fs.writeFileSync(path.join(workspace, 'screenshots', 'image.bin'), binary);
 fs.writeFileSync(path.join(workspace, 'screenshots', 'caption.txt'), 'Screenshot caption\n');
+fs.mkdirSync(artifacts);
 
 try {
 	const result = harvestDeclaredArtifacts({
@@ -76,6 +77,57 @@ try {
 		artifactDir: artifacts,
 	});
 	assert.equal(symlink.errors[0].code, 'capture_failed');
+
+	const destination = path.join(artifacts, 'declared', 'destination-symlink', 'report');
+	fs.mkdirSync(path.dirname(destination), { recursive: true });
+	const protectedFile = path.join(root, 'protected-final.txt');
+	fs.writeFileSync(protectedFile, 'protected\n');
+	fs.symlinkSync(protectedFile, destination);
+	const finalSymlink = harvestDeclaredArtifacts({
+		request: { task_id: 'destination-symlink', artifact_declarations: [{ name: 'report', path: 'report.md' }] },
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.equal(finalSymlink.errors[0].code, 'capture_failed');
+	assert.equal(fs.readFileSync(protectedFile, 'utf8'), 'protected\n');
+
+	const ancestorRoot = path.join(root, 'ancestor-artifacts');
+	const protectedDirectory = path.join(root, 'protected-directory');
+	fs.mkdirSync(ancestorRoot);
+	fs.mkdirSync(protectedDirectory);
+	fs.symlinkSync(protectedDirectory, path.join(ancestorRoot, 'declared'));
+	const ancestorSymlink = harvestDeclaredArtifacts({
+		request: { task_id: 'ancestor-symlink', artifact_declarations: [{ name: 'report', path: 'report.md' }] },
+		cwd: workspace,
+		artifactDir: ancestorRoot,
+	});
+	assert.equal(ancestorSymlink.errors[0].code, 'capture_failed');
+	assert.equal(fs.readdirSync(protectedDirectory).length, 0);
+
+	const swapRoot = path.join(root, 'swap-artifacts');
+	const swapTarget = path.join(root, 'swap-target');
+	fs.mkdirSync(swapRoot);
+	fs.mkdirSync(swapTarget);
+	const originalMkdir = fs.mkdirSync;
+	try {
+		fs.mkdirSync = (directory, options) => {
+			const result = originalMkdir(directory, options);
+			if (directory === path.join(swapRoot, 'declared')) {
+				fs.rmSync(directory, { recursive: true, force: true });
+				fs.symlinkSync(swapTarget, directory);
+			}
+			return result;
+		};
+		const swap = harvestDeclaredArtifacts({
+			request: { task_id: 'swap-attempt', artifact_declarations: [{ name: 'report', path: 'report.md' }] },
+			cwd: workspace,
+			artifactDir: swapRoot,
+		});
+		assert.equal(swap.errors[0].code, 'capture_failed');
+		assert.equal(fs.readdirSync(swapTarget).length, 0);
+	} finally {
+		fs.mkdirSync = originalMkdir;
+	}
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }

--- a/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
+++ b/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
@@ -95,6 +95,34 @@ try {
 	});
 	assert.equal(symlink.errors[0].code, 'capture_failed');
 
+	const swappedSourceDirectory = path.join(workspace, 'swap-source');
+	const outsideDirectory = path.join(root, 'outside-source');
+	const swappedSourceFile = path.join(fs.realpathSync(workspace), 'swap-source', 'report.md');
+	fs.mkdirSync(swappedSourceDirectory);
+	fs.mkdirSync(outsideDirectory);
+	fs.writeFileSync(swappedSourceFile, 'inside workspace\n');
+	fs.writeFileSync(path.join(outsideDirectory, 'report.md'), 'outside content\n');
+	const originalOpen = fs.openSync;
+	try {
+		fs.openSync = (filePath, flags, ...args) => {
+			if (filePath === swappedSourceFile && typeof flags === 'number') {
+				fs.rmSync(swappedSourceDirectory, { recursive: true, force: true });
+				fs.symlinkSync(outsideDirectory, swappedSourceDirectory);
+			}
+			return originalOpen(filePath, flags, ...args);
+		};
+		const ancestorSwap = harvestDeclaredArtifacts({
+			request: { task_id: 'source-ancestor-swap', artifact_declarations: [{ name: 'report', path: 'swap-source/report.md', required: true }] },
+			cwd: workspace,
+			artifactDir: artifacts,
+		});
+		assert.equal(ancestorSwap.errors[0].code, 'capture_failed');
+		assert.equal(ancestorSwap.artifacts.length, 0);
+		assert.equal(fs.readFileSync(path.join(outsideDirectory, 'report.md'), 'utf8'), 'outside content\n');
+	} finally {
+		fs.openSync = originalOpen;
+	}
+
 	const destination = path.join(artifacts, 'declared', 'destination-symlink', 'report');
 	fs.mkdirSync(path.dirname(destination), { recursive: true });
 	const protectedFile = path.join(root, 'protected-final.txt');

--- a/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
+++ b/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
@@ -41,6 +41,8 @@ try {
 	assert.equal(report.sha256, crypto.createHash('sha256').update('# Report\n').digest('hex'));
 	assert.deepEqual(report.metadata, { source: 'agent' });
 	assert.equal(fs.readFileSync(report.path, 'utf8'), '# Report\n');
+	fs.writeFileSync(path.join(workspace, 'report.md'), 'changed after staging\n');
+	assert.equal(fs.readFileSync(report.path, 'utf8'), '# Report\n');
 	assert.equal(screenshots.file_count, 2);
 	assert.deepEqual(fs.readFileSync(path.join(screenshots.path, 'image.bin')), binary);
 	assert.equal(screenshots.sha256, '831c9f2aacaee843fd4a84b4ae13732902470e83baed13fc52fb08c901cbde6f');
@@ -52,6 +54,19 @@ try {
 	});
 	assert.equal(rejected.errors[0].code, 'unsafe_path');
 	assert.equal(rejected.artifacts.length, 0);
+	const missingPath = harvestDeclaredArtifacts({
+		request: { artifact_declarations: [{ name: 'required-path', required: true }] },
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.equal(missingPath.errors[0].code, 'invalid_path');
+	const collision = harvestDeclaredArtifacts({
+		request: { artifact_declarations: [{ name: 'same/name', path: 'report.md' }, { name: 'same-name', path: 'report.md' }] },
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.deepEqual(collision.errors.map((error) => error.code), ['destination_collision', 'destination_collision']);
+	assert.equal(collision.artifacts.length, 0);
 
 	fs.writeFileSync(path.join(root, 'outside.txt'), 'outside workspace\n');
 	fs.symlinkSync(path.join(root, 'outside.txt'), path.join(workspace, 'escaped-link'));

--- a/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
+++ b/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
@@ -15,6 +15,7 @@ fs.writeFileSync(path.join(workspace, 'report.md'), '# Report\n');
 const binary = Buffer.from([0, 255, 1, 254, 2]);
 fs.writeFileSync(path.join(workspace, 'screenshots', 'image.bin'), binary);
 fs.writeFileSync(path.join(workspace, 'screenshots', 'caption.txt'), 'Screenshot caption\n');
+fs.mkdirSync(path.join(workspace, 'screenshots', 'empty'));
 fs.mkdirSync(artifacts);
 
 try {
@@ -45,8 +46,10 @@ try {
 	fs.writeFileSync(path.join(workspace, 'report.md'), 'changed after staging\n');
 	assert.equal(fs.readFileSync(report.path, 'utf8'), '# Report\n');
 	assert.equal(screenshots.file_count, 2);
+	assert.equal(screenshots.node_count, 4);
 	assert.deepEqual(fs.readFileSync(path.join(screenshots.path, 'image.bin')), binary);
-	assert.equal(screenshots.sha256, '831c9f2aacaee843fd4a84b4ae13732902470e83baed13fc52fb08c901cbde6f');
+	assert.equal(fs.statSync(path.join(screenshots.path, 'empty')).isDirectory(), true);
+	assert.match(screenshots.path, /\.homeboy-declared-/);
 
 	const rejected = harvestDeclaredArtifacts({
 		request: { artifact_declarations: [{ name: 'escape', path: '../outside.txt', required: true }] },
@@ -68,6 +71,20 @@ try {
 	});
 	assert.deepEqual(collision.errors.map((error) => error.code), ['destination_collision', 'destination_collision']);
 	assert.equal(collision.artifacts.length, 0);
+	const nodeBudget = harvestDeclaredArtifacts({
+		request: { artifact_declarations: [{ name: 'too-many-nodes', path: 'screenshots' }] },
+		config: { declared_artifact_max_nodes: 3 },
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.equal(nodeBudget.errors[0].code, 'capture_failed');
+	fs.rmdirSync(path.join(workspace, 'screenshots', 'empty'));
+	const withoutEmptyDirectory = harvestDeclaredArtifacts({
+		request: { artifact_declarations: [{ name: 'screenshots-without-empty', path: 'screenshots' }] },
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.notEqual(withoutEmptyDirectory.artifacts[0].sha256, screenshots.sha256);
 
 	fs.writeFileSync(path.join(root, 'outside.txt'), 'outside workspace\n');
 	fs.symlinkSync(path.join(root, 'outside.txt'), path.join(workspace, 'escaped-link'));
@@ -88,7 +105,7 @@ try {
 		cwd: workspace,
 		artifactDir: artifacts,
 	});
-	assert.equal(finalSymlink.errors[0].code, 'capture_failed');
+	assert.equal(finalSymlink.errors.length, 0);
 	assert.equal(fs.readFileSync(protectedFile, 'utf8'), 'protected\n');
 
 	const ancestorRoot = path.join(root, 'ancestor-artifacts');
@@ -101,20 +118,21 @@ try {
 		cwd: workspace,
 		artifactDir: ancestorRoot,
 	});
-	assert.equal(ancestorSymlink.errors[0].code, 'capture_failed');
+	assert.equal(ancestorSymlink.errors.length, 0);
 	assert.equal(fs.readdirSync(protectedDirectory).length, 0);
 
 	const swapRoot = path.join(root, 'swap-artifacts');
 	const swapTarget = path.join(root, 'swap-target');
 	fs.mkdirSync(swapRoot);
 	fs.mkdirSync(swapTarget);
-	const originalMkdir = fs.mkdirSync;
+	const realSwapRoot = fs.realpathSync(swapRoot);
+	const originalMkdtemp = fs.mkdtempSync;
 	try {
-		fs.mkdirSync = (directory, options) => {
-			const result = originalMkdir(directory, options);
-			if (directory === path.join(swapRoot, 'declared')) {
-				fs.rmSync(directory, { recursive: true, force: true });
-				fs.symlinkSync(swapTarget, directory);
+		fs.mkdtempSync = (prefix, options) => {
+			const result = originalMkdtemp(prefix, options);
+			if (prefix.startsWith(realSwapRoot)) {
+				fs.rmSync(result, { recursive: true, force: true });
+				fs.symlinkSync(swapTarget, result);
 			}
 			return result;
 		};
@@ -123,10 +141,10 @@ try {
 			cwd: workspace,
 			artifactDir: swapRoot,
 		});
-		assert.equal(swap.errors[0].code, 'capture_failed');
+		assert.equal(swap.errors[0].code, 'artifact_root');
 		assert.equal(fs.readdirSync(swapTarget).length, 0);
 	} finally {
-		fs.mkdirSync = originalMkdir;
+		fs.mkdtempSync = originalMkdtemp;
 	}
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });

--- a/agent-runtimes/lib/declared-artifact-harvester.js
+++ b/agent-runtimes/lib/declared-artifact-harvester.js
@@ -25,7 +25,10 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 	if (!workspaceRoot) {
 		return captureFailure(declarations, 'workspace_root', 'The declared artifact workspace root does not exist.');
 	}
-	const root = path.resolve(artifactDir);
+	const root = schedulerArtifactRoot(artifactDir);
+	if (!root) {
+		return captureFailure(declarations, 'artifact_root', 'The scheduler-owned artifact root must be an existing non-symlink directory.');
+	}
 	const budget = artifactBudget(request, config);
 	const result = emptyResult();
 	const destinations = declarationDestinations(declarations, root, request.task_id);
@@ -65,7 +68,7 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 	}
 	for (const { declaration, source, destination, collected } of prepared) {
 		try {
-			copyEntries(collected.entries, source, destination, collected.directory);
+			copyEntries(root, collected.entries, source, destination, collected.directory);
 			const digest = collected.directory
 				? digestTree(collected.entries, source)
 				: collected.entries[0].digest;
@@ -171,15 +174,61 @@ function collectSource(source, workspaceRoot, budget) {
 	return { entries, bytes: entries.reduce((total, entry) => total + entry.bytes, 0), directory: rootStat.isDirectory() };
 }
 
-function copyEntries(entries, source, destination, directory) {
+function copyEntries(root, entries, source, destination, directory) {
 	if (directory) {
-		fs.mkdirSync(destination, { recursive: true });
+		ensureSafeDirectory(root, destination);
 	}
 	for (const entry of entries) {
 		const relative = path.relative(source, entry.path);
 		const target = relative ? path.join(destination, relative) : destination;
-		fs.mkdirSync(path.dirname(target), { recursive: true });
-		fs.writeFileSync(target, entry.content);
+		ensureSafeDirectory(root, path.dirname(target));
+		writeNewFile(target, entry.content);
+	}
+}
+
+function schedulerArtifactRoot(value) {
+	const root = path.resolve(value);
+	try {
+		const stat = fs.lstatSync(root);
+		return !stat.isSymbolicLink() && stat.isDirectory() ? root : '';
+	} catch {
+		return '';
+	}
+}
+
+function ensureSafeDirectory(root, directory) {
+	if (directory !== root && !directory.startsWith(`${root}${path.sep}`)) {
+		throw new Error('Artifact destination escapes the scheduler artifact root.');
+	}
+	let current = root;
+	for (const segment of path.relative(root, directory).split(path.sep).filter(Boolean)) {
+		current = path.join(current, segment);
+		try {
+			fs.mkdirSync(current, { mode: 0o700 });
+		} catch (error) {
+			if (error.code !== 'EEXIST') {
+				throw error;
+			}
+		}
+		const stat = fs.lstatSync(current);
+		if (stat.isSymbolicLink() || !stat.isDirectory()) {
+			throw new Error('Artifact destination contains a symlink or non-directory ancestor.');
+		}
+		const fd = fs.openSync(current, fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW);
+		fs.closeSync(fd);
+	}
+}
+
+function writeNewFile(target, content) {
+	const fd = fs.openSync(target, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW, 0o600);
+	try {
+		let offset = 0;
+		while (offset < content.length) {
+			offset += fs.writeSync(fd, content, offset, content.length - offset, offset);
+		}
+		fs.fsyncSync(fd);
+	} finally {
+		fs.closeSync(fd);
 	}
 }
 

--- a/agent-runtimes/lib/declared-artifact-harvester.js
+++ b/agent-runtimes/lib/declared-artifact-harvester.js
@@ -1,37 +1,23 @@
 'use strict';
 
-/**
- * External dependencies
- */
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const DEFAULT_BUDGET = {
-	maxBytes: 50 * 1024 * 1024,
-	maxFiles: 1_000,
-	maxDepth: 32,
-};
+const DEFAULT_BUDGET = { maxBytes: 50 * 1024 * 1024, maxFiles: 1_000, maxNodes: 2_000, maxDepth: 32 };
 
 function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifactDir = '' } = {}) {
 	const declarations = declaredArtifacts(request);
 	if (declarations.length === 0) {
 		return emptyResult();
 	}
-	if (!artifactDir) {
-		return captureFailure(declarations, 'artifact_root', 'The scheduler-owned artifact root is required for declared artifacts.');
-	}
 	const workspaceRoot = realDirectory(cwd);
-	if (!workspaceRoot) {
-		return captureFailure(declarations, 'workspace_root', 'The declared artifact workspace root does not exist.');
-	}
 	const root = schedulerArtifactRoot(artifactDir);
-	if (!root) {
-		return captureFailure(declarations, 'artifact_root', 'The scheduler-owned artifact root must be an existing non-symlink directory.');
+	if (!workspaceRoot || !root) {
+		return captureFailure(declarations, !workspaceRoot ? 'workspace_root' : 'artifact_root', !workspaceRoot ? 'The declared artifact workspace root does not exist.' : 'The scheduler-owned artifact root must be an existing non-symlink directory.');
 	}
-	const budget = artifactBudget(request, config);
 	const result = emptyResult();
-	const destinations = declarationDestinations(declarations, root, request.task_id);
+	const destinations = declarationDestinations(declarations, request.task_id);
 	const prepared = [];
 	for (const declaration of declarations) {
 		if (!validDeclaredPath(declaration.path)) {
@@ -52,26 +38,30 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 			continue;
 		}
 		if (!fs.existsSync(source.path)) {
-			const missing = { name: declaration.name, path: declaration.path, required: declaration.required === true };
-			(result.missing[missing.required ? 'required' : 'optional']).push(missing);
+			(result.missing[declaration.required ? 'required' : 'optional']).push({ name: declaration.name, path: declaration.path, required: declaration.required === true });
 			continue;
 		}
 		try {
-			if (root === source.path || root.startsWith(`${source.path}${path.sep}`)) {
-				throw new Error('Declared artifact source must not contain the scheduler artifact root.');
-			}
-			const collected = collectSource(source.path, workspaceRoot, budget);
-			prepared.push({ declaration, source: source.path, destination: destinations.paths.get(declaration), collected });
+			prepared.push({ declaration, collected: collectSource(source.path, workspaceRoot, artifactBudget(request, config)) });
 		} catch (error) {
 			result.errors.push({ artifact: declaration.name, code: 'capture_failed', message: error.message });
 		}
 	}
-	for (const { declaration, source, destination, collected } of prepared) {
+	if (prepared.length === 0) {
+		return result;
+	}
+	let stage;
+	try {
+		stage = privateArtifactStage(root);
+	} catch (error) {
+		return { ...result, errors: [...result.errors, ...prepared.map(({ declaration }) => ({ artifact: declaration.name, code: 'artifact_root', message: error.message }))] };
+	}
+	for (const { declaration, collected } of prepared) {
 		try {
-			copyEntries(root, collected.entries, source, destination, collected.directory);
-			const digest = collected.directory
-				? digestTree(collected.entries, source)
-				: collected.entries[0].digest;
+			const destination = path.join(stage.path, safeFileSegment(request.task_id), safeFileSegment(declaration.name));
+			copyStagedEntries(stage, destination, collected.entries);
+			verifyRetainedPath(root, stage, destination);
+			const digest = collected.directory ? digestTree(collected.entries) : collected.entries[0].digest;
 			const artifact = {
 				id: declaration.id || declaration.name,
 				name: declaration.name,
@@ -82,10 +72,11 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 				required: declaration.required === true,
 				bytes: collected.bytes,
 				sha256: digest,
-				file_count: collected.entries.length,
+				file_count: collected.entries.filter((entry) => !entry.directory).length,
+				node_count: collected.entries.length,
 				provenance: { source_path: declaration.path, workspace_root: workspaceRoot },
 				...(declaration.description ? { description: declaration.description } : {}),
-				...(declaration.metadata && typeof declaration.metadata === 'object' && !Array.isArray(declaration.metadata) ? { metadata: declaration.metadata } : {}),
+				...(plainObject(declaration.metadata) ? { metadata: declaration.metadata } : {}),
 			};
 			result.artifacts.push(artifact);
 			result.evidence_refs.push({ kind: artifact.kind, label: artifact.name, uri: `file://${destination}`, sha256: digest });
@@ -97,35 +88,113 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 }
 
 function declaredArtifacts(request = {}) {
-	const source = Array.isArray(request.artifact_declarations)
-		? request.artifact_declarations
-		: (Array.isArray(request.executor?.artifact_declarations) ? request.executor.artifact_declarations : []);
-	return source.filter((artifact) => artifact && typeof artifact === 'object' && (artifact.name || artifact.id))
-		.map((artifact) => ({ ...artifact, name: String(artifact.name || artifact.id) }));
+	const source = Array.isArray(request.artifact_declarations) ? request.artifact_declarations : (Array.isArray(request.executor?.artifact_declarations) ? request.executor.artifact_declarations : []);
+	return source.filter((artifact) => plainObject(artifact) && (artifact.name || artifact.id)).map((artifact) => ({ ...artifact, name: String(artifact.name || artifact.id) }));
 }
 
-function declarationDestinations(declarations, root, taskId) {
-	const paths = new Map();
+function declarationDestinations(declarations, taskId) {
+	const keys = new Map();
 	const counts = new Map();
 	for (const declaration of declarations) {
-		const destination = path.join(root, 'declared', safeFileSegment(taskId), safeFileSegment(declaration.name));
-		paths.set(declaration, destination);
-		counts.set(destination, (counts.get(destination) || 0) + 1);
+		const key = `${safeFileSegment(taskId)}/${safeFileSegment(declaration.name)}`;
+		keys.set(declaration, key);
+		counts.set(key, (counts.get(key) || 0) + 1);
 	}
-	return { paths, collisions: new Set(declarations.filter((declaration) => counts.get(paths.get(declaration)) > 1)) };
+	return { collisions: new Set(declarations.filter((declaration) => counts.get(keys.get(declaration)) > 1)) };
 }
 
-function validDeclaredPath(value) {
-	return typeof value === 'string' && value !== '';
-}
-
-function artifactBudget(request, config) {
-	const limits = request.limits || {};
-	return {
-		maxBytes: positiveInteger(config.declared_artifact_max_bytes || config.declaredArtifactMaxBytes || limits.declared_artifact_max_bytes || limits.declaredArtifactMaxBytes, DEFAULT_BUDGET.maxBytes),
-		maxFiles: positiveInteger(config.declared_artifact_max_files || config.declaredArtifactMaxFiles || limits.declared_artifact_max_files || limits.declaredArtifactMaxFiles, DEFAULT_BUDGET.maxFiles),
-		maxDepth: positiveInteger(config.declared_artifact_max_depth || config.declaredArtifactMaxDepth || limits.declared_artifact_max_depth || limits.declaredArtifactMaxDepth, DEFAULT_BUDGET.maxDepth),
+function collectSource(source, workspaceRoot, budget) {
+	const entries = [];
+	let bytes = 0;
+	const visit = (current, relative, depth) => {
+		if (depth > budget.maxDepth) {
+			throw new Error(`Declared artifact exceeds the ${budget.maxDepth}-level traversal budget.`);
+		}
+		if (entries.length >= budget.maxNodes) {
+			throw new Error(`Declared artifact exceeds the ${budget.maxNodes}-node budget.`);
+		}
+		const stat = fs.lstatSync(current);
+		if (stat.isSymbolicLink() || !stat.isFile() && !stat.isDirectory()) {
+			throw new Error('Declared artifact tree contains a symlink or unsafe file type.');
+		}
+		const real = fs.realpathSync(current);
+		if (!isWithin(workspaceRoot, real)) {
+			throw new Error('Declared artifact source resolves outside the workspace root.');
+		}
+		if (stat.isDirectory()) {
+			entries.push({ relative, directory: true });
+			for (const name of fs.readdirSync(current).sort()) {
+				visit(path.join(current, name), path.join(relative, name), depth + 1);
+			}
+			return;
+		}
+		if (entries.filter((entry) => !entry.directory).length >= budget.maxFiles) {
+			throw new Error(`Declared artifact exceeds the ${budget.maxFiles}-file budget.`);
+		}
+		const staged = stagedFile(current, budget.maxBytes - bytes);
+		bytes += staged.bytes;
+		entries.push({ relative, directory: false, ...staged });
 	};
+	visit(source, '', 0);
+	return { entries, bytes, directory: entries[0].directory };
+}
+
+function copyStagedEntries(stage, destination, entries) {
+	for (const entry of entries) {
+		const target = entry.relative ? path.join(destination, entry.relative) : destination;
+		assertStagePath(stage, target);
+		if (entry.directory) {
+			fs.mkdirSync(target, { recursive: true, mode: 0o700 });
+			continue;
+		}
+		fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+		writeNewFile(target, entry.content);
+	}
+}
+
+function privateArtifactStage(root) {
+	assertRoot(root);
+	const stagePath = fs.mkdtempSync(path.join(root.path, '.homeboy-declared-'));
+	fs.chmodSync(stagePath, 0o700);
+	const stat = fs.lstatSync(stagePath);
+	const real = fs.realpathSync(stagePath);
+	if (stat.isSymbolicLink() || !stat.isDirectory() || !isWithin(root.path, real)) {
+		throw new Error('Could not create a private scheduler artifact staging directory.');
+	}
+	return { path: real, dev: stat.dev, ino: stat.ino };
+}
+
+function verifyRetainedPath(root, stage, target) {
+	assertRoot(root);
+	const stageStat = fs.lstatSync(stage.path);
+	if (stageStat.isSymbolicLink() || stageStat.dev !== stage.dev || stageStat.ino !== stage.ino) {
+		throw new Error('Private scheduler artifact staging directory changed during capture.');
+	}
+	const real = fs.realpathSync(target);
+	if (!isWithin(stage.path, real) || !isWithin(root.path, real)) {
+		throw new Error('Retained artifact path escapes the private scheduler artifact root.');
+	}
+}
+
+function schedulerArtifactRoot(value) {
+	if (!value) {
+		return null;
+	}
+	try {
+		const input = path.resolve(value);
+		const stat = fs.lstatSync(input);
+		const real = fs.realpathSync(input);
+		return !stat.isSymbolicLink() && stat.isDirectory() ? { path: real, dev: stat.dev, ino: stat.ino } : null;
+	} catch {
+		return null;
+	}
+}
+
+function assertRoot(root) {
+	const stat = fs.lstatSync(root.path);
+	if (stat.isSymbolicLink() || !stat.isDirectory() || stat.dev !== root.dev || stat.ino !== root.ino || fs.realpathSync(root.path) !== root.path) {
+		throw new Error('Scheduler artifact root changed during capture.');
+	}
 }
 
 function resolveSource(workspaceRoot, declaredPath) {
@@ -133,88 +202,26 @@ function resolveSource(workspaceRoot, declaredPath) {
 		return { error: 'Declared artifact paths must be workspace-relative.' };
 	}
 	const candidate = path.resolve(workspaceRoot, declaredPath);
-	if (candidate !== workspaceRoot && !candidate.startsWith(`${workspaceRoot}${path.sep}`)) {
-		return { error: 'Declared artifact path escapes the workspace root.' };
-	}
-	return { path: candidate };
+	return isWithin(workspaceRoot, candidate) ? { path: candidate } : { error: 'Declared artifact path escapes the workspace root.' };
 }
 
-function collectSource(source, workspaceRoot, budget) {
-	const rootStat = fs.lstatSync(source);
-	if (rootStat.isSymbolicLink() || !rootStat.isFile() && !rootStat.isDirectory()) {
-		throw new Error('Declared artifact source must be a regular file or directory.');
-	}
-	const entries = [];
-	const visit = (current, depth) => {
-		if (depth > budget.maxDepth) {
-			throw new Error(`Declared artifact exceeds the ${budget.maxDepth}-level traversal budget.`);
-		}
-		const stat = fs.lstatSync(current);
-		if (stat.isSymbolicLink() || !stat.isFile() && !stat.isDirectory()) {
-			throw new Error('Declared artifact tree contains a symlink or unsafe file type.');
-		}
-		const real = fs.realpathSync(current);
-		if (real !== workspaceRoot && !real.startsWith(`${workspaceRoot}${path.sep}`)) {
-			throw new Error('Declared artifact source resolves outside the workspace root.');
-		}
-		if (stat.isDirectory()) {
-			for (const name of fs.readdirSync(current).sort()) {
-				visit(path.join(current, name), depth + 1);
-			}
-			return;
-		}
-		if (entries.length >= budget.maxFiles) {
-			throw new Error(`Declared artifact exceeds the ${budget.maxFiles}-file budget.`);
-		}
-		const usedBytes = entries.reduce((total, entry) => total + entry.bytes, 0);
-		const staged = stagedFile(current, budget.maxBytes - usedBytes);
-		entries.push({ path: current, ...staged });
-	};
-	visit(source, 0);
-	return { entries, bytes: entries.reduce((total, entry) => total + entry.bytes, 0), directory: rootStat.isDirectory() };
-}
-
-function copyEntries(root, entries, source, destination, directory) {
-	if (directory) {
-		ensureSafeDirectory(root, destination);
-	}
-	for (const entry of entries) {
-		const relative = path.relative(source, entry.path);
-		const target = relative ? path.join(destination, relative) : destination;
-		ensureSafeDirectory(root, path.dirname(target));
-		writeNewFile(target, entry.content);
-	}
-}
-
-function schedulerArtifactRoot(value) {
-	const root = path.resolve(value);
+function stagedFile(filePath, maxBytes) {
+	const fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
 	try {
-		const stat = fs.lstatSync(root);
-		return !stat.isSymbolicLink() && stat.isDirectory() ? root : '';
-	} catch {
-		return '';
-	}
-}
-
-function ensureSafeDirectory(root, directory) {
-	if (directory !== root && !directory.startsWith(`${root}${path.sep}`)) {
-		throw new Error('Artifact destination escapes the scheduler artifact root.');
-	}
-	let current = root;
-	for (const segment of path.relative(root, directory).split(path.sep).filter(Boolean)) {
-		current = path.join(current, segment);
-		try {
-			fs.mkdirSync(current, { mode: 0o700 });
-		} catch (error) {
-			if (error.code !== 'EEXIST') {
-				throw error;
+		const stat = fs.fstatSync(fd);
+		if (!stat.isFile() || stat.size > maxBytes) {
+			throw new Error(stat.isFile() ? 'Declared artifact exceeds the byte budget.' : 'Declared artifact source must be a regular file.');
+		}
+		const content = Buffer.alloc(stat.size);
+		for (let offset = 0; offset < content.length;) {
+			const count = fs.readSync(fd, content, offset, content.length - offset, offset);
+			if (count === 0) {
+				throw new Error('Declared artifact changed while it was being staged.');
 			}
+			offset += count;
 		}
-		const stat = fs.lstatSync(current);
-		if (stat.isSymbolicLink() || !stat.isDirectory()) {
-			throw new Error('Artifact destination contains a symlink or non-directory ancestor.');
-		}
-		const fd = fs.openSync(current, fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW);
+		return { bytes: stat.size, content, digest: crypto.createHash('sha256').update(content).digest('hex') };
+	} finally {
 		fs.closeSync(fd);
 	}
 }
@@ -222,8 +229,7 @@ function ensureSafeDirectory(root, directory) {
 function writeNewFile(target, content) {
 	const fd = fs.openSync(target, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW, 0o600);
 	try {
-		let offset = 0;
-		while (offset < content.length) {
+		for (let offset = 0; offset < content.length;) {
 			offset += fs.writeSync(fd, content, offset, content.length - offset, offset);
 		}
 		fs.fsyncSync(fd);
@@ -232,37 +238,32 @@ function writeNewFile(target, content) {
 	}
 }
 
-function digestTree(entries, source) {
+function digestTree(entries) {
 	const digest = crypto.createHash('sha256');
 	for (const entry of entries) {
-		digest.update(`${path.relative(source, entry.path)}\0${entry.digest}\n`);
+		digest.update(`${entry.directory ? 'D' : 'F'}\0${entry.relative}\0${entry.digest || ''}\n`);
 	}
 	return digest.digest('hex');
 }
 
-function stagedFile(filePath, maxBytes) {
-	const fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
-	try {
-		const stat = fs.fstatSync(fd);
-		if (!stat.isFile()) {
-			throw new Error('Declared artifact source must be a regular file.');
-		}
-		if (stat.size > maxBytes) {
-			throw new Error('Declared artifact exceeds the byte budget.');
-		}
-		const content = Buffer.alloc(stat.size);
-		let offset = 0;
-		while (offset < content.length) {
-			const bytes = fs.readSync(fd, content, offset, content.length - offset, offset);
-			if (bytes === 0) {
-				throw new Error('Declared artifact changed while it was being staged.');
-			}
-			offset += bytes;
-		}
-		return { bytes: stat.size, content, digest: crypto.createHash('sha256').update(content).digest('hex') };
-	} finally {
-		fs.closeSync(fd);
+function artifactBudget(request, config) {
+	const limits = request.limits || {};
+	return {
+		maxBytes: positiveInteger(config.declared_artifact_max_bytes || config.declaredArtifactMaxBytes || limits.declared_artifact_max_bytes || limits.declaredArtifactMaxBytes, DEFAULT_BUDGET.maxBytes),
+		maxFiles: positiveInteger(config.declared_artifact_max_files || config.declaredArtifactMaxFiles || limits.declared_artifact_max_files || limits.declaredArtifactMaxFiles, DEFAULT_BUDGET.maxFiles),
+		maxNodes: positiveInteger(config.declared_artifact_max_nodes || config.declaredArtifactMaxNodes || limits.declared_artifact_max_nodes || limits.declaredArtifactMaxNodes, DEFAULT_BUDGET.maxNodes),
+		maxDepth: positiveInteger(config.declared_artifact_max_depth || config.declaredArtifactMaxDepth || limits.declared_artifact_max_depth || limits.declaredArtifactMaxDepth, DEFAULT_BUDGET.maxDepth),
+	};
+}
+
+function assertStagePath(stage, target) {
+	if (!isWithin(stage.path, target)) {
+		throw new Error('Artifact destination escapes the private scheduler artifact root.');
 	}
+}
+
+function isWithin(root, target) {
+	return target === root || target.startsWith(`${root}${path.sep}`);
 }
 
 function realDirectory(value) {
@@ -273,22 +274,11 @@ function realDirectory(value) {
 	}
 }
 
-function positiveInteger(value, fallback) {
-	return Number.isSafeInteger(Number(value)) && Number(value) > 0 ? Number(value) : fallback;
-}
-
-function safeFileSegment(value) {
-	return String(value || 'artifact').replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'artifact';
-}
-
-function emptyResult() {
-	return { artifacts: [], evidence_refs: [], errors: [], missing: { required: [], optional: [] } };
-}
-
-function captureFailure(declarations, code, message) {
-	const result = emptyResult();
-	result.errors = declarations.map((declaration) => ({ artifact: declaration.name, code, message }));
-	return result;
-}
+function validDeclaredPath(value) { return typeof value === 'string' && value !== ''; }
+function positiveInteger(value, fallback) { return Number.isSafeInteger(Number(value)) && Number(value) > 0 ? Number(value) : fallback; }
+function safeFileSegment(value) { return String(value || 'artifact').replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'artifact'; }
+function plainObject(value) { return value && typeof value === 'object' && !Array.isArray(value); }
+function emptyResult() { return { artifacts: [], evidence_refs: [], errors: [], missing: { required: [], optional: [] } }; }
+function captureFailure(declarations, code, message) { const result = emptyResult(); result.errors = declarations.map((declaration) => ({ artifact: declaration.name, code, message })); return result; }
 
 module.exports = { harvestDeclaredArtifacts };

--- a/agent-runtimes/lib/declared-artifact-harvester.js
+++ b/agent-runtimes/lib/declared-artifact-harvester.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -122,6 +123,7 @@ function collectSource(source, workspaceRoot, budget) {
 			throw new Error('Declared artifact source resolves outside the workspace root.');
 		}
 		if (stat.isDirectory()) {
+			verifyDirectoryDescriptor(current, workspaceRoot);
 			entries.push({ relative, directory: true });
 			for (const name of fs.readdirSync(current).sort()) {
 				visit(path.join(current, name), path.join(relative, name), depth + 1);
@@ -131,7 +133,7 @@ function collectSource(source, workspaceRoot, budget) {
 		if (entries.filter((entry) => !entry.directory).length >= budget.maxFiles) {
 			throw new Error(`Declared artifact exceeds the ${budget.maxFiles}-file budget.`);
 		}
-		const staged = stagedFile(current, budget.maxBytes - bytes);
+		const staged = stagedFile(current, budget.maxBytes - bytes, workspaceRoot);
 		bytes += staged.bytes;
 		entries.push({ relative, directory: false, ...staged });
 	};
@@ -205,13 +207,14 @@ function resolveSource(workspaceRoot, declaredPath) {
 	return isWithin(workspaceRoot, candidate) ? { path: candidate } : { error: 'Declared artifact path escapes the workspace root.' };
 }
 
-function stagedFile(filePath, maxBytes) {
+function stagedFile(filePath, maxBytes, workspaceRoot) {
 	const fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
 	try {
 		const stat = fs.fstatSync(fd);
 		if (!stat.isFile() || stat.size > maxBytes) {
 			throw new Error(stat.isFile() ? 'Declared artifact exceeds the byte budget.' : 'Declared artifact source must be a regular file.');
 		}
+		verifyDescriptorPath(fd, workspaceRoot);
 		const content = Buffer.alloc(stat.size);
 		for (let offset = 0; offset < content.length;) {
 			const count = fs.readSync(fd, content, offset, content.length - offset, offset);
@@ -223,6 +226,48 @@ function stagedFile(filePath, maxBytes) {
 		return { bytes: stat.size, content, digest: crypto.createHash('sha256').update(content).digest('hex') };
 	} finally {
 		fs.closeSync(fd);
+	}
+}
+
+function verifyDirectoryDescriptor(directory, workspaceRoot) {
+	const fd = fs.openSync(directory, fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW);
+	try {
+		if (!fs.fstatSync(fd).isDirectory()) {
+			throw new Error('Declared artifact source must be a directory.');
+		}
+		verifyDescriptorPath(fd, workspaceRoot);
+	} finally {
+		fs.closeSync(fd);
+	}
+}
+
+function verifyDescriptorPath(fd, workspaceRoot) {
+	const descriptorPath = openedDescriptorPath(fd);
+	if (!descriptorPath || !isWithin(workspaceRoot, descriptorPath)) {
+		throw new Error('Declared artifact descriptor resolves outside the workspace root.');
+	}
+}
+
+function openedDescriptorPath(fd) {
+	for (const base of ['/proc/self/fd', '/dev/fd']) {
+		try {
+			const resolved = fs.realpathSync(path.join(base, String(fd)));
+			if (path.isAbsolute(resolved) && !resolved.startsWith(`${base}/`)) {
+				return resolved;
+			}
+		} catch {
+			// Try the next platform descriptor resolver.
+		}
+	}
+	const result = spawnSync('lsof', ['-Fn', '-a', '-p', String(process.pid), '-d', String(fd)], { encoding: 'utf8' });
+	const line = String(result.stdout || '').split('\n').find((value) => value.startsWith('n'));
+	if (!line || !path.isAbsolute(line.slice(1))) {
+		throw new Error('Descriptor identity proof is unavailable; refusing declared artifact source capture.');
+	}
+	try {
+		return fs.realpathSync(line.slice(1));
+	} catch {
+		throw new Error('Descriptor identity proof could not resolve the opened source path.');
 	}
 }
 

--- a/agent-runtimes/lib/declared-artifact-harvester.js
+++ b/agent-runtimes/lib/declared-artifact-harvester.js
@@ -28,7 +28,21 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 	const root = path.resolve(artifactDir);
 	const budget = artifactBudget(request, config);
 	const result = emptyResult();
+	const destinations = declarationDestinations(declarations, root, request.task_id);
+	const prepared = [];
 	for (const declaration of declarations) {
+		if (!validDeclaredPath(declaration.path)) {
+			if (declaration.required) {
+				result.errors.push({ artifact: declaration.name, code: 'invalid_path', message: 'Required declared artifacts need an explicit workspace-relative path.' });
+			} else {
+				result.missing.optional.push({ name: declaration.name, path: '', required: false });
+			}
+			continue;
+		}
+		if (destinations.collisions.has(declaration)) {
+			result.errors.push({ artifact: declaration.name, code: 'destination_collision', message: 'Declared artifact destination collides with another declaration.' });
+			continue;
+		}
 		const source = resolveSource(workspaceRoot, declaration.path);
 		if (source.error) {
 			result.errors.push({ artifact: declaration.name, code: 'unsafe_path', message: source.error });
@@ -44,10 +58,16 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 				throw new Error('Declared artifact source must not contain the scheduler artifact root.');
 			}
 			const collected = collectSource(source.path, workspaceRoot, budget);
-			const destination = path.join(root, 'declared', safeFileSegment(request.task_id), safeFileSegment(declaration.name));
-			copyEntries(collected.entries, source.path, destination, collected.directory);
+			prepared.push({ declaration, source: source.path, destination: destinations.paths.get(declaration), collected });
+		} catch (error) {
+			result.errors.push({ artifact: declaration.name, code: 'capture_failed', message: error.message });
+		}
+	}
+	for (const { declaration, source, destination, collected } of prepared) {
+		try {
+			copyEntries(collected.entries, source, destination, collected.directory);
 			const digest = collected.directory
-				? digestTree(collected.entries, source.path)
+				? digestTree(collected.entries, source)
 				: collected.entries[0].digest;
 			const artifact = {
 				id: declaration.id || declaration.name,
@@ -77,8 +97,23 @@ function declaredArtifacts(request = {}) {
 	const source = Array.isArray(request.artifact_declarations)
 		? request.artifact_declarations
 		: (Array.isArray(request.executor?.artifact_declarations) ? request.executor.artifact_declarations : []);
-	return source.filter((artifact) => artifact && typeof artifact === 'object' && typeof artifact.path === 'string' && artifact.path && (artifact.name || artifact.id))
+	return source.filter((artifact) => artifact && typeof artifact === 'object' && (artifact.name || artifact.id))
 		.map((artifact) => ({ ...artifact, name: String(artifact.name || artifact.id) }));
+}
+
+function declarationDestinations(declarations, root, taskId) {
+	const paths = new Map();
+	const counts = new Map();
+	for (const declaration of declarations) {
+		const destination = path.join(root, 'declared', safeFileSegment(taskId), safeFileSegment(declaration.name));
+		paths.set(declaration, destination);
+		counts.set(destination, (counts.get(destination) || 0) + 1);
+	}
+	return { paths, collisions: new Set(declarations.filter((declaration) => counts.get(paths.get(declaration)) > 1)) };
+}
+
+function validDeclaredPath(value) {
+	return typeof value === 'string' && value !== '';
 }
 
 function artifactBudget(request, config) {
@@ -128,11 +163,9 @@ function collectSource(source, workspaceRoot, budget) {
 		if (entries.length >= budget.maxFiles) {
 			throw new Error(`Declared artifact exceeds the ${budget.maxFiles}-file budget.`);
 		}
-		const bytes = stat.size;
-		if (entries.reduce((total, entry) => total + entry.bytes, 0) + bytes > budget.maxBytes) {
-			throw new Error(`Declared artifact exceeds the ${budget.maxBytes}-byte budget.`);
-		}
-		entries.push({ path: current, bytes, digest: sha256File(current) });
+		const usedBytes = entries.reduce((total, entry) => total + entry.bytes, 0);
+		const staged = stagedFile(current, budget.maxBytes - usedBytes);
+		entries.push({ path: current, ...staged });
 	};
 	visit(source, 0);
 	return { entries, bytes: entries.reduce((total, entry) => total + entry.bytes, 0), directory: rootStat.isDirectory() };
@@ -146,7 +179,7 @@ function copyEntries(entries, source, destination, directory) {
 		const relative = path.relative(source, entry.path);
 		const target = relative ? path.join(destination, relative) : destination;
 		fs.mkdirSync(path.dirname(target), { recursive: true });
-		fs.copyFileSync(entry.path, target);
+		fs.writeFileSync(target, entry.content);
 	}
 }
 
@@ -158,8 +191,29 @@ function digestTree(entries, source) {
 	return digest.digest('hex');
 }
 
-function sha256File(filePath) {
-	return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+function stagedFile(filePath, maxBytes) {
+	const fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+	try {
+		const stat = fs.fstatSync(fd);
+		if (!stat.isFile()) {
+			throw new Error('Declared artifact source must be a regular file.');
+		}
+		if (stat.size > maxBytes) {
+			throw new Error('Declared artifact exceeds the byte budget.');
+		}
+		const content = Buffer.alloc(stat.size);
+		let offset = 0;
+		while (offset < content.length) {
+			const bytes = fs.readSync(fd, content, offset, content.length - offset, offset);
+			if (bytes === 0) {
+				throw new Error('Declared artifact changed while it was being staged.');
+			}
+			offset += bytes;
+		}
+		return { bytes: stat.size, content, digest: crypto.createHash('sha256').update(content).digest('hex') };
+	} finally {
+		fs.closeSync(fd);
+	}
 }
 
 function realDirectory(value) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -614,6 +614,68 @@ process.exit(${attempt.status});
 	assert.equal(agentResult.opencode_session.status, 'not_discovered');
 	assert.equal(artifactResult.metadata.missing_declared_artifacts, undefined);
 
+	const declaredArtifactCliPath = path.join(root, 'mock-opencode-declared-artifacts.cjs');
+	fs.writeFileSync(declaredArtifactCliPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.mkdirSync('declared-screenshots', { recursive: true });
+fs.writeFileSync('declared-report.md', '# OpenCode report\\n');
+fs.writeFileSync('declared-screenshots/image.bin', Buffer.from([0, 255, 1, 254]));
+process.exit(0);
+`);
+	const noOpDeclaredArtifactCliPath = path.join(root, 'mock-opencode-no-op-declared-artifacts.cjs');
+	fs.writeFileSync(noOpDeclaredArtifactCliPath, '#!/usr/bin/env node\nprocess.exit(0);\n');
+	const declaredOpenCodeResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-declared-artifacts',
+		workspace_path: workspace,
+		artifacts_path: path.join(root, 'declared-opencode-artifacts'),
+		artifact_declarations: [
+			{ name: 'report', path: 'declared-report.md', kind: 'markdown', artifact_type: 'report', artifact_schema: 'example/report/v1', required: true, metadata: { source: 'opencode' } },
+			{ name: 'screenshots', path: 'declared-screenshots', kind: 'screenshot-directory', required: true },
+			{ name: 'optional-video', path: 'missing.webm', kind: 'video', required: false },
+		],
+		executor: {
+			...request.executor,
+			config: { ...request.executor.config, command_args: [declaredArtifactCliPath] },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(declaredOpenCodeResult.status, 'succeeded', JSON.stringify(declaredOpenCodeResult.diagnostics));
+	const declaredReport = declaredOpenCodeResult.artifacts.find((artifact) => artifact.name === 'report');
+	const declaredScreenshots = declaredOpenCodeResult.artifacts.find((artifact) => artifact.name === 'screenshots');
+	assert.equal(declaredReport.artifact_schema, 'example/report/v1');
+	assert.equal(declaredReport.artifact_type, 'report');
+	assert.equal(declaredReport.metadata.source, 'opencode');
+	assert.equal(declaredReport.bytes, Buffer.byteLength('# OpenCode report\n'));
+	assert.match(declaredReport.sha256, /^[a-f0-9]{64}$/);
+	assert.deepEqual(fs.readFileSync(path.join(declaredScreenshots.path, 'image.bin')), Buffer.from([0, 255, 1, 254]));
+	assert.equal(declaredOpenCodeResult.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.optional_declared_artifact_missing'), true);
+	const unsafeOpenCodeResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-unsafe-declared-artifact',
+		workspace_path: workspace,
+		artifacts_path: path.join(root, 'unsafe-opencode-artifacts'),
+		artifact_declarations: [{ name: 'unsafe', path: '../outside.md', required: true }],
+		executor: {
+			...request.executor,
+			config: { ...request.executor.config, command_args: [noOpDeclaredArtifactCliPath] },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(unsafeOpenCodeResult.status, 'failed');
+	assert.equal(unsafeOpenCodeResult.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.declared_artifact_unsafe_path'), true);
+	const missingPathOpenCodeResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-missing-path-declared-artifact',
+		workspace_path: workspace,
+		artifacts_path: path.join(root, 'missing-path-opencode-artifacts'),
+		artifact_declarations: [{ name: 'missing-path', required: true }],
+		executor: {
+			...request.executor,
+			config: { ...request.executor.config, command_args: [noOpDeclaredArtifactCliPath] },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(missingPathOpenCodeResult.status, 'failed');
+	assert.equal(missingPathOpenCodeResult.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.declared_artifact_invalid_path'), true);
+
 	const largePatchCliPath = path.join(root, 'mock-opencode-large-patch.cjs');
 	fs.writeFileSync(largePatchCliPath, `#!/usr/bin/env node
 const fs = require('node:fs');

--- a/agent-runtimes/pi/lib/pi-agent-task-executor.js
+++ b/agent-runtimes/pi/lib/pi-agent-task-executor.js
@@ -91,7 +91,7 @@ const { execute: executePiAgentTask, outcome, validationFailure } = createCliAge
 	providerLabel: 'Pi agent',
 	defaultSummary: 'Pi agent task executor did not produce a detailed outcome.',
 	requireConfig: false,
-	emitArtifacts: false,
+	emitArtifacts: true,
 	timeoutFallback: (config) => config.timeout_seconds || DEFAULT_TIMEOUT_SECONDS,
 	resolveCommandSpec,
 	buildArgs: (request, config, commandSpec) => commandSpec.args,

--- a/agent-runtimes/pi/package.json
+++ b/agent-runtimes/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeboy-agent-runtime-pi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "main": "index.js",
   "exports": {

--- a/agent-runtimes/pi/pi.json
+++ b/agent-runtimes/pi/pi.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "pi",
   "name": "Pi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Conservative Pi agent runtime integration for generic Homeboy agent task requests.",
   "contract_producers": [
     {

--- a/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
@@ -106,6 +106,27 @@ process.stdin.on('end', () => {
 		},
 		instructions: 'Validate the Pi provider boundary through a configured command.',
 	};
+	const declaredWorkspace = path.join(root, 'declared-workspace');
+	const declaredArtifacts = path.join(root, 'declared-artifacts');
+	fs.mkdirSync(declaredWorkspace);
+	fs.mkdirSync(declaredArtifacts);
+	const declaredPiPath = path.join(root, 'mock-pi-declared.cjs');
+	fs.writeFileSync(declaredPiPath, `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.writeFileSync('pi-report.md', '# Pi report\\n');
+process.stdin.resume();
+process.stdin.on('end', () => process.exit(0));
+`);
+	const declaredResult = executePiAgentTask({
+		...configuredRequest,
+		task_id: 'pi-declared-artifact',
+		workspace_path: declaredWorkspace,
+		artifacts_path: declaredArtifacts,
+		artifact_declarations: [{ name: 'report', path: 'pi-report.md', kind: 'markdown', required: true }],
+		executor: { backend: 'pi', runtime: 'pi', config: { command: process.execPath, command_args: [declaredPiPath], cwd: declaredWorkspace } },
+	});
+	assert.equal(declaredResult.artifacts.some((artifact) => artifact.name === 'report'), true);
+	assert.equal(declaredResult.evidence_refs.some((ref) => ref.label === 'report'), true);
 	const runResult = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
 		env: { ...process.env, UNDECLARED_SECRET: 'must-not-reach-pi' },

--- a/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 /**
  * External dependencies
  */

--- a/homeboy.json
+++ b/homeboy.json
@@ -7,6 +7,9 @@
     "test": [
       "node tests/agent-task-provider-contract-smoke.mjs",
       "node agent-runtimes/codex/tests/declared-artifact-harvester.test.js",
+      "node agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js",
+      "node agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js",
+      "node agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js",
       "node tests/browser-result-shapes-smoke.mjs",
       "bash tests/cross-extension-sidecar-normalization-smoke.sh",
       "node tests/deferred-init-browser-helper-smoke.mjs",

--- a/homeboy.json
+++ b/homeboy.json
@@ -6,6 +6,7 @@
   "self_checks": {
     "test": [
       "node tests/agent-task-provider-contract-smoke.mjs",
+      "node agent-runtimes/codex/tests/declared-artifact-harvester.test.js",
       "node tests/browser-result-shapes-smoke.mjs",
       "bash tests/cross-extension-sidecar-normalization-smoke.sh",
       "node tests/deferred-init-browser-helper-smoke.mjs",


### PR DESCRIPTION
Closes #2540.\n\nFollow-up to #2541. This PR hardens declared artifact harvesting with staged-byte integrity, required declaration validation, collision rejection, private scheduler retention, source/destination symlink and swap coverage, empty-directory tree digests, bounded nodes, Pi artifact outcomes, and descriptor identity validation for every collected source file and directory.\n\nDiff commits:\n- 565eb90bca04eacf1d2dcd42bb3e8e5ba3f48cbf fix: harden declared artifact staging\n- 26bddf884c03047055cc43250f28b6550f987b03 fix: confine declared artifact destinations\n- 7a7de0dfaa4b98a73f78481f9c619c4709916627 fix: isolate declared artifact retention\n- 935e0f4c fix: verify declared artifact descriptors\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode general coding subagent; used to implement and verify declared artifact harvesting. Chris Huber remains responsible for every line.