### PR TITLE
fix(wordpress): resolve PHPStan config paths

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -75,6 +75,7 @@
       "node tests/helper-manifest-smoke.js",
       "bash tests/phpcs-ignore-fixer-multiline-sql-smoke.sh",
       "bash tests/phpstan-integrity-guard-smoke.sh",
+      "bash tests/phpstan-relative-include-path-smoke.sh",
       "bash tests/phpstan-relative-dependency-path-smoke.sh",
       "bash tests/release-scripts-smoke.sh",
       "bash tests/validation-dependencies-smoke.sh",

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -135,6 +135,7 @@ PHPSTAN_DEFAULT_CONFIG="${EXTENSION_PATH}/phpstan.neon.dist"
 PHPSTAN_COMPONENT_CONFIG=""
 PHPSTAN_COMPONENT_CONFIG_SOURCE="extension-default"
 PHPSTAN_COMPONENT_CONFIG_HAS_RULESET=0
+PHPSTAN_COMPONENT_CONFIG_INCLUDES_BASELINE=0
 PHPSTAN_BASE_CONFIG="$PHPSTAN_DEFAULT_CONFIG"
 PHPSTAN_LEVEL_SOURCE="extension-default"
 COMPONENT_BASELINE="${PLUGIN_PATH}/phpstan-baseline.neon"
@@ -256,7 +257,16 @@ if [ -n "$PHPSTAN_COMPONENT_CONFIG" ]; then
     if grep -Eq '^[[:space:]]*(level|customRulesetUsed):' "$PHPSTAN_COMPONENT_CONFIG"; then
         PHPSTAN_COMPONENT_CONFIG_HAS_RULESET=1
     fi
+    if grep -Eq '^[[:space:]]*-[[:space:]]+\.?/?phpstan-baseline\.neon([[:space:]]*(#.*)?)?$' "$PHPSTAN_COMPONENT_CONFIG"; then
+        PHPSTAN_COMPONENT_CONFIG_INCLUDES_BASELINE=1
+    fi
 fi
+
+homeboy_run_phpstan() {
+    # PHPStan resolves project-relative configuration and %currentWorkingDirectory%
+    # from its process CWD, not from the generated config file in TMPDIR.
+    (cd "$PLUGIN_PATH" && "$PHPSTAN_BIN" "$@")
+}
 
 generate_dependency_config() {
     local tmpfile
@@ -286,7 +296,7 @@ generate_dependency_config() {
         # do this here (rather than via --baseline) so every invocation path
         # (summary, full, retry) picks it up automatically through the single
         # config include chain.
-        if [ -f "$COMPONENT_BASELINE" ]; then
+        if [ -f "$COMPONENT_BASELINE" ] && [ "$PHPSTAN_COMPONENT_CONFIG_INCLUDES_BASELINE" -ne 1 ]; then
             printf '    - %s\n' "$COMPONENT_BASELINE"
             has_baseline=1
         fi
@@ -1011,7 +1021,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     set +e
     # Capture stderr separately to show PHPStan errors if it fails
     stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
-    json_output=$("$PHPSTAN_BIN" "${phpstan_args[@]}" --error-format=json 2>"$stderr_file")
+    json_output=$(homeboy_run_phpstan "${phpstan_args[@]}" --error-format=json 2>"$stderr_file")
     json_exit=$?
     stderr_output=$(cat "$stderr_file")
     rm -f "$stderr_file"
@@ -1328,7 +1338,7 @@ if [ "$PHPSTAN_CRITICAL_ONLY" -eq 1 ]; then
     echo "Running PHPStan critical-only check (style checks skipped)..."
     set +e
     stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
-    json_output=$("$PHPSTAN_BIN" "${phpstan_args[@]}" --error-format=json 2>"$stderr_file")
+    json_output=$(homeboy_run_phpstan "${phpstan_args[@]}" --error-format=json 2>"$stderr_file")
     full_exit=$?
     stderr_output=$(cat "$stderr_file")
     rm -f "$stderr_file"
@@ -1401,7 +1411,7 @@ set +e
 # avoids race conditions with `tee` in process substitution.
 stdout_file=$(homeboy_mktemp 'phpstan-stdout.XXXXXX')
 stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
-"$PHPSTAN_BIN" "${phpstan_args[@]}" >"$stdout_file" 2>"$stderr_file"
+homeboy_run_phpstan "${phpstan_args[@]}" >"$stdout_file" 2>"$stderr_file"
 full_exit=$?
 stdout_output=$(cat "$stdout_file")
 stderr_output=$(cat "$stderr_file")

--- a/wordpress/tests/phpstan-relative-include-path-smoke.sh
+++ b/wordpress/tests/phpstan-relative-include-path-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHPSTAN_RUNNER="${ROOT_DIR}/scripts/lint/phpstan-runner.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+COMPONENT_DIR="${TMP_ROOT}/component"
+CONFIG_TMPDIR="${TMP_ROOT}/generated-config"
+OUTPUT_FILE="${TMP_ROOT}/phpstan-output.txt"
+RESOLVE_CONTEXT_HELPER="${TMP_ROOT}/resolve-context.sh"
+SIDECAR_WRITER_HELPER="${TMP_ROOT}/sidecar-writer.sh"
+
+mkdir -p "$COMPONENT_DIR" "$CONFIG_TMPDIR"
+
+cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
+homeboy_resolve_context() {
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+    COMPONENT_PATH="$HOMEBOY_COMPONENT_PATH"
+    PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+    COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-phpstan-relative-include-path}"
+}
+SH
+
+cat > "$SIDECAR_WRITER_HELPER" <<'SH'
+homeboy_sidecar_merge_json_array() {
+    return 0
+}
+SH
+
+cat > "${COMPONENT_DIR}/plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: PHPStan Relative Include Fixture
+ */
+PHP
+
+cat > "${COMPONENT_DIR}/phpstan.neon" <<'NEON'
+includes:
+    - ./phpstan-baseline.neon
+NEON
+
+cat > "${COMPONENT_DIR}/phpstan-baseline.neon" <<'NEON'
+parameters:
+    ignoreErrors: []
+NEON
+
+if [ ! -x "${ROOT_DIR}/vendor/bin/phpstan" ]; then
+    echo "FAIL: PHPStan is not installed. Run composer install in ${ROOT_DIR}." >&2
+    exit 1
+fi
+
+set +e
+HOMEBOY_EXTENSION_PATH="$ROOT_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="phpstan-relative-include-path" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_PHPSTAN_THREADS=1 \
+TMPDIR="$CONFIG_TMPDIR" \
+bash -c 'cd "$1" && "$2"' _ "$CONFIG_TMPDIR" "$PHPSTAN_RUNNER" >"$OUTPUT_FILE" 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+    echo "FAIL: component-relative PHPStan includes should resolve from the component" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if grep -F "${CONFIG_TMPDIR}/phpstan-baseline.neon" "$OUTPUT_FILE" >/dev/null; then
+    echo "FAIL: PHPStan resolved the baseline from the generated config directory" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if grep -F "included multiple times" "$OUTPUT_FILE" >/dev/null; then
+    echo "FAIL: component baseline should be included exactly once" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+echo "PHPStan relative include path smoke passed"


### PR DESCRIPTION
## Summary

Fixes #2573.

PHPStan now always runs from `HOMEBOY_COMPONENT_PATH`, so `%currentWorkingDirectory%` and relative component config entries resolve from the materialized component rather than a caller or generated-config directory. The runner also avoids adding `phpstan-baseline.neon` twice when a component config already includes it.

## Verification

- `bash wordpress/tests/phpstan-relative-include-path-smoke.sh`
- `COLUMNS=240 bash wordpress/tests/phpstan-relative-dependency-path-smoke.sh`
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh wordpress/tests/phpstan-relative-include-path-smoke.sh`
- `jq empty wordpress/homeboy.json`

AI assistance: OpenAI GPT-5.6 Sol via OpenCode investigated the materialized-worktree behavior, implemented the runner fix, and added the regression coverage. Chris Huber remains responsible.