### PR TITLE
Resolve Discord completion routes from Kimaki context

### DIFF
--- a/discord/README.md
+++ b/discord/README.md
@@ -21,20 +21,26 @@ export DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/...'
 ```
 
 Homeboy discovers the `discord.run-completion` transport from this extension's
-manifest. Select it as the notification transport in Homeboy configuration or
-with the corresponding CLI option; Homeboy invokes the typed command with each
-run's caller context.
+manifest. A Homeboy version with extension-owned route resolver support can
+select it automatically from invocation-scoped Discord context. Explicit
+notification CLI or environment routes always take precedence.
 
 ## Usage
 
-A Discord-originated run must carry its non-secret, versioned route when it is
-created: `discord:v1:thread:<guild-id>:<thread-id>` or
-`discord:v1:channel:<guild-id>:<channel-id>`. Homeboy persists that opaque
-route with the run, so concurrent detached runs deliver independently.
+Kimaki-backed shell commands expose the owning Discord thread as
+`KIMAKI_THREAD_ID`. The extension validates that invocation-scoped value and
+derives `discord:v1:thread:<thread-id>` without notification flags. Homeboy
+persists the opaque route with the run, so concurrent detached runs deliver
+independently. Missing Kimaki context preserves route-less behavior; invalid
+context fails closed.
+
+Explicit routes remain available for other callers. The canonical thread form
+is `discord:v1:thread:<thread-id>`; legacy guild-bearing routes remain accepted
+for existing persisted runs.
 
 ```sh
 homeboy --notification-transport discord.run-completion \
-  --notification-route 'discord:v1:thread:123456789012345678:234567890123456789' \
+  --notification-route 'discord:v1:thread:234567890123456789' \
   --detach-after-handoff test
 ```
 

--- a/discord/discord.json
+++ b/discord/discord.json
@@ -12,7 +12,11 @@
     {
       "schema": "homeboy/notification-transport/v1",
       "id": "discord.run-completion",
-      "command": ["node", "{extension_path}/scripts/notify.mjs"]
+      "command": ["node", "{extension_path}/scripts/notify.mjs"],
+      "route_resolver": {
+        "schema": "homeboy/notification-route-resolver/v1",
+        "command": ["node", "{extension_path}/scripts/resolve-route.mjs"]
+      }
     }
   ]
 }

--- a/discord/scripts/resolve-route.mjs
+++ b/discord/scripts/resolve-route.mjs
@@ -1,0 +1,52 @@
+const requestSchema = 'homeboy/notification-route-resolver-request/v1';
+const responseSchema = 'homeboy/notification-route-resolver/v1';
+const transport = 'discord.run-completion';
+
+let input = '';
+for await (const chunk of process.stdin) input += chunk;
+
+let request;
+try {
+  request = JSON.parse(input);
+} catch {
+  fail('Invalid notification route resolver request');
+}
+
+if (process.exitCode === undefined && !isValidRequest(request)) {
+  fail('Invalid notification route resolver request');
+}
+
+if (process.exitCode === undefined) {
+  const threadId = process.env.KIMAKI_THREAD_ID;
+  if (!threadId) {
+    emit({ schema: responseSchema, status: 'unmatched' });
+  } else if (!/^\d{17,20}$/.test(threadId)) {
+    fail('Invalid Discord thread attribution');
+  } else {
+    emit({
+      schema: responseSchema,
+      status: 'matched',
+      route: `discord:v1:thread:${threadId}`,
+    });
+  }
+}
+
+function isValidRequest(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).sort().join(',') === 'schema,transport' &&
+    value.schema === requestSchema &&
+    value.transport === transport
+  );
+}
+
+function emit(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 2;
+}

--- a/discord/tests/resolve-route.test.mjs
+++ b/discord/tests/resolve-route.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const extensionPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const resolver = path.join(extensionPath, 'scripts/resolve-route.mjs');
+const request = {
+  schema: 'homeboy/notification-route-resolver-request/v1',
+  transport: 'discord.run-completion',
+};
+const threadOneId = '323456789012345678';
+const threadTwoId = '423456789012345678';
+
+await testMatchedRoute();
+await testMissingContextIsUnmatched();
+await testInvalidRequestsFailClosed();
+await testInvalidContextFailsClosedWithoutDisclosure();
+await testConcurrentInvocationsDoNotCrossRoutes();
+console.log('discord route resolver tests passed');
+
+async function testMatchedRoute() {
+  const result = await resolve({ KIMAKI_THREAD_ID: threadOneId });
+  assert.equal(result.code, 0);
+  assert.equal(result.stderr, '');
+  assert.deepEqual(JSON.parse(result.stdout), {
+    schema: 'homeboy/notification-route-resolver/v1',
+    status: 'matched',
+    route: `discord:v1:thread:${threadOneId}`,
+  });
+  assert.equal(result.stdout.split('\n').filter(Boolean).length, 1);
+}
+
+async function testMissingContextIsUnmatched() {
+  const result = await resolve({ DISCORD_THREAD_ID: threadOneId });
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    schema: 'homeboy/notification-route-resolver/v1',
+    status: 'unmatched',
+  });
+}
+
+async function testInvalidRequestsFailClosed() {
+  const invalidRequests = [
+    '{',
+    JSON.stringify({ ...request, schema: 'unsupported' }),
+    JSON.stringify({ ...request, transport: 'other.transport' }),
+    JSON.stringify({ ...request, unexpected: true }),
+  ];
+  for (const input of invalidRequests) {
+    const result = await resolve({ KIMAKI_THREAD_ID: threadOneId }, input);
+    assert.equal(result.code, 2);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'Invalid notification route resolver request\n');
+  }
+}
+
+async function testInvalidContextFailsClosedWithoutDisclosure() {
+  const secret = 'token=do-not-disclose';
+  for (const threadId of ['123', 'not-a-snowflake', '1'.repeat(21), secret]) {
+    const result = await resolve({ KIMAKI_THREAD_ID: threadId });
+    assert.equal(result.code, 2);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'Invalid Discord thread attribution\n');
+    assert.equal(`${result.stdout}${result.stderr}`.includes(threadId), false);
+  }
+}
+
+async function testConcurrentInvocationsDoNotCrossRoutes() {
+  const [first, second] = await Promise.all([
+    resolve({ KIMAKI_THREAD_ID: threadOneId }),
+    resolve({ KIMAKI_THREAD_ID: threadTwoId }),
+  ]);
+  assert.equal(JSON.parse(first.stdout).route, `discord:v1:thread:${threadOneId}`);
+  assert.equal(JSON.parse(second.stdout).route, `discord:v1:thread:${threadTwoId}`);
+}
+
+function resolve(env = {}, input = JSON.stringify(request)) {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [resolver], { env, stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += chunk));
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.on('error', reject);
+    child.on('close', (code) => resolveResult({ code, stdout, stderr }));
+    child.stdin.end(input);
+  });
+}

--- a/homeboy.json
+++ b/homeboy.json
@@ -14,6 +14,8 @@
       "bash tests/cross-extension-sidecar-normalization-smoke.sh",
       "node tests/deferred-init-browser-helper-smoke.mjs",
       "node tests/dependency-adapter-manifests-smoke.mjs",
+      "node discord/tests/notify.test.mjs",
+      "node discord/tests/resolve-route.test.mjs",
       "node tests/local-shell-agent-task-executor-boundary.test.mjs",
       "bash tests/project-scripts-pnpm-workspace-smoke.sh",
       "node tests/runtime-provider-resolver-smoke.mjs",


### PR DESCRIPTION
## Summary

- declare a bounded route resolver for `discord.run-completion`
- map only invocation-scoped `KIMAKI_THREAD_ID` to `discord:v1:thread:<thread-id>`
- return typed unmatched output for missing context and fail closed safely for invalid input
- cover concurrency isolation, canonical delivery, strict request shape, and secret-safe diagnostics

Depends on Extra-Chill/homeboy#11868.
Closes #2576

## Verification

- `node discord/tests/resolve-route.test.mjs`
- `node discord/tests/notify.test.mjs`
- `node tests/extension-shape-lint.mjs`
- `node tests/dependency-adapter-manifests-smoke.mjs`
- cross-repository invocation with Homeboy `0.334.0+4ce6bb8b8318`: valid context succeeded without notification flags; missing context stayed route-less; invalid context failed with a generic typed diagnostic; explicit route precedence succeeded

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the Discord transport and Homeboy resolver contracts, implemented the stateless resolver, and ran focused and cross-repository verification under Chris Huber's direction. Chris remains responsible for every line.