### PR TITLE
Repair stale managed WP Codebox paths during setup

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -235,6 +235,7 @@ printf '%s\n' 'module.exports = require("./native.js");' > "${COLD_INSTALL_DIR}/
     PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
     GITHUB_ENV="${COLD_GITHUB_ENV_FILE}" \
     HOMEBOY_WP_CODEBOX_BIN="${COLD_BIN}" \
+    HOMEBOY_WP_CODEBOX_CORE_MODULE="${COLD_INSTALL_DIR}/source/packages/runtime-core/dist/index.js" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COLD_INSTALL_DIR}" \
     FAKE_WP_CODEBOX_RELEASE_MISSING="1" \
     bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/cold-setup.out"
@@ -260,6 +261,25 @@ fi
 
 if ! node -e 'require(require.resolve("sharp", { paths: [ process.argv[1] ] }));' "${COLD_INSTALL_DIR}/source"; then
     echo "Expected source hydration to restore the cached native runtime dependency" >&2
+    exit 1
+fi
+
+EXTERNAL_CORE_ERROR="${TMPDIR}/external-core.err"
+if (
+    cd "${EXTENSION_DIR}"
+    HOME="${COLD_HOME}" \
+    PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COLD_INSTALL_DIR}" \
+    HOMEBOY_WP_CODEBOX_CORE_MODULE="${TMPDIR}/external/missing-core.js" \
+    bash "${ROOT_DIR}/scripts/build/setup.sh" >/dev/null 2> "${EXTERNAL_CORE_ERROR}"
+); then
+    echo "Missing external WP Codebox core overrides must fail closed" >&2
+    exit 1
+fi
+
+if ! grep -q 'Explicit WP Codebox core module override is not a file' "${EXTERNAL_CORE_ERROR}"; then
+    echo "Expected an explicit external core override diagnostic" >&2
+    cat "${EXTERNAL_CORE_ERROR}" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -86,6 +86,16 @@ install_wp_codebox() {
         return 1
     }
 
+    is_managed_install_path() {
+        local candidate="$1"
+        local install_root="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+
+        case "${candidate}" in
+            "${install_root}"/*) return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+
     configure_explicit_overrides() {
         local explicit_bin=""
         local explicit_core_module=""
@@ -107,10 +117,18 @@ install_wp_codebox() {
         explicit_core_module="$(first_non_empty_env WP_CODEBOX_CORE_MODULE HOMEBOY_WP_CODEBOX_CORE_MODULE || true)"
         if [ -n "${explicit_core_module}" ]; then
             configure_core_module "${explicit_core_module}" || {
-                echo "Explicit WP Codebox core module override is not a file: ${explicit_core_module}" >&2
-                exit 1
+                if is_managed_install_path "${explicit_core_module}"; then
+                    echo "Managed WP Codebox core module is missing; reinstalling: ${explicit_core_module}" >&2
+                    unset WP_CODEBOX_CORE_MODULE HOMEBOY_WP_CODEBOX_CORE_MODULE
+                    explicit_core_module=""
+                else
+                    echo "Explicit WP Codebox core module override is not a file: ${explicit_core_module}" >&2
+                    exit 1
+                fi
             }
-            configured_core_module=1
+            if [ -n "${explicit_core_module}" ]; then
+                configured_core_module=1
+            fi
         fi
 
         if [ "${configured_bin}" -eq 1 ] && { [ "${configured_core_module}" -eq 1 ] || resolve_core_module_from_known_locations; } && probe_wp_codebox_runtime "${HOMEBOY_WP_CODEBOX_BIN}" && probe_wp_codebox_native_runtime "$(wp_codebox_dependency_root "${HOMEBOY_WP_CODEBOX_BIN}")"; then


### PR DESCRIPTION
## Summary

- classify missing WP Codebox core paths under the managed install root as repairable cache state
- continue through deterministic installation for that stale managed state
- keep missing external core-module overrides fail-closed
- cover the exact stale runner path and the external-override boundary in setup smoke tests

Closes #2562.

## Verification

- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash -n wordpress/scripts/build/setup.sh wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `git diff --check`
- runner reproduction: `runner-exec-extension-setup-wordpress-homeboy-lab-ffd12725-57a8-4be9-9369-c065c8a4351a`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the runner setup failure, implemented the contract fix, and ran verification. Chris Huber reviewed and remains responsible for every line.