### PR TITLE
fix(rust): batch nextest shard manifests

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.32.2",
+  "version": "1.32.3",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
@@ -95,7 +95,8 @@
       "keys": [
         "HOMEBOY_TEST_INVENTORY_ONLY",
         "HOMEBOY_TEST_INVENTORY_FILE",
-        "HOMEBOY_TEST_SHARD_MANIFEST"
+        "HOMEBOY_TEST_SHARD_MANIFEST",
+        "HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES"
       ]
     },
     "passthrough_filter": {
@@ -128,6 +129,13 @@
       "type": "boolean",
       "default": true,
       "description": "When cargo-nextest is selected but unavailable, fall back to cargo test. Set false or HOMEBOY_RUST_NEXTEST_FALLBACK=0 to fail with an install diagnostic instead."
+    },
+    {
+      "id": "rust_nextest_filter_max_bytes",
+      "label": "Rust nextest filter maximum bytes",
+      "type": "number",
+      "default": 65536,
+      "description": "Maximum UTF-8 byte length for each serialized nextest -E filter during shard replay. Selected identities are deterministically batched under this bound."
     },
     {
       "id": "bench_criterion",

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.32.3",
+  "version": "1.32.4",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
@@ -133,7 +133,7 @@
     {
       "id": "rust_nextest_filter_max_bytes",
       "label": "Rust nextest filter maximum bytes",
-      "type": "number",
+      "type": "integer",
       "default": 65536,
       "description": "Maximum UTF-8 byte length for each serialized nextest -E filter during shard replay. Selected identities are deterministically batched under this bound."
     },

--- a/rust/scripts/lint-fix-results-smoke.sh
+++ b/rust/scripts/lint-fix-results-smoke.sh
@@ -5,18 +5,45 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
-RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
-RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-steps.sh}"
-COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${TMP_DIR}/sidecar-writer.sh}"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${TMP_DIR}/runner-prelude.sh}"
+RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${TMP_DIR}/runner-steps.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${TMP_DIR}/command-capture.sh}"
 
-if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
-    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
-    exit 1
-fi
+cat > "${TMP_DIR}/sidecar-writer.sh" <<'EOF'
+homeboy_sidecar_merge() { :; }
+homeboy_sidecar_emit() {
+    local kind="$1" result="$2"
+    [ "$kind" = "fix.result" ] || return 0
+    python3 - "$HOMEBOY_FIX_RESULTS_FILE" "$result" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+items = json.loads(path.read_text()) if path.exists() else []
+items.append(json.loads(sys.argv[2]))
+path.write_text(json.dumps(items))
+PY
+}
+EOF
+cat > "${TMP_DIR}/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+    PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+    source "$HOMEBOY_RUNTIME_SIDECAR_WRITER"
+}
+should_run_step() { return 0; }
+EOF
+cat > "${TMP_DIR}/runner-steps.sh" <<'EOF'
+should_run_step() { return 0; }
+EOF
+cat > "${TMP_DIR}/command-capture.sh" <<'EOF'
+homeboy_run_step_capture() { local output_var="$1" exit_var="$2"; shift 3; [ "$1" = -- ] && shift; local output status=0; output="$(mktemp)"; "$@" >"$output" 2>&1 || status=$?; printf -v "$output_var" '%s' "$output"; printf -v "$exit_var" '%s' "$status"; return "$status"; }
+homeboy_cleanup_step_capture() { rm -f "$1"; }
+EOF
 
 PROJECT_DIR="${TMP_DIR}/project"
 FAKE_BIN="${TMP_DIR}/bin"

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -3,23 +3,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
-COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
-if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
-    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
-    exit 1
-fi
-if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
-    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
-    exit 1
-fi
-
 PROJECT_DIR="$WORKDIR/project"
 HELPER_DIR="$WORKDIR/helpers"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-$HELPER_DIR/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-$HELPER_DIR/command-capture.sh}"
 mkdir -p "$PROJECT_DIR/src/core" "$PROJECT_DIR/tests/core" "$HELPER_DIR"
 
 cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
@@ -92,6 +82,19 @@ homeboy_resolve_context() {
     PROJECT_PATH="${HOMEBOY_COMPONENT_PATH}"
     EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH}"
 }
+EOF
+
+cat > "$HELPER_DIR/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+    PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+should_run_step() { return 0; }
+EOF
+
+cat > "$HELPER_DIR/command-capture.sh" <<'EOF'
+homeboy_run_step_capture() { local output_var="$1" exit_var="$2"; shift 3; [ "$1" = -- ] && shift; local output status=0; output="$(mktemp)"; "$@" 2>&1 | tee "$output"; status=${PIPESTATUS[0]}; printf -v "$output_var" '%s' "$output"; printf -v "$exit_var" '%s' "$status"; return "$status"; }
+homeboy_cleanup_step_capture() { rm -f "$1"; }
 EOF
 
 cat > "$HELPER_DIR/runner-steps.sh" <<'EOF'

--- a/rust/scripts/rust-nextest-runner-smoke.sh
+++ b/rust/scripts/rust-nextest-runner-smoke.sh
@@ -3,25 +3,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
-COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
-
-if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
-    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
-    exit 1
-fi
-if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
-    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
-    exit 1
-fi
 
 PROJECT_DIR="$WORKDIR/project"
 HELPER_DIR="$WORKDIR/helpers"
 BIN_DIR="$WORKDIR/bin"
 SIDECAR_DIR="$WORKDIR/sidecars"
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-$HELPER_DIR/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-$HELPER_DIR/command-capture.sh}"
 mkdir -p "$PROJECT_DIR/tests" "$HELPER_DIR" "$BIN_DIR" "$SIDECAR_DIR"
 
 cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
@@ -43,6 +33,20 @@ homeboy_resolve_context() {
     PROJECT_PATH="${HOMEBOY_COMPONENT_PATH}"
     EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH}"
 }
+EOF
+
+cat > "$HELPER_DIR/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+    PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+    [ -z "${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}" ] || source "$HOMEBOY_RUNTIME_SIDECAR_WRITER"
+}
+should_run_step() { return 0; }
+EOF
+
+cat > "$HELPER_DIR/command-capture.sh" <<'EOF'
+homeboy_run_step_capture() { local output_var="$1" exit_var="$2"; shift 3; [ "$1" = -- ] && shift; local output status=0; output="$(mktemp)"; "$@" >"$output" 2>&1 || status=$?; printf -v "$output_var" '%s' "$output"; printf -v "$exit_var" '%s' "$status"; return "$status"; }
+homeboy_cleanup_step_capture() { rm -f "$1"; }
 EOF
 
 cat > "$HELPER_DIR/runner-steps.sh" <<'EOF'
@@ -106,7 +110,7 @@ if [[ "$OUTPUT" != *"Running cargo nextest"* ]]; then
     exit 1
 fi
 
-EXPECTED_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n--test\nintegration_scope'
+EXPECTED_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n--workspace\n--test\nintegration_scope'
 ACTUAL_ARGS="$(cat "$WORKDIR/cargo-args.txt")"
 if [ "$ACTUAL_ARGS" != "$EXPECTED_ARGS" ]; then
     printf 'Expected nextest command shape:\n%s\nActual:\n%s\n' "$EXPECTED_ARGS" "$ACTUAL_ARGS" >&2

--- a/rust/scripts/rust-runner-steps-direct-smoke.sh
+++ b/rust/scripts/rust-runner-steps-direct-smoke.sh
@@ -2,20 +2,22 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
-RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/runner-prelude.sh}"
-COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/command-capture.sh}"
 PROJECT_DIR="$(mktemp -d)"
 trap 'rm -rf "$PROJECT_DIR"' EXIT
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-$PROJECT_DIR/runner-prelude.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-$PROJECT_DIR/command-capture.sh}"
 
-if [ ! -f "$RUNNER_PRELUDE_HELPER" ]; then
-    echo "Missing runner prelude helper: $RUNNER_PRELUDE_HELPER" >&2
-    exit 1
-fi
-if [ ! -f "$COMMAND_CAPTURE_HELPER" ]; then
-    echo "Missing command capture helper: $COMMAND_CAPTURE_HELPER" >&2
-    exit 1
-fi
+cat > "$PROJECT_DIR/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+    PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+should_run_step() { [ "${HOMEBOY_STEP:-}" != "none" ]; }
+EOF
+cat > "$PROJECT_DIR/command-capture.sh" <<'EOF'
+homeboy_run_step_capture() { local output_var="$1" exit_var="$2"; shift 3; [ "$1" = -- ] && shift; local output status=0; output="$(mktemp)"; "$@" >"$output" 2>&1 || status=$?; printf -v "$output_var" '%s' "$output"; printf -v "$exit_var" '%s' "$status"; return "$status"; }
+homeboy_cleanup_step_capture() { rm -f "$1"; }
+EOF
 
 cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
 [package]

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -193,6 +193,89 @@ rust_nextest_filter() {
     jq -r '[.selected[] | "package(=\(.package)) and kind(=\(.target_kind)) and binary(=\(.target)) and test(=\(.name))"] | join(" + ")' "$1"
 }
 
+rust_nextest_filter_max_bytes() {
+    local value
+    value="${HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES:-$(homeboy_setting rust_nextest_filter_max_bytes '.rust_nextest_filter_max_bytes' 65536)}"
+    case "$value" in
+        ''|0|*[!0-9]*)
+            echo "Error: HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES must be a positive integer." >&2
+            return 1
+            ;;
+        *) printf '%s' "$value" ;;
+    esac
+}
+
+rust_nextest_batches() {
+    local shard_file="$1" max_bytes="$2" batch_dir="$3"
+    python3 - "$shard_file" "$max_bytes" "$batch_dir" <<'PY'
+import json
+import pathlib
+import sys
+
+shard_path, max_bytes_raw, batch_dir = sys.argv[1:]
+max_bytes = int(max_bytes_raw)
+shard = json.load(open(shard_path, encoding="utf-8"))
+batches = []
+current = []
+current_size = 0
+
+def term(item):
+    return f'package(={item["package"]}) and kind(={item["target_kind"]}) and binary(={item["target"]}) and test(={item["name"]})'
+
+for item in shard["selected"]:
+    item_term = term(item)
+    item_size = len(item_term.encode("utf-8"))
+    if item_size > max_bytes:
+        raise SystemExit(f"Rust test shard error: nextest identity exceeds filter byte limit ({item['id']!r}: {item_size} > {max_bytes})")
+    added_size = item_size if not current else item_size + 3
+    if current and current_size + added_size > max_bytes:
+        batches.append(current)
+        current = []
+        current_size = 0
+    current.append(item)
+    current_size += item_size if current_size == 0 else added_size
+if current:
+    batches.append(current)
+if not batches or any(not batch for batch in batches):
+    raise SystemExit("Rust test shard error: nextest batching produced an empty batch")
+
+target_dir = pathlib.Path(batch_dir)
+for index, batch in enumerate(batches):
+    target = dict(shard, selected=batch)
+    filter_bytes = len(" + ".join(term(item) for item in batch).encode("utf-8"))
+    if filter_bytes > max_bytes:
+        raise SystemExit("Rust test shard error: nextest batch exceeds filter byte limit")
+    path = target_dir / f"{index:06d}.json"
+    path.write_text(json.dumps(target, separators=(",", ":")), encoding="utf-8")
+    print(path)
+PY
+}
+
+rust_validate_nextest_batches() {
+    local shard_file="$1" batch_dir="$2"
+    python3 - "$shard_file" "$batch_dir" <<'PY'
+import json
+import pathlib
+import sys
+
+expected = [item["id"] for item in json.load(open(sys.argv[1], encoding="utf-8"))["selected"]]
+actual = []
+for path in sorted(pathlib.Path(sys.argv[2]).glob("*.json")):
+    batch = json.load(open(path, encoding="utf-8"))["selected"]
+    if not batch:
+        raise SystemExit(f"Rust test shard error: nextest batch is empty: {path.name}")
+    actual.extend(item["id"] for item in batch)
+if len(actual) != len(set(actual)):
+    raise SystemExit("Rust test shard error: nextest batches contain duplicate identities")
+if set(actual) != set(expected) or len(actual) != len(expected):
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    raise SystemExit(f"Rust test shard error: nextest batch membership mismatch (missing={missing[:1]}, extra={extra[:1]})")
+if actual != expected:
+    raise SystemExit("Rust test shard error: nextest batches do not preserve manifest ordering")
+PY
+}
+
 rust_validate_nextest_membership() {
     local list_file="$1" shard_file="$2"
     python3 - "$list_file" "$shard_file" <<'PY'
@@ -470,26 +553,55 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
     SHARD_FAILED=0
     SHARD_SKIPPED=0
     if [ "$SELECTED_RUNNER" = "nextest" ]; then
-        NEXTEST_FILTER="$(rust_nextest_filter "$SHARD_DATA")"
-        NEXTEST_LIST="$(mktemp)"
-        homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
-        if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_OUTPUT" "$SHARD_DATA"; then
+        if ! NEXTEST_MAX_BYTES="$(rust_nextest_filter_max_bytes)"; then
             SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
             rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
-            rm -f "$NEXTEST_LIST_OUTPUT" "$NEXTEST_LIST"
+            rm -f "$SHARD_DATA"
             exit 1
         fi
-        rm -f "$NEXTEST_LIST_OUTPUT" "$NEXTEST_LIST"
-        echo "Replaying Rust nextest shard: ${SHARD_TOTAL} exact identities"
-        homeboy_run_step_capture SHARD_OUTPUT SHARD_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --manifest-path "${PROJECT_PATH}/Cargo.toml" --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
-        if ! NEXTEST_COUNTS="$(rust_nextest_counts "$SHARD_OUTPUT" "$SHARD_DATA")"; then
+        NEXTEST_BATCH_DIR="$(mktemp -d)"
+        if ! rust_nextest_batches "$SHARD_DATA" "$NEXTEST_MAX_BYTES" "$NEXTEST_BATCH_DIR" || ! rust_validate_nextest_batches "$SHARD_DATA" "$NEXTEST_BATCH_DIR"; then
             SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
             rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
-            rm -f "$SHARD_OUTPUT" "$SHARD_DATA"
+            rm -rf "$NEXTEST_BATCH_DIR"
+            rm -f "$SHARD_DATA"
             exit 1
         fi
-        IFS=$'\t' read -r SHARD_PASSED SHARD_FAILED SHARD_SKIPPED <<< "$NEXTEST_COUNTS"
-        rm -f "$SHARD_OUTPUT"
+        # Validate every planned filter before any test batch can execute.
+        for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
+            NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
+            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
+            if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_OUTPUT" "$NEXTEST_BATCH"; then
+                SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+                rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+                rm -f "$NEXTEST_LIST_OUTPUT"
+                rm -rf "$NEXTEST_BATCH_DIR"
+                rm -f "$SHARD_DATA"
+                exit 1
+            fi
+            rm -f "$NEXTEST_LIST_OUTPUT"
+        done
+        echo "Replaying Rust nextest shard: ${SHARD_TOTAL} exact identities in $(printf '%s\n' "$NEXTEST_BATCH_DIR"/*.json | wc -l | tr -d ' ') batches"
+        SHARD_EXIT=0
+        for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
+            NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
+            homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --manifest-path "${PROJECT_PATH}/Cargo.toml" --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
+            if ! NEXTEST_COUNTS="$(rust_nextest_counts "$SHARD_OUTPUT" "$NEXTEST_BATCH")"; then
+                SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+                rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+                rm -f "$SHARD_OUTPUT"
+                rm -rf "$NEXTEST_BATCH_DIR"
+                rm -f "$SHARD_DATA"
+                exit 1
+            fi
+            IFS=$'\t' read -r PASSED FAILED SKIPPED <<< "$NEXTEST_COUNTS"
+            SHARD_PASSED=$((SHARD_PASSED + PASSED))
+            SHARD_FAILED=$((SHARD_FAILED + FAILED))
+            SHARD_SKIPPED=$((SHARD_SKIPPED + SKIPPED))
+            [ "$NEXTEST_BATCH_EXIT" -eq 0 ] || SHARD_EXIT="$NEXTEST_BATCH_EXIT"
+            rm -f "$SHARD_OUTPUT"
+        done
+        rm -rf "$NEXTEST_BATCH_DIR"
     else
         while IFS=$'\t' read -r package target target_kind name; do
             case "$target_kind" in

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -194,11 +194,51 @@ rust_nextest_filter() {
 }
 
 rust_nextest_filter_max_bytes() {
-    local value
-    value="${HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES:-$(homeboy_setting rust_nextest_filter_max_bytes '.rust_nextest_filter_max_bytes' 65536)}"
-    case "$value" in
+    local configured value
+    configured="${HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES:-$(homeboy_setting rust_nextest_filter_max_bytes '.rust_nextest_filter_max_bytes' 65536)}"
+    case "$configured" in
         ''|0|*[!0-9]*)
             echo "Error: HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES must be a positive integer." >&2
+            return 1
+            ;;
+    esac
+    value="$(python3 - "$configured" <<'PY'
+import os
+import subprocess
+import sys
+
+configured = int(sys.argv[1])
+try:
+    arg_max = int(subprocess.check_output(["getconf", "ARG_MAX"], text=True).strip())
+except (OSError, subprocess.CalledProcessError, ValueError):
+    # This fallback remains below common POSIX ARG_MAX values when getconf is
+    # unavailable, so a runner never relies on an optimistic platform guess.
+    arg_max = 131072
+
+environment_bytes = sum(len(key.encode()) + len(value.encode()) + 2 for key, value in os.environ.items())
+pointer_bytes = (len(os.environ) + 32) * 8
+fixed_argv_bytes = 16384
+safety_bytes = 65536
+per_argument_ceiling = 65536
+safe_max = min(per_argument_ceiling, arg_max - environment_bytes - pointer_bytes - fixed_argv_bytes - safety_bytes)
+if safe_max <= 0:
+    raise SystemExit(
+        f"Rust test shard error: no safe nextest filter payload remains "
+        f"(ARG_MAX={arg_max}, environment_bytes={environment_bytes})"
+    )
+if configured > safe_max:
+    print(f"{safe_max}|{configured}|{arg_max}|{environment_bytes}")
+else:
+    print(f"{configured}||{arg_max}|{environment_bytes}")
+PY
+)" || return 1
+    IFS='|' read -r value clamped_from arg_max environment_bytes <<< "$value"
+    if [ -n "$clamped_from" ]; then
+        echo "Rust nextest filter limit clamped from ${clamped_from} to ${value} bytes (ARG_MAX=${arg_max}, environment_bytes=${environment_bytes})." >&2
+    fi
+    case "$value" in
+        ''|0|*[!0-9]*)
+            echo "Error: no safe nextest filter payload remains." >&2
             return 1
             ;;
         *) printf '%s' "$value" ;;
@@ -585,7 +625,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
         SHARD_EXIT=0
         for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
             NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
-            homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --manifest-path "${PROJECT_PATH}/Cargo.toml" --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
+            homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --manifest-path "${PROJECT_PATH}/Cargo.toml" --workspace --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
             if ! NEXTEST_COUNTS="$(rust_nextest_counts "$SHARD_OUTPUT" "$NEXTEST_BATCH")"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -32,7 +32,27 @@ if [ "${1:-}" = 'metadata' ]; then
   exit 0
 fi
 if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'list' ]; then
-  printf '%s\n' '{"rust-suites":{"shard-smoke":{"package-name":"shard-smoke","binary-name":"shard_smoke","kind":"lib","testcases":{"unit::alpha":{"ignored":false,"filter-match":{"status":"matches"}},"unit::beta":{"ignored":false,"filter-match":{"status":"matches"}},"unit::ignored":{"ignored":true,"filter-match":{"status":"matches"}},"profile::excluded":{"ignored":false,"filter-match":{"status":"mismatch"}}}},"shard-smoke::api":{"package-name":"shard-smoke","binary-name":"api","kind":"test","testcases":{"api::works":{"ignored":false,"filter-match":{"status":"matches"}}}}}}'
+  if [ "${HOMEBOY_NEXTEST_LIST_MODE:-pass}" = zero ]; then printf '%s\n' '{"rust-suites":{}}'; exit 0; fi
+  python3 - "$@" <<'PY'
+import json
+import os
+import re
+import sys
+
+count = int(os.environ.get("HOMEBOY_NEXTEST_TEST_COUNT", "4"))
+names = ["unit::alpha", "unit::beta", "unit::ignored", "api::works"] if count == 4 else [f"unit::long_test_{index:04d}_{'x' * 100}" for index in range(count)]
+args = sys.argv[1:]
+filter_value = args[args.index("-E") + 1] if "-E" in args else ""
+selected = set(re.findall(r"test\(=([^)]+)\)", filter_value)) if filter_value else set(names)
+suites = {}
+for name in names:
+    if name not in selected:
+        continue
+    binary, kind = ("api", "test") if name == "api::works" else ("shard_smoke", "lib")
+    suite = suites.setdefault(f"shard-smoke::{binary}", {"package-name": "shard-smoke", "binary-name": binary, "kind": kind, "testcases": {}})
+    suite["testcases"][name] = {"ignored": name == "unit::ignored", "filter-match": {"status": "matches"}}
+print(json.dumps({"rust-suites": suites}))
+PY
   exit 0
 fi
 if [[ " $* " == *' --workspace '* && " $* " == *' --no-run '* ]]; then
@@ -45,11 +65,25 @@ if [[ " $* " == *' --doc '* && " $* " == *' --list '* ]]; then
 fi
 if [ -n "${HOMEBOY_FAKE_CARGO_LOG:-}" ]; then printf '%s\n' "$*" >> "${HOMEBOY_FAKE_CARGO_LOG}"; fi
 if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'run' ]; then
-  case "${HOMEBOY_NEXTEST_MODE:-pass}" in
-    zero) exit 0 ;;
-    failure) printf '%s\n' '{"type":"test","name":"shard-smoke::shard_smoke$unit::alpha","event":"ok"}' '{"type":"test","name":"shard-smoke::shard_smoke$unit::beta","event":"failed"}' '{"type":"test","name":"shard-smoke::shard_smoke$unit::ignored","event":"ignored"}' '{"type":"test","name":"shard-smoke::api$api::works","event":"ok"}'; exit 1 ;;
-    *) printf '%s\n' '{"type":"test","name":"shard-smoke::shard_smoke$unit::alpha","event":"ok"}' '{"type":"test","name":"shard-smoke::shard_smoke$unit::beta","event":"ok"}' '{"type":"test","name":"shard-smoke::shard_smoke$unit::ignored","event":"ignored"}' '{"type":"test","name":"shard-smoke::api$api::works","event":"ok"}'; exit 0 ;;
-  esac
+  [ -z "${HOMEBOY_FAKE_NEXTEST_RUN_LOG:-}" ] || printf '%s\n' "$*" >> "$HOMEBOY_FAKE_NEXTEST_RUN_LOG"
+  python3 - "$@" <<'PY'
+import json
+import os
+import re
+import sys
+
+args = sys.argv[1:]
+names = re.findall(r"test\(=([^)]+)\)", args[args.index("-E") + 1])
+mode = os.environ.get("HOMEBOY_NEXTEST_MODE", "pass")
+if mode == "zero":
+    raise SystemExit(0)
+for name in names:
+    binary = "api" if name == "api::works" else "shard_smoke"
+    event = "failed" if mode == "failure" and name == "unit::beta" else "ignored" if name == "unit::ignored" else "ok"
+    print(json.dumps({"type": "test", "name": f"shard-smoke::{binary}${name}", "event": event}))
+raise SystemExit(1 if mode == "failure" else 0)
+PY
+  exit $?
 fi
 if [ -n "${HOMEBOY_FAIL_TEST:-}" ] && [[ " $* " == *" ${HOMEBOY_FAIL_TEST} "* ]]; then
   printf 'test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out\n'
@@ -229,6 +263,131 @@ import json
 import sys
 
 assert json.load(open(sys.argv[1])) == {"total": 4, "passed": 3, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+
+# A small limit forces deterministic batches. Every filter stays below the
+# bound while the aggregate result remains the immutable manifest total.
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES=150 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_RUN_LOG="$WORK_DIR/batched-nextest.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/batched-nextest-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/batched-nextest.out"
+
+python3 - "$WORK_DIR/batched-nextest.log" "$WORK_DIR/batched-nextest-results.json" <<'PY'
+import json
+import re
+import sys
+
+limit = 150
+lines = open(sys.argv[1]).read().splitlines()
+assert len(lines) == 4, lines
+selected = []
+for line in lines:
+    filter_value = line.split(" -E ", 1)[1]
+    assert len(filter_value.encode()) <= limit, filter_value
+    selected.extend(re.findall(r"test\(=([^)]+)\)", filter_value))
+assert selected == ["unit::alpha", "unit::beta", "unit::ignored", "api::works"], selected
+assert len(selected) == len(set(selected)), selected
+assert json.load(open(sys.argv[2])) == {"total": 4, "passed": 3, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+
+# A list validation failure is preflight-only: no batch run may have started.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES=150 \
+HOMEBOY_NEXTEST_LIST_MODE=zero \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_RUN_LOG="$WORK_DIR/zero-list-runs.log" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/zero-list.out" 2>&1
+ZERO_LIST_EXIT=$?
+set -e
+if [ "$ZERO_LIST_EXIT" -eq 0 ] || [ -e "$WORK_DIR/zero-list-runs.log" ]; then
+  printf 'Expected zero-list validation to fail before any nextest batch executes\n' >&2
+  exit 1
+fi
+
+# One identity that cannot fit the configured transport bound fails before list
+# or run, rather than attempting an oversized argv.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES=10 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/oversized-identity.out" 2>&1
+OVERSIZED_EXIT=$?
+set -e
+if [ "$OVERSIZED_EXIT" -eq 0 ] || ! grep -q 'identity exceeds filter byte limit' "$WORK_DIR/oversized-identity.out"; then
+  printf 'Expected individually oversized nextest identity rejection\n' >&2
+  exit 1
+fi
+
+# This manifest produces a monolithic filter well beyond typical ARG_MAX, but
+# bounded batches complete and retain the complete aggregate evidence.
+LARGE_INVENTORY="$WORK_DIR/large-nextest-inventory.json"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_TEST_COUNT=3000 \
+HOMEBOY_TEST_INVENTORY_ONLY=1 \
+HOMEBOY_TEST_INVENTORY_FILE="$LARGE_INVENTORY" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/large-inventory.out"
+python3 - "$LARGE_INVENTORY" "$WORK_DIR/large-nextest-manifest.json" <<'PY'
+import json
+import sys
+
+inventory = json.load(open(sys.argv[1]))
+manifest = {key: inventory[key] for key in ("runner", "inventory_fingerprint", "runner_fingerprint", "workspace_fingerprint")}
+manifest["schema"] = "homeboy/test-shard-manifest/v1"
+manifest["tests"] = [test["id"] for test in inventory["tests"]]
+json.dump(manifest, open(sys.argv[2], "w"))
+PY
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_TEST_COUNT=3000 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/large-nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_RUN_LOG="$WORK_DIR/large-nextest.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/large-nextest-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/large-nextest.out"
+python3 - "$WORK_DIR/large-nextest.log" "$WORK_DIR/large-nextest-results.json" <<'PY'
+import json
+import sys
+
+filters = [line.split(" -E ", 1)[1] for line in open(sys.argv[1])]
+assert len(filters) > 1, len(filters)
+assert all(len(value.encode()) <= 65536 for value in filters), max(map(lambda value: len(value.encode()), filters))
+assert json.load(open(sys.argv[2])) == {"total": 3000, "passed": 3000, "failed": 0, "skipped": 0, "partial": "rust-shard"}
 PY
 
 set +e

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -6,6 +6,23 @@ EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 WORK_DIR="$(mktemp -d -t homeboy-rust-shards.XXXXXX)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
+# The manifest must expose the same whole-byte contract enforced by the runner.
+python3 - "$EXTENSION_DIR/rust.json" <<'PY'
+import json
+import sys
+
+settings = json.load(open(sys.argv[1], encoding="utf-8"))["settings"]
+setting = next(item for item in settings if item["id"] == "rust_nextest_filter_max_bytes")
+assert setting["type"] == "integer", setting
+
+def accepts(value):
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+assert accepts(setting["default"]), setting
+assert accepts(65536)
+assert not accepts(65536.5)
+PY
+
 PROJECT_DIR="$WORK_DIR/project"
 BIN_DIR="$WORK_DIR/bin"
 mkdir -p "$PROJECT_DIR/src" "$PROJECT_DIR/member/src" "$BIN_DIR" "$WORK_DIR/annotations"

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -8,9 +8,11 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 
 PROJECT_DIR="$WORK_DIR/project"
 BIN_DIR="$WORK_DIR/bin"
-mkdir -p "$PROJECT_DIR/src" "$BIN_DIR" "$WORK_DIR/annotations"
-printf '[package]\nname = "shard-smoke"\nversion = "0.1.0"\nedition = "2021"\n' > "$PROJECT_DIR/Cargo.toml"
+mkdir -p "$PROJECT_DIR/src" "$PROJECT_DIR/member/src" "$BIN_DIR" "$WORK_DIR/annotations"
+printf '[package]\nname = "shard-smoke"\nversion = "0.1.0"\nedition = "2021"\n\n[workspace]\nmembers = ["member"]\n' > "$PROJECT_DIR/Cargo.toml"
 printf 'pub fn fixture() {}\n' > "$PROJECT_DIR/src/lib.rs"
+printf '[package]\nname = "member-smoke"\nversion = "0.1.0"\nedition = "2021"\n' > "$PROJECT_DIR/member/Cargo.toml"
+printf '#[cfg(test)]\nmod tests { #[test] fn member_works() {} }\n' > "$PROJECT_DIR/member/src/lib.rs"
 
 cat > "$BIN_DIR/test-lib" <<'EOF'
 #!/usr/bin/env bash
@@ -20,7 +22,11 @@ cat > "$BIN_DIR/test-api" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' 'api::works: test'
 EOF
-chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api"
+cat > "$BIN_DIR/test-member" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'member::member_works: test'
+EOF
+chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member"
 
 cat > "$BIN_DIR/cargo" <<'EOF'
 #!/usr/bin/env bash
@@ -28,10 +34,11 @@ set -euo pipefail
 if [ "${1:-}" = '--version' ]; then printf 'cargo 1.80.0\n'; exit 0; fi
 if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = '--version' ]; then printf 'cargo-nextest 0.9.0\n'; exit 0; fi
 if [ "${1:-}" = 'metadata' ]; then
-  printf '{"packages":[{"id":"shard-smoke 0.1.0 (path+file:///fixture)","name":"shard-smoke"}],"workspace_root":"%s"}\n' "$PWD"
+  printf '{"packages":[{"id":"shard-smoke 0.1.0 (path+file:///fixture)","name":"shard-smoke"},{"id":"member-smoke 0.1.0 (path+file:///fixture/member)","name":"member-smoke"}],"workspace_root":"%s"}\n' "$PWD"
   exit 0
 fi
 if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'list' ]; then
+  [ -z "${HOMEBOY_FAKE_NEXTEST_LOG:-}" ] || printf 'list %s\n' "$*" >> "$HOMEBOY_FAKE_NEXTEST_LOG"
   if [ "${HOMEBOY_NEXTEST_LIST_MODE:-pass}" = zero ]; then printf '%s\n' '{"rust-suites":{}}'; exit 0; fi
   python3 - "$@" <<'PY'
 import json
@@ -39,8 +46,8 @@ import os
 import re
 import sys
 
-count = int(os.environ.get("HOMEBOY_NEXTEST_TEST_COUNT", "4"))
-names = ["unit::alpha", "unit::beta", "unit::ignored", "api::works"] if count == 4 else [f"unit::long_test_{index:04d}_{'x' * 100}" for index in range(count)]
+count = int(os.environ.get("HOMEBOY_NEXTEST_TEST_COUNT", "5"))
+names = ["unit::alpha", "unit::beta", "unit::ignored", "api::works", "member::member_works"] if count == 5 else [f"unit::long_test_{index:04d}_{'x' * 100}" for index in range(count)]
 args = sys.argv[1:]
 filter_value = args[args.index("-E") + 1] if "-E" in args else ""
 selected = set(re.findall(r"test\(=([^)]+)\)", filter_value)) if filter_value else set(names)
@@ -48,8 +55,8 @@ suites = {}
 for name in names:
     if name not in selected:
         continue
-    binary, kind = ("api", "test") if name == "api::works" else ("shard_smoke", "lib")
-    suite = suites.setdefault(f"shard-smoke::{binary}", {"package-name": "shard-smoke", "binary-name": binary, "kind": kind, "testcases": {}})
+    package, binary, kind = ("shard-smoke", "api", "test") if name == "api::works" else ("member-smoke", "member_smoke", "lib") if name == "member::member_works" else ("shard-smoke", "shard_smoke", "lib")
+    suite = suites.setdefault(f"{package}::{binary}", {"package-name": package, "binary-name": binary, "kind": kind, "testcases": {}})
     suite["testcases"][name] = {"ignored": name == "unit::ignored", "filter-match": {"status": "matches"}}
 print(json.dumps({"rust-suites": suites}))
 PY
@@ -58,6 +65,7 @@ fi
 if [[ " $* " == *' --workspace '* && " $* " == *' --no-run '* ]]; then
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"shard_smoke","kind":["lib"]},"executable":"%s/test-lib"}\n' "$(dirname "$0")"
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"api","kind":["test"]},"executable":"%s/test-api"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"member-smoke 0.1.0 (path+file:///fixture/member)","target":{"name":"member_smoke","kind":["lib"]},"executable":"%s/test-member"}\n' "$(dirname "$0")"
   exit 0
 fi
 if [[ " $* " == *' --doc '* && " $* " == *' --list '* ]]; then
@@ -65,6 +73,7 @@ if [[ " $* " == *' --doc '* && " $* " == *' --list '* ]]; then
 fi
 if [ -n "${HOMEBOY_FAKE_CARGO_LOG:-}" ]; then printf '%s\n' "$*" >> "${HOMEBOY_FAKE_CARGO_LOG}"; fi
 if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'run' ]; then
+  [ -z "${HOMEBOY_FAKE_NEXTEST_LOG:-}" ] || printf 'run %s\n' "$*" >> "$HOMEBOY_FAKE_NEXTEST_LOG"
   [ -z "${HOMEBOY_FAKE_NEXTEST_RUN_LOG:-}" ] || printf '%s\n' "$*" >> "$HOMEBOY_FAKE_NEXTEST_RUN_LOG"
   python3 - "$@" <<'PY'
 import json
@@ -78,10 +87,10 @@ mode = os.environ.get("HOMEBOY_NEXTEST_MODE", "pass")
 if mode == "zero":
     raise SystemExit(0)
 for name in names:
-    binary = "api" if name == "api::works" else "shard_smoke"
+    package, binary = ("shard-smoke", "api") if name == "api::works" else ("member-smoke", "member_smoke") if name == "member::member_works" else ("shard-smoke", "shard_smoke")
     event = "failed" if mode == "failure" and name == "unit::beta" else "ignored" if name == "unit::ignored" else "ok"
-    print(json.dumps({"type": "test", "name": f"shard-smoke::{binary}${name}", "event": event}))
-raise SystemExit(1 if mode == "failure" else 0)
+    print(json.dumps({"type": "test", "name": f"{package}::{binary}${name}", "event": event}))
+raise SystemExit(1 if mode == "failure" and "unit::beta" in names else 0)
 PY
   exit $?
 fi
@@ -166,6 +175,7 @@ assert first["schema"] == "homeboy/test-inventory/v1", first
 assert nextest["schema"] == "homeboy/test-inventory/v1", nextest
 assert all(set(test) == {"id", "package", "target", "target_kind", "name"} for test in first["tests"]), first
 assert [test["id"] for test in first["tests"]] == [
+    "member-smoke::lib::member_smoke::member::member_works",
     "shard-smoke::lib::shard_smoke::unit::alpha",
     "shard-smoke::lib::shard_smoke::unit::beta",
     "shard-smoke::lib::shard_smoke::unit::ignored",
@@ -214,12 +224,13 @@ python3 - "$WORK_DIR/cargo.log" <<'PY'
 import sys
 
 lines = open(sys.argv[1]).read().splitlines()
-assert len(lines) == 4, lines
+assert len(lines) == 5, lines
 assert all(" --exact --test-threads=1" in line for line in lines), lines
 assert sum("unit::alpha" in line for line in lines) == 1, lines
 assert sum("unit::beta" in line for line in lines) == 1, lines
 assert sum("unit::ignored" in line for line in lines) == 1, lines
 assert sum("api::works" in line for line in lines) == 1, lines
+assert sum("member::member_works" in line for line in lines) == 1, lines
 PY
 
 python3 - "$WORK_DIR/test-results.json" "$WORK_DIR/annotations/rust-test-shard.json" <<'PY'
@@ -227,9 +238,9 @@ import json
 import sys
 
 results = json.load(open(sys.argv[1]))
-assert results == {"total": 4, "passed": 3, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
+assert results == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
 record = json.load(open(sys.argv[2]))[0]
-assert (record["executed"], record["passed"], record["failed"], record["skipped"]) == (4, 3, 0, 1), record
+assert (record["executed"], record["passed"], record["failed"], record["skipped"]) == (5, 4, 0, 1), record
 assert record["duration_ms"] >= 0, record
 PY
 
@@ -239,6 +250,7 @@ HOMEBOY_SKIP_LINT=1 \
 HOMEBOY_RUST_TEST_RUNNER=nextest \
 HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
 HOMEBOY_FAKE_CARGO_LOG="$WORK_DIR/cargo.log" \
+HOMEBOY_FAKE_NEXTEST_LOG="$WORK_DIR/nextest-selection.log" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
 HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
 HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/nextest-test-results.json" \
@@ -252,17 +264,27 @@ python3 - "$WORK_DIR/cargo.log" <<'PY'
 import sys
 
 lines = open(sys.argv[1]).read().splitlines()
-nextest = lines[4:]
+nextest = lines[5:]
 assert len(nextest) == 1, lines
-assert "nextest run" in nextest[0] and " --test-threads 1 " in nextest[0], nextest
-assert "test(=unit::alpha)" in nextest[0] and "test(=unit::beta)" in nextest[0] and "test(=api::works)" in nextest[0], nextest
+assert "nextest run" in nextest[0] and " --workspace " in nextest[0] and " --test-threads 1 " in nextest[0], nextest
+assert "test(=unit::alpha)" in nextest[0] and "test(=unit::beta)" in nextest[0] and "test(=api::works)" in nextest[0] and "test(=member::member_works)" in nextest[0], nextest
 PY
 
 python3 - "$WORK_DIR/nextest-test-results.json" <<'PY'
 import json
 import sys
 
-assert json.load(open(sys.argv[1])) == {"total": 4, "passed": 3, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+
+python3 - "$WORK_DIR/nextest-selection.log" <<'PY'
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+assert len(lines) == 3, lines
+assert lines[1].startswith("list nextest list") and lines[2].startswith("run nextest run"), lines
+assert all(" --workspace " in line for line in lines), lines
+assert all("test(=member::member_works)" in line for line in lines[1:]), lines
 PY
 
 # A small limit forces deterministic batches. Every filter stays below the
@@ -290,15 +312,49 @@ import sys
 
 limit = 150
 lines = open(sys.argv[1]).read().splitlines()
-assert len(lines) == 4, lines
+assert len(lines) == 5, lines
 selected = []
 for line in lines:
     filter_value = line.split(" -E ", 1)[1]
     assert len(filter_value.encode()) <= limit, filter_value
     selected.extend(re.findall(r"test\(=([^)]+)\)", filter_value))
-assert selected == ["unit::alpha", "unit::beta", "unit::ignored", "api::works"], selected
+assert selected == ["member::member_works", "unit::alpha", "unit::beta", "unit::ignored", "api::works"], selected
 assert len(selected) == len(set(selected)), selected
-assert json.load(open(sys.argv[2])) == {"total": 4, "passed": 3, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+assert json.load(open(sys.argv[2])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+
+# A nonzero batch exit remains aggregate evidence: every prevalidated batch
+# runs exactly once, and the final shard fails only after all outcomes exist.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES=150 \
+HOMEBOY_NEXTEST_MODE=failure \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_RUN_LOG="$WORK_DIR/batched-failure.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/batched-failure-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/batched-failure.out" 2>&1
+BATCH_FAILURE_EXIT=$?
+set -e
+python3 - "$WORK_DIR/batched-failure.log" "$WORK_DIR/batched-failure-results.json" "$BATCH_FAILURE_EXIT" <<'PY'
+import json
+import re
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+selected = [name for line in lines for name in re.findall(r"test\(=([^)]+)\)", line)]
+assert int(sys.argv[3]) != 0, sys.argv[3]
+assert selected == ["member::member_works", "unit::alpha", "unit::beta", "unit::ignored", "api::works"], selected
+assert len(selected) == len(set(selected)), selected
+assert json.load(open(sys.argv[2])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
 PY
 
 # A list validation failure is preflight-only: no batch run may have started.
@@ -345,10 +401,39 @@ fi
 # This manifest produces a monolithic filter well beyond typical ARG_MAX, but
 # bounded batches complete and retain the complete aggregate evidence.
 LARGE_INVENTORY="$WORK_DIR/large-nextest-inventory.json"
+LARGE_ENVIRONMENT="$(python3 -c 'print("x" * 100000)')"
+GETCONF_DIR="$WORK_DIR/getconf-bin"
+mkdir -p "$GETCONF_DIR"
+cat > "$GETCONF_DIR/getconf" <<'EOF'
+#!/usr/bin/env bash
+printf '131072\n'
+EOF
+chmod +x "$GETCONF_DIR/getconf"
+
+# A process with no remaining exec payload fails before either list or run.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_INHERITED_PADDING="$LARGE_ENVIRONMENT" \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$GETCONF_DIR:$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/no-safe-payload.out" 2>&1
+NO_SAFE_PAYLOAD_EXIT=$?
+set -e
+if [ "$NO_SAFE_PAYLOAD_EXIT" -eq 0 ] || ! grep -q 'no safe nextest filter payload remains' "$WORK_DIR/no-safe-payload.out"; then
+  printf 'Expected no-safe-payload nextest filter rejection\n' >&2
+  exit 1
+fi
+
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_RUST_TEST_RUNNER=nextest \
 HOMEBOY_NEXTEST_TEST_COUNT=3000 \
+HOMEBOY_INHERITED_PADDING="$LARGE_ENVIRONMENT" \
 HOMEBOY_TEST_INVENTORY_ONLY=1 \
 HOMEBOY_TEST_INVENTORY_FILE="$LARGE_INVENTORY" \
 HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
@@ -370,6 +455,8 @@ HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_SKIP_LINT=1 \
 HOMEBOY_RUST_TEST_RUNNER=nextest \
 HOMEBOY_NEXTEST_TEST_COUNT=3000 \
+HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES=999999 \
+HOMEBOY_INHERITED_PADDING="$LARGE_ENVIRONMENT" \
 HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/large-nextest-manifest.json" \
 HOMEBOY_FAKE_NEXTEST_RUN_LOG="$WORK_DIR/large-nextest.log" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
@@ -379,7 +466,7 @@ HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
 HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
 HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
 PATH="$BIN_DIR:$PATH" \
-bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/large-nextest.out"
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/large-nextest.out" 2>&1
 python3 - "$WORK_DIR/large-nextest.log" "$WORK_DIR/large-nextest-results.json" <<'PY'
 import json
 import sys
@@ -389,6 +476,10 @@ assert len(filters) > 1, len(filters)
 assert all(len(value.encode()) <= 65536 for value in filters), max(map(lambda value: len(value.encode()), filters))
 assert json.load(open(sys.argv[2])) == {"total": 3000, "passed": 3000, "failed": 0, "skipped": 0, "partial": "rust-shard"}
 PY
+if ! grep -q 'filter limit clamped from 999999' "$WORK_DIR/large-nextest.out"; then
+  printf 'Expected oversized configured nextest filter limit to clamp\n' >&2
+  exit 1
+fi
 
 set +e
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
@@ -448,10 +539,10 @@ import json
 import sys
 
 results = json.load(open(sys.argv[1]))
-assert results == {"total": 4, "passed": 2, "failed": 1, "skipped": 1, "partial": "rust-shard"}, results
+assert results == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}, results
 record = json.load(open(sys.argv[2]))[0]
 assert record["status"] == "failed", record
-assert (record["total"], record["executed"], record["passed"], record["failed"], record["skipped"]) == (4, 4, 2, 1, 1), record
+assert (record["total"], record["executed"], record["passed"], record["failed"], record["skipped"]) == (5, 5, 3, 1, 1), record
 assert record["duration_ms"] >= 0, record
 PY
 

--- a/rust/tests/workspace-member-test-scope-smoke.sh
+++ b/rust/tests/workspace-member-test-scope-smoke.sh
@@ -21,6 +21,18 @@ EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 WORK_DIR="$(mktemp -d -t homeboy-rust-ws-scope.XXXXXX)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
+cat > "${WORK_DIR}/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+    PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+should_run_step() { return 0; }
+EOF
+cat > "${WORK_DIR}/command-capture.sh" <<'EOF'
+homeboy_run_step_capture() { local output_var="$1" exit_var="$2"; shift 3; [ "$1" = -- ] && shift; local output status=0; output="$(mktemp)"; "$@" 2>&1 | tee "$output"; status=${PIPESTATUS[0]}; printf -v "$output_var" '%s' "$output"; printf -v "$exit_var" '%s' "$status"; return "$status"; }
+homeboy_cleanup_step_capture() { rm -f "$1"; }
+EOF
+
 if ! command -v cargo >/dev/null 2>&1; then
     printf 'SKIP: cargo is not installed\n'
     exit 0
@@ -85,6 +97,8 @@ run_runner() {
         HOMEBOY_SKIP_LINT=1 \
         HOMEBOY_TEST_SCOPE_KIND="${scope_kind}" \
         HOMEBOY_TEST_RUNNER_ARGS="${runner_args}" \
+        HOMEBOY_RUNTIME_RUNNER_PRELUDE="${WORK_DIR}/runner-prelude.sh" \
+        HOMEBOY_RUNTIME_COMMAND_CAPTURE="${WORK_DIR}/command-capture.sh" \
         bash "${EXTENSION_DIR}/scripts/test-runner.sh" >"${WORK_DIR}/out.log" 2>&1
     RUNNER_EXIT=$?
     set -e

--- a/rust/tests/zero-test-scope-fallback-smoke.sh
+++ b/rust/tests/zero-test-scope-fallback-smoke.sh
@@ -14,6 +14,18 @@ EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 WORK_DIR="$(mktemp -d -t homeboy-rust-zero-scope.XXXXXX)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
+cat > "${WORK_DIR}/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+    PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+should_run_step() { return 0; }
+EOF
+cat > "${WORK_DIR}/command-capture.sh" <<'EOF'
+homeboy_run_step_capture() { local output_var="$1" exit_var="$2"; shift 3; [ "$1" = -- ] && shift; local output status=0; output="$(mktemp)"; "$@" 2>&1 | tee "$output"; status=${PIPESTATUS[0]}; printf -v "$output_var" '%s' "$output"; printf -v "$exit_var" '%s' "$status"; return "$status"; }
+homeboy_cleanup_step_capture() { rm -f "$1"; }
+EOF
+
 if ! command -v cargo >/dev/null 2>&1; then
     printf 'SKIP: cargo is not installed\n'
     exit 0
@@ -51,6 +63,8 @@ run_runner() {
         HOMEBOY_CHANGED_TEST_FILES="src/lib_tests.rs" \
         HOMEBOY_TEST_SCOPE_KIND="${scope_kind}" \
         HOMEBOY_TEST_RUNNER_ARGS="$(printf -- '--\n%s' "${filter}")" \
+        HOMEBOY_RUNTIME_RUNNER_PRELUDE="${WORK_DIR}/runner-prelude.sh" \
+        HOMEBOY_RUNTIME_COMMAND_CAPTURE="${WORK_DIR}/command-capture.sh" \
         bash "${EXTENSION_DIR}/scripts/test-runner.sh" >"${WORK_DIR}/out.log" 2>&1
     RUNNER_EXIT=$?
     set -e


### PR DESCRIPTION
## Summary
- deterministically batch immutable nextest shard identities by serialized `-E` UTF-8 byte length, under a configurable 64 KiB default
- preflight every batch and its complete membership before executing any batch, then aggregate serial result evidence
- make Rust smoke fixtures self-contained against the runtime-helper seam

Fixes #2545
Required for homeboy-action#345.

## Verification
- complete Rust extension shell/unit/integration test suite
- `shellcheck -x -e SC1091,SC2034,SC2086` across changed Rust shell tests and runner
- `bash -n` across changed Rust shell tests and runner
- `git diff --check`

The shard smoke covers forced multi-batch filters, exact ordered membership, per-filter byte limits, aggregate outcomes, zero-list preflight preventing all execution, oversized identities, and a 3,000-test manifest that would exceed typical `ARG_MAX` as one filter.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented deterministic batching, validation, fixture repairs, and verification. Chris Huber remains responsible for every line.