### PR TITLE
Fix CLI executor failure outcome schemas

### DIFF
--- a/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js
@@ -100,6 +100,7 @@ try {
 	assert.equal(fs.existsSync(scriptPath), true, `provider command target should exist: ${scriptPath}`);
 
 	const mockCliPath = path.join(root, 'mock-codex.cjs');
+	const failedCliPath = path.join(root, 'mock-codex-failed.cjs');
 	const declaredArtifactCliPath = path.join(root, 'mock-codex-declared-artifacts.cjs');
 	const omittedModelCliPath = path.join(root, 'mock-codex-without-model.cjs');
 	fs.writeFileSync(omittedModelCliPath, `#!/usr/bin/env node
@@ -117,6 +118,11 @@ assert.equal(process.env.UNDECLARED_SECRET, undefined);
 process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
 process.stderr.write(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN || 'missing secret');
 process.exit(0);
+`);
+	fs.writeFileSync(failedCliPath, `#!/usr/bin/env node
+process.stdout.write('Codex partial output');
+process.stderr.write('Codex provider failure');
+process.exit(23);
 `);
 	fs.writeFileSync(declaredArtifactCliPath, `#!/usr/bin/env node
 const fs = require('node:fs');
@@ -210,6 +216,35 @@ process.exit(0);
 	assert.equal(missingDeclaredResult.status, 'failed');
 	assert.equal(missingDeclaredResult.failure_code, 'agent_task.declared_artifact_harvest_failed');
 	assert.equal(missingDeclaredResult.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.required_declared_artifact_missing'), true);
+	const failedRun = spawnSync(process.execPath, [scriptPath], {
+		encoding: 'utf8',
+		input: JSON.stringify({
+			...request,
+			task_id: 'codex-nonzero-exit',
+			executor: {
+				...request.executor,
+				config: {
+					...request.executor.config,
+					command: process.execPath,
+					command_args: [failedCliPath, 'exec'],
+				},
+			},
+			artifact_declarations: [
+				{ name: 'patch', required: true },
+				{ name: 'agent_result', required: true },
+				{ name: 'transcript', required: true },
+			],
+		}),
+	});
+	assert.equal(failedRun.status, 0, failedRun.stderr);
+	const failedOutcome = JSON.parse(failedRun.stdout);
+	assert.equal(failedOutcome.status, 'failed');
+	assert.equal(failedOutcome.failure_code, 'agent_task.codex_failed');
+	assert.equal(failedOutcome.metadata.exit_code, 23);
+	assert.equal(failedOutcome.artifacts.every((artifact) => artifact.schema === 'homeboy/agent-task-artifact/v1' && artifact.uri.startsWith('file:')), true);
+	assert.equal(failedOutcome.evidence_refs.every((ref) => ref.uri.startsWith('file:') && !Object.hasOwn(ref, 'path')), true);
+	assert.deepEqual(failedOutcome.artifacts.map((artifact) => artifact.name).sort(), ['codex-stderr', 'codex-stdout']);
+	assertStrictAgentTaskOutcome(failedOutcome);
 	const runResult = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
 		env: {
@@ -257,3 +292,25 @@ process.exit(0);
 }
 
 process.stdout.write('Codex agent task executor boundary passed\n');
+
+function assertStrictAgentTaskOutcome(outcome) {
+	assert.equal(outcome.schema, 'homeboy/agent-task-outcome/v1');
+	assert.equal(typeof outcome.task_id, 'string');
+	assert.equal(typeof outcome.status, 'string');
+	assert.equal(typeof outcome.summary, 'string');
+	assert.equal(Array.isArray(outcome.artifacts), true);
+	assert.equal(Array.isArray(outcome.evidence_refs), true);
+	for (const artifact of outcome.artifacts) {
+		assert.equal(artifact.schema, 'homeboy/agent-task-artifact/v1');
+		assert.equal(typeof artifact.id, 'string');
+		assert.equal(typeof artifact.kind, 'string');
+		assert.equal(typeof artifact.uri, 'string');
+		assert.equal(new URL(artifact.uri).protocol, 'file:');
+		assert.equal(Number.isInteger(artifact.size_bytes), true);
+	}
+	for (const ref of outcome.evidence_refs) {
+		assert.equal(typeof ref.kind, 'string');
+		assert.equal(typeof ref.uri, 'string');
+		assert.equal(new URL(ref.uri).protocol, 'file:');
+	}
+}

--- a/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
+++ b/agent-runtimes/codex/tests/declared-artifact-harvester.test.js
@@ -40,6 +40,10 @@ try {
 	assert.equal(report.artifact_schema, 'example/report/v1');
 	assert.equal(report.artifact_type, 'report');
 	assert.equal(report.required, true);
+	assert.equal(report.schema, 'homeboy/agent-task-artifact/v1');
+	assert.equal(new URL(report.uri).protocol, 'file:');
+	assert.equal(report.url, report.uri);
+	assert.equal(report.size_bytes, Buffer.byteLength('# Report\n'));
 	assert.equal(report.sha256, crypto.createHash('sha256').update('# Report\n').digest('hex'));
 	assert.deepEqual(report.metadata, { source: 'agent' });
 	assert.equal(fs.readFileSync(report.path, 'utf8'), '# Report\n');
@@ -63,7 +67,18 @@ try {
 		cwd: workspace,
 		artifactDir: artifacts,
 	});
-	assert.equal(missingPath.errors[0].code, 'invalid_path');
+	assert.deepEqual(missingPath, { artifacts: [], evidence_refs: [], errors: [], missing: { required: [], optional: [] } });
+	const pathlessWithoutArtifactRoot = harvestDeclaredArtifacts({
+		request: { artifact_declarations: [{ name: 'candidate', required: true }] },
+		cwd: workspace,
+	});
+	assert.deepEqual(pathlessWithoutArtifactRoot, { artifacts: [], evidence_refs: [], errors: [], missing: { required: [], optional: [] } });
+	const emptyPath = harvestDeclaredArtifacts({
+		request: { artifact_declarations: [{ name: 'empty-path', path: '', required: true }] },
+		cwd: workspace,
+		artifactDir: artifacts,
+	});
+	assert.equal(emptyPath.errors[0].code, 'invalid_path');
 	const collision = harvestDeclaredArtifacts({
 		request: { artifact_declarations: [{ name: 'same/name', path: 'report.md' }, { name: 'same-name', path: 'report.md' }] },
 		cwd: workspace,

--- a/agent-runtimes/lib/cli-agent-task-executor.js
+++ b/agent-runtimes/lib/cli-agent-task-executor.js
@@ -6,12 +6,14 @@
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
 
 /**
  * Internal dependencies
  */
 const {
 	AGENT_TASK_REQUEST_SCHEMA,
+	AGENT_TASK_ARTIFACT_SCHEMA,
 } = require('../../agent-task-contracts');
 const {
 	normalizeAgentTaskOutcome,
@@ -192,9 +194,21 @@ function createCliAgentTaskExecutor(spec) {
 			const filePath = path.join(artifactDir, `${safeFileSegment(request.task_id)}-${artifactProvider}-${stream}.txt`);
 			fs.mkdirSync(path.dirname(filePath), { recursive: true });
 			fs.writeFileSync(filePath, content);
-			const artifact = { id: `${artifactProvider}-${stream}`, name: `${artifactProvider}-${stream}`, kind: 'provider-process-stream', stream, path: filePath, bytes: Buffer.byteLength(content) };
+			const artifact = {
+				schema: AGENT_TASK_ARTIFACT_SCHEMA,
+				id: `${artifactProvider}-${stream}`,
+				name: `${artifactProvider}-${stream}`,
+				kind: 'provider-process-stream',
+				stream,
+				path: filePath,
+				uri: pathToFileURL(filePath).href,
+				url: pathToFileURL(filePath).href,
+				bytes: Buffer.byteLength(content),
+				size_bytes: Buffer.byteLength(content),
+				metadata: { stream },
+			};
 			artifacts.push(artifact);
-			evidence_refs.push({ kind: 'provider-process-stream', label: `${artifactProvider} ${stream}`, path: filePath });
+			evidence_refs.push({ kind: 'provider-process-stream', label: `${artifactProvider} ${stream}`, uri: artifact.uri });
 		}
 		return { artifacts, evidence_refs };
 	}

--- a/agent-runtimes/lib/cli-agent-task-executor.test.js
+++ b/agent-runtimes/lib/cli-agent-task-executor.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+require('../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createCliAgentTaskExecutor } = require('./cli-agent-task-executor');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-cli-executor-conformance-'));
+try {
+	const command = path.join(root, 'fixture-command.cjs');
+	fs.writeFileSync(command, `#!/usr/bin/env node
+const mode = process.argv[2];
+if (mode === 'success') process.stdout.write('completed');
+if (mode === 'failure') { process.stdout.write('partial'); process.stderr.write('failed'); process.exit(23); }
+if (mode === 'cancelled') process.kill(process.pid, 'SIGTERM');
+`);
+
+	const executor = createCliAgentTaskExecutor({
+		backend: 'fixture',
+		providerId: 'fixture.agent-task-executor',
+		providerLabel: 'Fixture agent',
+		defaultSummary: 'Fixture executor failed.',
+		artifactProvider: 'fixture',
+		collectArtifacts: true,
+		resolveCommandSpec: () => ({ command: process.execPath, args: [command] }),
+		buildArgs: (request, config, commandSpec) => [...commandSpec.args, config.mode],
+		buildSpawn: () => ({}),
+		messages: {
+			invalidRequest: { code: 'invalid_request', summary: 'Invalid request.' },
+			invalidCommand: { code: 'invalid_command', summary: 'Invalid command.' },
+			notFound: { code: 'not_found', summary: 'Not found.', hint: 'Install fixture.' },
+			timeout: { code: 'timeout', summary: 'Timed out.' },
+			spawnFailed: { code: 'spawn_failed', summary: 'Spawn failed.' },
+			success: { summary: 'Succeeded.', diag: 'Completed.' },
+			failed: { code: 'failed', summary: 'Failed.', diag: (status) => `Exited ${status}.` },
+		},
+	});
+
+	for (const [mode, expectedStatus] of [['success', 'succeeded'], ['failure', 'failed'], ['cancelled', 'failed'], ['no-candidate', 'succeeded']]) {
+		const outcome = executor.execute({
+			schema: 'homeboy/agent-task-request/v1',
+			task_id: `fixture-${mode}`,
+			executor: {
+				backend: 'fixture',
+				config: { mode: mode === 'no-candidate' ? 'success' : mode, artifacts_path: path.join(root, mode) },
+			},
+			instructions: 'Run the fixture.',
+			...(mode === 'no-candidate' ? { artifact_declarations: [{ name: 'patch', required: true }, { name: 'agent_result', required: true }, { name: 'transcript', required: true }] } : {}),
+		});
+		assert.equal(outcome.status, expectedStatus);
+		assert.equal(outcome.evidence_refs.every((ref) => typeof ref.uri === 'string' && ref.uri.startsWith('file:') && !Object.hasOwn(ref, 'path')), true);
+		assert.equal(outcome.artifacts.every((artifact) => artifact.schema === 'homeboy/agent-task-artifact/v1' && typeof artifact.uri === 'string' && artifact.uri.startsWith('file:') && Number.isInteger(artifact.size_bytes)), true);
+		assert.equal(outcome.artifacts.every((artifact) => artifact.url === artifact.uri), true);
+		assert.equal(outcome.artifacts.every((artifact) => artifact.bytes === artifact.size_bytes), true);
+		if (mode === 'cancelled') {
+			assert.equal(outcome.metadata.signal, 'SIGTERM');
+			assert.equal(outcome.metadata.exit_code, null);
+		}
+		if (mode === 'no-candidate') {
+			assert.deepEqual(outcome.artifacts.map((artifact) => artifact.name), ['fixture-stdout']);
+			assert.equal(outcome.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.required_declared_artifact_missing'), false);
+		}
+		assertStrictAgentTaskOutcome(outcome);
+	}
+} finally {
+	fs.rmSync(root, { recursive: true, force: true });
+}
+
+process.stdout.write('CLI agent task executor cross-runtime conformance passed\n');
+
+function assertStrictAgentTaskOutcome(outcome) {
+	assert.equal(outcome.schema, 'homeboy/agent-task-outcome/v1');
+	assert.equal(typeof outcome.task_id, 'string');
+	assert.equal(typeof outcome.status, 'string');
+	assert.equal(typeof outcome.summary, 'string');
+	assert.equal(Array.isArray(outcome.artifacts), true);
+	assert.equal(Array.isArray(outcome.evidence_refs), true);
+	for (const artifact of outcome.artifacts) {
+		assert.equal(artifact.schema, 'homeboy/agent-task-artifact/v1');
+		assert.equal(typeof artifact.id, 'string');
+		assert.equal(typeof artifact.kind, 'string');
+		assert.equal(typeof artifact.uri, 'string');
+		assert.equal(new URL(artifact.uri).protocol, 'file:');
+		assert.equal(Number.isInteger(artifact.size_bytes), true);
+	}
+	for (const ref of outcome.evidence_refs) {
+		assert.equal(typeof ref.kind, 'string');
+		assert.equal(typeof ref.uri, 'string');
+		assert.equal(new URL(ref.uri).protocol, 'file:');
+	}
+}

--- a/agent-runtimes/lib/declared-artifact-harvester.js
+++ b/agent-runtimes/lib/declared-artifact-harvester.js
@@ -4,6 +4,8 @@ const crypto = require('node:crypto');
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { AGENT_TASK_ARTIFACT_SCHEMA } = require('../../agent-task-contracts');
 
 const DEFAULT_BUDGET = { maxBytes: 50 * 1024 * 1024, maxFiles: 1_000, maxNodes: 2_000, maxDepth: 32 };
 
@@ -12,15 +14,20 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 	if (declarations.length === 0) {
 		return emptyResult();
 	}
+	// Declarations without a source path describe candidates; they are not files to capture.
+	const sourcedDeclarations = declarations.filter((declaration) => declaration.path !== undefined && declaration.path !== null);
+	if (sourcedDeclarations.length === 0) {
+		return emptyResult();
+	}
 	const workspaceRoot = realDirectory(cwd);
 	const root = schedulerArtifactRoot(artifactDir);
 	if (!workspaceRoot || !root) {
-		return captureFailure(declarations, !workspaceRoot ? 'workspace_root' : 'artifact_root', !workspaceRoot ? 'The declared artifact workspace root does not exist.' : 'The scheduler-owned artifact root must be an existing non-symlink directory.');
+		return captureFailure(sourcedDeclarations, !workspaceRoot ? 'workspace_root' : 'artifact_root', !workspaceRoot ? 'The declared artifact workspace root does not exist.' : 'The scheduler-owned artifact root must be an existing non-symlink directory.');
 	}
 	const result = emptyResult();
-	const destinations = declarationDestinations(declarations, request.task_id);
+	const destinations = declarationDestinations(sourcedDeclarations, request.task_id);
 	const prepared = [];
-	for (const declaration of declarations) {
+	for (const declaration of sourcedDeclarations) {
 		if (!validDeclaredPath(declaration.path)) {
 			if (declaration.required) {
 				result.errors.push({ artifact: declaration.name, code: 'invalid_path', message: 'Required declared artifacts need an explicit workspace-relative path.' });
@@ -63,15 +70,20 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 			copyStagedEntries(stage, destination, collected.entries);
 			verifyRetainedPath(root, stage, destination);
 			const digest = collected.directory ? digestTree(collected.entries) : collected.entries[0].digest;
+			const uri = pathToFileURL(destination).href;
 			const artifact = {
+				schema: AGENT_TASK_ARTIFACT_SCHEMA,
 				id: declaration.id || declaration.name,
 				name: declaration.name,
 				kind: declaration.kind || declaration.artifact_type || declaration.type || (collected.directory ? 'directory' : 'file'),
 				...(declaration.artifact_type ? { artifact_type: declaration.artifact_type } : {}),
 				...(declaration.artifact_schema || declaration.schema ? { artifact_schema: declaration.artifact_schema || declaration.schema } : {}),
 				path: destination,
+				uri,
+				url: uri,
 				required: declaration.required === true,
 				bytes: collected.bytes,
+				size_bytes: collected.bytes,
 				sha256: digest,
 				file_count: collected.entries.filter((entry) => !entry.directory).length,
 				node_count: collected.entries.length,
@@ -80,7 +92,7 @@ function harvestDeclaredArtifacts({ request = {}, config = {}, cwd = '', artifac
 				...(plainObject(declaration.metadata) ? { metadata: declaration.metadata } : {}),
 			};
 			result.artifacts.push(artifact);
-			result.evidence_refs.push({ kind: artifact.kind, label: artifact.name, uri: `file://${destination}`, sha256: digest });
+			result.evidence_refs.push({ kind: artifact.kind, label: artifact.name, uri, sha256: digest });
 		} catch (error) {
 			result.errors.push({ artifact: declaration.name, code: 'capture_failed', message: error.message });
 		}

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -4,6 +4,7 @@
  * Internal dependencies
  */
 const {
+	AGENT_TASK_ARTIFACT_SCHEMA,
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 	agentTaskProviderContractFields,
 	agentTaskPolicyToolPermissions,
@@ -26,6 +27,7 @@ const { applyOpenCodeRuntimeTools } = require('../../lib/runtime-tool-adapter');
 const { spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
 
 const OPENCODE_PROVIDER_ID = 'opencode.agent-task-executor';
 const OPENCODE_PROVIDER_LABEL = 'OpenCode agent task executor';
@@ -468,7 +470,7 @@ function missingDeclaredArtifacts(request = {}, artifacts = []) {
 function declaredArtifactRequirements(request = {}) {
 	const expected = arrayValue(request.expected_artifacts).map((name) => ({ name: String(name), required: true }));
 	const declared = arrayValue(request.artifact_declarations || request.executor?.artifact_declarations)
-		.filter((artifact) => artifact && typeof artifact === 'object' && artifact.required === true)
+		.filter((artifact) => artifact && typeof artifact === 'object' && artifact.required === true && typeof artifact.path === 'string' && artifact.path !== '')
 		.map((artifact) => ({ name: artifact.name || artifact.id || artifact.output_key, kind: artifact.kind, required: true }))
 		.filter((artifact) => artifact.name);
 	return [...expected, ...declared];
@@ -860,11 +862,15 @@ function collectOpenCodeArtifacts(context = {}, structured = {}) {
 			return;
 		}
 		const artifact = {
+			schema: AGENT_TASK_ARTIFACT_SCHEMA,
 			id: requirement.name,
 			name: requirement.name,
 			kind: requirement.kind || fallbackKind,
 			path: filePath,
+			uri: fileUri(filePath),
+			url: fileUri(filePath),
 			bytes: Buffer.byteLength(artifactContent),
+			size_bytes: Buffer.byteLength(artifactContent),
 		};
 		artifacts.push(artifact);
 		evidence_refs.push({ kind: artifact.kind, label: requirement.name, uri: fileUri(filePath) });
@@ -970,12 +976,16 @@ function collectOpenCodeRuntimeLogs(context = {}) {
 			continue;
 		}
 		const artifact = {
+			schema: AGENT_TASK_ARTIFACT_SCHEMA,
 			id: `opencode-runtime-${stream}`,
 			name: `opencode-runtime-${stream}`,
 			kind: 'opencode-runtime-log',
 			stream,
 			path: filePath,
+			uri: fileUri(filePath),
+			url: fileUri(filePath),
 			bytes,
+			size_bytes: bytes,
 		};
 		artifacts.push(artifact);
 		evidence_refs.push({ kind: artifact.kind, label: `OpenCode ${stream}`, uri: fileUri(filePath) });
@@ -990,13 +1000,13 @@ function collectOpenCodeProgressEvents(context = {}) {
 	}
 	const bytes = fs.statSync(filePath).size;
 	return {
-		artifacts: [{ id: 'progress_events', name: 'progress_events', kind: 'agent-task-progress', path: filePath, bytes }],
+		artifacts: [{ schema: AGENT_TASK_ARTIFACT_SCHEMA, id: 'progress_events', name: 'progress_events', kind: 'agent-task-progress', path: filePath, uri: fileUri(filePath), url: fileUri(filePath), bytes, size_bytes: bytes }],
 		evidence_refs: [{ kind: 'agent-task-progress', label: 'OpenCode progress events', uri: fileUri(filePath) }],
 	};
 }
 
 function fileUri(filePath) {
-	return `file://${filePath}`;
+	return pathToFileURL(filePath).href;
 }
 
 function mergeEvidence(primary = {}, secondary = {}) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -629,6 +629,7 @@ process.exit(${attempt.status});
 	assert.equal(transcript.includes('refresh-token-must-not-leak'), false);
 	assert.match(transcript, /\[redacted\]/);
 	assert.equal(artifactResult.artifacts.some((artifact) => artifact.name === 'opencode-runtime-stdout'), true);
+	assert.equal(artifactResult.artifacts.every((artifact) => artifact.schema === 'homeboy/agent-task-artifact/v1' && artifact.url === artifact.uri && Number.isInteger(artifact.size_bytes)), true);
 	assert.equal(artifactResult.evidence_refs.every((ref) => ref.uri.startsWith('file://')), true);
 	assert.equal(artifactResult.evidence_refs.some((ref) => Object.hasOwn(ref, 'path')), false);
 	const runtimeStdout = fs.readFileSync(artifactResult.artifacts.find((artifact) => artifact.name === 'opencode-runtime-stdout').path, 'utf8');
@@ -672,6 +673,9 @@ process.exit(0);
 	assert.equal(declaredReport.artifact_type, 'report');
 	assert.equal(declaredReport.metadata.source, 'opencode');
 	assert.equal(declaredReport.bytes, Buffer.byteLength('# OpenCode report\n'));
+	assert.equal(declaredReport.schema, 'homeboy/agent-task-artifact/v1');
+	assert.equal(declaredReport.url, declaredReport.uri);
+	assert.equal(declaredReport.size_bytes, Buffer.byteLength('# OpenCode report\n'));
 	assert.match(declaredReport.sha256, /^[a-f0-9]{64}$/);
 	assert.deepEqual(fs.readFileSync(path.join(declaredScreenshots.path, 'image.bin')), Buffer.from([0, 255, 1, 254]));
 	assert.equal(declaredOpenCodeResult.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.optional_declared_artifact_missing'), true);
@@ -699,8 +703,9 @@ process.exit(0);
 			config: { ...request.executor.config, command_args: [noOpDeclaredArtifactCliPath] },
 		},
 	}, { env: fixtureEnv });
-	assert.equal(missingPathOpenCodeResult.status, 'failed');
-	assert.equal(missingPathOpenCodeResult.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.declared_artifact_invalid_path'), true);
+	assert.equal(missingPathOpenCodeResult.status, 'succeeded');
+	assert.equal(missingPathOpenCodeResult.diagnostics.some((diagnostic) => diagnostic.class === 'agent_task.declared_artifact_invalid_path'), false);
+	assert.equal(missingPathOpenCodeResult.artifacts.some((artifact) => artifact.name === 'missing-path'), false);
 
 	const largePatchCliPath = path.join(root, 'mock-opencode-large-patch.cjs');
 	fs.writeFileSync(largePatchCliPath, `#!/usr/bin/env node


### PR DESCRIPTION
## Summary

- emit canonical file URIs and schema-valid stream artifacts from shared CLI executors
- omit pathless candidate declarations rather than report invalid artifact paths
- retain legacy artifact path/byte fields while adding canonical URI/size fields
- align OpenCode artifacts with the same shared outcome contract
- add success, failure, cancellation, and no-candidate conformance coverage

Fixes #2567. Owning-layer repair for Extra-Chill/homeboy#11795.

## Verification

- shared CLI executor conformance test
- Codex executor boundary test
- OpenCode executor boundary test
- extension shape lint
- Node syntax checks
- `git diff --check origin/main...HEAD`

## AI Assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode general coding subagents
- Use: Traced the malformed Codex outcome to the shared executor, implemented portable schema-conformant evidence, reviewed cross-runtime compatibility, and added boundary tests under Chris Huber's direction. Chris remains responsible for every line.
