### PR TITLE
Advertise runtime tool attachment capability

### DIFF
--- a/agent-runtimes/claude-code/claude-code.json
+++ b/agent-runtimes/claude-code/claude-code.json
@@ -97,7 +97,8 @@
         "provider_owned_auth",
         "provider_owned_session",
         "provider_owned_cancellation",
-        "nested_orchestrator"
+        "nested_orchestrator",
+        "runtime_tool_attachment"
       ],
       "workspace_materialization": {
         "cwd": "git_checkout"

--- a/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
+++ b/agent-runtimes/claude-code/lib/claude-code-agent-task-executor.js
@@ -40,6 +40,7 @@ const CLAUDE_CODE_CAPABILITIES = [
 	'provider_owned_session',
 	'provider_owned_cancellation',
 	'nested_orchestrator',
+	'runtime_tool_attachment',
 ];
 
 function providerContract(options = {}) {

--- a/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js
@@ -47,6 +47,7 @@ assert.deepEqual(provider.provider_preflight['claude-code'].optional_secret_env,
 assert.equal(provider.redacted_metadata_keys.includes('claude_code_auth'), true);
 assert.equal(provider.capabilities.includes('repo_workspace'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
+assert.equal(provider.capabilities.includes('runtime_tool_attachment'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
 const fixtureRuntimeTool = {

--- a/agent-runtimes/codex/codex.json
+++ b/agent-runtimes/codex/codex.json
@@ -100,7 +100,8 @@
         "structured_outcome",
         "provider_owned_auth",
         "provider_owned_session",
-        "provider_owned_cancellation"
+        "provider_owned_cancellation",
+        "runtime_tool_attachment"
       ],
       "workspace_materialization": {
         "cwd": "git_checkout"

--- a/agent-runtimes/codex/lib/codex-agent-task-executor.js
+++ b/agent-runtimes/codex/lib/codex-agent-task-executor.js
@@ -38,6 +38,7 @@ const CODEX_CAPABILITIES = [
 	'provider_owned_auth',
 	'provider_owned_session',
 	'provider_owned_cancellation',
+	'runtime_tool_attachment',
 ];
 
 function providerContract(options = {}) {

--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -51,6 +51,7 @@ assert.deepEqual(provider.provider_defaults.codex.command_args, CODEX_DEFAULT_CO
 assert.equal(provider.redacted_metadata_keys.includes('codex_auth'), true);
 assert.equal(provider.capabilities.includes('repo_workspace'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
+assert.equal(provider.capabilities.includes('runtime_tool_attachment'), true);
 assert.equal(provider.capabilities.includes('nested_orchestrator'), false);
 assert.equal(provider.capabilities.includes('wordpress_sandbox'), false);
 

--- a/agent-runtimes/lib/runtime-tool-adapter.test.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.test.js
@@ -23,6 +23,17 @@ const request = {
 		capabilities: ['fixture'],
 		readiness: { status: 'ready', evidence: { kind: 'version_command', success: true } },
 		lifecycle: 'runtime_owned',
+	}, {
+		schema: RESOLVED_RUNTIME_TOOL_SCHEMA,
+		id: 'fixture.second',
+		transport: 'stdio',
+		argv: ['/fixture/second'],
+		executable: '/fixture/second',
+		env: {},
+		secret_env_names: [],
+		capabilities: ['second-fixture'],
+		readiness: { status: 'ready', evidence: { kind: 'declared_probe', success: true } },
+		lifecycle: 'runtime_owned',
 	}],
 };
 const env = { FIXTURE_TOKEN: 'private-token' };
@@ -33,13 +44,18 @@ const openCode = applyOpenCodeRuntimeTools({}, request, env);
 assert.deepEqual(openCode.mcp['fixture.mcp'], {
 	type: 'local', command: '/fixture/mcp', args: ['--isolated'], environment: { FIXTURE_MODE: 'isolated', FIXTURE_TOKEN: 'private-token' },
 });
+assert.deepEqual(openCode.mcp['fixture.second'], {
+	type: 'local', command: '/fixture/second', args: [], environment: {},
+});
 const codex = codexRuntimeToolConfigArgs(request, env);
 assert.equal(codex.includes('mcp_servers.fixture.mcp.command="/fixture/mcp"'), true);
 assert.equal(codex.includes('mcp_servers.fixture.mcp.args=["--isolated"]'), true);
 assert.equal(codex.some((value) => value.includes('private-token')), true);
+assert.equal(codex.includes('mcp_servers.fixture.second.command="/fixture/second"'), true);
 const adapter = adapterRuntimeToolRequest(request, env);
 assert.deepEqual(adapter.resolved_runtime_tools[0].argv, ['/fixture/mcp', '--isolated']);
 assert.equal(adapter.resolved_runtime_tools[0].env.FIXTURE_TOKEN, 'private-token');
+assert.deepEqual(adapter.resolved_runtime_tools[1].argv, ['/fixture/second']);
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], readiness: 'missing' }] }), /unready/);
 assert.throws(() => resolvedRuntimeTools({ resolved_runtime_tools: [{ ...request.resolved_runtime_tools[0], lifecycle: 'caller_owned' }] }), /unready/);
 assert.throws(() => resolvedRuntimeTools({ runtime_tools: [{ id: 'raw.echo', command: ['/bin/echo', 'unsafe'] }] }), /resolved by Homeboy/);

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -83,6 +83,7 @@ const OPENCODE_CAPABILITIES = [
 	'live_progress_events',
 	'nested_orchestrator',
 	'run_scoped_scratch',
+	'runtime_tool_attachment',
 ];
 
 const OPENCODE_COMMAND = 'node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs';

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -116,7 +116,8 @@
         "provider_owned_cancellation",
         "live_progress_events",
         "nested_orchestrator",
-        "run_scoped_scratch"
+        "run_scoped_scratch",
+        "runtime_tool_attachment"
       ],
       "workspace_materialization": {
         "cwd": "git_checkout",

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -34,6 +34,11 @@ const fixtureRuntimeTool = {
 	id: 'fixture.mcp', transport: 'stdio', argv: [process.execPath, '--fixture-mcp', '--isolated'],
 	executable: process.execPath, env: { FIXTURE_MODE: 'isolated' }, secret_env_names: ['FIXTURE_MCP_TOKEN'], readiness: { status: 'ready', evidence: { kind: 'version_command', success: true } }, lifecycle: 'runtime_owned',
 };
+const secondFixtureRuntimeTool = {
+	schema: 'homeboy/resolved-agent-task-runtime-tool/v1',
+	id: 'fixture.second', transport: 'stdio', argv: [process.execPath, '--second-fixture-mcp'],
+	executable: process.execPath, env: {}, secret_env_names: [], readiness: { status: 'ready', evidence: { kind: 'declared_probe', success: true } }, lifecycle: 'runtime_owned',
+};
 
 function secretEnvRequirementForProvider(contract, provider) {
 	return contract.secret_env_requirements.find((requirement) => (
@@ -124,6 +129,7 @@ assert.equal(provider.redacted_metadata_keys.includes('opencode_auth'), true);
 assert.equal(provider.capabilities.includes('repo_workspace'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('run_scoped_scratch'), true);
+assert.equal(provider.capabilities.includes('runtime_tool_attachment'), true);
 assert.equal(provider.capabilities.includes('live_progress_events'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
@@ -160,12 +166,21 @@ try {
 const assert = require('node:assert/strict');
 assert.equal(process.argv[2], 'run');
 assert.equal(process.argv.includes('--model'), false);
-assert.equal(process.argv.at(-1), 'Prove the OpenCode provider boundary without leaking secrets.');
+const instruction = process.argv.at(-1);
+assert.equal([
+  'Prove the OpenCode provider boundary without leaking secrets.',
+  'Prove two attached runtime tools without leaking secrets.',
+].includes(instruction), true);
 assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN, 'refresh-token-must-not-leak');
 assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN, 'access-token-must-not-leak');
 assert.equal(process.env.UNDECLARED_SECRET, undefined);
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
 assert.equal(config.agent.title.disable, true);
+if (instruction === 'Prove two attached runtime tools without leaking secrets.') {
+  assert.equal(typeof config.mcp, 'object');
+  assert.deepEqual(config.mcp['fixture.mcp'].args, ['--fixture-mcp', '--isolated']);
+  assert.deepEqual(config.mcp['fixture.second'].args, ['--second-fixture-mcp']);
+}
 process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
 process.stderr.write(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN || 'missing secret');
 process.exit(0);
@@ -203,7 +218,11 @@ process.exit(0);
 			FIXTURE_MCP_TOKEN: 'fixture-token-must-not-leak',
 			UNDECLARED_SECRET: 'must-not-reach-opencode',
 		},
-		input: JSON.stringify({ ...request, resolved_runtime_tools: [fixtureRuntimeTool] }),
+		input: JSON.stringify({
+			...request,
+			instructions: 'Prove two attached runtime tools without leaking secrets.',
+			resolved_runtime_tools: [fixtureRuntimeTool, secondFixtureRuntimeTool],
+		}),
 	});
 	assert.equal(runResult.status, 0, runResult.stderr);
 	const fixtureEnv = {

--- a/agent-runtimes/pi/lib/pi-agent-task-executor.js
+++ b/agent-runtimes/pi/lib/pi-agent-task-executor.js
@@ -36,6 +36,7 @@ function providerContract(options = {}) {
 			'cli_runtime',
 			'workspace_materialization',
 			'structured_outcome',
+			'runtime_tool_attachment',
 		],
 		workspace_materialization: {
 			cwd: 'request_workspace',

--- a/agent-runtimes/pi/pi.json
+++ b/agent-runtimes/pi/pi.json
@@ -74,7 +74,8 @@
       "capabilities": [
         "cli_runtime",
         "workspace_materialization",
-        "structured_outcome"
+        "structured_outcome",
+        "runtime_tool_attachment"
       ],
       "workspace_materialization": {
         "cwd": "request_workspace",

--- a/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js
@@ -38,6 +38,7 @@ assert.deepEqual(provider.secret_env_requirements, []);
 assert.deepEqual(provider.provider_defaults, {});
 assert.equal(provider.capabilities.includes('cli_runtime'), true);
 assert.equal(provider.capabilities.includes('structured_outcome'), true);
+assert.equal(provider.capabilities.includes('runtime_tool_attachment'), true);
 assert.equal(provider.capabilities.includes('repo_workspace'), false);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'pi.json'), 'utf8'));

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -261,6 +261,14 @@ promotion ordering, retention, and cleanup preview/apply reporting. A runtime do
 delete, lease, or retain the root: that would duplicate controller lifecycle state and could
 remove an active attempt's scratch.
 
+### Runtime tool attachment
+
+Providers that advertise `runtime_tool_attachment` accept Homeboy-resolved runtime tools and
+project every validated tool into the backend's native tool configuration. Homeboy owns tool
+declaration resolution and readiness; providers reject unresolved declarations and preserve the
+resolved command, environment, secret-name, capability-evidence, and runtime-owned lifecycle
+boundary during attachment.
+
 Capabilities are selection and orchestration promises. Declare a capability only
 when the provider can satisfy it for every request accepted by that provider.
 


### PR DESCRIPTION
## Summary\n\n- define the backend-neutral `runtime_tool_attachment` provider promise\n- advertise it from Claude Code, Codex, OpenCode, and Pi, which already consume Homeboy-resolved runtime tools\n- prove manifest synchronization and two-tool projection through the OpenCode executor boundary\n\n## Verification\n\n- `node agent-runtimes/lib/runtime-tool-adapter.test.js`\n- OpenCode executor boundary and manifest drift check\n- Codex executor boundary\n- Claude Code executor boundary\n- Pi executor boundary\n- `git diff --check`\n- three independent review passes; no blocking findings remain\n\nCloses #2559.\n\nDownstream tracker: https://github.a8c.com/chubes4/wp-build/issues/1292\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode compared provider manifests with executor behavior, implemented the generic capability declaration, expanded deterministic coverage, and coordinated independent reviews. Chris Huber reviewed and remains responsible for every line.