### PR TITLE
Fix OpenCode runtime tool MCP config

### DIFF
--- a/agent-runtimes/lib/runtime-tool-adapter.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.js
@@ -89,9 +89,9 @@ function applyOpenCodeRuntimeTools(content = {}, request = {}, env = process.env
 	for (const tool of tools) {
 		mcp[tool.id] = {
 			type: 'local',
-			command: tool.argv[0],
-			args: tool.argv.slice(1),
+			command: [...tool.argv],
 			environment: runtimeToolEnvironment(tool, env),
+			enabled: true,
 		};
 	}
 	return { ...content, mcp };

--- a/agent-runtimes/lib/runtime-tool-adapter.test.js
+++ b/agent-runtimes/lib/runtime-tool-adapter.test.js
@@ -42,10 +42,10 @@ assert.deepEqual(resolvedRuntimeTools(request, env)[0].argv, ['/fixture/mcp', '-
 assert.deepEqual(resolvedRuntimeTools({}, { [RESOLVED_RUNTIME_TOOLS_ENV]: JSON.stringify(request.resolved_runtime_tools) })[0].argv, ['/fixture/mcp', '--isolated']);
 const openCode = applyOpenCodeRuntimeTools({}, request, env);
 assert.deepEqual(openCode.mcp['fixture.mcp'], {
-	type: 'local', command: '/fixture/mcp', args: ['--isolated'], environment: { FIXTURE_MODE: 'isolated', FIXTURE_TOKEN: 'private-token' },
+	type: 'local', command: ['/fixture/mcp', '--isolated'], environment: { FIXTURE_MODE: 'isolated', FIXTURE_TOKEN: 'private-token' }, enabled: true,
 });
 assert.deepEqual(openCode.mcp['fixture.second'], {
-	type: 'local', command: '/fixture/second', args: [], environment: {},
+	type: 'local', command: ['/fixture/second'], environment: {}, enabled: true,
 });
 const codex = codexRuntimeToolConfigArgs(request, env);
 assert.equal(codex.includes('mcp_servers.fixture.mcp.command="/fixture/mcp"'), true);

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -178,8 +178,12 @@ const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
 assert.equal(config.agent.title.disable, true);
 if (instruction === 'Prove two attached runtime tools without leaking secrets.') {
   assert.equal(typeof config.mcp, 'object');
-  assert.deepEqual(config.mcp['fixture.mcp'].args, ['--fixture-mcp', '--isolated']);
-  assert.deepEqual(config.mcp['fixture.second'].args, ['--second-fixture-mcp']);
+  assert.equal(config.mcp['fixture.mcp'].command[0], process.execPath);
+  assert.deepEqual(config.mcp['fixture.mcp'].command.slice(1), ['--fixture-mcp', '--isolated']);
+  assert.equal(config.mcp['fixture.mcp'].enabled, true);
+  assert.equal(config.mcp['fixture.second'].command[0], process.execPath);
+  assert.deepEqual(config.mcp['fixture.second'].command.slice(1), ['--second-fixture-mcp']);
+  assert.equal(config.mcp['fixture.second'].enabled, true);
 }
 process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
 process.stderr.write(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN || 'missing secret');


### PR DESCRIPTION
## Summary

- project resolved runtime tools as complete OpenCode MCP command arrays
- mark projected local MCP servers enabled
- update shared adapter and OpenCode executor boundaries to assert the current schema

Fixes #2571.

## Verification

- `node agent-runtimes/lib/runtime-tool-adapter.test.js`
- `npm run test:opencode-agent-task-executor-boundary`
- `node --check agent-runtimes/lib/runtime-tool-adapter.js`
- `git diff --check`

## AI Assistance

- Model: OpenAI GPT-5.6 Sol
- Tool: OpenCode
- Use: Diagnosed the current OpenCode MCP config mismatch from runtime stderr, updated the adapter projection, and added boundary coverage under Chris Huber's direction. Chris remains responsible for every line.