### PR TITLE
Fix OpenCode runtime progress relay

### DIFF
--- a/agent-runtimes/lib/cli-agent-task-executor-bin.js
+++ b/agent-runtimes/lib/cli-agent-task-executor-bin.js
@@ -19,7 +19,7 @@ const fs = require('node:fs');
  *
  * @param {{execute: Function, outcome: Function, providerContract: Function}} executor Provider executor surface.
  */
-async function runCliAgentTaskExecutorBin({ execute, outcome, providerContract }) {
+async function runCliAgentTaskExecutorBin({ execute, outcome, providerContract, onProgress }) {
 	if (process.argv.includes('--provider-contract')) {
 		process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
 		process.exit(0);
@@ -42,7 +42,7 @@ async function runCliAgentTaskExecutorBin({ execute, outcome, providerContract }
 		}
 	}
 
-	process.stdout.write(`${JSON.stringify(await execute(request), null, 2)}\n`);
+	process.stdout.write(`${JSON.stringify(await execute(request, { onProgress }), null, 2)}\n`);
 	process.exit(0);
 }
 

--- a/agent-runtimes/opencode/lib/opencode-progress-events.js
+++ b/agent-runtimes/opencode/lib/opencode-progress-events.js
@@ -74,11 +74,11 @@ function translateOpenCodeEvent(frame = {}, context = {}) {
 		const failed = Boolean(part.state?.error || part.error || frame.error) || ['error', 'failed'].includes(status);
 		const completed = ['completed', 'complete', 'done', 'success', 'succeeded'].includes(status);
 		const type = progressType(tool, failed ? 'failed' : completed ? 'completed' : 'started');
-		return progressEnvelope(type, tool, input, frame, context, failed ? part.state?.error || part.error || frame.error : '');
+		return progressEnvelope(type, tool, input, frame, context, failed ? part.state?.error || part.error || frame.error : '', sessionId(part, frame));
 	}
 	const error = stringValue(frame.error || frame.message);
 	if (error && /(retry|rate limit|quota|backoff)/i.test(error)) {
-		return progressEnvelope('provider.retrying', '', {}, frame, context, error);
+		return progressEnvelope('provider.retrying', '', {}, frame, context, error, sessionId({}, frame));
 	}
 	return null;
 }
@@ -92,7 +92,7 @@ function progressType(tool, state) {
 	return `tool.${state}`;
 }
 
-function progressEnvelope(type, tool, input, frame, context, error) {
+function progressEnvelope(type, tool, input, frame, context, error, session_id) {
 	const data = {};
 	if (tool) data.tool = bounded(sanitize(tool, context), 80);
 	const candidatePath = stringValue(input.path || input.filePath || input.filepath || input.file || input.pattern);
@@ -106,11 +106,20 @@ function progressEnvelope(type, tool, input, frame, context, error) {
 	return {
 		schema: OPENCODE_PROGRESS_EVENT_SCHEMA,
 		task_id: context.taskId || 'unknown-task',
+		session_id,
 		source: 'provider',
 		type,
 		timestamp: validTimestamp(frame.timestamp || frame.time?.created || frame.created_at) || timestamp(context.now),
 		data,
 	};
+}
+
+function sessionId(part, frame) {
+	const value = stringValue(
+		part.session_id || part.sessionID || part.session?.id
+		|| frame.session_id || frame.sessionID || frame.session?.id
+	);
+	return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value) ? value : 'unknown';
 }
 
 function workspaceRelativePath(value, workspace) {

--- a/agent-runtimes/opencode/package.json
+++ b/agent-runtimes/opencode/package.json
@@ -19,7 +19,8 @@
     "check:runtime-manifest": "node scripts/agent/homeboy-opencode-runtime-manifest.cjs --check",
     "test:opencode-agent-task-executor": "node tests/opencode-agent-task-executor-boundary.test.js",
     "test:opencode-agent-task-executor-boundary": "node tests/opencode-agent-task-executor-boundary.test.js",
-    "test:opencode-progress-events": "node tests/opencode-progress-events.test.js"
+    "test:opencode-progress-events": "node tests/opencode-progress-events.test.js",
+    "test:opencode-progress-relay": "node tests/opencode-progress-relay.test.js"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
+++ b/agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
@@ -20,4 +20,35 @@ runCliAgentTaskExecutorBin({
 	execute: executeOpenCodeAgentTask,
 	outcome,
 	providerContract,
+	onProgress: relayProgress,
 });
+
+function relayProgress(event = {}) {
+	const progress = {
+		schema: 'homeboy/agent-task-runtime-progress/v1',
+		provider: 'opencode',
+		session_id: safeSessionId(event.session_id),
+		category: safeCategory(event.type),
+		latest_activity_at: safeTimestamp(event.timestamp),
+	};
+	try {
+		// stderr preserves stdout as the terminal AgentTaskOutcome channel.
+		process.stderr.write(`${JSON.stringify(progress)}\n`);
+	} catch {
+		// Parent progress is advisory; a closed parent pipe must not end the task.
+	}
+}
+
+function safeSessionId(value) {
+	return typeof value === 'string' && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value) ? value : 'unknown';
+}
+
+function safeCategory(value) {
+	return typeof value === 'string' && /^(?:command|file\.(?:read|search|edit)|tool)\.(?:started|completed|failed)$|^provider\.retrying$/.test(value)
+		? value
+		: 'provider.activity';
+}
+
+function safeTimestamp(value) {
+	return typeof value === 'string' && !Number.isNaN(Date.parse(value)) ? value : new Date().toISOString();
+}

--- a/agent-runtimes/opencode/tests/opencode-progress-events.test.js
+++ b/agent-runtimes/opencode/tests/opencode-progress-events.test.js
@@ -16,7 +16,7 @@ try {
 		taskId: 'task-2311', cwd: workspace, filePath: eventPath,
 		env: { ACCESS_TOKEN: 'top-secret-token' }, now: '2026-07-20T12:00:00.000Z', onProgress: (event) => live.push(event),
 	});
-	adapter.consume('stdout', `${JSON.stringify({ timestamp: '2026-07-20T12:00:01.000Z', parts: [{ tool: 'read', input: { path: path.join(workspace, 'src/index.js') }, state: { status: 'completed' } }] })}\n`);
+	adapter.consume('stdout', `${JSON.stringify({ sessionID: 'ses_123', timestamp: '2026-07-20T12:00:01.000Z', parts: [{ tool: 'read', input: { path: path.join(workspace, 'src/index.js') }, state: { status: 'completed' } }] })}\n`);
 	adapter.consume('stdout', `${JSON.stringify({ parts: [{ tool: 'bash', input: { command: `ACCESS_TOKEN=top-secret-token npm test ${path.join(workspace, 'package.json')}` }, state: { status: 'completed', exit_code: 0 } }] })}\n`);
 	adapter.consume('stderr', `${JSON.stringify({ error: 'Rate limit reached; retrying with token top-secret-token.' })}\n`);
 	const summary = adapter.finish();
@@ -24,6 +24,7 @@ try {
 	assert.deepEqual(live.map((event) => event.type), ['file.read.completed', 'command.completed', 'provider.retrying']);
 	assert.deepEqual(live.map((event) => event.sequence), [1, 2, 3]);
 	assert.deepEqual(live.map((event) => event.cursor), ['opencode:1', 'opencode:2', 'opencode:3']);
+	assert.equal(live[0].session_id, 'ses_123');
 	assert.equal(live[0].data.path, 'src/index.js');
 	assert.equal(live[1].data.command.includes('top-secret-token'), false);
 	assert.equal(live[1].data.command.includes('ACCESS_TOKEN=[redacted]'), true);

--- a/agent-runtimes/opencode/tests/opencode-progress-relay.test.js
+++ b/agent-runtimes/opencode/tests/opencode-progress-relay.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const runtimeRoot = path.join(__dirname, '..');
+const executor = path.join(runtimeRoot, 'scripts', 'agent', 'homeboy-opencode-agent-task-executor.cjs');
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-opencode-progress-relay-'));
+
+function run(request) {
+	const child = spawn(process.execPath, [executor], {
+		cwd: root,
+		env: { ...process.env, HOMEBOY_AGENT_TASK_REQUEST: JSON.stringify(request) },
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	const stdout = [];
+	const stderr = [];
+	let exited = false;
+	let progressBeforeExit = false;
+	child.stdout.on('data', (chunk) => stdout.push(chunk));
+	child.stderr.on('data', (chunk) => {
+		stderr.push(chunk);
+		progressBeforeExit ||= !exited;
+	});
+	return {
+		interim: () => ({ stdout: Buffer.concat(stdout).toString('utf8'), stderr: Buffer.concat(stderr).toString('utf8') }),
+		result: new Promise((resolve, reject) => {
+			child.on('error', reject);
+			child.on('close', (status) => resolve({ status, stdout: Buffer.concat(stdout).toString('utf8'), stderr: Buffer.concat(stderr).toString('utf8'), progressBeforeExit }));
+			child.on('exit', () => { exited = true; });
+		}),
+	};
+}
+
+function requestFor(commandArgs, artifactsPath) {
+	return {
+		schema: 'homeboy/agent-task-request/v1',
+		task_id: 'relay-fixture',
+		instructions: 'Verify progress relay.',
+		artifacts_path: artifactsPath,
+		executor: { backend: 'opencode', runtime: 'opencode', config: { runtime_bin: process.execPath, command_args: commandArgs } },
+	};
+}
+
+(async () => {
+	try {
+		const streamingCli = path.join(root, 'streaming-opencode.cjs');
+		fs.writeFileSync(streamingCli, `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({ sessionID: 'ses_fixture_123', timestamp: '2026-08-07T12:00:00.000Z', parts: [{ tool: 'bash', input: { command: 'TOKEN=super-secret-token run --snapshot=' + 'x'.repeat(10000) }, state: { status: 'completed' } }] }) + '\\n');
+setTimeout(() => process.exit(0), 250);
+`);
+		const streamed = run(requestFor([streamingCli], path.join(root, 'stream-artifacts')));
+		const streamedResult = await streamed.result;
+		assert.equal(streamedResult.status, 0, streamedResult.stderr);
+		assert.equal(streamedResult.progressBeforeExit, true);
+		assert.equal(streamedResult.stdout.includes('super-secret-token'), false);
+		assert.equal(streamedResult.stderr.includes('super-secret-token'), false);
+		assert.equal(streamedResult.stderr.includes('snapshot='), false);
+		const relayed = streamedResult.stderr.trim().split('\n').map((line) => JSON.parse(line));
+		assert.deepEqual(relayed, [{
+			schema: 'homeboy/agent-task-runtime-progress/v1', provider: 'opencode', session_id: 'ses_fixture_123',
+			category: 'command.completed', latest_activity_at: '2026-08-07T12:00:00.000Z',
+		}]);
+		assert.ok(Buffer.byteLength(streamedResult.stderr) < 300);
+		const runtimeLog = fs.readFileSync(path.join(root, 'stream-artifacts', 'relay-fixture-opencode-runtime-stdout.log'), 'utf8');
+		assert.match(runtimeLog, /snapshot=/);
+
+		const silentCli = path.join(root, 'silent-opencode.cjs');
+		fs.writeFileSync(silentCli, '#!/usr/bin/env node\nsetTimeout(() => process.exit(0), 250);\n');
+		const silent = run(requestFor([silentCli], path.join(root, 'silent-artifacts')));
+		await new Promise((resolve) => setTimeout(resolve, 75));
+		assert.deepEqual(silent.interim(), { stdout: '', stderr: '' });
+		const silentResult = await silent.result;
+		assert.equal(silentResult.status, 0, silentResult.stderr);
+		assert.equal(silentResult.stderr, '');
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+})().then(() => process.stdout.write('OpenCode parent progress relay passed\n'));

--- a/agent-runtimes/opencode/tests/opencode-progress-relay.test.js
+++ b/agent-runtimes/opencode/tests/opencode-progress-relay.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../../../runtime-agent-ci/tests/helpers/runtime-contract-constants-fixture.cjs');
+
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');

--- a/homeboy.json
+++ b/homeboy.json
@@ -8,6 +8,7 @@
       "node tests/agent-task-provider-contract-smoke.mjs",
       "node agent-runtimes/codex/tests/declared-artifact-harvester.test.js",
       "node agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js",
+      "node agent-runtimes/opencode/tests/opencode-progress-relay.test.js",
       "node agent-runtimes/claude-code/tests/claude-code-agent-task-executor-boundary.test.js",
       "node agent-runtimes/pi/tests/pi-agent-task-executor-boundary.test.js",
       "node tests/browser-result-shapes-smoke.mjs",


### PR DESCRIPTION
## Summary
- Relay a bounded JSONL progress envelope to stderr as OpenCode events arrive.
- Keep stdout reserved for the terminal AgentTaskOutcome and retain the runtime event logs as artifacts.
- Cover early progress delivery, parent-output redaction and bounding, and silent-runtime behavior with deterministic fixtures.
- Load the deterministic Homeboy contract fixture in the relay integration test so it runs without an installed `homeboy` binary.

Closes #2578

## Verification
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `npm run check:runtime-manifest`
- `node tests/opencode-agent-task-executor-boundary.test.js`
- `bash scripts/ci/run-self-checks.sh . test` (24 passed; unrelated local cross-extension sidecar smoke failed because its temporary Go fixture was missing)
- `git diff --check`

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented the parent-visible OpenCode progress relay and deterministic tests. OpenAI gpt-5.6-terra via OpenCode diagnosed and repaired the CI-only missing contract-fixture setup. Chris Huber remains responsible for every line.