### PR TITLE
fix(wordpress): resolve the WP Codebox CLI through one validated seam

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -5,7 +5,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
+      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
       "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs"
     ],
     "test": [
@@ -13,6 +13,7 @@
       "bash scripts/build/setup-wp-codebox-smoke.sh",
       "bash scripts/build/update-wp-codebox-cache-smoke.sh",
       "bash scripts/test/wp-codebox-doctor-smoke.sh",
+      "bash scripts/test/wp-codebox-cli-resolution-smoke.sh",
       "bash tests/installed-test-helper-resolution-smoke.sh",
       "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -75,6 +75,25 @@ install_wp_codebox() {
         esac
     }
 
+    # A wrapper written into ${HOME}/.local/bin by an earlier install keeps
+    # resolving on PATH after its exec target is pruned or a build is
+    # interrupted. Anything that trusts PATH then reaches a missing entrypoint
+    # and dies inside the runtime rather than here, so drop the wrapper as soon
+    # as its target is gone.
+    prune_stale_wp_codebox_wrapper() {
+        local wrapper="$1"
+        local target
+
+        [ -f "${wrapper}" ] || return 0
+
+        target="$(sed -n 's/^exec \(node \)\?"\([^"]*\)".*$/\2/p' "${wrapper}" | head -1)"
+        [ -n "${target}" ] || return 0
+        [ ! -e "${target}" ] || return 0
+
+        echo "Removing stale WP Codebox wrapper ${wrapper}; its target no longer exists: ${target}" >&2
+        rm -f "${wrapper}"
+    }
+
     first_non_empty_env() {
         local name
         for name in "$@"; do
@@ -144,6 +163,8 @@ install_wp_codebox() {
         done
         return 1
     }
+
+    prune_stale_wp_codebox_wrapper "${HOME}/.local/bin/wp-codebox"
 
     if configure_explicit_overrides; then
         return 0

--- a/wordpress/scripts/lib/wp-codebox-paths.sh
+++ b/wordpress/scripts/lib/wp-codebox-paths.sh
@@ -94,7 +94,12 @@ homeboy_wp_codebox_resolve_bin() {
         fi
     done
 
-    if ! command -v wp-codebox >/dev/null 2>&1; then
+    if homeboy_wp_codebox_managed_cache_is_incomplete; then
+        local managed_cli
+        managed_cli="$(homeboy_wp_codebox_managed_cli_candidates | head -1)"
+        echo "Error: the managed WP Codebox cache is incomplete; its built CLI entrypoint is missing at ${managed_cli}." >&2
+        echo "       Re-run the WordPress extension setup to rebuild it, or set HOMEBOY_WP_CODEBOX_BIN / settings wp_codebox_bin to a working CLI." >&2
+    elif ! command -v wp-codebox >/dev/null 2>&1; then
         if [ "$config_label" = "config" ]; then
             echo "ERROR: wp-codebox not found; set HOMEBOY_WP_CODEBOX_BIN or config wp_codebox_bin" >&2
         else
@@ -139,10 +144,29 @@ homeboy_wp_codebox_global_cli_candidates() {
     done
 }
 
+homeboy_wp_codebox_managed_install_root() {
+    printf '%s\n' "${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+}
+
 homeboy_wp_codebox_managed_cli_candidates() {
-    local install_dir="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+    local install_dir
+    install_dir="$(homeboy_wp_codebox_managed_install_root)"
 
     printf '%s\n' "${install_dir}/source/packages/cli/dist/index.js"
+}
+
+# True when the managed source checkout exists but its built CLI entrypoint does
+# not. That is an incomplete cache: the clone succeeded and the build did not,
+# or the build output was pruned. Callers refresh it rather than treating the
+# checkout as a satisfied install.
+homeboy_wp_codebox_managed_cache_is_incomplete() {
+    local install_dir
+    local repo_dir
+    install_dir="$(homeboy_wp_codebox_managed_install_root)"
+    repo_dir="${install_dir}/source"
+
+    [ -d "${repo_dir}" ] || return 1
+    [ ! -f "${repo_dir}/packages/cli/dist/index.js" ]
 }
 
 homeboy_wp_codebox_bin_is_runnable() {
@@ -165,6 +189,26 @@ homeboy_wp_codebox_bin_is_runnable() {
     "$bin" commands >/dev/null 2>&1
 }
 
+# Presence check for a binary a caller pinned explicitly. An ambient candidate
+# additionally has to answer `commands`, because an install can leave a wrapper
+# on PATH after its target is gone. A pinned binary is not ambient: the caller
+# named it, so only require that it is actually there to run.
+homeboy_wp_codebox_bin_is_present() {
+    local bin="$1"
+
+    case "$bin" in
+        *.js|*.cjs|*.mjs)
+            [ -f "$bin" ]
+            ;;
+        /*|./*|../*)
+            [ -x "$bin" ]
+            ;;
+        *)
+            command -v "$bin" >/dev/null 2>&1
+            ;;
+    esac
+}
+
 homeboy_wp_codebox_set_command() {
     local bin="$1"
 
@@ -183,6 +227,56 @@ homeboy_wp_codebox_resolve_command() {
     bin="$(homeboy_wp_codebox_resolve_bin "$settings_json")" || return 1
     homeboy_wp_codebox_set_command "$bin"
     printf '%s\n' "$bin"
+}
+
+# Serialize the resolved invocation as a JSON argv array so non-shell consumers
+# (the PHPUnit adapter) inherit this resolver's precedence and `node` prefixing
+# instead of maintaining a second candidate list.
+homeboy_wp_codebox_command_json() {
+    local element
+    local encoded
+    local out=""
+
+    for element in "${HOMEBOY_WP_CODEBOX_COMMAND[@]}"; do
+        encoded="$(printf '%s' "$element" | jq -R -s '.')"
+        if [ -z "$out" ]; then
+            out="$encoded"
+        else
+            out="${out},${encoded}"
+        fi
+    done
+
+    printf '[%s]\n' "$out"
+}
+
+homeboy_wp_codebox_publish_command() {
+    HOMEBOY_WP_CODEBOX_COMMAND_JSON="$(homeboy_wp_codebox_command_json)"
+    export HOMEBOY_WP_CODEBOX_COMMAND_JSON
+}
+
+# Resolve once and export the argv contract for child processes.
+#
+# An explicit override that is present wins outright. The general resolver
+# deliberately ranks the managed cache ahead of the environment so a stale
+# exported path cannot shadow a freshly built cache, but a caller that pins a
+# binary — a test fixture, or an operator pointing at a local build — means it.
+# An override pointing at something that is not there is skipped rather than
+# trusted, so a dangling pin still falls through to full resolution and its
+# diagnostics instead of reaching the runtime.
+homeboy_wp_codebox_export_command() {
+    local settings_json="${1:-${HOMEBOY_SETTINGS_JSON:-}}"
+    local override
+
+    for override in "${HOMEBOY_WP_CODEBOX_BIN:-}" "${WP_CODEBOX_BIN:-}"; do
+        [ -n "$override" ] || continue
+        homeboy_wp_codebox_bin_is_present "$override" || continue
+        homeboy_wp_codebox_set_command "$override"
+        homeboy_wp_codebox_publish_command
+        return 0
+    done
+
+    homeboy_wp_codebox_resolve_command "$settings_json" >/dev/null || return 1
+    homeboy_wp_codebox_publish_command
 }
 
 homeboy_wp_codebox_resolved_bin_path() {

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VALIDATION_DEPENDENCIES="${HOMEBOY_WORDPRESS_VALIDATION_DEPENDENCIES_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
+WP_CODEBOX_PATHS="${HOMEBOY_WORDPRESS_WP_CODEBOX_PATHS_HELPER:-${SCRIPT_DIR}/../lib/wp-codebox-paths.sh}"
 
 # Resolve the component declaration before handing the recipe to WP Codebox. The
 # adapter consumes the resulting generic path contract; it never knows consumer
@@ -14,5 +15,14 @@ if [ -f "$VALIDATION_DEPENDENCIES" ]; then
         homeboy_export_validation_dependency_paths "${HOMEBOY_COMPONENT_PATH:?HOMEBOY_COMPONENT_PATH is required}"
     fi
 fi
+
+# Resolve the WP Codebox CLI here, once, and hand the adapter a concrete argv.
+# The shell resolver owns candidate precedence, existence checks, the runtime
+# probe that rejects a stale PATH wrapper, and `node` prefixing for a `.js`
+# entrypoint. Resolving before exec means an unusable CLI fails with a Homeboy
+# diagnostic naming the missing artifact instead of a raw Node module stack.
+# shellcheck source=../lib/wp-codebox-paths.sh
+source "$WP_CODEBOX_PATHS"
+homeboy_wp_codebox_export_command "${HOMEBOY_SETTINGS_JSON:-}"
 
 exec node "${SCRIPT_DIR}/wp-codebox-phpunit-adapter.mjs" "$@"

--- a/wordpress/scripts/test/wp-codebox-cli-resolution-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-cli-resolution-smoke.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pins the WP Codebox CLI resolution contract shared by the managed WordPress
+# PHPUnit runner.
+#
+# Regression: a wrapper left on PATH by an earlier install pointed at a managed
+# source cache whose `packages/cli/dist/index.js` had never been built. The
+# PHPUnit adapter resolved the CLI on its own — bare env vars falling back to
+# the literal string `wp-codebox` — so it exec'd that wrapper and the operator
+# got a raw `Cannot find module` Node stack instead of a Homeboy diagnosis.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PATHS_LIB="${EXTENSION_ROOT}/scripts/lib/wp-codebox-paths.sh"
+ADAPTER="${EXTENSION_ROOT}/scripts/test/wp-codebox-phpunit-adapter.mjs"
+RUNNER="${EXTENSION_ROOT}/scripts/test/test-runner-wp-codebox.sh"
+SETUP="${EXTENSION_ROOT}/scripts/build/setup.sh"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+failures=0
+
+fail() {
+    echo "FAIL: $1" >&2
+    failures=$((failures + 1))
+}
+
+pass() {
+    echo "ok: $1"
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+# A managed cache that was cloned but never built: the source tree exists and
+# the CLI entrypoint does not.
+INCOMPLETE_CACHE="${TMP_ROOT}/incomplete-cache"
+mkdir -p "${INCOMPLETE_CACHE}/source/packages/cli"
+
+# A managed cache with a built CLI entrypoint.
+COMPLETE_CACHE="${TMP_ROOT}/complete-cache"
+mkdir -p "${COMPLETE_CACHE}/source/packages/cli/dist"
+cat > "${COMPLETE_CACHE}/source/packages/cli/dist/index.js" <<'NODE'
+#!/usr/bin/env node
+process.stdout.write('commands\n');
+NODE
+
+# A wrapper of the exact shape an earlier install wrote, pointing at the
+# unbuilt entrypoint.
+STALE_BIN_DIR="${TMP_ROOT}/stale-bin"
+mkdir -p "${STALE_BIN_DIR}"
+cat > "${STALE_BIN_DIR}/wp-codebox" <<EOF
+#!/usr/bin/env bash
+exec node "${INCOMPLETE_CACHE}/source/packages/cli/dist/index.js" "\$@"
+EOF
+chmod +x "${STALE_BIN_DIR}/wp-codebox"
+
+# --- 1. a stale PATH wrapper is never handed back as a usable CLI -----------
+
+resolution_stderr="${TMP_ROOT}/resolution.err"
+resolution_stdout="${TMP_ROOT}/resolution.out"
+set +e
+env -i \
+    PATH="${STALE_BIN_DIR}:/usr/bin:/bin" \
+    HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${INCOMPLETE_CACHE}" \
+    bash -c 'source "$1" && homeboy_wp_codebox_resolve_bin ""' \
+    wp-codebox-resolution "${PATHS_LIB}" \
+    > "${resolution_stdout}" 2> "${resolution_stderr}"
+resolution_status=$?
+set -e
+
+if [ "${resolution_status}" -eq 0 ]; then
+    fail "resolver accepted a stale wrapper whose target is missing (returned: $(cat "${resolution_stdout}"))"
+else
+    pass "resolver rejects a stale wrapper whose target is missing"
+fi
+
+if grep -q "${INCOMPLETE_CACHE}/source/packages/cli/dist/index.js" "${resolution_stderr}"; then
+    pass "resolver diagnostic names the missing CLI entrypoint"
+else
+    fail "resolver diagnostic does not name the missing CLI entrypoint: $(cat "${resolution_stderr}")"
+fi
+
+if grep -qi 'Cannot find module' "${resolution_stderr}"; then
+    fail "resolver leaked a raw Node module error instead of a Homeboy diagnostic"
+else
+    pass "resolver does not leak a raw Node module error"
+fi
+
+# --- 2. an incomplete managed cache is reported as incomplete ---------------
+
+if env -i PATH="/usr/bin:/bin" HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${INCOMPLETE_CACHE}" \
+    bash -c 'source "$1" && homeboy_wp_codebox_managed_cache_is_incomplete' \
+    wp-codebox-cache "${PATHS_LIB}"; then
+    pass "an unbuilt managed source cache is classified incomplete"
+else
+    fail "an unbuilt managed source cache was not classified incomplete"
+fi
+
+if env -i PATH="/usr/bin:/bin" HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
+    bash -c 'source "$1" && homeboy_wp_codebox_managed_cache_is_incomplete' \
+    wp-codebox-cache "${PATHS_LIB}"; then
+    fail "a built managed source cache was misclassified as incomplete"
+else
+    pass "a built managed source cache is not classified incomplete"
+fi
+
+# --- 3. the exported argv prefixes node for a .js entrypoint ----------------
+
+command_json="$(env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
+    bash -c 'source "$1" && homeboy_wp_codebox_export_command "" && printf "%s" "$HOMEBOY_WP_CODEBOX_COMMAND_JSON"' \
+    wp-codebox-command "${PATHS_LIB}" 2>/dev/null || true)"
+
+expected_json="[\"node\",\"${COMPLETE_CACHE}/source/packages/cli/dist/index.js\"]"
+if [ "${command_json}" = "${expected_json}" ]; then
+    pass "exported argv prefixes node for a .js entrypoint"
+else
+    fail "exported argv is ${command_json}, expected ${expected_json}"
+fi
+
+# --- 4. a validated explicit override outranks the managed cache ------------
+
+OVERRIDE_BIN="${TMP_ROOT}/override-wp-codebox"
+cat > "${OVERRIDE_BIN}" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "${OVERRIDE_BIN}"
+
+override_json="$(env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
+    HOMEBOY_WP_CODEBOX_BIN="${OVERRIDE_BIN}" \
+    bash -c 'source "$1" && homeboy_wp_codebox_export_command "" && printf "%s" "$HOMEBOY_WP_CODEBOX_COMMAND_JSON"' \
+    wp-codebox-override "${PATHS_LIB}" 2>/dev/null || true)"
+
+if [ "${override_json}" = "[\"${OVERRIDE_BIN}\"]" ]; then
+    pass "a runnable explicit override outranks the managed cache"
+else
+    fail "explicit override produced ${override_json}, expected [\"${OVERRIDE_BIN}\"]"
+fi
+
+# A pin at a path that is not there is a dangling pin, not an instruction to
+# hand it to the runtime.
+dangling_override_json="$(env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
+    HOMEBOY_WP_CODEBOX_BIN="${TMP_ROOT}/does-not-exist/wp-codebox" \
+    bash -c 'source "$1" && homeboy_wp_codebox_export_command "" && printf "%s" "$HOMEBOY_WP_CODEBOX_COMMAND_JSON"' \
+    wp-codebox-dangling-override "${PATHS_LIB}" 2>/dev/null || true)"
+
+if [ "${dangling_override_json}" = "${expected_json}" ]; then
+    pass "a dangling explicit override falls through to full resolution"
+else
+    fail "dangling override produced ${dangling_override_json}, expected ${expected_json}"
+fi
+
+# An override is pinned by the caller, so it is not subjected to the ambient
+# `commands` probe: a CLI that exits non-zero for unknown verbs is still used.
+NONPROBING_OVERRIDE="${TMP_ROOT}/nonprobing-wp-codebox"
+cat > "${NONPROBING_OVERRIDE}" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "${NONPROBING_OVERRIDE}"
+
+nonprobing_json="$(env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
+    HOMEBOY_WP_CODEBOX_BIN="${NONPROBING_OVERRIDE}" \
+    bash -c 'source "$1" && homeboy_wp_codebox_export_command "" && printf "%s" "$HOMEBOY_WP_CODEBOX_COMMAND_JSON"' \
+    wp-codebox-nonprobing "${PATHS_LIB}" 2>/dev/null || true)"
+
+if [ "${nonprobing_json}" = "[\"${NONPROBING_OVERRIDE}\"]" ]; then
+    pass "an explicit override is not subjected to the ambient runtime probe"
+else
+    fail "non-probing override produced ${nonprobing_json}, expected [\"${NONPROBING_OVERRIDE}\"]"
+fi
+
+# --- 5. the adapter consumes the resolved argv, never a bare CLI string -----
+
+if grep -q "HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'" "${ADAPTER}"; then
+    fail "the adapter still resolves the CLI inline instead of using the shared seam"
+else
+    pass "the adapter has no inline CLI fallback expression"
+fi
+
+if grep -q 'homeboy_wp_codebox_export_command' "${RUNNER}"; then
+    pass "the runner resolves and exports the CLI argv before exec'ing the adapter"
+else
+    fail "the runner does not export a resolved CLI argv"
+fi
+
+if grep -q 'homeboy_wp_codebox_export_command' "${ADAPTER}"; then
+    pass "the adapter delegates resolution to the shared shell library"
+else
+    fail "the adapter does not delegate resolution to the shared shell library"
+fi
+
+if grep -q 'HOMEBOY_WP_CODEBOX_COMMAND_JSON' "${ADAPTER}"; then
+    pass "the adapter consumes the exported argv contract"
+else
+    fail "the adapter does not consume the exported argv contract"
+fi
+
+# --- 6. setup prunes a stale wrapper whose target is gone -------------------
+
+PRUNE_BIN_DIR="${TMP_ROOT}/prune-bin"
+mkdir -p "${PRUNE_BIN_DIR}"
+cp "${STALE_BIN_DIR}/wp-codebox" "${PRUNE_BIN_DIR}/wp-codebox"
+
+prune_snippet="$(sed -n '/^    prune_stale_wp_codebox_wrapper() {$/,/^    }$/p' "${SETUP}")"
+if [ -z "${prune_snippet}" ]; then
+    fail "setup.sh no longer defines prune_stale_wp_codebox_wrapper"
+else
+    bash -c "
+set -euo pipefail
+${prune_snippet#    }
+prune_stale_wp_codebox_wrapper '${PRUNE_BIN_DIR}/wp-codebox'
+" 2>/dev/null || true
+
+    if [ -f "${PRUNE_BIN_DIR}/wp-codebox" ]; then
+        fail "setup did not prune a wrapper whose target is missing"
+    else
+        pass "setup prunes a wrapper whose target is missing"
+    fi
+
+    cat > "${PRUNE_BIN_DIR}/wp-codebox" <<EOF
+#!/usr/bin/env bash
+exec node "${COMPLETE_CACHE}/source/packages/cli/dist/index.js" "\$@"
+EOF
+    bash -c "
+set -euo pipefail
+${prune_snippet#    }
+prune_stale_wp_codebox_wrapper '${PRUNE_BIN_DIR}/wp-codebox'
+" 2>/dev/null || true
+
+    if [ -f "${PRUNE_BIN_DIR}/wp-codebox" ]; then
+        pass "setup keeps a wrapper whose target exists"
+    else
+        fail "setup pruned a wrapper whose target exists"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+
+if [ "${failures}" -ne 0 ]; then
+    echo "" >&2
+    echo "WP Codebox CLI resolution smoke failed (${failures} assertion(s))." >&2
+    exit 1
+fi
+
+echo ""
+echo "WP Codebox CLI resolution smoke passed."

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -16,6 +16,11 @@ const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMP
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const extensionRoot = path.resolve(scriptDirectory, '../..');
 const harnessSource = path.join(extensionRoot, 'vendor');
+// Resolved WP Codebox invocation as an argv array, e.g.
+// ['node', '/abs/packages/cli/dist/index.js'] or ['/abs/bin/wp-codebox'].
+// Declared with the module's other top-level bindings: the statements below run
+// before any later declaration is initialized.
+let wpCodeboxCommandCache;
 const NATIVE_MARIADB_CAPABILITY = 'runtime-service:mysql:native:mariadb';
 const RUNTIME_SERVICE_CAPABILITIES_SCHEMA = 'wp-codebox/runtime-service-capabilities/v1';
 const slug = process.env.COMPONENT_ID || path.basename(componentPath);
@@ -110,7 +115,8 @@ async function runCaptured(args) {
   const secretValues = configuredSecretValues();
 
   return new Promise((resolve, reject) => {
-    const child = spawn(process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', args, { cwd: componentPath, stdio: ['ignore', 'pipe', 'pipe'] });
+    const [command, ...prefix] = wpCodeboxCommand();
+    const child = spawn(command, [...prefix, ...args], { cwd: componentPath, stdio: ['ignore', 'pipe', 'pipe'] });
     const stdoutFile = createWriteStream(stdoutPath);
     const stderrFile = createWriteStream(stderrPath);
     const stdoutRedactor = createLineRedactor(secretValues);
@@ -189,7 +195,8 @@ function createLineRedactor(secretValues) {
 }
 
 function run(args) {
-  const result = spawnSync(process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', args, { cwd: componentPath, env: environmentWithoutDatabaseAdministration(), encoding: 'utf8', stdio: 'inherit' });
+  const [command, ...prefix] = wpCodeboxCommand();
+  const result = spawnSync(command, [...prefix, ...args], { cwd: componentPath, env: environmentWithoutDatabaseAdministration(), encoding: 'utf8', stdio: 'inherit' });
   if (result.error) {
     throw result.error;
   }
@@ -197,6 +204,45 @@ function run(args) {
     process.exit(result.status ?? 1);
   }
 }
+function wpCodeboxCommand() {
+  if (wpCodeboxCommandCache === undefined) {
+    wpCodeboxCommandCache = resolveWpCodeboxCommand();
+  }
+  return wpCodeboxCommandCache;
+}
+
+// The shell library at scripts/lib/wp-codebox-paths.sh is the single source of
+// truth for candidate precedence, the runtime probe, and `node` prefixing.
+// `test-runner-wp-codebox.sh` normally resolves and exports the argv before this
+// adapter starts; when the adapter is invoked directly, delegate to the same
+// library rather than maintaining a second precedence list here.
+function resolveWpCodeboxCommand() {
+  const exported = parseCommandArgv(process.env.HOMEBOY_WP_CODEBOX_COMMAND_JSON);
+  if (exported) {
+    return exported;
+  }
+
+  const library = path.join(scriptDirectory, '../lib/wp-codebox-paths.sh');
+  const result = spawnSync('bash', ['-c', `source "$1" && homeboy_wp_codebox_export_command "\${HOMEBOY_SETTINGS_JSON:-}" && printf '%s' "$HOMEBOY_WP_CODEBOX_COMMAND_JSON"`, 'wp-codebox-resolve', library], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
+
+  const resolved = result.status === 0 ? parseCommandArgv(result.stdout) : undefined;
+  if (!resolved) {
+    throw new Error('WP Codebox CLI could not be resolved; see the resolver diagnostics above.');
+  }
+  return resolved;
+}
+
+function parseCommandArgv(value) {
+  const parsed = json(value, undefined);
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    return undefined;
+  }
+  if (!parsed.every((entry) => typeof entry === 'string' && entry !== '')) {
+    return undefined;
+  }
+  return parsed;
+}
+
 function required(value, name) { if (!value) { throw new Error(`${name} is required`); } return value; }
 async function resolveWordPressTopology(configuration, pluginDirectory) {
   const fromEnv = process.env.HOMEBOY_WORDPRESS_MULTISITE;
@@ -409,7 +455,8 @@ function requireDatabaseServiceCapability(service) {
   if (!service?.requiredCapability) {
     return;
   }
-  const result = spawnSync(process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', ['runtime', 'descriptor', '--json'], {
+  const [command, ...prefix] = wpCodeboxCommand();
+  const result = spawnSync(command, [...prefix, 'runtime', 'descriptor', '--json'], {
     cwd: componentPath,
     env: environmentWithoutDatabaseAdministration(),
     encoding: 'utf8',
@@ -1115,11 +1162,13 @@ function resolvePhpunitBootstrap(configuration, profile) {
 }
 async function persistRecipeEvidence(artifactDirectory, recipeOptions, generatedRecipePath, profile, resolvedDependencies) {
   const sourceRefs = [{ slug, source: root, source_subpath: subpath || null }, ...resolvedDependencies.map((dependency) => ({ slug: dependency.slug, source: dependency.source }))];
+  const wpCodeboxArgv = wpCodeboxCommand();
+  const wpCodeboxCli = wpCodeboxArgv[wpCodeboxArgv.length - 1];
   await Promise.all([
     copyFile(generatedRecipePath, path.join(artifactDirectory, 'wp-codebox-phpunit-recipe.json')),
     writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-recipe-options.json'), `${JSON.stringify(recipeOptions, null, 2)}\n`),
     writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-profile.json'), `${JSON.stringify({ wordpress: { topology }, phpunit: { config: profile.config, cwd: profile.cwd, test_root: profile.testRoot, environment: profile.environment, bootstrap_mode: recipeOptions.bootstrapMode, project_bootstrap: recipeOptions.projectBootstrap || null, passthrough_args: recipeOptions.phpunitArgs, extra_mounts: recipeOptions.mounts } }, null, 2)}\n`),
-    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-provenance.json'), `${JSON.stringify({ source_refs: sourceRefs, activation: { order: activationPlan.map(({ role, slug: planSlug }) => ({ role, slug: planSlug, activate: true })) }, scope: { selected_test_file: selectedTestFile || null, changed_test_files: changedTestFiles }, wp_codebox: { cli_bin: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', resolved_cli_path: process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox', command: [process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'] } }, null, 2)}\n`),
+    writeFile(path.join(artifactDirectory, 'wp-codebox-phpunit-provenance.json'), `${JSON.stringify({ source_refs: sourceRefs, activation: { order: activationPlan.map(({ role, slug: planSlug }) => ({ role, slug: planSlug, activate: true })) }, scope: { selected_test_file: selectedTestFile || null, changed_test_files: changedTestFiles }, wp_codebox: { cli_bin: wpCodeboxCli, resolved_cli_path: wpCodeboxCli, command: wpCodeboxArgv } }, null, 2)}\n`),
   ]);
 }
 function runScript(script, args) {


### PR DESCRIPTION
Fixes the failure reported in Extra-Chill/homeboy#11713.

## The failure

`homeboy review test <wordpress-component> --placement local` died before PHPUnit executed:

```text
Error: Cannot find module '/home/opencode/.cache/homeboy/wp-codebox/source/packages/cli/dist/index.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1455:15)
```

Dependency hydration and all block builds succeeded; the test phase reported zero executed tests and exited 1 at WP Codebox CLI startup.

## Root cause

Two defects cooperating.

**1. The adapter resolved the CLI itself.** `wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs` repeated `process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'` at four spawn sites (`runCaptured`, `run`, the `runtime descriptor --json` probe, and `persistRecipeEvidence`). That path never consulted `wordpress/scripts/lib/wp-codebox-paths.sh`, so it skipped the existence check, the `commands` probe, and the `node` prefix that library applies to a `.js` entrypoint. `test-runner-wp-codebox.sh` did not resolve or export a binary either, so the adapter routinely fell through to the bare string `wp-codebox` off `PATH`.

**2. A stale `PATH` wrapper outlives the cached build.** `wordpress/scripts/build/setup.sh` writes a wrapper into `${HOME}/.local/bin` that hardcodes its exec target. Confirmed on the reporting host:

```bash
#!/usr/bin/env bash
exec node "<install_root>/source/packages/cli/dist/index.js" "$@"
```

When the managed source checkout exists but `packages/cli/dist/index.js` was never built or was pruned, that wrapper still resolves on `PATH`. The shell resolver already rejected it — its `commands` probe fails — but the adapter never asked, so `node` got a missing module and the operator got a stack trace instead of a diagnosis.

## The change

- **One resolution seam.** Every adapter spawn goes through `wpCodeboxCommand()`, which consumes an argv contract (`HOMEBOY_WP_CODEBOX_COMMAND_JSON`) exported by `test-runner-wp-codebox.sh`, and delegates back to the shell library when the adapter is invoked directly. Candidate precedence, the runtime probe, and `node` prefixing live in exactly one place; the four duplicated fallback expressions are gone.
- **Override precedence preserved.** An explicit `HOMEBOY_WP_CODEBOX_BIN` / `WP_CODEBOX_BIN` is presence-checked and wins over the managed cache — that was the adapter's prior contract, and the general resolver deliberately ranks the managed cache first so a stale exported path cannot shadow a fresh build. A pinned binary is not ambient, so it is not subjected to the `commands` probe; a *dangling* pin still falls through to full resolution and its diagnostics.
- **Named failures.** When the managed cache is incomplete, the resolver says so and names the missing entrypoint plus its remediation, instead of letting a raw `Cannot find module` escape.
- **Self-healing PATH.** `setup.sh` prunes a `${HOME}/.local/bin/wp-codebox` wrapper whose exec target no longer exists, so it cannot poison `PATH` for later runs.

## Verification

New `wordpress/scripts/test/wp-codebox-cli-resolution-smoke.sh` (14 assertions), registered in `wordpress/homeboy.json` lint and test self-checks. It **fails on the parent commit** and passes here.

Run locally, all green:

| gate | result |
|---|---|
| `wp-codebox-cli-resolution-smoke.sh` (new) | pass |
| `wp-codebox-canonical-cli-adapters-smoke.mjs` | pass |
| `wp-codebox-phpunit-{multisite,aggregate,evidence,target-activation}-smoke` | pass |
| `wp-codebox-database-service-smoke.mjs` | pass |
| `setup-wp-codebox-smoke.sh`, `update-wp-codebox-cache-smoke.sh` | pass |
| `wp-codebox-doctor-smoke.sh`, `wp-codebox-mount-translation-smoke.sh` | pass |
| `full-suite-no-phpunit-smoke.sh` | pass |
| full `bash -n` + `node --check` lint gate | pass |

No existing test needed modification, which is the evidence that the change is behaviour-preserving for the contracts already pinned.

`test-runner-file-routing-smoke.sh` is not runnable on the verification host — it needs a working Playground sandbox and fails on `main` there too (`Error: spawnSync wp-codebox ENOENT`, the very defect this PR fixes).

Refs Extra-Chill/homeboy#11713