### PR TITLE
fix(rust): parse mixed nextest list output

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -322,24 +322,7 @@ rust_validate_nextest_membership() {
 import json
 import sys
 
-raw = open(sys.argv[1], encoding="utf-8", errors="replace").read()
-decoder = json.JSONDecoder()
-listed = []
-offset = 0
-while (index := raw.find("{", offset)) != -1:
-    try:
-        candidate, end = decoder.raw_decode(raw[index:])
-    except json.JSONDecodeError:
-        offset = index + 1
-        continue
-    if isinstance(candidate, dict) and "rust-suites" in candidate:
-        listed.append(candidate)
-    offset = index + end
-if len(listed) != 1:
-    raise SystemExit(
-        f"Rust test shard error: expected exactly one nextest list JSON document, found {len(listed)}"
-    )
-listed = listed[0]
+listed = json.load(open(sys.argv[1], encoding="utf-8"))
 expected = {item["id"] for item in json.load(open(sys.argv[2], encoding="utf-8"))["selected"]}
 actual = set()
 for suite in listed.get("rust-suites", {}).values():
@@ -351,6 +334,12 @@ if actual != expected:
     extra = sorted(actual - expected)
     raise SystemExit(f"Rust test shard error: nextest exact filter membership mismatch (missing={missing[:1]}, extra={extra[:1]})")
 PY
+}
+
+rust_capture_stdout() {
+    local stdout_file="$1"
+    shift
+    "$@" > "$stdout_file"
 }
 
 rust_nextest_counts() {
@@ -627,16 +616,19 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
         # Validate every planned filter before any test batch can execute.
         for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
             NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
-            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
-            if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_OUTPUT" "$NEXTEST_BATCH"; then
+            NEXTEST_LIST_JSON="$(mktemp)"
+            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
+            if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_JSON" "$NEXTEST_BATCH"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
-                rm -f "$NEXTEST_LIST_OUTPUT"
+                homeboy_cleanup_step_capture "$NEXTEST_LIST_OUTPUT"
+                homeboy_cleanup_step_capture "$NEXTEST_LIST_JSON"
                 rm -rf "$NEXTEST_BATCH_DIR"
                 rm -f "$SHARD_DATA"
                 exit 1
             fi
-            rm -f "$NEXTEST_LIST_OUTPUT"
+            homeboy_cleanup_step_capture "$NEXTEST_LIST_OUTPUT"
+            homeboy_cleanup_step_capture "$NEXTEST_LIST_JSON"
         done
         echo "Replaying Rust nextest shard: ${SHARD_TOTAL} exact identities in $(printf '%s\n' "$NEXTEST_BATCH_DIR"/*.json | wc -l | tr -d ' ') batches"
         SHARD_EXIT=0

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -322,7 +322,24 @@ rust_validate_nextest_membership() {
 import json
 import sys
 
-listed = json.load(open(sys.argv[1], encoding="utf-8"))
+raw = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+decoder = json.JSONDecoder()
+listed = []
+offset = 0
+while (index := raw.find("{", offset)) != -1:
+    try:
+        candidate, end = decoder.raw_decode(raw[index:])
+    except json.JSONDecodeError:
+        offset = index + 1
+        continue
+    if isinstance(candidate, dict) and "rust-suites" in candidate:
+        listed.append(candidate)
+    offset = index + end
+if len(listed) != 1:
+    raise SystemExit(
+        f"Rust test shard error: expected exactly one nextest list JSON document, found {len(listed)}"
+    )
+listed = listed[0]
 expected = {item["id"] for item in json.load(open(sys.argv[2], encoding="utf-8"))["selected"]}
 actual = set()
 for suite in listed.get("rust-suites", {}).values():

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -56,6 +56,8 @@ if [ "${1:-}" = 'metadata' ]; then
 fi
 if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'list' ]; then
   [ -z "${HOMEBOY_FAKE_NEXTEST_LOG:-}" ] || printf 'list %s\n' "$*" >> "$HOMEBOY_FAKE_NEXTEST_LOG"
+  # cargo-nextest writes build progress to stderr before its JSON list payload.
+  printf '   Compiling shard-smoke v0.1.0\n' >&2
   if [ "${HOMEBOY_NEXTEST_LIST_MODE:-pass}" = zero ]; then printf '%s\n' '{"rust-suites":{}}'; exit 0; fi
   python3 - "$@" <<'PY'
 import json
@@ -132,8 +134,21 @@ homeboy_runner_init() {
 should_run_step() { return 0; }
 EOF
 cat > "$WORK_DIR/command-capture.sh" <<'EOF'
-homeboy_run_step_capture() { local output_var="$1" exit_var="$2"; shift 3; [ "$1" = -- ] && shift; local output status=0; output="$(mktemp)"; "$@" >"$output" 2>&1 || status=$?; printf -v "$output_var" '%s' "$output"; printf -v "$exit_var" '%s' "$status"; return "$status"; }
-homeboy_cleanup_step_capture() { rm -f "$1"; }
+homeboy_run_step_capture() {
+  local output_var="$1" exit_var="$2" step_name="$3"
+  shift 3
+  [ "${1:-}" != -- ] || shift
+  local output_file
+  output_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-command.XXXXXX")"
+  set +e
+  "$@" 2>&1 | tee "$output_file"
+  local command_exit=${PIPESTATUS[0]}
+  set -e
+  printf -v "$output_var" '%s' "$output_file"
+  printf -v "$exit_var" '%s' "$command_exit"
+  return "$command_exit"
+}
+homeboy_cleanup_step_capture() { local output_file="$1"; [ -z "$output_file" ] || rm -f "$output_file"; }
 EOF
 cat > "$WORK_DIR/write-test-results.sh" <<'EOF'
 homeboy_write_test_results() {

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -58,6 +58,11 @@ if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'list' ]; then
   [ -z "${HOMEBOY_FAKE_NEXTEST_LOG:-}" ] || printf 'list %s\n' "$*" >> "$HOMEBOY_FAKE_NEXTEST_LOG"
   # cargo-nextest writes build progress to stderr before its JSON list payload.
   printf '   Compiling shard-smoke v0.1.0\n' >&2
+  if [ "${HOMEBOY_NEXTEST_LIST_MODE:-pass}" = stderr-json-only ]; then
+    printf '%s\n' '{"rust-suites":{}}' >&2
+    printf 'not json\n'
+    exit 0
+  fi
   if [ "${HOMEBOY_NEXTEST_LIST_MODE:-pass}" = zero ]; then printf '%s\n' '{"rust-suites":{}}'; exit 0; fi
   python3 - "$@" <<'PY'
 import json
@@ -407,6 +412,26 @@ ZERO_LIST_EXIT=$?
 set -e
 if [ "$ZERO_LIST_EXIT" -eq 0 ] || [ -e "$WORK_DIR/zero-list-runs.log" ]; then
   printf 'Expected zero-list validation to fail before any nextest batch executes\n' >&2
+  exit 1
+fi
+
+# JSON-looking diagnostics cannot substitute for a missing stdout payload.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_LIST_MODE=stderr-json-only \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_RUN_LOG="$WORK_DIR/stderr-json-runs.log" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/stderr-json.out" 2>&1
+STDERR_JSON_EXIT=$?
+set -e
+if [ "$STDERR_JSON_EXIT" -eq 0 ] || [ -e "$WORK_DIR/stderr-json-runs.log" ]; then
+  printf 'Expected stderr JSON to remain diagnostic-only during nextest preflight\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- preserve Homeboy's live diagnostic capture while writing `nextest list` stdout to a dedicated JSON file
- validate exact shard membership only from the stdout payload, keeping stderr diagnostic-only
- exercise shard replay with shipped `2>&1 | tee` semantics, realistic compiler progress, and JSON-looking stderr

## Root cause

`cargo nextest list` writes compiler progress to stderr before its JSON payload. Homeboy's shipped command-capture helper intentionally merges stderr and stdout, but Rust shard membership validation used `json.load` on the complete mixed stream. The parser failed before replay and every shard reported zero executed tests.

Consumer evidence: https://github.com/Extra-Chill/homeboy/actions/runs/31024297500

Fixes #2545

## Verification

- `bash rust/tests/test-shard-inventory-smoke.sh`
- `bash rust/scripts/rust-nextest-runner-smoke.sh`
- `bash rust/scripts/rust-changed-scope-smoke.sh`
- `bash rust/tests/workspace-member-test-scope-smoke.sh`
- `bash rust/tests/env-provider-smoke.sh`
- `bash rust/tests/zero-test-scope-fallback-smoke.sh`
- `bash rust/tests/fingerprint-policy-flow-smoke.sh`
- `bash -n rust/scripts/test-runner.sh rust/tests/test-shard-inventory-smoke.sh`
- `git diff --check`

Independent re-review at `9c0f8636` found no code issues. Residual proof requires a released extension consumer rerun with real cargo-nextest.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the released consumer failure, traced mixed command-capture output through the Rust extension, implemented and independently reviewed the stdout-provenance fix, and ran focused verification. Chris Huber remains responsible for every line.