### PR TITLE
fix(rust): inventory only test-profile artifacts

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -654,7 +654,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
     else
         while IFS=$'\t' read -r package target target_kind name; do
             case "$target_kind" in
-                lib|proc-macro|cdylib|staticlib|dylib) TARGET_ARGS=(--lib) ;;
+                lib|rlib|proc-macro|cdylib|staticlib|dylib) TARGET_ARGS=(--lib) ;;
                 bin) TARGET_ARGS=(--bin "$target") ;;
                 doc) TARGET_ARGS=(--doc) ;;
                 example) TARGET_ARGS=(--example "$target") ;;

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -654,7 +654,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
     else
         while IFS=$'\t' read -r package target target_kind name; do
             case "$target_kind" in
-                lib) TARGET_ARGS=(--lib) ;;
+                lib|proc-macro|cdylib|staticlib|dylib) TARGET_ARGS=(--lib) ;;
                 bin) TARGET_ARGS=(--bin "$target") ;;
                 doc) TARGET_ARGS=(--doc) ;;
                 example) TARGET_ARGS=(--example "$target") ;;

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -55,7 +55,9 @@ def cargo_inventory(workspace_root, packages):
             message = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if message.get("reason") != "compiler-artifact" or not message.get("executable"):
+        if (message.get("reason") != "compiler-artifact"
+                or not message.get("executable")
+                or not message.get("profile", {}).get("test")):
             continue
         target = message.get("target", {})
         kinds = target.get("kind", [])

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -61,15 +61,13 @@ def cargo_inventory(workspace_root, packages):
             continue
         target = message.get("target", {})
         kinds = target.get("kind", [])
-        if not set(kinds).intersection({"lib", "bin", "test", "bench", "example"}):
-            continue
         listed = run([message["executable"], "--list"], workspace_root)
         if listed.returncode:
             fail(f"could not list tests for {target.get('name', 'unknown target')}: {listed.stderr.strip()}")
         package = packages.get(message.get("package_id"))
         if not package:
             fail("cargo emitted a test executable without a resolvable package")
-        target_kind = next(kind for kind in kinds if kind in {"lib", "bin", "test", "bench", "example"})
+        target_kind = kinds[0] if kinds else "unknown"
         for test_line in listed.stdout.splitlines():
             name, separator, _kind = test_line.partition(": ")
             if separator and name:

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -47,6 +47,10 @@ cat > "$BIN_DIR/test-proc-macro" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' 'macros::expands: test'
 EOF
+cat > "$BIN_DIR/test-rlib" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'rlib::works: test'
+EOF
 cat > "$BIN_DIR/bench-audit-self" <<'EOF'
 #!/usr/bin/env bash
 if [ -n "${HOMEBOY_BENCH_LIST_LOG:-}" ]; then
@@ -56,7 +60,7 @@ printf '%s\n' "thread 'main' panicked at src/bin/bench-audit-self.rs:44:40:" >&2
 printf '%s\n' 'CARGO_MANIFEST_DIR not set (run via cargo): NotPresent' >&2
 exit 101
 EOF
-chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member" "$BIN_DIR/test-proc-macro" "$BIN_DIR/bench-audit-self"
+chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member" "$BIN_DIR/test-proc-macro" "$BIN_DIR/test-rlib" "$BIN_DIR/bench-audit-self"
 
 cat > "$BIN_DIR/cargo" <<'EOF'
 #!/usr/bin/env bash
@@ -104,6 +108,7 @@ if [[ " $* " == *' --workspace '* && " $* " == *' --no-run '* ]]; then
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"api","kind":["test"]},"profile":{"test":true},"executable":"%s/test-api"}\n' "$(dirname "$0")"
   printf '{"reason":"compiler-artifact","package_id":"member-smoke 0.1.0 (path+file:///fixture/member)","target":{"name":"member_smoke","kind":["lib"]},"profile":{"test":true},"executable":"%s/test-member"}\n' "$(dirname "$0")"
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"macros","kind":["proc-macro"]},"profile":{"test":true},"executable":"%s/test-proc-macro"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"rlib_fixture","kind":["rlib"]},"profile":{"test":true},"executable":"%s/test-rlib"}\n' "$(dirname "$0")"
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"bench-audit-self","kind":["bin"]},"profile":{"test":false},"executable":"%s/bench-audit-self"}\n' "$(dirname "$0")"
   exit 0
 fi
@@ -235,6 +240,7 @@ assert [test["id"] for test in first["tests"]] == [
     "shard-smoke::lib::shard_smoke::unit::beta",
     "shard-smoke::lib::shard_smoke::unit::ignored",
     "shard-smoke::proc-macro::macros::macros::expands",
+    "shard-smoke::rlib::rlib_fixture::rlib::works",
     "shard-smoke::test::api::api::works",
 ], first
 assert nextest["runner"] == "nextest", nextest
@@ -285,7 +291,7 @@ python3 - "$WORK_DIR/cargo.log" <<'PY'
 import sys
 
 lines = open(sys.argv[1]).read().splitlines()
-assert len(lines) == 6, lines
+assert len(lines) == 7, lines
 assert all(" --exact --test-threads=1" in line for line in lines), lines
 assert sum("unit::alpha" in line for line in lines) == 1, lines
 assert sum("unit::beta" in line for line in lines) == 1, lines
@@ -293,7 +299,9 @@ assert sum("unit::ignored" in line for line in lines) == 1, lines
 assert sum("api::works" in line for line in lines) == 1, lines
 assert sum("member::member_works" in line for line in lines) == 1, lines
 assert sum("macros::expands" in line for line in lines) == 1, lines
+assert sum("rlib::works" in line for line in lines) == 1, lines
 assert sum(" --lib " in line and "macros::expands" in line for line in lines) == 1, lines
+assert sum(" --lib " in line and "rlib::works" in line for line in lines) == 1, lines
 PY
 
 python3 - "$WORK_DIR/test-results.json" "$WORK_DIR/annotations/rust-test-shard.json" <<'PY'
@@ -301,9 +309,9 @@ import json
 import sys
 
 results = json.load(open(sys.argv[1]))
-assert results == {"total": 6, "passed": 5, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
+assert results == {"total": 7, "passed": 6, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
 record = json.load(open(sys.argv[2]))[0]
-assert (record["executed"], record["passed"], record["failed"], record["skipped"]) == (6, 5, 0, 1), record
+assert (record["executed"], record["passed"], record["failed"], record["skipped"]) == (7, 6, 0, 1), record
 assert record["duration_ms"] >= 0, record
 PY
 
@@ -327,7 +335,7 @@ python3 - "$WORK_DIR/cargo.log" <<'PY'
 import sys
 
 lines = open(sys.argv[1]).read().splitlines()
-nextest = lines[6:]
+nextest = lines[7:]
 assert len(nextest) == 1, lines
 assert "nextest run" in nextest[0] and " --workspace " in nextest[0] and " --test-threads 1 " in nextest[0], nextest
 assert "test(=unit::alpha)" in nextest[0] and "test(=unit::beta)" in nextest[0] and "test(=api::works)" in nextest[0] and "test(=member::member_works)" in nextest[0], nextest
@@ -622,10 +630,10 @@ import json
 import sys
 
 results = json.load(open(sys.argv[1]))
-assert results == {"total": 6, "passed": 4, "failed": 1, "skipped": 1, "partial": "rust-shard"}, results
+assert results == {"total": 7, "passed": 5, "failed": 1, "skipped": 1, "partial": "rust-shard"}, results
 record = json.load(open(sys.argv[2]))[0]
 assert record["status"] == "failed", record
-assert (record["total"], record["executed"], record["passed"], record["failed"], record["skipped"]) == (6, 6, 4, 1, 1), record
+assert (record["total"], record["executed"], record["passed"], record["failed"], record["skipped"]) == (7, 7, 5, 1, 1), record
 assert record["duration_ms"] >= 0, record
 PY
 

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -43,12 +43,20 @@ cat > "$BIN_DIR/test-member" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' 'member::member_works: test'
 EOF
-cat > "$BIN_DIR/non-test-bin" <<'EOF'
+cat > "$BIN_DIR/test-proc-macro" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' 'non-test executable must not be listed' >&2
-exit 1
+printf '%s\n' 'macros::expands: test'
 EOF
-chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member" "$BIN_DIR/non-test-bin"
+cat > "$BIN_DIR/bench-audit-self" <<'EOF'
+#!/usr/bin/env bash
+if [ -n "${HOMEBOY_BENCH_LIST_LOG:-}" ]; then
+  printf 'invoked\n' >> "$HOMEBOY_BENCH_LIST_LOG"
+fi
+printf '%s\n' "thread 'main' panicked at src/bin/bench-audit-self.rs:44:40:" >&2
+printf '%s\n' 'CARGO_MANIFEST_DIR not set (run via cargo): NotPresent' >&2
+exit 101
+EOF
+chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member" "$BIN_DIR/test-proc-macro" "$BIN_DIR/bench-audit-self"
 
 cat > "$BIN_DIR/cargo" <<'EOF'
 #!/usr/bin/env bash
@@ -95,7 +103,8 @@ if [[ " $* " == *' --workspace '* && " $* " == *' --no-run '* ]]; then
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"shard_smoke","kind":["lib"]},"profile":{"test":true},"executable":"%s/test-lib"}\n' "$(dirname "$0")"
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"api","kind":["test"]},"profile":{"test":true},"executable":"%s/test-api"}\n' "$(dirname "$0")"
   printf '{"reason":"compiler-artifact","package_id":"member-smoke 0.1.0 (path+file:///fixture/member)","target":{"name":"member_smoke","kind":["lib"]},"profile":{"test":true},"executable":"%s/test-member"}\n' "$(dirname "$0")"
-  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"normal","kind":["bin"]},"profile":{"test":false},"executable":"%s/non-test-bin"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"macros","kind":["proc-macro"]},"profile":{"test":true},"executable":"%s/test-proc-macro"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"bench-audit-self","kind":["bin"]},"profile":{"test":false},"executable":"%s/bench-audit-self"}\n' "$(dirname "$0")"
   exit 0
 fi
 if [[ " $* " == *' --doc '* && " $* " == *' --list '* ]]; then
@@ -179,10 +188,12 @@ EOF
 INVENTORY_A="$WORK_DIR/inventory-a.json"
 INVENTORY_B="$WORK_DIR/inventory-b.json"
 INVENTORY_NEXTEST="$WORK_DIR/inventory-nextest.json"
+BENCH_LIST_LOG="$WORK_DIR/bench-list.log"
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_TEST_INVENTORY_ONLY=1 \
 HOMEBOY_TEST_INVENTORY_FILE="$INVENTORY_A" \
+HOMEBOY_BENCH_LIST_LOG="$BENCH_LIST_LOG" \
 HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
 HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
 PATH="$BIN_DIR:$PATH" \
@@ -191,6 +202,7 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_TEST_INVENTORY_ONLY=1 \
 HOMEBOY_TEST_INVENTORY_FILE="$INVENTORY_B" \
+HOMEBOY_BENCH_LIST_LOG="$BENCH_LIST_LOG" \
 HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
 HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
 PATH="$BIN_DIR:$PATH" \
@@ -222,6 +234,7 @@ assert [test["id"] for test in first["tests"]] == [
     "shard-smoke::lib::shard_smoke::unit::alpha",
     "shard-smoke::lib::shard_smoke::unit::beta",
     "shard-smoke::lib::shard_smoke::unit::ignored",
+    "shard-smoke::proc-macro::macros::macros::expands",
     "shard-smoke::test::api::api::works",
 ], first
 assert nextest["runner"] == "nextest", nextest
@@ -241,6 +254,11 @@ json.dump(manifest, open(sys.argv[4], "w"))
 nextest_manifest = dict(manifest, runner=nextest["runner"], inventory_fingerprint=nextest["inventory_fingerprint"], runner_fingerprint=nextest["runner_fingerprint"], workspace_fingerprint=nextest["workspace_fingerprint"], tests=[test["id"] for test in nextest["tests"]])
 json.dump(nextest_manifest, open(sys.argv[5], "w"))
 PY
+
+if [ -e "$BENCH_LIST_LOG" ] || grep -q 'CARGO_MANIFEST_DIR not set' "$WORK_DIR/inventory-a.out"; then
+  printf 'Expected non-test bench artifact to remain uninvoked and unreported\n' >&2
+  exit 1
+fi
 
 if grep -q 'Running pre-test lint checks' "$WORK_DIR/inventory-a.out" || ! grep -q 'Skipping lint (test inventory only)' "$WORK_DIR/inventory-a.out"; then
   printf 'Expected inventory-only run to bypass pre-test lint\n' >&2
@@ -267,13 +285,15 @@ python3 - "$WORK_DIR/cargo.log" <<'PY'
 import sys
 
 lines = open(sys.argv[1]).read().splitlines()
-assert len(lines) == 5, lines
+assert len(lines) == 6, lines
 assert all(" --exact --test-threads=1" in line for line in lines), lines
 assert sum("unit::alpha" in line for line in lines) == 1, lines
 assert sum("unit::beta" in line for line in lines) == 1, lines
 assert sum("unit::ignored" in line for line in lines) == 1, lines
 assert sum("api::works" in line for line in lines) == 1, lines
 assert sum("member::member_works" in line for line in lines) == 1, lines
+assert sum("macros::expands" in line for line in lines) == 1, lines
+assert sum(" --lib " in line and "macros::expands" in line for line in lines) == 1, lines
 PY
 
 python3 - "$WORK_DIR/test-results.json" "$WORK_DIR/annotations/rust-test-shard.json" <<'PY'
@@ -281,9 +301,9 @@ import json
 import sys
 
 results = json.load(open(sys.argv[1]))
-assert results == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
+assert results == {"total": 6, "passed": 5, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
 record = json.load(open(sys.argv[2]))[0]
-assert (record["executed"], record["passed"], record["failed"], record["skipped"]) == (5, 4, 0, 1), record
+assert (record["executed"], record["passed"], record["failed"], record["skipped"]) == (6, 5, 0, 1), record
 assert record["duration_ms"] >= 0, record
 PY
 
@@ -307,7 +327,7 @@ python3 - "$WORK_DIR/cargo.log" <<'PY'
 import sys
 
 lines = open(sys.argv[1]).read().splitlines()
-nextest = lines[5:]
+nextest = lines[6:]
 assert len(nextest) == 1, lines
 assert "nextest run" in nextest[0] and " --workspace " in nextest[0] and " --test-threads 1 " in nextest[0], nextest
 assert "test(=unit::alpha)" in nextest[0] and "test(=unit::beta)" in nextest[0] and "test(=api::works)" in nextest[0] and "test(=member::member_works)" in nextest[0], nextest
@@ -602,10 +622,10 @@ import json
 import sys
 
 results = json.load(open(sys.argv[1]))
-assert results == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}, results
+assert results == {"total": 6, "passed": 4, "failed": 1, "skipped": 1, "partial": "rust-shard"}, results
 record = json.load(open(sys.argv[2]))[0]
 assert record["status"] == "failed", record
-assert (record["total"], record["executed"], record["passed"], record["failed"], record["skipped"]) == (5, 5, 3, 1, 1), record
+assert (record["total"], record["executed"], record["passed"], record["failed"], record["skipped"]) == (6, 6, 4, 1, 1), record
 assert record["duration_ms"] >= 0, record
 PY
 

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -43,7 +43,12 @@ cat > "$BIN_DIR/test-member" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' 'member::member_works: test'
 EOF
-chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member"
+cat > "$BIN_DIR/non-test-bin" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'non-test executable must not be listed' >&2
+exit 1
+EOF
+chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member" "$BIN_DIR/non-test-bin"
 
 cat > "$BIN_DIR/cargo" <<'EOF'
 #!/usr/bin/env bash
@@ -87,9 +92,10 @@ PY
   exit 0
 fi
 if [[ " $* " == *' --workspace '* && " $* " == *' --no-run '* ]]; then
-  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"shard_smoke","kind":["lib"]},"executable":"%s/test-lib"}\n' "$(dirname "$0")"
-  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"api","kind":["test"]},"executable":"%s/test-api"}\n' "$(dirname "$0")"
-  printf '{"reason":"compiler-artifact","package_id":"member-smoke 0.1.0 (path+file:///fixture/member)","target":{"name":"member_smoke","kind":["lib"]},"executable":"%s/test-member"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"shard_smoke","kind":["lib"]},"profile":{"test":true},"executable":"%s/test-lib"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"api","kind":["test"]},"profile":{"test":true},"executable":"%s/test-api"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"member-smoke 0.1.0 (path+file:///fixture/member)","target":{"name":"member_smoke","kind":["lib"]},"profile":{"test":true},"executable":"%s/test-member"}\n' "$(dirname "$0")"
+  printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"normal","kind":["bin"]},"profile":{"test":false},"executable":"%s/non-test-bin"}\n' "$(dirname "$0")"
   exit 0
 fi
 if [[ " $* " == *' --doc '* && " $* " == *' --list '* ]]; then


### PR DESCRIPTION
## Summary
- inventory only Cargo compiler artifacts with `profile.test: true`
- skip normal executable artifacts before invoking `--list`
- cover a non-test executable that fails if discovery invokes it

Closes https://github.com/Extra-Chill/homeboy/issues/11637

## Verification
- `bash rust/tests/test-shard-inventory-smoke.sh`
- `python3 rust/scripts/test-shard-inventory.py --project /Users/chubes/Developer/homeboy@fix-11637-bench-audit-discovery --runner cargo --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-11637-inventory.json`
- `bash -n rust/tests/test-shard-inventory-smoke.sh`

AI assistance: OpenAI GPT-5.6 Sol via OpenCode diagnosed, implemented, and verified; Chris Huber responsible.