### PR TITLE
fix(opencode): allow nested Cook workspaces

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -335,12 +335,13 @@ function opencodeExternalDirectoryPatterns(request = {}, config = {}) {
 		return [];
 	}
 
-	const concreteWorkspace = concretePath(opencodeWorkspacePermissionRoot(request, config));
 	const patterns = [...workspacePatterns];
 	const attemptRoot = config.runtime_env?.TMPDIR;
 	if (isAbsolutePath(attemptRoot)) {
 		const concreteAttemptRoot = concretePath(attemptRoot);
-		if (isStrictDescendant(concreteWorkspace, concreteAttemptRoot)) {
+		if (opencodeWorkspacePermissionRoots(request, config).some((workspaceRoot) => (
+			isStrictDescendant(concretePath(workspaceRoot), concreteAttemptRoot)
+		))) {
 			// OpenCode discovers project metadata from this Homeboy-provided attempt root.
 			patterns.unshift(path.join(concreteAttemptRoot, '*'));
 		}
@@ -350,12 +351,20 @@ function opencodeExternalDirectoryPatterns(request = {}, config = {}) {
 }
 
 function opencodeWorkspaceReadPatterns(request = {}, config = {}) {
-	const workspaceRoot = opencodeWorkspacePermissionRoot(request, config);
-	return isAbsolutePath(workspaceRoot) ? [path.join(concretePath(workspaceRoot), '**')] : [];
+	return opencodeWorkspacePermissionRoots(request, config)
+		.filter(isAbsolutePath)
+		.map((workspaceRoot) => path.join(concretePath(workspaceRoot), '**'));
 }
 
 function opencodeWorkspacePermissionRoot(request = {}, config = {}) {
 	return config.workspace_permission_root || resolveOpenCodeCwd(request, config);
+}
+
+function opencodeWorkspacePermissionRoots(request = {}, config = {}) {
+	return [...new Set([
+		opencodeWorkspacePermissionRoot(request, config),
+		resolveOpenCodeCwd(request, config),
+	].filter(isAbsolutePath))];
 }
 
 function concretePath(candidate) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -386,7 +386,10 @@ assert.equal(config.agent.title.disable, true);
 		});
 		const concreteWorkspace = concretePath(permissionWorkspace.workspace);
 		const concretePermissionRoot = concretePath(permissionWorkspace.workspacePermissionRoot || permissionWorkspace.workspace);
-		const workspacePattern = path.join(concretePermissionRoot, '**');
+		const workspacePatterns = [...new Set([
+			path.join(concretePermissionRoot, '**'),
+			path.join(concreteWorkspace, '**'),
+		])];
 		const concreteAttemptRoot = permissionWorkspace.attemptRoot && concretePath(permissionWorkspace.attemptRoot);
 		const attemptRootPattern = concreteAttemptRoot && path.join(concreteAttemptRoot, '*');
 		const expectedAttemptRootPattern = permissionWorkspace.allowAttemptRoot ? attemptRootPattern : undefined;
@@ -397,7 +400,10 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 assert.equal(process.cwd(), ${JSON.stringify(concreteWorkspace)});
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
-assert.equal(config.permission.external_directory[${JSON.stringify(workspacePattern)}], 'allow');
+for (const pattern of ${JSON.stringify(workspacePatterns)}) {
+  assert.equal(config.permission.external_directory[pattern], 'allow');
+  assert.equal(config.agent.build.permission.external_directory[pattern], 'allow');
+}
 assert.equal(config.permission.external_directory[${JSON.stringify(attemptRootPattern)}], ${JSON.stringify(expectedAttemptRootPattern ? 'allow' : undefined)});
 assert.equal(config.permission.external_directory[${JSON.stringify(path.join(ambientTmpdir, '*'))}], undefined);
 assert.equal(config.permission.external_directory['/unrelated/**'], 'deny');
@@ -413,24 +419,12 @@ assert.deepEqual(config.permission.glob, { '*': 'allow' });
 		});
 		assert.deepEqual(config.permission.edit, { '*': 'allow' });
 		assert.deepEqual(config.permission.bash, { '*': 'allow', 'git push *': 'deny' });
-		assert.deepEqual(config.agent.build.permission, ${JSON.stringify(expectedAttemptRootPattern ? {
-			read: { '*': 'allow', '..': 'deny', '../*': 'deny', '..\\*': 'deny', '*.env': 'deny' },
-			glob: { '*': 'allow' },
-			grep: { '*': 'allow', secret: 'deny' },
-			edit: { '*': 'allow' },
-			bash: { '*': 'allow', 'git push *': 'deny' },
-			external_directory: {
-			[attemptRootPattern]: 'allow',
-			[workspacePattern]: 'allow',
-			},
-		} : {
-			read: { '*': 'allow', '..': 'deny', '../*': 'deny', '..\\*': 'deny', '*.env': 'deny' },
-			glob: { '*': 'allow' },
-			grep: { '*': 'allow', secret: 'deny' },
-			edit: { '*': 'allow' },
-			bash: { '*': 'allow', 'git push *': 'deny' },
-			external_directory: { [workspacePattern]: 'allow' },
-		})});
+		assert.deepEqual(config.agent.build.permission.read, config.permission.read);
+		assert.deepEqual(config.agent.build.permission.glob, config.permission.glob);
+		assert.deepEqual(config.agent.build.permission.grep, config.permission.grep);
+		assert.deepEqual(config.agent.build.permission.edit, config.permission.edit);
+		assert.deepEqual(config.agent.build.permission.bash, config.permission.bash);
+assert.equal(config.agent.build.permission.external_directory[${JSON.stringify(attemptRootPattern)}], ${JSON.stringify(expectedAttemptRootPattern ? 'allow' : undefined)});
 fs.writeFileSync(${JSON.stringify(configCapturePath)}, JSON.stringify(config));
 process.exit(0);
 `);
@@ -475,6 +469,8 @@ process.exit(0);
 				path.join(concreteAttemptRoot, '*'),
 				path.join(concreteAttemptRoot, 'workspace', 'packages', 'runtime-playground', 'src', '*'),
 				path.join(concreteAttemptRoot, 'workspace', 'tests', '*'),
+				path.join(concreteWorkspace, 'packages', 'runtime-playground', 'src', '*'),
+				path.join(concreteWorkspace, 'tests', '*'),
 			]
 			: [path.join(concreteWorkspace, 'tests', '*')];
 		for (const requestedPattern of requestedPatterns) {
@@ -511,7 +507,7 @@ process.exit(0);
 		if (permissionWorkspace.workspacePermissionRoot) {
 			assert.equal(
 				externalDirectoryAction(generatedConfig, 'build', path.join(concreteWorkspace, '**')),
-				'deny'
+				'allow'
 			);
 		}
 		if (permissionWorkspace.label === 'controller-scratch') {
@@ -522,6 +518,9 @@ process.exit(0);
 				// OpenCode asks for this parent-directory glob, not the calling tool's glob.
 				const exactAttemptRequest = path.join(concreteAttemptRoot, '*');
 				assert.equal(externalDirectoryRules.findLast((rule) => rule.pattern === exactAttemptRequest)?.action, 'allow');
+				for (const workspacePattern of workspacePatterns) {
+					assert.equal(externalDirectoryRules.findLast((rule) => rule.pattern === workspacePattern)?.action, 'allow');
+				}
 				assert.equal(externalDirectoryRules.findLast((rule) => rule.pattern === path.join(root, 'controller-scratch', 'unrelated-attempt', '*'))?.action || 'deny', 'deny');
 			}
 		}


### PR DESCRIPTION
## Summary
- preserve both the canonical workspace permission root and the executor cwd when nested Cook dispatches provide different task-owned paths
- retain the attempt-root allowance only when one of those roots is inside the declared attempt
- cover suffixed controller-scratch attempts, nested Cook workspaces, resolved OpenCode policy rules, and unrelated-path denial

Closes #2350

## Verification
- `npm run --silent test:opencode-agent-task-executor-boundary`
- `npm run --silent test:opencode-progress-events`
- `npm run --silent check:runtime-manifest`
- `npm test --silent` in `runtime-agent-ci`

## AI Assistance
OpenAI gpt-5.6-terra via OpenCode investigated durable Homeboy run artifacts, implemented the permission-root fix, and added regression coverage. Chris Huber remains responsible for every line.