### PR TITLE
fix: discover JavaScript tests in nested packages

### DIFF
--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -444,87 +444,99 @@ homeboy_wordpress_is_node_test_file() {
 #   3. the first declared package script from
 #      HOMEBOY_WORDPRESS_JS_TEST_SCRIPT_CANDIDATES
 #
-# Sets JS_TEST_SCRIPT and JS_TEST_SCRIPT_SOURCE. Returns 0 when a repository
-# runner is declared, 1 when none is declared, and 2 when an explicitly
-# declared script is missing from the package manifest.
-JS_TEST_SCRIPT=""
-JS_TEST_SCRIPT_SOURCE=""
-JS_TEST_SCRIPT_RESOLVED=0
-JS_TEST_SCRIPT_STATUS=1
+homeboy_wordpress_js_package_owner() {
+    local rel_path="$1"
+    local current="${PLUGIN_PATH}/$(dirname "$rel_path")"
+    local component_root="${PLUGIN_PATH%/}"
 
+    while :; do
+        if [ -f "${current}/package.json" ]; then
+            printf '%s\n' "$current"
+            return 0
+        fi
+        [ "$current" != "$component_root" ] || break
+        current="$(dirname "$current")"
+    done
+    printf '%s\n' "$component_root"
+}
+
+# Sets JS_TEST_SCRIPT and JS_TEST_SCRIPT_SOURCE for the package in
+# HOMEBOY_PROJECT_ROOT. Returns 0 when a runner is declared, 1 when none is
+# declared, and 2 when an explicitly declared script or package contract is
+# missing.
 homeboy_wordpress_resolve_js_test_script() {
-    local configured candidate
+    local package_root="$1"
+    local configured candidate package_rel
 
-    if [ "$JS_TEST_SCRIPT_RESOLVED" -eq 1 ]; then
-        return "$JS_TEST_SCRIPT_STATUS"
-    fi
-    JS_TEST_SCRIPT_RESOLVED=1
-    JS_TEST_SCRIPT_STATUS=1
+    JS_TEST_SCRIPT=""
+    JS_TEST_SCRIPT_SOURCE=""
 
     configured="${HOMEBOY_WORDPRESS_JS_TEST_SCRIPT:-}"
     if [ -z "$configured" ]; then
         configured="$(homeboy_setting wordpress_js_test_script '.wordpress_js_test_script // .js_test_script // empty')"
     fi
 
-    if [ ! -f "${PLUGIN_PATH}/package.json" ] || ! type homeboy_project_init >/dev/null 2>&1; then
+    if [ ! -f "${package_root}/package.json" ] || ! type homeboy_project_init >/dev/null 2>&1; then
         if [ -n "$configured" ]; then
-            echo "ERROR: declared JavaScript test script '${configured}' requires a package manifest at ${PLUGIN_PATH}/package.json" >&2
-            JS_TEST_SCRIPT_STATUS=2
+            echo "ERROR: declared JavaScript test script '${configured}' requires an owning package manifest at ${package_root}/package.json" >&2
+            return 2
         fi
-        return "$JS_TEST_SCRIPT_STATUS"
+        return 1
     fi
 
-    if ! homeboy_project_init --ecosystem nodejs --path "$PLUGIN_PATH" >/dev/null 2>&1; then
+    if ! homeboy_project_init --ecosystem nodejs --path "$package_root" >/dev/null 2>&1; then
         if [ -n "$configured" ]; then
-            echo "ERROR: could not resolve the Node.js project contract for ${PLUGIN_PATH}" >&2
-            JS_TEST_SCRIPT_STATUS=2
+            echo "ERROR: could not resolve the Node.js project contract for owning package ${package_root}" >&2
+            return 2
         fi
-        return "$JS_TEST_SCRIPT_STATUS"
+        return 1
     fi
 
     if [ -n "$configured" ]; then
         if ! homeboy_project_has_script "$configured"; then
-            echo "ERROR: declared JavaScript test script '${configured}' is not defined in ${PLUGIN_PATH}/package.json" >&2
-            JS_TEST_SCRIPT_STATUS=2
-            return "$JS_TEST_SCRIPT_STATUS"
+            echo "ERROR: declared JavaScript test script '${configured}' is not defined in owning package ${package_root}/package.json" >&2
+            return 2
         fi
         JS_TEST_SCRIPT="$configured"
-        JS_TEST_SCRIPT_SOURCE="declared setting wordpress_js_test_script -> package.json scripts.${configured}"
-        JS_TEST_SCRIPT_STATUS=0
+        package_rel="${package_root#"${PLUGIN_PATH%/}/"}"
+        [ "$package_rel" != "$package_root" ] || package_rel=""
+        JS_TEST_SCRIPT_SOURCE="${package_rel:+${package_rel}/}package.json scripts.${configured}"
         return 0
     fi
 
-    for candidate in ${HOMEBOY_WORDPRESS_JS_TEST_SCRIPT_CANDIDATES:-test:unit test:unit:js test:js}; do
+    for candidate in ${HOMEBOY_WORDPRESS_JS_TEST_SCRIPT_CANDIDATES:-test:unit test:unit:js test:js test}; do
         if homeboy_project_has_script "$candidate"; then
             JS_TEST_SCRIPT="$candidate"
-            JS_TEST_SCRIPT_SOURCE="package.json scripts.${candidate}"
-            JS_TEST_SCRIPT_STATUS=0
+            package_rel="${package_root#"${PLUGIN_PATH%/}/"}"
+            [ "$package_rel" != "$package_root" ] || package_rel=""
+            JS_TEST_SCRIPT_SOURCE="${package_rel:+${package_rel}/}package.json scripts.${candidate}"
             return 0
         fi
     done
 
-    return "$JS_TEST_SCRIPT_STATUS"
+    return 1
 }
 
 # True when the file itself imports Node's built-in test runner, which is the
 # only extension-independent evidence that `node --test` is the right backend.
 homeboy_wordpress_is_native_node_test_file() {
     local rel_path="$1"
-    grep -qE "(require\(|from[[:space:]]+|import[[:space:]]*\()[[:space:]]*['\"]node:test['\"]" "${PLUGIN_PATH}/${rel_path}" 2>/dev/null
+    local test_path="$rel_path"
+    if [ "${rel_path#/}" = "$rel_path" ]; then
+        test_path="${PLUGIN_PATH}/${rel_path}"
+    fi
+    grep -qE "(require\(|from[[:space:]]+|import[[:space:]]*\()[[:space:]]*['\"]node:test['\"]" "$test_path" 2>/dev/null
 }
 
 homeboy_wordpress_run_declared_js_test_files() {
-    local test_files_raw="$1"
+    local package_root="$1"
+    local test_files_raw="$2"
     local test_file rel_path run_command exit_code
     local selected=()
 
     while IFS= read -r test_file; do
         [ -n "$test_file" ] || continue
-        if ! rel_path="$(homeboy_wordpress_rel_test_file "$test_file")"; then
-            echo "ERROR: requested JavaScript test file not found or outside the component: ${test_file}" >&2
-            return 2
-        fi
-        selected+=("$rel_path")
+        selected+=("$test_file")
     done <<< "$test_files_raw"
 
     if [ "${#selected[@]}" -eq 0 ]; then
@@ -533,14 +545,18 @@ homeboy_wordpress_run_declared_js_test_files() {
     fi
 
     if ! run_command="$(homeboy_project_run_script_command "$JS_TEST_SCRIPT")"; then
-        echo "ERROR: could not resolve the package runner command for script '${JS_TEST_SCRIPT}'" >&2
+        echo "ERROR: could not resolve the package runner command for script '${JS_TEST_SCRIPT}' in owning package ${package_root}" >&2
         return 2
     fi
 
-    homeboy_project_ensure_dependencies
+    if ! homeboy_project_ensure_dependencies; then
+        echo "ERROR: could not hydrate dependencies for owning package ${package_root}; install its lockfile dependencies before running '${JS_TEST_SCRIPT}'" >&2
+        return 2
+    fi
 
     echo "Running declared JavaScript tests..."
     echo "  Component: ${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
+    echo "  Package: ${package_root}"
     echo "  Backend: package-script"
     echo "  Contract: ${JS_TEST_SCRIPT_SOURCE}"
     echo "  Command: ${run_command} -- ${selected[*]}"
@@ -550,7 +566,7 @@ homeboy_wordpress_run_declared_js_test_files() {
 
     exit_code=0
     # shellcheck disable=SC2086
-    (cd "$PLUGIN_PATH" && $run_command -- "${selected[@]}") || exit_code=$?
+    (cd "$package_root" && $run_command -- "${selected[@]}") || exit_code=$?
 
     if [ "$exit_code" -eq 0 ]; then
         echo "JS_TEST_SUMMARY:backend=package-script script=${JS_TEST_SCRIPT} files=${#selected[@]} status=ok"
@@ -566,18 +582,16 @@ homeboy_wordpress_run_declared_js_test_files() {
 # neither is knowable.
 homeboy_wordpress_run_js_unit_test_files() {
     local test_files_raw="$1"
-    local resolve_status=0
-    local test_file rel_path
+    local test_file rel_path package_root package_files resolve_status
+    local component_root package_rel
     local ambiguous=()
+    local owner_list=()
+    local owner_key
+    local status=0
+    declare -A owner_files
+    declare -A seen_owner
 
-    homeboy_wordpress_resolve_js_test_script || resolve_status=$?
-    if [ "$resolve_status" -eq 2 ]; then
-        return 2
-    fi
-    if [ "$resolve_status" -eq 0 ]; then
-        homeboy_wordpress_run_declared_js_test_files "$test_files_raw"
-        return $?
-    fi
+    component_root="${PLUGIN_PATH%/}"
 
     while IFS= read -r test_file; do
         [ -n "$test_file" ] || continue
@@ -585,23 +599,55 @@ homeboy_wordpress_run_js_unit_test_files() {
             echo "ERROR: requested JavaScript test file not found or outside the component: ${test_file}" >&2
             return 2
         fi
-        if ! homeboy_wordpress_is_native_node_test_file "$rel_path"; then
-            ambiguous+=("$rel_path")
+        package_root="$(homeboy_wordpress_js_package_owner "$rel_path")"
+        package_rel="${package_root#"${component_root}/"}"
+        if [ "$package_root" = "$component_root" ] || [ "$package_rel" = "$package_root" ]; then
+            package_files="$rel_path"
+        else
+            package_files="${rel_path#"${package_rel}/"}"
+        fi
+        owner_files["$package_root"]+="${owner_files[$package_root]:+$'\n'}${package_files}"
+        if [ -z "${seen_owner[$package_root]:-}" ]; then
+            owner_list+=("$package_root")
+            seen_owner["$package_root"]=1
         fi
     done <<< "$test_files_raw"
 
-    if [ "${#ambiguous[@]}" -gt 0 ]; then
-        echo "ERROR: cannot select a JavaScript test framework for: ${ambiguous[*]}" >&2
-        echo "  The files do not import Node's built-in 'node:test' runner and the component declares no JavaScript test script." >&2
-        echo "  Add a package.json test script (for example \"test:unit\": \"wp-scripts test-unit-js\"), set the wordpress_js_test_script setting, or import 'node:test' in the tests." >&2
-        return 2
-    fi
-
-    homeboy_wordpress_run_node_test_files "$test_files_raw"
+    for owner_key in "${owner_list[@]}"; do
+        package_files="${owner_files[$owner_key]}"
+        JS_TEST_SCRIPT=""
+        JS_TEST_SCRIPT_SOURCE=""
+        if homeboy_wordpress_resolve_js_test_script "$owner_key"; then
+            homeboy_wordpress_run_declared_js_test_files "$owner_key" "$package_files" || status=$?
+        else
+            resolve_status=$?
+            if [ "$resolve_status" -eq 2 ]; then
+                status=2
+                continue
+            fi
+            ambiguous=()
+            while IFS= read -r rel_path; do
+                [ -n "$rel_path" ] || continue
+                if ! homeboy_wordpress_is_native_node_test_file "${owner_key}/${rel_path}"; then
+                    ambiguous+=("$rel_path")
+                fi
+            done <<< "$package_files"
+            if [ "${#ambiguous[@]}" -gt 0 ]; then
+                echo "ERROR: cannot select a JavaScript test framework for: ${ambiguous[*]} (owning package ${owner_key})" >&2
+                echo "  The files do not import Node's built-in 'node:test' runner and owning package ${owner_key}/package.json declares no JavaScript test script." >&2
+                echo "  Add a package.json test script (for example \"test:unit\": \"wp-scripts test-unit-js\"), set the wordpress_js_test_script setting, or import 'node:test' in the tests." >&2
+                status=2
+                continue
+            fi
+            homeboy_wordpress_run_node_test_files "$owner_key" "$package_files" || status=$?
+        fi
+    done
+    return "$status"
 }
 
 homeboy_wordpress_run_node_test_files() {
-    local test_files_raw="$1"
+    local package_root="$1"
+    local test_files_raw="$2"
     local node_bin="${HOMEBOY_NODE_BIN:-node}"
     local test_file test_abs rel_path exit_code
     local passed=0
@@ -610,18 +656,16 @@ homeboy_wordpress_run_node_test_files() {
 
     echo "Running Node test files..."
     echo "  Component: ${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
+    echo "  Package: ${package_root}"
     echo "  Backend: node-test"
     echo "  Contract: ${JS_TEST_SCRIPT_SOURCE:-native node:test import}"
 
     while IFS= read -r test_file; do
         [ -n "$test_file" ] || continue
-        if ! rel_path="$(homeboy_wordpress_rel_test_file "$test_file")"; then
-            echo "ERROR: requested Node test file not found or outside the component: ${test_file}" >&2
-            return 2
-        fi
-        test_abs="${PLUGIN_PATH}/${rel_path}"
+        rel_path="$test_file"
+        test_abs="${package_root}/${rel_path}"
         echo "NODE_TEST_BEGIN:${rel_path}"
-        if "$node_bin" --test "$test_abs"; then
+        if (cd "$package_root" && "$node_bin" --test "$test_abs"); then
             echo "NODE_TEST_OK:${rel_path}"
             passed=$((passed + 1))
         else

--- a/wordpress/tests/js-test-framework-routing-smoke.sh
+++ b/wordpress/tests/js-test-framework-routing-smoke.sh
@@ -47,8 +47,9 @@ mkdir -p "$stubs"
 cat > "${stubs}/npm" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+printf 'NPM_CWD:%s\n' "$PWD"
 printf 'NPM_INVOKED:%s\n' "$*"
-if [ "${1:-}" = "run" ] && [ "${2:-}" = "test:unit" ]; then
+if [ "${1:-}" = "run" ] && { [ "${2:-}" = "test:unit" ] || [ "${2:-}" = "test:js" ] || [ "${2:-}" = "test" ]; }; then
     echo "PASS ${*:4}"
     echo "Test Suites: 1 passed, 1 total"
     exit 0
@@ -106,6 +107,80 @@ HOMEBOY_COMPONENT_SHAPE="plugin" \
 
 assert_contains "${WORK_DIR}/jest-file.out" "Backend: package-script"
 assert_not_contains "${WORK_DIR}/jest-file.out" "Backend: node-test"
+
+# --- Nested packages: nearest package owns script, cwd, and relative paths --
+nested_component="${WORK_DIR}/nested-component"
+calendar_package="${nested_component}/inc/Blocks/Calendar"
+player_package="${nested_component}/blocks/Player"
+mkdir -p "${nested_component}/src" "${nested_component}/node_modules" \
+    "${calendar_package}/src" "${calendar_package}/node_modules" \
+    "${player_package}/src" "${player_package}/node_modules"
+cat > "${nested_component}/package.json" <<'JSON'
+{
+  "name": "nested-root",
+  "scripts": {
+    "test": "root-default-tests",
+    "test:unit": "root-tests"
+  }
+}
+JSON
+cat > "${player_package}/package.json" <<'JSON'
+{
+  "name": "player",
+  "scripts": {
+    "test:js": "player-tests"
+  }
+}
+JSON
+cat > "${calendar_package}/package.json" <<'JSON'
+{
+  "name": "calendar",
+  "scripts": {
+    "test": "wp-scripts test-unit-js"
+  }
+}
+JSON
+cat > "${nested_component}/src/root.test.js" <<'JS'
+describe( 'root package', () => {
+	it( 'uses the root runner', () => expect( true ).toBe( true ) );
+} );
+JS
+cat > "${calendar_package}/src/frontend.test.ts" <<'JS'
+describe( 'calendar package', () => {
+	it( 'uses the nested runner', () => expect( true ).toBe( true ) );
+} );
+JS
+cat > "${player_package}/src/player.test.js" <<'JS'
+describe( 'player package', () => {
+	it( 'uses its own nested runner', () => expect( true ).toBe( true ) );
+} );
+JS
+
+PATH="${stubs}:${PATH}" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="nested" \
+HOMEBOY_COMPONENT_PATH="$nested_component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_CHANGED_TEST_FILES=$'src/root.test.js\ninc/Blocks/Calendar/src/frontend.test.ts\nblocks/Player/src/player.test.js' \
+    bash "$RUNNER" > "${WORK_DIR}/nested.out" 2>&1
+
+assert_contains "${WORK_DIR}/nested.out" "Package: ${nested_component}"
+assert_contains "${WORK_DIR}/nested.out" "Contract: package.json scripts.test:unit"
+assert_contains "${WORK_DIR}/nested.out" "NPM_CWD:${nested_component}"
+assert_contains "${WORK_DIR}/nested.out" "NPM_INVOKED:run test:unit -- src/root.test.js"
+assert_contains "${WORK_DIR}/nested.out" "Package: ${calendar_package}"
+assert_contains "${WORK_DIR}/nested.out" "Contract: inc/Blocks/Calendar/package.json scripts.test"
+assert_contains "${WORK_DIR}/nested.out" "NPM_CWD:${calendar_package}"
+assert_contains "${WORK_DIR}/nested.out" "NPM_INVOKED:run test -- src/frontend.test.ts"
+assert_not_contains "${WORK_DIR}/nested.out" "run test -- inc/Blocks/Calendar/src/frontend.test.ts"
+assert_contains "${WORK_DIR}/nested.out" "Package: ${player_package}"
+assert_contains "${WORK_DIR}/nested.out" "Contract: blocks/Player/package.json scripts.test:js"
+assert_contains "${WORK_DIR}/nested.out" "NPM_CWD:${player_package}"
+assert_contains "${WORK_DIR}/nested.out" "NPM_INVOKED:run test:js -- src/player.test.js"
+assert_contains "${WORK_DIR}/nested.out" "JS_TEST_SUMMARY:backend=package-script script=test:unit files=1 status=ok"
+assert_contains "${WORK_DIR}/nested.out" "JS_TEST_SUMMARY:backend=package-script script=test files=1 status=ok"
+assert_contains "${WORK_DIR}/nested.out" "JS_TEST_SUMMARY:backend=package-script script=test:js files=1 status=ok"
 
 # --- Native node:test component: built-in runner stays selected ------------
 native_component="${WORK_DIR}/native-component"
@@ -197,5 +272,40 @@ if [ "$status" -ne 2 ]; then
     exit 1
 fi
 assert_contains "${WORK_DIR}/missing-script.out" "declared JavaScript test script 'test:missing' is not defined"
+
+# --- Nested package without a runner: diagnostics identify the owner --------
+missing_owner_component="${WORK_DIR}/missing-owner-component"
+missing_owner_package="${missing_owner_component}/blocks/widget"
+mkdir -p "${missing_owner_package}/src"
+cat > "${missing_owner_package}/package.json" <<'JSON'
+{
+  "name": "widget",
+  "scripts": {}
+}
+JSON
+cat > "${missing_owner_package}/src/widget.test.js" <<'JS'
+describe( 'widget', () => {
+	it( 'has no package runner', () => expect( true ).toBe( true ) );
+} );
+JS
+
+set +e
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="missing-owner" \
+HOMEBOY_COMPONENT_PATH="$missing_owner_component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_CHANGED_TEST_FILES="blocks/widget/src/widget.test.js" \
+    bash "$RUNNER" > "${WORK_DIR}/missing-owner.out" 2>&1
+status=$?
+set -e
+
+if [ "$status" -ne 2 ]; then
+    echo "Expected a nested package without a runner to exit 2, got $status" >&2
+    sed 's/^/  /' "${WORK_DIR}/missing-owner.out" >&2
+    exit 1
+fi
+assert_contains "${WORK_DIR}/missing-owner.out" "owning package ${missing_owner_package}"
+assert_contains "${WORK_DIR}/missing-owner.out" "${missing_owner_package}/package.json declares no JavaScript test script"
 
 echo "WordPress JavaScript test framework routing smoke passed"


### PR DESCRIPTION
## Summary

- resolve each selected JavaScript test to its nearest owning `package.json`
- group mixed selections by package and run each package's declared test script from its own working directory
- pass package-relative test paths while preserving root-package, configured-script, and native `node:test` behavior
- add owner-specific dependency and missing-runner diagnostics

## Why

WordPress components can contain independently managed Gutenberg packages. The test runner previously inspected only the component root, so valid nested Jest suites failed framework selection. A root proxy could pass discovery but then executed outside the nested dependency context. Package ownership belongs in the generic runner rather than in downstream wrappers.

This closes #2547.

## Package Rules

- the nearest ancestor `package.json` inside the component owns a selected file
- existing focused-script priority remains `test:unit`, `test:unit:js`, `test:js`, followed by `test`
- selected files are grouped in first-seen package order
- package runners receive paths relative to their owning package
- native `node:test` files without a package script execute from their package context

## Tests

- `bash wordpress/tests/js-test-framework-routing-smoke.sh`
- `bash scripts/ci/run-self-checks.sh wordpress lint`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/tests/js-test-framework-routing-smoke.sh`
- `git diff --check`

The broader `test-runner-file-routing-smoke.sh` requires the intentionally skipped `wordpress/vendor` bootstrap locally; the PR self-check workflow installs Composer and npm dependencies before running the full matrix.

## Evidence

- DME framework-selection failure: https://github.com/Extra-Chill/data-machine-events/actions/runs/31018462486
- DME root-proxy dependency-context failure: https://github.com/Extra-Chill/data-machine-events/actions/runs/31019727914
- the nested DME Calendar Jest suite passes directly: 11 suites, 70 tests

## Residual Risk

The grouping implementation uses Bash associative arrays, matching the repository's Bash runner contract and Linux CI environment.

## AI Assistance

OpenCode was used to investigate the runner contract, implement the generic package-ownership behavior, and extend regression coverage. The patch was manually reviewed and verified with focused and declared lint gates.