### PR TITLE
fix(wordpress): parse Node package test counts

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -25,6 +25,7 @@
       "bash tests/wordpress-install-command-smoke.sh",
       "bash tests/wordpress-release-artifact-version-smoke.sh",
       "bash tests/wordpress-runtime-helper-resolver-smoke.sh",
+      "bash wordpress/tests/node-test-result-parser-smoke.sh",
       "node tests/wp-codebox-adapter-contract-smoke.mjs",
       "node tests/wp-codebox-callback-data-smoke.mjs",
       "node tests/wp-codebox-install-overrides-persist-smoke.mjs"

--- a/scripts/lib/test-result-adapters.sh
+++ b/scripts/lib/test-result-adapters.sh
@@ -109,11 +109,39 @@ def parse_cargo_test():
     return True
 
 
+def parse_node_test():
+    # A WordPress package script can invoke several nested Node TAP suites. Its
+    # terminal package summary is the authoritative invocation count.
+    summaries = re.findall(
+        r"^passed:\s*(\d+);\s*failed:\s*(\d+);\s*intentionally skipped:\s*(\d+)\s*$",
+        text,
+        flags=re.MULTILINE,
+    )
+    if summaries:
+        passed, failed, skipped = map(int, summaries[-1])
+        emit(passed + failed + skipped, passed, failed, skipped)
+        return True
+
+    # Without a package summary, use one complete Node TAP summary rather than
+    # adding nested summaries from separately invoked test commands.
+    tap_summaries = re.findall(
+        r"^# tests\s+(\d+)\s*$.*?^# pass\s+(\d+)\s*$.*?^# fail\s+(\d+)\s*$.*?^# skipped\s+(\d+)\s*$",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not tap_summaries:
+        return False
+    total, passed, failed, skipped = map(int, tap_summaries[-1])
+    emit(total, passed, failed, skipped)
+    return True
+
+
 adapter_functions = {
     "host-smoke": parse_host_smoke,
     "phpunit": parse_phpunit,
     "phpunit-testdox": parse_phpunit_testdox,
     "cargo-test": parse_cargo_test,
+    "node-test": parse_node_test,
 }
 
 for adapter in adapters:

--- a/wordpress/tests/fixtures/node-test-results/nested-tap-package-summary.txt
+++ b/wordpress/tests/fixtures/node-test-results/nested-tap-package-summary.txt
@@ -1,0 +1,15 @@
+# tests 259
+# suites 0
+# pass 259
+# fail 0
+# skipped 0
+TAP version 13
+# tests 14
+# suites 0
+# pass 14
+# fail 0
+# skipped 0
+standalone-php: selected 40
+node: selected 10
+passed: 50; failed: 0; intentionally skipped: 0
+JS_TEST_SUMMARY:backend=package-script script=test files=1 status=ok

--- a/wordpress/tests/node-test-result-parser-smoke.sh
+++ b/wordpress/tests/node-test-result-parser-smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORDPRESS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPOSITORY_ROOT="$(cd "${WORDPRESS_ROOT}/.." && pwd)"
+CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR:-$(cd "${REPOSITORY_ROOT}/.." && pwd)/homeboy}/crates/homeboy-extension/src/runtime"
+FIXTURE="${WORDPRESS_ROOT}/tests/fixtures/node-test-results/nested-tap-package-summary.txt"
+RESULTS="$(mktemp "${TMPDIR:-/tmp}/homeboy-node-test-results.XXXXXX")"
+trap 'rm -f "$RESULTS"' EXIT
+
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${CORE_RUNTIME_DIR}/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$RESULTS" \
+    bash "${WORDPRESS_ROOT}/scripts/test/parse-test-results.sh" "$FIXTURE" wp-codebox-json node-test
+
+node - "$RESULTS" <<'JS'
+const fs = require('node:fs');
+const result = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (
+  Object.keys(result).sort().join(',') !== 'failed,passed,skipped,total' ||
+  !Object.values(result).every(Number.isInteger) ||
+  result.total !== 50 || result.passed !== 50 || result.failed !== 0 || result.skipped !== 0
+) {
+  throw new Error(`Unexpected parsed result: ${JSON.stringify(result)}`);
+}
+JS
+
+printf '%s\n' 'node test result parser smoke passed'

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1076,7 +1076,7 @@
   "test": {
     "result_parse": {
       "extension_script": "scripts/test/parse-test-results.sh",
-      "adapters": ["wp-codebox-json"]
+      "adapters": ["wp-codebox-json", "node-test"]
     },
     "changed_file_routing": {
       "strategy": "exclusive_env",


### PR DESCRIPTION
## Summary
- parse terminal Node package summaries through the shared test-result adapter
- register the adapter after `wp-codebox-json` so structured WP Codebox results retain precedence
- add a bounded nested-TAP fixture proving the canonical count result is 50 passed, 0 failed without double-counting nested suites

## Verification
- `bash wordpress/tests/node-test-result-parser-smoke.sh`
- `bash wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash wordpress/tests/installed-test-helper-resolution-smoke.sh`
- declared self-check sequence started successfully; its pre-existing `bash tests/cross-extension-sidecar-normalization-smoke.sh` failure is unrelated (missing temporary `go-lint-findings.json`)

Closes #1990

AI-assisted: OpenAI openai/gpt-5.6-sol via OpenCode implemented the shared parser, fixture test, verification, and PR. Chris Huber remains responsible for every line.