### PR TITLE
fix(rust): make nextest preflight authoritative

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -724,12 +724,14 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
             rm -f "$SHARD_DATA"
             exit 1
         fi
-        # Validate every planned filter before any test batch can execute.
+        # Capture filter argv values once. Preflight and execution consume the
+        # same shell-owned bytes, never a mutable filter file.
+        declare -A NEXTEST_FILTERS NEXTEST_FILTER_DIGESTS
         for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
             [ -f "$NEXTEST_BATCH" ] || continue
             NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
-            printf '%s' "$NEXTEST_FILTER" > "${NEXTEST_BATCH}.filter"
-            shasum -a 256 "${NEXTEST_BATCH}.filter" | cut -d ' ' -f 1 > "${NEXTEST_BATCH}.filter.sha256"
+            NEXTEST_FILTERS["$NEXTEST_BATCH"]="$NEXTEST_FILTER"
+            NEXTEST_FILTER_DIGESTS["$NEXTEST_BATCH"]="$(printf '%s' "$NEXTEST_FILTER" | shasum -a 256 | cut -d ' ' -f 1)"
             NEXTEST_LIST_JSON="$(mktemp)"
             homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
             if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_JSON" "$NEXTEST_BATCH"; then
@@ -749,8 +751,8 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
         SHARD_EXIT=0
         for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
             [ -f "$NEXTEST_BATCH" ] || continue
-            NEXTEST_FILTER="$(<"${NEXTEST_BATCH}.filter")"
-            if [ "$(shasum -a 256 "${NEXTEST_BATCH}.filter" | cut -d ' ' -f 1)" != "$(<"${NEXTEST_BATCH}.filter.sha256")" ]; then
+            NEXTEST_FILTER="${NEXTEST_FILTERS[$NEXTEST_BATCH]}"
+            if [ "$(printf '%s' "$NEXTEST_FILTER" | shasum -a 256 | cut -d ' ' -f 1)" != "${NEXTEST_FILTER_DIGESTS[$NEXTEST_BATCH]}" ]; then
                 echo "Rust test shard error: nextest filter changed after preflight." >&2
                 exit 1
             fi

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -357,6 +357,18 @@ if actual != expected:
 PY
 }
 
+rust_nextest_execution_data() {
+    python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+source, target = sys.argv[1:]
+data = json.load(open(source, encoding="utf-8"))
+data["selected"] = [item for item in data["selected"] if item.get("expected_outcome", "executed") == "executed"]
+json.dump(data, open(target, "w"), separators=(",", ":"))
+PY
+}
+
 rust_validate_nextest_membership() {
     local list_file="$1" shard_file="$2"
     python3 - "$list_file" "$shard_file" <<'PY'
@@ -364,15 +376,23 @@ import json
 import sys
 
 listed = json.load(open(sys.argv[1], encoding="utf-8"))
-expected = {item["id"] for item in json.load(open(sys.argv[2], encoding="utf-8"))["selected"]}
-actual = set()
+expected = [item["id"] for item in json.load(open(sys.argv[2], encoding="utf-8"))["selected"]]
+if len(expected) != len(set(expected)):
+    raise SystemExit("Rust test shard error: nextest preflight contains duplicate planned identities")
+actual = []
 for suite in listed.get("rust-suites", {}).values():
+    if not all(isinstance(suite.get(key), str) and suite[key] for key in ("package-name", "kind", "binary-name")):
+        raise SystemExit("Rust test shard error: nextest preflight emitted a malformed suite identity")
     for name, testcase in suite.get("testcases", {}).items():
+        if not isinstance(name, str) or not isinstance(testcase, dict):
+            raise SystemExit("Rust test shard error: nextest preflight emitted a malformed testcase identity")
         if testcase.get("filter-match", {}).get("status") == "matches":
-            actual.add(f'{suite["package-name"]}::{suite["kind"]}::{suite["binary-name"]}::{name}')
-if actual != expected:
-    missing = sorted(expected - actual)
-    extra = sorted(actual - expected)
+            actual.append(f'{suite["package-name"]}::{suite["kind"]}::{suite["binary-name"]}::{name}')
+if len(actual) != len(set(actual)):
+    raise SystemExit("Rust test shard error: nextest preflight emitted duplicate runnable identities")
+if set(actual) != set(expected):
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
     raise SystemExit(f"Rust test shard error: nextest exact filter membership mismatch (missing={missing[:1]}, extra={extra[:1]})")
 PY
 }
@@ -441,14 +461,14 @@ for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
     status = event.get("event")
     if status not in {"ok", "passed", "failed", "fail", "ignored", "skipped"}:
         continue
-    emitted = emitted_identity(event.get("name"))
+    try:
+        emitted = emitted_identity(event.get("name"))
+    except SystemExit:
+        # Child processes inherit libtest JSON. Scheduler preflight, not their
+        # diagnostics, is the authority for shard membership.
+        continue
     if emitted not in planned_by_emitted:
-        # Nested libtest helpers can report an ignored/skipped terminal event
-        # even though the shard selected only their parent test. They did not
-        # execute, so they are neither membership evidence nor result counts.
-        if status in {"ignored", "skipped"}:
-            continue
-        raise SystemExit(f"Rust test shard error: nextest emitted an unexpected test identity: {event.get('name')}")
+        continue
     if planned_by_emitted[emitted] in actual:
         raise SystemExit(f"Rust test shard error: nextest emitted an unexpected or duplicate test identity: {event.get('name')}")
     actual.add(planned_by_emitted[emitted])
@@ -684,7 +704,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
     SHARD_TOTAL="$(jq '.selected | length' "$SHARD_DATA")"
     SHARD_PASSED=0
     SHARD_FAILED=0
-    SHARD_SKIPPED=0
+    SHARD_SKIPPED="$(jq '[.selected[] | select(.expected_outcome == "skipped")] | length' "$SHARD_DATA")"
     if [ "$SELECTED_RUNNER" = "nextest" ]; then
         if ! NEXTEST_MAX_BYTES="$(rust_nextest_filter_max_bytes)"; then
             SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
@@ -692,35 +712,48 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
             rm -f "$SHARD_DATA"
             exit 1
         fi
+        NEXTEST_EXECUTION_DATA="$(mktemp)"
+        rust_nextest_execution_data "$SHARD_DATA" "$NEXTEST_EXECUTION_DATA"
+        NEXTEST_RUNNABLE_TOTAL="$(jq '.selected | length' "$NEXTEST_EXECUTION_DATA")"
         NEXTEST_BATCH_DIR="$(mktemp -d)"
-        if ! rust_nextest_batches "$SHARD_DATA" "$NEXTEST_MAX_BYTES" "$NEXTEST_BATCH_DIR" || ! rust_validate_nextest_batches "$SHARD_DATA" "$NEXTEST_BATCH_DIR"; then
+        if [ "$NEXTEST_RUNNABLE_TOTAL" -gt 0 ] && { ! rust_nextest_batches "$NEXTEST_EXECUTION_DATA" "$NEXTEST_MAX_BYTES" "$NEXTEST_BATCH_DIR" || ! rust_validate_nextest_batches "$NEXTEST_EXECUTION_DATA" "$NEXTEST_BATCH_DIR"; }; then
             SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
             rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
             rm -rf "$NEXTEST_BATCH_DIR"
+            rm -f "$NEXTEST_EXECUTION_DATA"
             rm -f "$SHARD_DATA"
             exit 1
         fi
         # Validate every planned filter before any test batch can execute.
         for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
+            [ -f "$NEXTEST_BATCH" ] || continue
             NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
+            printf '%s' "$NEXTEST_FILTER" > "${NEXTEST_BATCH}.filter"
+            shasum -a 256 "${NEXTEST_BATCH}.filter" | cut -d ' ' -f 1 > "${NEXTEST_BATCH}.filter.sha256"
             NEXTEST_LIST_JSON="$(mktemp)"
-            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list --workspace --run-ignored all --message-format json -E "$NEXTEST_FILTER" || true
+            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
             if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_JSON" "$NEXTEST_BATCH"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
                 homeboy_cleanup_step_capture "$NEXTEST_LIST_OUTPUT"
                 homeboy_cleanup_step_capture "$NEXTEST_LIST_JSON"
                 rm -rf "$NEXTEST_BATCH_DIR"
+                rm -f "$NEXTEST_EXECUTION_DATA"
                 rm -f "$SHARD_DATA"
                 exit 1
             fi
             homeboy_cleanup_step_capture "$NEXTEST_LIST_OUTPUT"
             homeboy_cleanup_step_capture "$NEXTEST_LIST_JSON"
         done
-        echo "Replaying Rust nextest shard: ${SHARD_TOTAL} exact identities in $(printf '%s\n' "$NEXTEST_BATCH_DIR"/*.json | wc -l | tr -d ' ') batches"
+        echo "Replaying Rust nextest shard: ${NEXTEST_RUNNABLE_TOTAL} runnable identities and ${SHARD_SKIPPED} planned skipped identities"
         SHARD_EXIT=0
         for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
-            NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
+            [ -f "$NEXTEST_BATCH" ] || continue
+            NEXTEST_FILTER="$(<"${NEXTEST_BATCH}.filter")"
+            if [ "$(shasum -a 256 "${NEXTEST_BATCH}.filter" | cut -d ' ' -f 1)" != "$(<"${NEXTEST_BATCH}.filter.sha256")" ]; then
+                echo "Rust test shard error: nextest filter changed after preflight." >&2
+                exit 1
+            fi
             homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --manifest-path "${PROJECT_PATH}/Cargo.toml" --workspace --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
             if ! NEXTEST_COUNTS="$(rust_nextest_counts "$SHARD_OUTPUT" "$NEXTEST_BATCH")"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
@@ -738,6 +771,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
             rm -f "$SHARD_OUTPUT"
         done
         rm -rf "$NEXTEST_BATCH_DIR"
+        rm -f "$NEXTEST_EXECUTION_DATA"
     else
         while IFS=$'\t' read -r package target target_kind name; do
             case "$target_kind" in

--- a/rust/tests/fixtures/nextest-shard-real/alpha/src/lib.rs
+++ b/rust/tests/fixtures/nextest-shard-real/alpha/src/lib.rs
@@ -2,13 +2,24 @@
 mod tests {
     #[test]
     fn selected_parent() {
-        let status =
-            std::process::Command::new(std::env::current_exe().expect("current test binary"))
-                .args(["--exact", "tests::ignored_child_helper"])
-                .stdout(std::process::Stdio::inherit())
-                .status()
-                .expect("run ignored nested helper");
+        let binary = std::env::current_exe().expect("current test binary");
+        let status = std::process::Command::new(&binary)
+            .args(["--exact", "tests::ignored_child_helper"])
+            .stdout(std::process::Stdio::inherit())
+            .status()
+            .expect("run ignored nested helper");
         assert!(status.success());
+        assert!(std::process::Command::new(&binary)
+            .args(["--exact", "tests::nested_ok_helper"])
+            .stdout(std::process::Stdio::inherit())
+            .status()
+            .expect("run successful nested helper")
+            .success());
+        let _ = std::process::Command::new(&binary)
+            .args(["--exact", "tests::nested_failed_helper"])
+            .stdout(std::process::Stdio::inherit())
+            .status()
+            .expect("run failing nested helper");
     }
 
     #[test]
@@ -21,6 +32,16 @@ mod tests {
     #[ignore]
     fn ignored_child_helper() {
         assert!(true);
+    }
+
+    #[test]
+    fn nested_ok_helper() {
+        assert!(true);
+    }
+
+    #[test]
+    fn nested_failed_helper() {
+        panic!("nested child failure is observational");
     }
 
     #[test]

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -442,13 +442,13 @@ import sys
 
 limit = 150
 lines = open(sys.argv[1]).read().splitlines()
-assert len(lines) == 5, lines
+assert len(lines) == 4, lines
 selected = []
 for line in lines:
     filter_value = line.split(" -E ", 1)[1]
     assert len(filter_value.encode()) <= limit, filter_value
     selected.extend(re.findall(r"test\(=([^)]+)\)", filter_value))
-assert selected == ["member::member_works", "unit::alpha", "unit::beta", "unit::ignored", "api::works"], selected
+assert selected == ["member::member_works", "unit::alpha", "unit::beta", "api::works"], selected
 assert len(selected) == len(set(selected)), selected
 assert json.load(open(sys.argv[2])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
 PY
@@ -482,7 +482,7 @@ import sys
 lines = open(sys.argv[1]).read().splitlines()
 selected = [name for line in lines for name in re.findall(r"test\(=([^)]+)\)", line)]
 assert int(sys.argv[3]) != 0, sys.argv[3]
-assert selected == ["member::member_works", "unit::alpha", "unit::beta", "unit::ignored", "api::works"], selected
+assert selected == ["member::member_works", "unit::alpha", "unit::beta", "api::works"], selected
 assert len(selected) == len(set(selected)), selected
 assert json.load(open(sys.argv[2])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
 PY
@@ -681,8 +681,8 @@ PATH="$BIN_DIR:$PATH" \
 bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/nextest-malformed.out" 2>&1
 MALFORMED_EXIT=$?
 set -e
-if [ "$MALFORMED_EXIT" -eq 0 ] || ! grep -q 'nextest emitted a malformed test identity' "$WORK_DIR/nextest-malformed.out"; then
-  printf 'Expected malformed nextest event identity to fail closed\n' >&2
+if [ "$MALFORMED_EXIT" -eq 0 ] || ! grep -q 'nextest executed membership does not match the shard manifest' "$WORK_DIR/nextest-malformed.out"; then
+  printf 'Expected malformed planned terminal stream to fail closed\n' >&2
   exit 1
 fi
 python3 - "$WORK_DIR/nextest-malformed-results.json" <<'PY'
@@ -714,8 +714,6 @@ assert_nextest_event_rejected() {
   fi
 }
 
-assert_nextest_event_rejected terminal-outside-ok 'nextest emitted an unexpected test identity'
-assert_nextest_event_rejected terminal-outside-failed 'nextest emitted an unexpected test identity'
 assert_nextest_event_rejected duplicate-terminal 'nextest emitted an unexpected or duplicate test identity'
 assert_nextest_event_rejected missing-terminal 'nextest executed membership does not match the shard manifest'
 


### PR DESCRIPTION
## Review Update

Fixes the TOCTOU review finding. Each batch captures its generated filter expression once in a Bash associative array, computes SHA-256 over `printf %s` of those exact permitted bytes, and invokes nextest with that same retained argv value. Execution never rereads a mutable filter or digest file, so post-preflight file substitution cannot alter the executed filter or satisfy the captured digest.

## Summary

Attempt 4 follow-up for #2552. Canonical filtered `cargo nextest list` is scheduler authority. Terminal parsing counts only preflight-planned runnable IDs; nested process-helper lifecycle and terminal JSON is observational. Planned skipped tests are excluded from execution and count skipped; duplicate/missing/failing planned runnable terminals remain failures.

## Verification

- `bash scripts/ci/run-self-checks.sh rust test`
- `bash scripts/ci/run-self-checks.sh rust lint`
- `cargo fmt --manifest-path rust/tests/fixtures/nextest-shard-real/Cargo.toml --all -- --check`
- `bash -n rust/scripts/test-runner.sh`
- `git diff --check`

AI assistance: OpenAI openai/gpt-5.6-terra via OpenCode fixed the reviewed TOCTOU boundary by retaining exact in-memory filter argv bytes and hashing those bytes, then ran the listed gates. Chris Huber remains responsible for every line.