### PR TITLE
Make WordPress autofixers contract-safe

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -55,6 +55,7 @@
       "bash scripts/bench/bench-runner-runtime-backend-smoke.sh",
       "bash scripts/lint/eslint-no-files-smoke.sh",
       "bash scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh",
+      "bash tests/php-fixer-safety-smoke.sh",
       "bash scripts/lint/phpcs-config-selection-smoke.sh",
       "bash scripts/lint/phpcs-warnings-gate-smoke.sh",
       "bash scripts/test/parse-test-failures-sidecar-smoke.sh",

--- a/wordpress/scripts/lint/php-fixers/empty-catch-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/empty-catch-fixer.php
@@ -60,6 +60,12 @@ function process_file( $filepath ) {
 	while ( $i < $count ) {
 		$line    = $lines[ $i ];
 		$trimmed = trim( $line );
+		$is_suppressed = fixer_line_has_phpcs_ignore( $lines, $i );
+		if ( $is_suppressed ) {
+			$new_lines[] = $line;
+			$i++;
+			continue;
+		}
 
 		// Pattern 1: catch with captured variable — `catch ( \Exception $var ) {`
 		if ( preg_match( '/\}\s*catch\s*\(\s*\\\\?[\w\\\\]+\s+(\$\w+)\s*\)\s*\{/', $trimmed, $m ) ) {
@@ -81,7 +87,7 @@ function process_file( $filepath ) {
 				}
 			}
 
-			if ( ! body_has_code( $body_lines ) ) {
+			if ( ! $is_suppressed && ! fixer_lines_have_phpcs_ignore( $body_lines ) && ! body_has_code( $body_lines ) ) {
 				// Detect indent from the catch line.
 				preg_match( '/^(\s*)/', $lines[ $catch_start - 1 ], $indent_match );
 				$catch_indent = $indent_match[1];
@@ -117,13 +123,12 @@ function process_file( $filepath ) {
 		if ( preg_match( '/(\}\s*catch\s*\(\s*\\\\?[\w\\\\]+)\s*\)\s*\{/', $trimmed, $m )
 			&& ! preg_match( '/\$\w+/', $trimmed )
 		) {
-			// Rewrite catch line to add $e variable.
+			// Keep the original line until the body has been checked for suppressions.
 			$rewritten = preg_replace(
 				'/(\}\s*catch\s*\(\s*\\\\?[\w\\\\]+)\s*(\)\s*\{)/',
 				'$1 $e $2',
 				$line
 			);
-			$new_lines[] = $rewritten;
 			$i++;
 
 			$body_lines  = array();
@@ -140,7 +145,8 @@ function process_file( $filepath ) {
 				}
 			}
 
-			if ( ! body_has_code( $body_lines ) ) {
+			if ( ! $is_suppressed && ! fixer_lines_have_phpcs_ignore( $body_lines ) && ! body_has_code( $body_lines ) ) {
+				$new_lines[] = $rewritten;
 				preg_match( '/^(\s*)/', $lines[ $catch_start - 1 ], $indent_match );
 				$catch_indent = $indent_match[1];
 				$body_indent  = $catch_indent . "\t";
@@ -154,6 +160,7 @@ function process_file( $filepath ) {
 				$new_lines[] = "{$body_indent}unset( \$e );\n";
 				$fixes++;
 			} else {
+				$new_lines[] = $line;
 				foreach ( $body_lines as $body_line ) {
 					$new_lines[] = $body_line;
 				}

--- a/wordpress/scripts/lint/php-fixers/fixer-helpers.php
+++ b/wordpress/scripts/lint/php-fixers/fixer-helpers.php
@@ -67,6 +67,39 @@ function fixer_path_is_excluded($path) {
 }
 
 /**
+ * Check whether a fixer target is explicitly suppressed for PHPCS.
+ *
+ * @param array $lines Source lines.
+ * @param int   $line_index Zero-based target line index.
+ * @return bool True when the target or its preceding line has a suppression.
+ */
+function fixer_line_has_phpcs_ignore(array $lines, $line_index) {
+    foreach ([$line_index - 1, $line_index] as $index) {
+        if (isset($lines[$index]) && strpos($lines[$index], 'phpcs:ignore') !== false) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Check whether any line in a code region explicitly suppresses PHPCS.
+ *
+ * @param array $lines Source lines.
+ * @return bool True when the region contains a suppression.
+ */
+function fixer_lines_have_phpcs_ignore(array $lines) {
+    foreach ($lines as $line) {
+        if (strpos($line, 'phpcs:ignore') !== false) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Detect pure-PHP test harness files that don't bootstrap WordPress.
  *
  * Smoke tests (`tests/*-smoke.php`, `tests/smoke-*.php`) and PHPUnit test classes

--- a/wordpress/scripts/lint/php-fixers/unused-param-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/unused-param-fixer.php
@@ -989,7 +989,7 @@ function is_override_method($tokens, $func_info) {
  * Determine if a parameter can be safely removed.
  *
  * Criteria:
- * - Method must be private (or have no external callers).
+ * - Method must be private.
  * - The param must be the LAST parameter (removing non-last params changes call semantics).
  * - We can find all call sites.
  */
@@ -1036,34 +1036,9 @@ function can_remove_param($tokens, $func_info, $param_name, $filepath, $scan_roo
         return $result;
     }
 
-    // Standalone functions (no class) — find callers across codebase.
-    if ($func_info['visibility'] === null) {
-        $class_name = find_enclosing_class($tokens, $func_info['func_token']);
-        if ($class_name === null) {
-            // It's a standalone function — scan codebase for callers.
-            $call_sites = find_call_sites_in_codebase($func_info['name'], $scan_root, $filepath);
-            $result['call_sites'] = $call_sites;
-            $result['removable']  = true;
-            return $result;
-        }
-    }
-
-    // Public/protected methods with zero callers across codebase are safe to trim.
-    if (in_array($func_info['visibility'], ['public', 'protected'], true)) {
-        $call_sites = find_call_sites_in_codebase($func_info['name'], $scan_root, $filepath);
-        if (empty($call_sites)) {
-            $result['removable'] = true;
-            return $result;
-        }
-        // Has callers — still removable if it's the last param and callers
-        // don't pass it (param has a default value).
-        $has_default = param_has_default($tokens, $func_info, $param_name);
-        if ($has_default) {
-            $result['call_sites'] = $call_sites;
-            $result['removable']  = true;
-            return $result;
-        }
-    }
+    // Global and non-private methods may be invoked by plugin consumers, hooks,
+    // reflection, or dynamically constructed callbacks that static scans cannot
+    // prove complete. Preserve their public contract and insert a noop instead.
 
     return $result;
 }

--- a/wordpress/scripts/lint/php-fixers/wp-alternatives-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/wp-alternatives-fixer.php
@@ -54,6 +54,9 @@ function process_file( $filepath ) {
 		// strip_tags(...) → wp_strip_all_tags(...)
 		// Match standalone strip_tags calls, not inside wp_strip_all_tags already.
 		if ( preg_match( '/\bstrip_tags\s*\(/', $line ) && false === strpos( $line, 'wp_strip_all_tags' ) ) {
+			if ( fixer_line_has_phpcs_ignore( $lines, $idx ) || strip_tags_is_guarded_fallback( $lines, $idx ) ) {
+				continue;
+			}
 			$line    = preg_replace( '/\bstrip_tags\s*\(\s*/', 'wp_strip_all_tags( ', $line );
 			$fixes++;
 			$changed = true;
@@ -65,10 +68,7 @@ function process_file( $filepath ) {
 		// Skip if already using wp_delete_file.
 		if ( preg_match( '/\bunlink\s*\(/', $line ) && false === strpos( $line, 'wp_delete_file' ) ) {
 			// Skip lines already suppressed with phpcs:ignore.
-			if ( false !== strpos( $line, 'phpcs:ignore' ) ) {
-				continue;
-			}
-			if ( $idx > 0 && false !== strpos( $lines[ $idx - 1 ], 'phpcs:ignore' ) ) {
+			if ( fixer_line_has_phpcs_ignore( $lines, $idx ) ) {
 				continue;
 			}
 
@@ -85,4 +85,21 @@ function process_file( $filepath ) {
 	}
 
 	return $fixes;
+}
+
+/**
+ * Preserve fallback implementations guarded by wp_strip_all_tags availability.
+ */
+function strip_tags_is_guarded_fallback( $lines, $line_index ) {
+	for ( $i = $line_index - 1; $i >= 0; $i-- ) {
+		if ( preg_match( '/\bfunction\b/', $lines[ $i ] ) ) {
+			break;
+		}
+
+		if ( preg_match( '/\bfunction_exists\s*\(\s*[\'\"]wp_strip_all_tags[\'\"]\s*\)/', $lines[ $i ] ) ) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/wordpress/tests/php-fixer-safety-smoke.sh
+++ b/wordpress/tests/php-fixer-safety-smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Regression coverage for conservative custom PHP fixer behavior (#2557).
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${TESTS_DIR}/.." && pwd)"
+FIXERS_DIR="${EXTENSION_DIR}/scripts/lint/php-fixers"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+assert_contains() {
+	if ! grep -qE "$1" "$2"; then
+		fail "$3"
+	fi
+}
+
+assert_not_contains() {
+	if grep -qE "$1" "$2"; then
+		fail "$3"
+	fi
+}
+
+cat > "${TMP_DIR}/alternatives.php" <<'PHP'
+<?php
+function normalize_legacy( $text ) {
+	if ( function_exists( 'wp_strip_all_tags' ) ) {
+		return wp_strip_all_tags( $text );
+	}
+
+	return strip_tags( $text );
+}
+
+function normalize_current( $text ) {
+	return strip_tags( $text );
+}
+PHP
+
+php "${FIXERS_DIR}/wp-alternatives-fixer.php" "${TMP_DIR}/alternatives.php" >/dev/null
+assert_contains 'return strip_tags\( \$text \);' "${TMP_DIR}/alternatives.php" "availability-guarded fallback must remain strip_tags"
+assert_contains 'return wp_strip_all_tags\( \$text \);' "${TMP_DIR}/alternatives.php" "unguarded strip_tags call must still be fixed"
+
+cat > "${TMP_DIR}/catches.php" <<'PHP'
+<?php
+try {
+	throw new SuppressedException();
+} catch ( SuppressedException ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+}
+
+try {
+	throw new FixedException();
+} catch ( FixedException ) {
+}
+PHP
+
+php "${FIXERS_DIR}/empty-catch-fixer.php" "${TMP_DIR}/catches.php" >/dev/null
+assert_contains 'SuppressedException.*phpcs:ignore' "${TMP_DIR}/catches.php" "suppressed catch must remain intact"
+assert_not_contains 'SuppressedException \$e' "${TMP_DIR}/catches.php" "suppressed catch must not gain a variable"
+assert_contains 'unset\( \$e \);' "${TMP_DIR}/catches.php" "unsuppressed empty catch must still be fixed"
+
+cat > "${TMP_DIR}/phpcs" <<'SH'
+#!/usr/bin/env bash
+case "$5" in
+*private.php)
+	printf '%s\n' '{"files":{"'"$5"'":{"messages":[{"message":"The method parameter $unused is never used","line":3,"column":1,"source":"Generic.CodeAnalysis.UnusedFunctionParameter"}]}}}'
+	;;
+*)
+	printf '%s\n' '{"files":{"'"$5"'":{"messages":[{"message":"The function parameter $context is never used","line":2,"column":1,"source":"Generic.CodeAnalysis.UnusedFunctionParameter"}]}}}'
+	;;
+esac
+SH
+chmod +x "${TMP_DIR}/phpcs"
+touch "${TMP_DIR}/phpcs.xml"
+
+cat > "${TMP_DIR}/public.php" <<'PHP'
+<?php
+function public_callback( $value, $context = null ) {
+	return $value;
+}
+
+public_callback( 'value', 'live context' );
+PHP
+
+php "${FIXERS_DIR}/unused-param-fixer.php" "${TMP_DIR}/public.php" --phpcs-binary="${TMP_DIR}/phpcs" --phpcs-standard="${TMP_DIR}/phpcs.xml" >/dev/null
+assert_contains 'function public_callback\( \$value, \$context = null \)' "${TMP_DIR}/public.php" "global callable signature must be preserved"
+assert_contains "public_callback\( 'value', 'live context' \);" "${TMP_DIR}/public.php" "live two-argument caller must be preserved"
+assert_contains 'unset\( \$context \);' "${TMP_DIR}/public.php" "global callable must receive a noop reference"
+
+cat > "${TMP_DIR}/private.php" <<'PHP'
+<?php
+class Example {
+	private function format( $value, $unused ) {
+		return $value;
+	}
+
+	public function run() {
+		return $this->format( 'value', 'unused' );
+	}
+}
+PHP
+
+php "${FIXERS_DIR}/unused-param-fixer.php" "${TMP_DIR}/private.php" --phpcs-binary="${TMP_DIR}/phpcs" --phpcs-standard="${TMP_DIR}/phpcs.xml" >/dev/null
+assert_contains 'private function format\( \$value[[:space:]]*\)' "${TMP_DIR}/private.php" "private method signature must still be safely trimmed"
+assert_not_contains "format\( 'value'," "${TMP_DIR}/private.php" "private method caller must be updated with the signature"
+
+echo "php fixer safety smoke passed"


### PR DESCRIPTION
## Summary
- preserve availability-guarded WordPress fallbacks
- keep global/public/protected callable signatures stable
- honor explicit PHPCS suppression on empty catches
- add deterministic safety smoke coverage and register it in the WordPress profile

Closes #2557.

## Verification
- `bash wordpress/tests/php-fixer-safety-smoke.sh`
- `bash wordpress/scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh`
- PHP syntax checks for touched fixers
- Bash syntax and JSON validation
- `git diff --check`

## AI assistance
OpenCode general coding subagent with OpenAI GPT-5.6 Sol traced three unsafe fixer families, implemented conservative guards, and added deterministic smoke coverage. Chris Huber reviewed and remains responsible for every line.