### PR TITLE
fix(rust): account for planned ignored nextest tests

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -396,6 +396,12 @@ def planned_identity(item):
         raise SystemExit("Rust test shard error: shard manifest contains a malformed planned nextest identity")
     return values
 
+def planned_outcome(item):
+    outcome = item.get("expected_outcome", "executed")
+    if outcome not in {"executed", "skipped"}:
+        raise SystemExit("Rust test shard error: shard manifest contains an invalid planned nextest outcome")
+    return outcome
+
 def emitted_identity(value):
     # libtest-json-plus omits Cargo's target kind and encodes its remaining
     # identity as package::target$test. Reconcile that structured projection,
@@ -410,12 +416,15 @@ def emitted_identity(value):
 
 planned_by_emitted = {}
 expected_identities = set()
+expected_skipped = set()
 for item in expected:
     planned = planned_identity(item)
     package, target_kind, target, test = planned
     if planned in expected_identities:
         raise SystemExit(f"Rust test shard error: shard manifest contains a duplicate planned nextest identity: {package}::{target_kind}::{target}::{test}")
     expected_identities.add(planned)
+    if planned_outcome(item) == "skipped":
+        expected_skipped.add(planned)
     emitted = package, target, test
     if emitted in planned_by_emitted:
         raise SystemExit(f"Rust test shard error: nextest output identity is ambiguous: {package}::{target}${test}")
@@ -446,8 +455,13 @@ for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
     if status in {"ok", "passed"}: passed += 1
     elif status in {"failed", "fail"}: failed += 1
     else: skipped += 1
-if actual != expected_identities:
-    raise SystemExit(f"Rust test shard error: nextest executed membership does not match the shard manifest (missing={sorted(expected_identities - actual)[:1]})")
+missing = expected_identities - actual
+unexpected_missing = missing - expected_skipped
+if unexpected_missing:
+    raise SystemExit(f"Rust test shard error: nextest executed membership does not match the shard manifest (missing={sorted(unexpected_missing)[:1]})")
+# Nextest intentionally omits ignored tests from its default event stream.
+# Their listed disposition is canonical execution policy, not a relaxed match.
+skipped += len(missing)
 print(f"{passed}\t{failed}\t{skipped}")
 PY
 }
@@ -690,7 +704,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
         for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
             NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
             NEXTEST_LIST_JSON="$(mktemp)"
-            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
+            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list --workspace --run-ignored all --message-format json -E "$NEXTEST_FILTER" || true
             if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_JSON" "$NEXTEST_BATCH"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -76,7 +76,7 @@ def cargo_inventory(workspace_root, packages):
 
 
 def nextest_inventory(workspace_root):
-    result = run(["cargo", "nextest", "list", "--workspace", "--message-format", "json"], workspace_root)
+    result = run(["cargo", "nextest", "list", "--workspace", "--run-ignored", "all", "--message-format", "json"], workspace_root)
     if result.returncode:
         fail(f"could not enumerate nextest tests: {result.stderr.strip()}")
     try:
@@ -95,7 +95,16 @@ def nextest_inventory(workspace_root):
                 fail("nextest emitted an invalid testcase identity")
             if testcase.get("filter-match", {}).get("status") != "matches":
                 continue
-            tests.append({"id": f"{package}::{target_kind}::{target}::{name}", "package": package, "target": target, "target_kind": target_kind, "name": name})
+            tests.append({
+                "id": f"{package}::{target_kind}::{target}::{name}",
+                "package": package,
+                "target": target,
+                "target_kind": target_kind,
+                "name": name,
+                # nextest list is the canonical source for tests that its
+                # default run policy intentionally skips without a terminal.
+                "expected_outcome": "skipped" if testcase.get("ignored") else "executed",
+            })
     return tests
 
 

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -156,6 +156,23 @@ def inventory(project, runner):
     return record
 
 
+def legacy_inventory_fingerprint(current):
+    """Fingerprint the v1 nextest inventory emitted before ignored tests were listed."""
+    legacy_tests = []
+    for test in current["tests"]:
+        if test.get("expected_outcome") == "skipped":
+            continue
+        legacy_tests.append({key: test[key] for key in ("id", "package", "target", "target_kind", "name")})
+    legacy = {
+        "schema": SCHEMA,
+        "runner": current["runner"],
+        "runner_fingerprint": current["runner_fingerprint"],
+        "workspace_fingerprint": current["workspace_fingerprint"],
+        "tests": legacy_tests,
+    }
+    return digest(json.dumps(legacy, sort_keys=True, separators=(",", ":"))), {test["id"] for test in legacy_tests}
+
+
 def validate(manifest_path, current):
     try:
         manifest = json.loads(Path(manifest_path).read_text())
@@ -165,7 +182,7 @@ def validate(manifest_path, current):
         fail("unsupported shard manifest schema")
     if manifest.get("runner") != current.get("runner"):
         fail("shard manifest runner does not match the selected runner")
-    for key in ("inventory_fingerprint", "runner_fingerprint", "workspace_fingerprint"):
+    for key in ("runner_fingerprint", "workspace_fingerprint"):
         if manifest.get(key) != current.get(key):
             fail(f"stale shard manifest: {key} does not match the current inventory")
     selected = manifest.get("tests")
@@ -179,6 +196,13 @@ def validate(manifest_path, current):
     missing = [identity for identity in selected if identity not in known]
     if missing:
         fail(f"shard manifest contains unresolvable test identity: {missing[0]}")
+    if manifest.get("inventory_fingerprint") != current.get("inventory_fingerprint"):
+        legacy_fingerprint, legacy_ids = legacy_inventory_fingerprint(current)
+        if manifest.get("inventory_fingerprint") != legacy_fingerprint:
+            fail("stale shard manifest: inventory_fingerprint does not match the current or compatible legacy inventory")
+        legacy_missing = [identity for identity in selected if identity not in legacy_ids]
+        if legacy_missing:
+            fail(f"legacy shard manifest selects tests outside the legacy inventory: {legacy_missing[0]}")
     return [known[identity] for identity in selected]
 
 

--- a/rust/tests/fixtures/nextest-shard-real/alpha/src/lib.rs
+++ b/rust/tests/fixtures/nextest-shard-real/alpha/src/lib.rs
@@ -13,6 +13,12 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn planned_ignored() {
+        assert!(true);
+    }
+
+    #[test]
+    #[ignore]
     fn ignored_child_helper() {
         assert!(true);
     }

--- a/rust/tests/nextest-shard-real-smoke.sh
+++ b/rust/tests/nextest-shard-real-smoke.sh
@@ -75,8 +75,9 @@ import json
 import sys
 
 inventory = json.load(open(sys.argv[1], encoding="utf-8"))
-selected = [test["id"] for test in inventory["tests"] if test["name"] == "tests::selected_parent"]
-assert len(selected) == 1, inventory["tests"]
+selected = [test["id"] for test in inventory["tests"] if test["name"] in {"tests::selected_parent", "tests::planned_ignored"}]
+assert len(selected) == 2, inventory["tests"]
+assert sum(test["expected_outcome"] == "skipped" for test in inventory["tests"] if test["id"] in selected) == 1, inventory["tests"]
 manifest = {key: inventory[key] for key in ("runner", "inventory_fingerprint", "runner_fingerprint", "workspace_fingerprint")}
 manifest["schema"] = "homeboy/test-shard-manifest/v1"
 manifest["tests"] = selected
@@ -120,7 +121,7 @@ assert any(event.get("event") in {"started", "queued", "running"} and event.get(
 assert any(event.get("event") == "ignored" and event.get("name", "").endswith("$tests::ignored_child_helper") for event in events), events
 assert any(event.get("event") in {"ok", "passed"} and event.get("name", "").endswith("$tests::selected_parent") for event in events), events
 results = json.load(open(sys.argv[2], encoding="utf-8"))
-assert results == {"total": 1, "passed": 1, "failed": 0, "skipped": 0, "partial": "rust-shard"}, results
+assert results == {"total": 2, "passed": 1, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
 PY
 
 printf 'real nextest shard smoke ok\n'

--- a/rust/tests/nextest-shard-real-smoke.sh
+++ b/rust/tests/nextest-shard-real-smoke.sh
@@ -70,6 +70,54 @@ HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
 HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
 bash "$EXTENSION_DIR/scripts/test-runner.sh" >/dev/null
 
+if [ -n "${HOMEBOY_PARENT_EXTENSION_DIR:-}" ]; then
+    PARENT_INVENTORY="$WORK_DIR/parent-inventory.json"
+    PARENT_MANIFEST="$WORK_DIR/parent-manifest.json"
+    python3 "$HOMEBOY_PARENT_EXTENSION_DIR/scripts/test-shard-inventory.py" \
+        --project "$FIXTURE_DIR" --runner nextest --output "$PARENT_INVENTORY"
+    python3 - "$PARENT_INVENTORY" "$PARENT_MANIFEST" <<'PY'
+import json
+import sys
+
+inventory = json.load(open(sys.argv[1], encoding="utf-8"))
+selected = [test["id"] for test in inventory["tests"] if test["name"] == "tests::selected_parent"]
+assert len(selected) == 1, inventory["tests"]
+manifest = {key: inventory[key] for key in ("runner", "inventory_fingerprint", "runner_fingerprint", "workspace_fingerprint")}
+manifest["schema"] = "homeboy/test-shard-manifest/v1"
+manifest["tests"] = selected
+json.dump(manifest, open(sys.argv[2], "w"), indent=2)
+PY
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_RUST_TEST_RUNNER=nextest \
+    HOMEBOY_TEST_SHARD_MANIFEST="$PARENT_MANIFEST" \
+    HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/parent-results.json" \
+    HOMEBOY_REAL_NEXTEST_EVENT_STREAM="$WORK_DIR/parent-events.jsonl" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+    HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+    bash "$EXTENSION_DIR/scripts/test-runner.sh" >"$WORK_DIR/parent-runner.out"
+    python3 - "$WORK_DIR/parent-results.json" "$PARENT_MANIFEST" "$WORK_DIR/tampered-parent-manifest.json" "$WORK_DIR/stale-parent-manifest.json" <<'PY'
+import json
+import sys
+
+results = json.load(open(sys.argv[1], encoding="utf-8"))
+assert results == {"total": 1, "passed": 1, "failed": 0, "skipped": 0, "partial": "rust-shard"}, results
+manifest = json.load(open(sys.argv[2], encoding="utf-8"))
+tampered = dict(manifest, tests=manifest["tests"] + ["nextest-shard-alpha::lib::nextest_shard_alpha::tests::planned_ignored"])
+json.dump(tampered, open(sys.argv[3], "w"))
+stale = dict(manifest, workspace_fingerprint="stale")
+json.dump(stale, open(sys.argv[4], "w"))
+PY
+    for invalid in "$WORK_DIR/tampered-parent-manifest.json" "$WORK_DIR/stale-parent-manifest.json"; do
+        if python3 "$EXTENSION_DIR/scripts/test-shard-inventory.py" --project "$FIXTURE_DIR" --runner nextest --output "$WORK_DIR/invalid.json" --manifest "$invalid" >/dev/null 2>&1; then
+            printf 'Expected incompatible parent manifest rejection: %s\n' "$invalid" >&2
+            exit 1
+        fi
+    done
+fi
+
 python3 - "$INVENTORY" "$WORK_DIR/manifest.json" <<'PY'
 import json
 import sys

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -141,6 +141,8 @@ mode = os.environ.get("HOMEBOY_NEXTEST_MODE", "pass")
 if mode == "zero":
     raise SystemExit(0)
 for name in names:
+    if mode == "planned-ignored-absent" and name == "unit::ignored":
+        continue
     if mode == "missing-terminal" and name == "unit::beta":
         continue
     package, binary = ("shard-smoke", "api") if name == "api::works" else ("member-smoke", "member_smoke") if name == "member::member_works" else ("shard-smoke", "shard_smoke")
@@ -605,6 +607,8 @@ HOMEBOY_SKIP_LINT=1 \
 HOMEBOY_RUST_TEST_RUNNER=nextest \
 HOMEBOY_NEXTEST_MODE=zero \
 HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/nextest-zero-results.json" \
 HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
 HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
 PATH="$BIN_DIR:$PATH" \
@@ -624,6 +628,12 @@ if [ "$ZERO_EXIT" -eq 0 ] || ! grep -q 'nextest executed membership does not mat
   printf 'Expected nextest zero-selection shard replay to fail closed\n' >&2
   exit 1
 fi
+python3 - "$WORK_DIR/nextest-zero-results.json" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1])) == {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "partial": "rust-shard"}
+PY
 
 set +e
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
@@ -632,6 +642,8 @@ HOMEBOY_SKIP_LINT=1 \
 HOMEBOY_RUST_TEST_RUNNER=nextest \
 HOMEBOY_NEXTEST_MODE=malformed \
 HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/nextest-malformed-results.json" \
 HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
 HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
 PATH="$BIN_DIR:$PATH" \
@@ -642,6 +654,12 @@ if [ "$MALFORMED_EXIT" -eq 0 ] || ! grep -q 'nextest emitted a malformed test id
   printf 'Expected malformed nextest event identity to fail closed\n' >&2
   exit 1
 fi
+python3 - "$WORK_DIR/nextest-malformed-results.json" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1])) == {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "partial": "rust-shard"}
+PY
 
 assert_nextest_event_rejected() {
   local mode="$1" expected="$2" output
@@ -685,6 +703,27 @@ HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
 PATH="$BIN_DIR:$PATH" \
 bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/ignored-outside.out"
 python3 - "$WORK_DIR/ignored-outside-results.json" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+
+# nextest list marked unit::ignored as skipped. Default nextest execution does
+# not terminalize it, but the immutable manifest still reports one skipped test.
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_MODE=planned-ignored-absent \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/planned-ignored-results.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/planned-ignored.out"
+python3 - "$WORK_DIR/planned-ignored-results.json" <<'PY'
 import json
 import sys
 

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -243,7 +243,8 @@ HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
 PATH="$BIN_DIR:$PATH" \
 bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/inventory-nextest.out"
 
-python3 - "$INVENTORY_A" "$INVENTORY_B" "$INVENTORY_NEXTEST" "$WORK_DIR/manifest.json" "$WORK_DIR/nextest-manifest.json" <<'PY'
+python3 - "$INVENTORY_A" "$INVENTORY_B" "$INVENTORY_NEXTEST" "$WORK_DIR/manifest.json" "$WORK_DIR/nextest-manifest.json" "$WORK_DIR/legacy-nextest-manifest.json" <<'PY'
+import hashlib
 import json
 import sys
 
@@ -280,7 +281,37 @@ assert all(isinstance(test_id, str) for test_id in manifest["tests"]), manifest
 json.dump(manifest, open(sys.argv[4], "w"))
 nextest_manifest = dict(manifest, runner=nextest["runner"], inventory_fingerprint=nextest["inventory_fingerprint"], runner_fingerprint=nextest["runner_fingerprint"], workspace_fingerprint=nextest["workspace_fingerprint"], tests=[test["id"] for test in nextest["tests"]])
 json.dump(nextest_manifest, open(sys.argv[5], "w"))
+
+# This is the exact v1 nextest projection emitted before ignored tests were
+# listed: only runnable tests and no expected_outcome metadata participate.
+legacy_tests = [{key: test[key] for key in ("id", "package", "target", "target_kind", "name")} for test in nextest["tests"] if test.get("expected_outcome") != "skipped"]
+legacy_inventory = {key: nextest[key] for key in ("schema", "runner", "runner_fingerprint", "workspace_fingerprint")}
+legacy_inventory["tests"] = legacy_tests
+legacy_fingerprint = hashlib.sha256(json.dumps(legacy_inventory, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+legacy_manifest = dict(nextest_manifest, inventory_fingerprint=legacy_fingerprint, tests=[legacy_tests[0]["id"]])
+json.dump(legacy_manifest, open(sys.argv[6], "w"))
 PY
+
+# A parent v1 manifest may carry only the legacy runnable projection. The
+# candidate accepts that exact fingerprint while resolving IDs against its
+# richer inventory; tampered legacy selections remain typed rejections.
+PATH="$BIN_DIR:$PATH" python3 "$EXTENSION_DIR/scripts/test-shard-inventory.py" --project "$PROJECT_DIR" --runner nextest --output "$WORK_DIR/legacy-nextest-selected.json" --manifest "$WORK_DIR/legacy-nextest-manifest.json"
+python3 - "$WORK_DIR/legacy-nextest-selected.json" "$WORK_DIR/legacy-nextest-manifest.json" "$WORK_DIR/legacy-tampered.json" "$WORK_DIR/legacy-stale.json" <<'PY'
+import json
+import sys
+
+selected = json.load(open(sys.argv[1]))["selected"]
+assert len(selected) == 1 and selected[0]["expected_outcome"] == "executed", selected
+manifest = json.load(open(sys.argv[2]))
+json.dump(dict(manifest, tests=manifest["tests"] + ["shard-smoke::lib::shard_smoke::unit::ignored"]), open(sys.argv[3], "w"))
+json.dump(dict(manifest, workspace_fingerprint="stale"), open(sys.argv[4], "w"))
+PY
+for invalid in "$WORK_DIR/legacy-tampered.json" "$WORK_DIR/legacy-stale.json"; do
+  if PATH="$BIN_DIR:$PATH" python3 "$EXTENSION_DIR/scripts/test-shard-inventory.py" --project "$PROJECT_DIR" --runner nextest --output "$WORK_DIR/legacy-invalid.json" --manifest "$invalid" >/dev/null 2>&1; then
+    printf 'Expected typed legacy manifest rejection: %s\n' "$invalid" >&2
+    exit 1
+  fi
+done
 
 if [ -e "$BENCH_LIST_LOG" ] || grep -q 'CARGO_MANIFEST_DIR not set' "$WORK_DIR/inventory-a.out"; then
   printf 'Expected non-test bench artifact to remain uninvoked and unreported\n' >&2


### PR DESCRIPTION
## Summary

Follow-up to #2553 for Homeboy attempt 3. `cargo nextest list --run-ignored all` exposes tests that default `cargo nextest run` intentionally does not terminalize. Attempt 3 produced 9-16 missing tests with zero skipped counts because the runner treated every selected identity as requiring a terminal event.

The inventory preserves canonical nextest ignored disposition additively as `expected_outcome: skipped`. The runner lists ignored tests for inventory and preflight membership, executes with nextest default ignored policy, then counts missing planned skipped identities as skipped. Missing planned runnable identities still fail closed. Out-of-manifest `ok`/`failed` remain fail-closed; nested unplanned ignored terminals remain observational.

## v1 Compatibility

Validation retains strict runner and workspace fingerprints. For `inventory_fingerprint`, it accepts exactly two projections:

- The current disposition-aware inventory fingerprint.
- The explicit parent v1 projection: runnable nextest entries only, with the historical five identity fields and no `expected_outcome`.

A legacy-fingerprint manifest must select only IDs from that legacy projection, and every selected ID must resolve uniquely in the current inventory. Other inventory fingerprints, tampered legacy selections, stale workspace fingerprints, duplicate IDs, and unresolvable IDs reject with typed errors. Existing v1 manifests remain the schema; omitted `expected_outcome` defaults to `executed` for selected records. No fingerprint check is broadly skipped.

## Evidence

- Follow-up: #2552 and #2553
- Related consumer tracker: Extra-Chill/homeboy-action#345
- Attempt 3 evidence: planned ignored tests were included by list policy but omitted from default nextest terminal events, yielding 9-16 missing identities and zero sidecars in affected shards.
- Actual parent-manifest proof: `HOMEBOY_PARENT_EXTENSION_DIR=/Users/chubes/Developer/homeboy-extensions@proof-2554-parent/rust bash rust/tests/nextest-shard-real-smoke.sh`
- The base runner generates a v1 manifest; candidate accepts it and executes one runnable test with `{total:1, passed:1, failed:0, skipped:0}`. Tampered and stale parent manifests reject.
- Current ignored-policy proof: `bash rust/tests/nextest-shard-real-smoke.sh` reports `{total:2, passed:1, failed:0, skipped:1}` for a selected runnable parent and planned ignored test.
- Missing runnable terminals retain the exact zero-sidecar result `{total:0, passed:0, failed:0, skipped:0, partial:rust-shard}`.

## Verification

- `bash scripts/ci/run-self-checks.sh rust test`
- `bash scripts/ci/run-self-checks.sh rust lint`
- `bash -n rust/scripts/test-runner.sh rust/tests/test-shard-inventory-smoke.sh rust/tests/nextest-shard-real-smoke.sh`
- `python3 -m py_compile rust/scripts/test-shard-inventory.py`
- `cargo fmt --manifest-path rust/tests/fixtures/nextest-shard-real/Cargo.toml --all -- --check`
- `git diff --check`

AI assistance: OpenAI openai/gpt-5.6-terra via OpenCode generated and consumed an actual PR-parent v1 manifest, implemented explicit dual inventory fingerprint validation, added regression coverage, and ran the listed gates. Chris Huber remains responsible for every line.