### PR TITLE
Count nextest shard outcomes from terminal events exactly

### DIFF
--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -56,6 +56,9 @@ write_fix_results_sidecar() {
     fi
 }
 
+# Register before any harness temporary so the harness composes this sidecar.
+trap write_fix_results_sidecar EXIT
+
 clippy_all_enabled() {
     if [ "${HOMEBOY_CLIPPY_ALL:-}" = "1" ]; then
         return 0
@@ -182,8 +185,6 @@ with open(target, "w", encoding="utf-8") as handle:
 PY
     homeboy_lint_findings_merge_file "$findings_file"
 }
-
-trap write_fix_results_sidecar EXIT
 
 # Verify this is a Rust project
 if [ ! -f "${PROJECT_PATH}/Cargo.toml" ]; then

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -404,11 +404,12 @@ rust_capture_stdout() {
 }
 
 rust_nextest_counts() {
-    python3 - "$1" "$2" <<'PY'
+    python3 - "$1" "$2" "$3" <<'PY'
 import json
 import sys
 
 expected = json.load(open(sys.argv[2], encoding="utf-8"))["selected"]
+failed_names_file = sys.argv[3]
 
 def planned_identity(item):
     values = (item.get("package"), item.get("target_kind"), item.get("target"), item.get("name"))
@@ -449,8 +450,24 @@ for item in expected:
     if emitted in planned_by_emitted:
         raise SystemExit(f"Rust test shard error: nextest output identity is ambiguous: {package}::{target}${test}")
     planned_by_emitted[emitted] = planned
-passed = failed = skipped = 0
-actual = set()
+
+# nextest's retry count is u32 and its attempt number is retry_count + 1.
+# Its TestInstanceId appends the decimal attempt only when it exceeds one.
+MAX_RETRY_ATTEMPT = 2**32
+
+def retry_base_identity(emitted):
+    package, target, test = emitted
+    base, marker, attempt_text = test.rpartition("#")
+    if not marker:
+        return None
+    if not base or not attempt_text.isdecimal():
+        return "invalid"
+    attempt = int(attempt_text)
+    if attempt < 2 or attempt > MAX_RETRY_ATTEMPT or attempt_text != str(attempt):
+        return "invalid"
+    return package, target, base
+
+outcomes = {}
 for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
     try:
         event = json.loads(line)
@@ -460,32 +477,92 @@ for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
         continue
     if event.get("type") != "test":
         continue
-    status = event.get("event")
-    if status not in {"ok", "passed", "failed", "fail", "ignored", "skipped"}:
-        continue
     try:
         emitted = emitted_identity(event.get("name"))
     except SystemExit:
         # Child processes inherit libtest JSON. Scheduler preflight, not their
         # diagnostics, is the authority for shard membership.
         continue
-    if emitted not in planned_by_emitted:
+    exact = planned_by_emitted.get(emitted)
+    retry_base = retry_base_identity(emitted)
+    if exact:
+        normalized = planned_by_emitted.get(retry_base) if retry_base != "invalid" and retry_base else None
+        if normalized:
+            raise SystemExit(f"Rust test shard error: nextest retry suffix is ambiguous between planned identities: {event.get('name')}")
+        planned = exact
+    elif retry_base == "invalid":
+        base = emitted[0], emitted[1], emitted[2].rpartition("#")[0]
+        if base in planned_by_emitted:
+            raise SystemExit(f"Rust test shard error: nextest emitted a malformed retry suffix: {event.get('name')}")
         continue
-    if planned_by_emitted[emitted] in actual:
+    else:
+        planned = planned_by_emitted.get(retry_base) if retry_base else None
+    if not planned:
+        continue
+    status = event.get("event")
+    if status not in {"ok", "passed", "failed", "fail", "ignored", "skipped"}:
+        continue
+    if planned in outcomes:
         raise SystemExit(f"Rust test shard error: nextest emitted an unexpected or duplicate test identity: {event.get('name')}")
-    actual.add(planned_by_emitted[emitted])
-    if status in {"ok", "passed"}: passed += 1
-    elif status in {"failed", "fail"}: failed += 1
-    else: skipped += 1
-missing = expected_identities - actual
+    outcomes[planned] = status
+missing = expected_identities - outcomes.keys()
 unexpected_missing = missing - expected_skipped
 if unexpected_missing:
     raise SystemExit(f"Rust test shard error: nextest executed membership does not match the shard manifest (missing={sorted(unexpected_missing)[:1]})")
 # Nextest intentionally omits ignored tests from its default event stream.
 # Their listed disposition is canonical execution policy, not a relaxed match.
-skipped += len(missing)
+passed = sum(status in {"ok", "passed"} for status in outcomes.values())
+failed_names = sorted(
+    f"{package}::{target}${test}"
+    for (package, _target_kind, target, test), status in outcomes.items()
+    if status in {"failed", "fail"}
+)
+failed = len(failed_names)
+skipped = sum(status in {"ignored", "skipped"} for status in outcomes.values()) + len(missing)
+with open(failed_names_file, "w", encoding="utf-8") as handle:
+    handle.write("\n".join(failed_names))
+    if failed_names:
+        handle.write("\n")
 print(f"{passed}\t{failed}\t{skipped}")
 PY
+}
+
+rust_nextest_merge_failure_evidence() {
+    local failed_names_file="$1" records_file failures_file name record
+    homeboy_test_failures_enabled || return 0
+    [ -s "$failed_names_file" ] || return 0
+
+    records_file="$(mktemp)" || return 1
+    failures_file="$(mktemp)" || {
+        rm -f "$records_file"
+        return 1
+    }
+    while IFS= read -r name; do
+        [ -n "$name" ] || continue
+        record="$(homeboy_test_failure_record_json "rust-nextest" "$name" "${name%%\$*}" "" "" "nextest reported failed test: ${name}" "test_failure")"
+        printf '%s\n' "$record" >> "$records_file"
+    done < "$failed_names_file"
+    if ! jq -s '.' "$records_file" > "$failures_file"; then
+        rm -f "$records_file" "$failures_file"
+        return 1
+    fi
+    if homeboy_test_failures_merge_file "$failures_file"; then
+        :
+    else
+        local merge_exit=$?
+        rm -f "$records_file" "$failures_file"
+        return "$merge_exit"
+    fi
+    rm -f "$records_file" "$failures_file"
+}
+
+rust_nextest_cleanup() {
+    local status="${1:-$?}" path
+    for path in "${NEXTEST_BATCH_FAILED_NAMES:-}" "${NEXTEST_FAILED_NAMES:-}" "${NEXTEST_EXECUTION_DATA:-}" "${SHARD_OUTPUT:-}" "${NEXTEST_LIST_JSON:-}" "${NEXTEST_LIST_OUTPUT:-}" "${SHARD_DATA:-}"; do
+        [ -z "$path" ] || homeboy_runner_harness_cleanup_path file "$path" || true
+    done
+    [ -z "${NEXTEST_BATCH_DIR:-}" ] || homeboy_runner_harness_cleanup_path directory "$NEXTEST_BATCH_DIR" || true
+    return "$status"
 }
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -714,16 +791,42 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
             rm -f "$SHARD_DATA"
             exit 1
         fi
-        NEXTEST_EXECUTION_DATA="$(mktemp)"
-        rust_nextest_execution_data "$SHARD_DATA" "$NEXTEST_EXECUTION_DATA"
-        NEXTEST_RUNNABLE_TOTAL="$(jq '.selected | length' "$NEXTEST_EXECUTION_DATA")"
-        NEXTEST_BATCH_DIR="$(mktemp -d)"
+        NEXTEST_EXECUTION_DATA=""
+        NEXTEST_BATCH_DIR=""
+        NEXTEST_FAILED_NAMES=""
+        NEXTEST_BATCH_FAILED_NAMES=""
+        SHARD_OUTPUT=""
+        NEXTEST_LIST_JSON=""
+        NEXTEST_LIST_OUTPUT=""
+        if ! NEXTEST_EXECUTION_DATA="$(mktemp)"; then
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+            rust_nextest_cleanup 1
+            exit 1
+        fi
+        homeboy_runner_harness_register_cleanup "$NEXTEST_EXECUTION_DATA"
+        if ! rust_nextest_execution_data "$SHARD_DATA" "$NEXTEST_EXECUTION_DATA"; then
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+            rust_nextest_cleanup 1
+            exit 1
+        fi
+        if ! NEXTEST_RUNNABLE_TOTAL="$(jq '.selected | length' "$NEXTEST_EXECUTION_DATA")"; then
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+            rust_nextest_cleanup 1
+            exit 1
+        fi
+        if ! homeboy_runner_harness_temp_dir NEXTEST_BATCH_DIR; then
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+            rust_nextest_cleanup 1
+            exit 1
+        fi
         if [ "$NEXTEST_RUNNABLE_TOTAL" -gt 0 ] && { ! rust_nextest_batches "$NEXTEST_EXECUTION_DATA" "$NEXTEST_MAX_BYTES" "$NEXTEST_BATCH_DIR" || ! rust_validate_nextest_batches "$NEXTEST_EXECUTION_DATA" "$NEXTEST_BATCH_DIR"; }; then
             SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
             rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
-            rm -rf "$NEXTEST_BATCH_DIR"
-            rm -f "$NEXTEST_EXECUTION_DATA"
-            rm -f "$SHARD_DATA"
+            rust_nextest_cleanup 1
             exit 1
         fi
         # Capture filter argv values once. Preflight and execution consume the
@@ -734,16 +837,20 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
             NEXTEST_FILTER="$(rust_nextest_filter "$NEXTEST_BATCH")"
             NEXTEST_FILTERS["$NEXTEST_BATCH"]="$NEXTEST_FILTER"
             NEXTEST_FILTER_DIGESTS["$NEXTEST_BATCH"]="$(printf '%s' "$NEXTEST_FILTER" | shasum -a 256 | cut -d ' ' -f 1)"
-            NEXTEST_LIST_JSON="$(mktemp)"
+            if ! NEXTEST_LIST_JSON="$(mktemp)"; then
+                SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+                rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+                rust_nextest_cleanup 1
+                exit 1
+            fi
+            homeboy_runner_harness_register_cleanup "$NEXTEST_LIST_JSON"
             homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
             if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_JSON" "$NEXTEST_BATCH"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
                 homeboy_cleanup_step_capture "$NEXTEST_LIST_OUTPUT"
                 homeboy_cleanup_step_capture "$NEXTEST_LIST_JSON"
-                rm -rf "$NEXTEST_BATCH_DIR"
-                rm -f "$NEXTEST_EXECUTION_DATA"
-                rm -f "$SHARD_DATA"
+                rust_nextest_cleanup 1
                 exit 1
             fi
             homeboy_cleanup_step_capture "$NEXTEST_LIST_OUTPUT"
@@ -751,31 +858,57 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
         done
         echo "Replaying Rust nextest shard: ${NEXTEST_RUNNABLE_TOTAL} runnable identities and ${SHARD_SKIPPED} planned skipped identities"
         SHARD_EXIT=0
+        if ! NEXTEST_FAILED_NAMES="$(mktemp)"; then
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+            rust_nextest_cleanup 1
+            exit 1
+        fi
+        homeboy_runner_harness_register_cleanup "$NEXTEST_FAILED_NAMES"
         for NEXTEST_BATCH in "$NEXTEST_BATCH_DIR"/*.json; do
             [ -f "$NEXTEST_BATCH" ] || continue
             NEXTEST_FILTER="${NEXTEST_FILTERS[$NEXTEST_BATCH]}"
             if [ "$(printf '%s' "$NEXTEST_FILTER" | shasum -a 256 | cut -d ' ' -f 1)" != "${NEXTEST_FILTER_DIGESTS[$NEXTEST_BATCH]}" ]; then
                 echo "Rust test shard error: nextest filter changed after preflight." >&2
+                SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+                rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+                rust_nextest_cleanup 1
                 exit 1
             fi
             homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --manifest-path "${PROJECT_PATH}/Cargo.toml" --workspace --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
-            if ! NEXTEST_COUNTS="$(rust_nextest_counts "$SHARD_OUTPUT" "$NEXTEST_BATCH")"; then
+            if ! NEXTEST_BATCH_FAILED_NAMES="$(mktemp)"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
-                rm -f "$SHARD_OUTPUT"
-                rm -rf "$NEXTEST_BATCH_DIR"
-                rm -f "$SHARD_DATA"
+                rust_nextest_cleanup 1
+                exit 1
+            fi
+            homeboy_runner_harness_register_cleanup "$NEXTEST_BATCH_FAILED_NAMES"
+            if ! NEXTEST_COUNTS="$(rust_nextest_counts "$SHARD_OUTPUT" "$NEXTEST_BATCH" "$NEXTEST_BATCH_FAILED_NAMES")"; then
+                SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+                rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+                rust_nextest_cleanup 1
                 exit 1
             fi
             IFS=$'\t' read -r PASSED FAILED SKIPPED <<< "$NEXTEST_COUNTS"
+            cat "$NEXTEST_BATCH_FAILED_NAMES" >> "$NEXTEST_FAILED_NAMES"
+            rm -f "$NEXTEST_BATCH_FAILED_NAMES"
             SHARD_PASSED=$((SHARD_PASSED + PASSED))
             SHARD_FAILED=$((SHARD_FAILED + FAILED))
             SHARD_SKIPPED=$((SHARD_SKIPPED + SKIPPED))
             [ "$NEXTEST_BATCH_EXIT" -eq 0 ] || SHARD_EXIT="$NEXTEST_BATCH_EXIT"
             rm -f "$SHARD_OUTPUT"
         done
-        rm -rf "$NEXTEST_BATCH_DIR"
-        rm -f "$NEXTEST_EXECUTION_DATA"
+        if rust_nextest_merge_failure_evidence "$NEXTEST_FAILED_NAMES"; then
+            :
+        else
+            NEXTEST_MERGE_EXIT=$?
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            SHARD_EXECUTED=$((SHARD_PASSED + SHARD_FAILED + SHARD_SKIPPED))
+            rust_emit_shard_result failed "$SHARD_TOTAL" "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED" "$((SHARD_ELAPSED*1000))"
+            rust_nextest_cleanup "$NEXTEST_MERGE_EXIT"
+            exit "$NEXTEST_MERGE_EXIT"
+        fi
+        rust_nextest_cleanup 0
     else
         while IFS=$'\t' read -r package target target_kind name; do
             case "$target_kind" in

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -89,6 +89,10 @@ import sys
 
 count = int(os.environ.get("HOMEBOY_NEXTEST_TEST_COUNT", "5"))
 names = ["unit::alpha", "unit::beta", "unit::ignored", "api::works", "member::member_works"] if count == 5 else [f"unit::long_test_{index:04d}_{'x' * 100}" for index in range(count)]
+if os.environ.get("HOMEBOY_NEXTEST_LIST_MODE") == "retry-suffix-exact":
+    names = ["unit::exact#1", "unit::exact#2"]
+if os.environ.get("HOMEBOY_NEXTEST_LIST_MODE") == "retry-suffix-ambiguous":
+    names = ["unit::alpha", "unit::alpha#2"]
 if os.environ.get("HOMEBOY_NEXTEST_LIST_MODE") == "filter-escape":
     names.append("unit::closing)")
 if os.environ.get("HOMEBOY_NEXTEST_LIST_MODE") == "filter-control":
@@ -146,9 +150,19 @@ for name in names:
     if mode == "missing-terminal" and name == "unit::beta":
         continue
     package, binary = ("shard-smoke", "api") if name == "api::works" else ("member-smoke", "member_smoke") if name == "member::member_works" else ("shard-smoke", "shard_smoke")
-    event = "failed" if mode == "failure" and name == "unit::beta" else "ignored" if name == "unit::ignored" else "ok"
-    # This is the libtest-json-plus terminal event shape emitted by nextest.
+    event = "failed" if (mode == "failure" and name == "unit::beta") or (mode in {"leaky-failure", "retry-failure"} and name == "unit::alpha") else "ignored" if name == "unit::ignored" else "ok"
     runtime_name = "malformed" if mode == "malformed" else f"{package}::{binary}${name}"
+    if mode in {"retry-success", "retry-failure"} and name == "unit::alpha":
+        # libtest-json-plus v0.1 records the final retry attempt by suffixing
+        # the emitted test name; it emits one terminal test event.
+        runtime_name = f"{runtime_name}#2"
+    if mode == "retry-suffix-malformed" and name == "unit::alpha":
+        runtime_name = f"{runtime_name}#oops"
+    if mode == "retry-suffix-maximum" and name == "unit::alpha":
+        runtime_name = f"{runtime_name}#4294967296"
+    if mode == "retry-suffix-out-of-range" and name == "unit::alpha":
+        runtime_name = f"{runtime_name}#4294967297"
+    # This is the libtest-json-plus terminal event shape emitted by nextest.
     print(json.dumps({"type": "test", "name": runtime_name, "event": event, "exec_time": 0.001}))
     if mode == "string-event" and name == "unit::alpha":
         # Released nextest output can interleave a JSON string with terminal events.
@@ -158,7 +172,7 @@ for name in names:
 if mode in {"terminal-outside-ok", "terminal-outside-failed", "terminal-outside-ignored"}:
     event = {"terminal-outside-ok": "ok", "terminal-outside-failed": "failed", "terminal-outside-ignored": "ignored"}[mode]
     print(json.dumps({"type": "test", "name": "outside::suite$terminal", "event": event, "exec_time": 0.001}))
-raise SystemExit(1 if mode == "failure" and "unit::beta" in names else 0)
+raise SystemExit(1 if mode in {"failure", "leaky-failure", "retry-failure"} and ({"unit::beta", "unit::alpha"} & set(names)) else 0)
 PY
   exit $?
 fi
@@ -212,6 +226,19 @@ PY
 EOF
 cat > "$WORK_DIR/sidecar-writer.sh" <<'EOF'
 homeboy_merge_annotations() { cp "$2" "${HOMEBOY_ANNOTATIONS_DIR}/$1.json"; }
+homeboy_merge_test_failures() {
+  [ "${HOMEBOY_SIDECAR_MERGE_FAIL:-}" != 1 ] || return 42
+  python3 - "$HOMEBOY_TEST_FAILURES_FILE" "$1" <<'PY'
+import json
+import os
+import sys
+
+target, incoming = sys.argv[1:]
+existing = json.load(open(target)) if os.path.exists(target) else []
+records = json.load(open(incoming))
+json.dump(existing + records, open(target, "w"))
+PY
+}
 EOF
 
 INVENTORY_A="$WORK_DIR/inventory-a.json"
@@ -403,6 +430,27 @@ import sys
 assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
 PY
 
+# Nextest reports a leaky test's final disposition with an ordinary terminal
+# event. A leaky pass therefore contributes exactly one passed identity.
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_MODE=leaky-pass \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/leaky-pass-results.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/leaky-pass.out"
+python3 - "$WORK_DIR/leaky-pass-results.json" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+
 # A real libtest-json-plus identity omits `target_kind`; the released replay
 # path must reconcile it to the inventory's package/kind/target/test record.
 if ! grep -q 'Rust shard result: total=5 passed=4 failed=0 skipped=1' "$WORK_DIR/nextest-runner.out"; then
@@ -458,6 +506,7 @@ PY
 
 # A nonzero batch exit remains aggregate evidence: every prevalidated batch
 # runs exactly once, and the final shard fails only after all outcomes exist.
+printf '%s\n' '[{"test_name":"pre-existing failure"}]' > "$WORK_DIR/batched-failure-evidence.json"
 set +e
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
@@ -470,6 +519,7 @@ HOMEBOY_FAKE_NEXTEST_RUN_LOG="$WORK_DIR/batched-failure.log" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
 HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
 HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/batched-failure-results.json" \
+HOMEBOY_TEST_FAILURES_FILE="$WORK_DIR/batched-failure-evidence.json" \
 HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
 HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
 HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
@@ -477,17 +527,19 @@ PATH="$BIN_DIR:$PATH" \
 bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/batched-failure.out" 2>&1
 BATCH_FAILURE_EXIT=$?
 set -e
-python3 - "$WORK_DIR/batched-failure.log" "$WORK_DIR/batched-failure-results.json" "$BATCH_FAILURE_EXIT" <<'PY'
+python3 - "$WORK_DIR/batched-failure.log" "$WORK_DIR/batched-failure-results.json" "$WORK_DIR/batched-failure-evidence.json" "$BATCH_FAILURE_EXIT" <<'PY'
 import json
 import re
 import sys
 
 lines = open(sys.argv[1]).read().splitlines()
 selected = [name for line in lines for name in re.findall(r"test\(=([^)]+)\)", line)]
-assert int(sys.argv[3]) != 0, sys.argv[3]
+assert int(sys.argv[4]) != 0, sys.argv[4]
 assert selected == ["member::member_works", "unit::alpha", "unit::beta", "api::works"], selected
 assert len(selected) == len(set(selected)), selected
 assert json.load(open(sys.argv[2])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
+evidence = json.load(open(sys.argv[3]))
+assert [record["test_name"] for record in evidence] == ["pre-existing failure", "shard-smoke::shard_smoke$unit::beta"], evidence
 PY
 
 # A list validation failure is preflight-only: no batch run may have started.
@@ -720,6 +772,113 @@ assert_nextest_event_rejected() {
 assert_nextest_event_rejected duplicate-terminal 'nextest emitted an unexpected or duplicate test identity'
 assert_nextest_event_rejected missing-terminal 'nextest executed membership does not match the shard manifest'
 
+# libtest-json-plus v0.1 emits one final terminal retry event, naming the
+# attempt with #<attempt>. The suffix normalizes at the identity boundary.
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES=150 \
+HOMEBOY_NEXTEST_MODE=retry-success \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/retry-success-results.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/retry-success.out"
+python3 - "$WORK_DIR/retry-success-results.json" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+
+# A final retry failure preserves the normalized test identity in evidence.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_MODE=retry-failure \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/retry-failure-results.json" \
+HOMEBOY_TEST_FAILURES_FILE="$WORK_DIR/retry-failure-evidence.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/retry-failure.out" 2>&1
+RETRY_FAILURE_EXIT=$?
+set -e
+python3 - "$WORK_DIR/retry-failure-results.json" "$WORK_DIR/retry-failure-evidence.json" "$RETRY_FAILURE_EXIT" <<'PY'
+import json
+import sys
+
+assert int(sys.argv[3]) != 0, sys.argv[3]
+assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
+assert [record["test_name"] for record in json.load(open(sys.argv[2]))] == ["shard-smoke::shard_smoke$unit::alpha"]
+PY
+
+# A sidecar merge failure remains the runner's failure status while retaining
+# the shard-result contract produced from the completed terminal stream.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_MODE=failure \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/merge-failure-results.json" \
+HOMEBOY_TEST_FAILURES_FILE="$WORK_DIR/merge-failure-evidence.json" \
+HOMEBOY_SIDECAR_MERGE_FAIL=1 \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/merge-failure.out" 2>&1
+MERGE_FAILURE_EXIT=$?
+set -e
+python3 - "$WORK_DIR/merge-failure-results.json" "$MERGE_FAILURE_EXIT" <<'PY'
+import json
+import sys
+
+assert int(sys.argv[2]) == 42, sys.argv[2]
+assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
+PY
+
+# A leaky failure is likewise a final failed event, with durable evidence.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_MODE=leaky-failure \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/leaky-failure-results.json" \
+HOMEBOY_TEST_FAILURES_FILE="$WORK_DIR/leaky-failure-evidence.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/leaky-failure.out" 2>&1
+LEAKY_FAILURE_EXIT=$?
+set -e
+python3 - "$WORK_DIR/leaky-failure-results.json" "$WORK_DIR/leaky-failure-evidence.json" "$LEAKY_FAILURE_EXIT" <<'PY'
+import json
+import sys
+
+assert int(sys.argv[3]) != 0, sys.argv[3]
+assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
+assert [record["test_name"] for record in json.load(open(sys.argv[2]))] == ["shard-smoke::shard_smoke$unit::alpha"]
+PY
+
 # A non-object JSON record is diagnostic-only. Planned terminal IDs remain the
 # authority for membership and counts.
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
@@ -806,6 +965,77 @@ manifest["tests"] = [test["id"] for test in inventory["tests"]]
 json.dump(manifest, open(sys.argv[2], "w"))
 PY
 }
+
+assert_nextest_terminal_rejected_with_manifest() {
+  local mode="$1" list_mode="$2" manifest="$3" expected="$4" output
+  output="$WORK_DIR/nextest-${mode}.out"
+  set +e
+  HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+  HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+  HOMEBOY_SKIP_LINT=1 \
+  HOMEBOY_RUST_TEST_RUNNER=nextest \
+  HOMEBOY_NEXTEST_MODE="$mode" \
+  HOMEBOY_NEXTEST_LIST_MODE="$list_mode" \
+  HOMEBOY_TEST_SHARD_MANIFEST="$manifest" \
+  HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+  HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+  PATH="$BIN_DIR:$PATH" \
+  bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$output" 2>&1
+  local result=$?
+  set -e
+  if [ "$result" -eq 0 ] || ! grep -q "$expected" "$output"; then
+    printf 'Expected %s nextest terminal rejection\n' "$mode" >&2
+    exit 1
+  fi
+}
+
+EXACT_SUFFIX_INVENTORY="$WORK_DIR/exact-suffix-inventory.json"
+EXACT_SUFFIX_MANIFEST="$WORK_DIR/exact-suffix-manifest.json"
+make_nextest_manifest retry-suffix-exact "$EXACT_SUFFIX_INVENTORY" "$EXACT_SUFFIX_MANIFEST"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_LIST_MODE=retry-suffix-exact \
+HOMEBOY_TEST_SHARD_MANIFEST="$EXACT_SUFFIX_MANIFEST" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/exact-suffix-results.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/exact-suffix.out"
+python3 - "$WORK_DIR/exact-suffix-results.json" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1])) == {"total": 2, "passed": 2, "failed": 0, "skipped": 0, "partial": "rust-shard"}
+PY
+
+AMBIGUOUS_SUFFIX_INVENTORY="$WORK_DIR/ambiguous-suffix-inventory.json"
+AMBIGUOUS_SUFFIX_MANIFEST="$WORK_DIR/ambiguous-suffix-manifest.json"
+make_nextest_manifest retry-suffix-ambiguous "$AMBIGUOUS_SUFFIX_INVENTORY" "$AMBIGUOUS_SUFFIX_MANIFEST"
+assert_nextest_terminal_rejected_with_manifest pass retry-suffix-ambiguous "$AMBIGUOUS_SUFFIX_MANIFEST" 'nextest retry suffix is ambiguous between planned identities'
+assert_nextest_terminal_rejected_with_manifest retry-suffix-malformed pass "$WORK_DIR/nextest-manifest.json" 'nextest emitted a malformed retry suffix'
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_NEXTEST_MODE=retry-suffix-maximum \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/retry-suffix-maximum-results.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/retry-suffix-maximum.out"
+python3 - "$WORK_DIR/retry-suffix-maximum-results.json" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
+PY
+assert_nextest_terminal_rejected_with_manifest retry-suffix-out-of-range pass "$WORK_DIR/nextest-manifest.json" 'nextest emitted a malformed retry suffix'
 
 ESCAPED_INVENTORY="$WORK_DIR/escaped-inventory.json"
 ESCAPED_MANIFEST="$WORK_DIR/escaped-manifest.json"

--- a/scripts/lib/runner-harness.sh
+++ b/scripts/lib/runner-harness.sh
@@ -76,7 +76,15 @@ homeboy_runner_harness_mktemp() {
 homeboy_runner_harness_temp_root() {
     local tmpdir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"
     [ -d "$tmpdir" ] && [ -w "$tmpdir" ] || return 1
-    (cd "$tmpdir" && pwd -P)
+    local root
+    root="$(cd "$tmpdir" && pwd -P)" || return 1
+    case "$root" in *$'\t'*|*$'\n'*) return 1 ;; esac
+    printf '%s\n' "$root"
+}
+
+homeboy_runner_harness_path_is_serializable() {
+    local path="$1"
+    case "$path" in *$'\t'*|*$'\r'*|*$'\n'*) return 1 ;; esac
 }
 
 homeboy_runner_harness_append_exit_trap() {
@@ -97,7 +105,16 @@ homeboy_runner_harness_register_owned_directory() {
 
 homeboy_runner_harness_directory_identity() {
     local path="$1"
-    stat -f '%d:%i' "$path" 2>/dev/null || stat -c '%d:%i' "$path" 2>/dev/null
+    python3 - "$path" <<'PY'
+import os
+import stat
+import sys
+
+entry = os.lstat(sys.argv[1])
+if not stat.S_ISDIR(entry.st_mode):
+    raise SystemExit(1)
+print(f"{entry.st_dev}:{entry.st_ino}")
+PY
 }
 
 homeboy_runner_harness_is_owned_directory() {
@@ -123,6 +140,10 @@ homeboy_runner_harness_register_cleanup() {
     local path="$1"
     local kind="${2:-file}"
     [ -n "$path" ] || return 0
+    if ! homeboy_runner_harness_path_is_serializable "$path"; then
+        echo "homeboy_runner_harness_register_cleanup: refusing control character in path" >&2
+        return 2
+    fi
     case "$kind" in
         file) ;;
         directory)
@@ -149,9 +170,16 @@ homeboy_runner_harness_temp() {
     local __var_name="$1"
     local template="${2:-homeboy-runner.XXXXXX}"
     local __tmp
+    if ! homeboy_runner_harness_path_is_serializable "$template"; then
+        echo "homeboy_runner_harness_temp: refusing control character in template" >&2
+        return 2
+    fi
     __tmp="$(homeboy_runner_harness_mktemp "$template")"
     printf -v "$__var_name" '%s' "$__tmp"
-    homeboy_runner_harness_register_cleanup "$__tmp"
+    if ! homeboy_runner_harness_register_cleanup "$__tmp"; then
+        rm -f -- "$__tmp"
+        return 1
+    fi
 }
 
 homeboy_runner_harness_temp_dir() {
@@ -160,6 +188,7 @@ homeboy_runner_harness_temp_dir() {
     local __tmp
     local root
     root="$(homeboy_runner_harness_temp_root)" || return 1
+    homeboy_runner_harness_path_is_serializable "$template" || return 2
     case "$template" in homeboy-runner.XXXXXX) ;; *) return 2 ;; esac
     __tmp="$(mktemp -d "${root}/${template}")" || return 1
     printf -v "$__var_name" '%s' "$__tmp"

--- a/scripts/lib/runner-harness.sh
+++ b/scripts/lib/runner-harness.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # Shared shell-runner harness helpers for extension wrappers.
+#
+# Install custom EXIT traps before the first harness temporary registration.
+# The harness captures and composes those traps. A later replacement must be
+# followed by another registration to be composed.
 
 # Runtime helpers live in Homeboy's source tree. There is exactly one place that
 # knows how to find them: runtime-helper-resolver.sh, which honours an explicit
@@ -69,13 +73,75 @@ homeboy_runner_harness_mktemp() {
     mktemp 2>/dev/null
 }
 
+homeboy_runner_harness_temp_root() {
+    local tmpdir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"
+    [ -d "$tmpdir" ] && [ -w "$tmpdir" ] || return 1
+    (cd "$tmpdir" && pwd -P)
+}
+
+homeboy_runner_harness_append_exit_trap() {
+    local declaration="$1"
+    [ -n "$declaration" ] || return 0
+    case $'\n'"${HOMEBOY_RUNNER_HARNESS_EXIT_TRAPS:-}"$'\n' in
+        *$'\n'"$declaration"$'\n'*) return 0 ;;
+    esac
+    HOMEBOY_RUNNER_HARNESS_EXIT_TRAPS="${HOMEBOY_RUNNER_HARNESS_EXIT_TRAPS:-}${HOMEBOY_RUNNER_HARNESS_EXIT_TRAPS:+$'\n'}${declaration}"
+}
+
+homeboy_runner_harness_register_owned_directory() {
+    local path="$1" identity marker
+    identity="$(homeboy_runner_harness_directory_identity "$path")" || return 1
+    marker="$(mktemp "${path}/.homeboy-owned.XXXXXX")" || return 1
+    HOMEBOY_RUNNER_HARNESS_OWNED_DIRS="${HOMEBOY_RUNNER_HARNESS_OWNED_DIRS:-}${HOMEBOY_RUNNER_HARNESS_OWNED_DIRS:+$'\n'}${path}"$'\t'"${identity}"$'\t'"${marker}"
+}
+
+homeboy_runner_harness_directory_identity() {
+    local path="$1"
+    stat -f '%d:%i' "$path" 2>/dev/null || stat -c '%d:%i' "$path" 2>/dev/null
+}
+
+homeboy_runner_harness_is_owned_directory() {
+    local path="$1" root parent base owned identity marker
+    [ -d "$path" ] && [ ! -L "$path" ] || return 1
+    root="$(homeboy_runner_harness_temp_root)" || return 1
+    parent="$(cd "$(dirname "$path")" && pwd -P)" || return 1
+    base="$(basename "$path")"
+    [ "$parent" = "$root" ] || return 1
+    case "$base" in homeboy-runner.*) ;; *) return 1 ;; esac
+    while IFS=$'\t' read -r owned identity marker; do
+        [ "$owned" = "$path" ] || continue
+        [ "$(homeboy_runner_harness_directory_identity "$path")" = "$identity" ] || return 1
+        [ -f "$marker" ] && [ ! -L "$marker" ] || return 1
+        return 0
+    done <<EOF
+${HOMEBOY_RUNNER_HARNESS_OWNED_DIRS:-}
+EOF
+    return 1
+}
+
 homeboy_runner_harness_register_cleanup() {
     local path="$1"
+    local kind="${2:-file}"
     [ -n "$path" ] || return 0
-    HOMEBOY_RUNNER_HARNESS_CLEANUP="${HOMEBOY_RUNNER_HARNESS_CLEANUP:-}${HOMEBOY_RUNNER_HARNESS_CLEANUP:+$'\n'}$path"
-    if [ "${HOMEBOY_RUNNER_HARNESS_TRAP_SET:-0}" != "1" ]; then
-        trap 'homeboy_runner_harness_cleanup' EXIT
-        HOMEBOY_RUNNER_HARNESS_TRAP_SET=1
+    case "$kind" in
+        file) ;;
+        directory)
+            if ! homeboy_runner_harness_is_owned_directory "$path"; then
+                echo "homeboy_runner_harness_register_cleanup: refusing unowned directory: $path" >&2
+                return 2
+            fi
+            ;;
+        *)
+            echo "homeboy_runner_harness_register_cleanup: unsupported cleanup kind: $kind" >&2
+            return 2
+            ;;
+    esac
+    HOMEBOY_RUNNER_HARNESS_CLEANUP="${HOMEBOY_RUNNER_HARNESS_CLEANUP:-}${HOMEBOY_RUNNER_HARNESS_CLEANUP:+$'\n'}${kind}"$'\t'"${path}"
+    local current_trap
+    current_trap="$(trap -p EXIT)"
+    if [ "$current_trap" != "trap -- 'homeboy_runner_harness_exit' EXIT" ]; then
+        homeboy_runner_harness_append_exit_trap "$current_trap"
+        trap 'homeboy_runner_harness_exit' EXIT
     fi
 }
 
@@ -88,13 +154,78 @@ homeboy_runner_harness_temp() {
     homeboy_runner_harness_register_cleanup "$__tmp"
 }
 
-homeboy_runner_harness_cleanup() {
-    local path
-    while IFS= read -r path; do
-        [ -n "$path" ] && rm -f "$path"
+homeboy_runner_harness_temp_dir() {
+    local __var_name="$1"
+    local template="${2:-homeboy-runner.XXXXXX}"
+    local __tmp
+    local root
+    root="$(homeboy_runner_harness_temp_root)" || return 1
+    case "$template" in homeboy-runner.XXXXXX) ;; *) return 2 ;; esac
+    __tmp="$(mktemp -d "${root}/${template}")" || return 1
+    printf -v "$__var_name" '%s' "$__tmp"
+    if ! homeboy_runner_harness_register_owned_directory "$__tmp" || ! homeboy_runner_harness_register_cleanup "$__tmp" directory; then
+        rm -rf -- "$__tmp"
+        return 1
+    fi
+}
+
+homeboy_runner_harness_forget_cleanup() {
+    local forgotten_kind="$1" forgotten_path="$2" kind path retained=""
+    while IFS=$'\t' read -r kind path; do
+        [ "$kind" = "$forgotten_kind" ] && [ "$path" = "$forgotten_path" ] && continue
+        retained="${retained}${retained:+$'\n'}${kind}"$'\t'"${path}"
     done <<EOF
 ${HOMEBOY_RUNNER_HARNESS_CLEANUP:-}
 EOF
+    HOMEBOY_RUNNER_HARNESS_CLEANUP="$retained"
+}
+
+homeboy_runner_harness_cleanup_path() {
+    local kind="$1" path="$2"
+    [ -n "$path" ] || return 0
+    case "$kind" in
+        directory)
+            if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+                homeboy_runner_harness_forget_cleanup "$kind" "$path"
+            elif homeboy_runner_harness_is_owned_directory "$path"; then
+                rm -rf -- "$path"
+                homeboy_runner_harness_forget_cleanup "$kind" "$path"
+            else
+                echo "homeboy_runner_harness_cleanup: refusing changed owned directory: $path" >&2
+                return 1
+            fi
+            ;;
+        file)
+            rm -f -- "$path"
+            homeboy_runner_harness_forget_cleanup "$kind" "$path"
+            ;;
+        *) return 2 ;;
+    esac
+}
+
+homeboy_runner_harness_cleanup() {
+    local kind path
+    while IFS=$'\t' read -r kind path; do
+        [ -n "$path" ] || continue
+        homeboy_runner_harness_cleanup_path "$kind" "$path" || true
+    done <<EOF
+${HOMEBOY_RUNNER_HARNESS_CLEANUP:-}
+EOF
+}
+
+homeboy_runner_harness_exit() {
+    local status=$?
+    local declaration
+    trap - EXIT
+    set +e
+    homeboy_runner_harness_cleanup
+    while IFS= read -r declaration; do
+        [ -n "$declaration" ] || continue
+        (eval "$declaration"; exit "$status")
+    done <<EOF
+${HOMEBOY_RUNNER_HARNESS_EXIT_TRAPS:-}
+EOF
+    exit "$status"
 }
 
 homeboy_runner_harness_note_failure() {

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -183,6 +183,126 @@ if [ ! -f "$HARNESS_TEMP" ]; then
     echo "Expected harness temp helper to create a file" >&2
     exit 1
 fi
+
+HARNESS_EXIT_FILE="$TMP_DIR/harness-exit-file"
+HARNESS_EXIT_DIR_PATH="$TMP_DIR/harness-exit-dir-path"
+HARNESS_EXIT_SUMMARY="$TMP_DIR/harness-exit-summary"
+printf 'temporary\n' > "$HARNESS_EXIT_FILE"
+set +e
+HOMEBOY_CACHE_DIR="$TMP_DIR" HOMEBOY_HARNESS_SUMMARY="$HARNESS_EXIT_SUMMARY" HOMEBOY_HARNESS_DIR_PATH="$HARNESS_EXIT_DIR_PATH" bash -c '
+    source "$1"
+    homeboy_print_failure_summary() { printf "failure summary\n" > "$HOMEBOY_HARNESS_SUMMARY"; }
+    trap homeboy_print_failure_summary EXIT
+    homeboy_runner_harness_register_cleanup "$3"
+    homeboy_runner_harness_temp_dir OWNED_DIRECTORY
+    printf "%s\n" "$OWNED_DIRECTORY" > "$HOMEBOY_HARNESS_DIR_PATH"
+    exit 37
+' _ "$RUNNER_HARNESS_HELPER" ignored "$HARNESS_EXIT_FILE"
+HARNESS_EXIT=$?
+set -e
+HARNESS_EXIT_DIR="$(<"$HARNESS_EXIT_DIR_PATH")"
+if [ "$HARNESS_EXIT" -ne 37 ] || [ -e "$HARNESS_EXIT_FILE" ] || [ -e "$HARNESS_EXIT_DIR" ]; then
+    echo "Expected harness EXIT cleanup to preserve failure status and remove files and directories" >&2
+    exit 1
+fi
+assert_contains "$HARNESS_EXIT_SUMMARY" 'failure summary'
+
+HARNESS_SIDECAR_FILE="$TMP_DIR/harness-sidecar"
+HARNESS_SIDECAR_TEMP="$TMP_DIR/harness-sidecar-temp"
+printf 'temporary\n' > "$HARNESS_SIDECAR_TEMP"
+set +e
+HOMEBOY_HARNESS_SIDECAR="$HARNESS_SIDECAR_FILE" bash -c '
+    source "$1"
+    sidecar_exit_handler() { printf "sidecar\n" >> "$HOMEBOY_HARNESS_SIDECAR"; }
+    trap sidecar_exit_handler EXIT
+    homeboy_runner_harness_register_cleanup "$3"
+    exit 23
+' _ "$RUNNER_HARNESS_HELPER" ignored "$HARNESS_SIDECAR_TEMP"
+HARNESS_SIDECAR_EXIT=$?
+set -e
+if [ "$HARNESS_SIDECAR_EXIT" -ne 23 ] || [ -e "$HARNESS_SIDECAR_TEMP" ] || [ "$(wc -l < "$HARNESS_SIDECAR_FILE" | tr -d ' ')" -ne 1 ]; then
+    echo "Expected harness to compose the existing sidecar EXIT handler exactly once" >&2
+    exit 1
+fi
+
+HARNESS_REPLACED_FILE="$TMP_DIR/harness-replaced-sidecars"
+HARNESS_REPLACED_FIRST="$TMP_DIR/harness-replaced-first"
+HARNESS_REPLACED_SECOND="$TMP_DIR/harness-replaced-second"
+printf 'first\n' > "$HARNESS_REPLACED_FIRST"
+printf 'second\n' > "$HARNESS_REPLACED_SECOND"
+set +e
+HOMEBOY_HARNESS_REPLACED="$HARNESS_REPLACED_FILE" bash -c '
+    source "$1"
+    first_exit_handler() { printf "first\n" >> "$HOMEBOY_HARNESS_REPLACED"; }
+    replacement_exit_handler() { printf "replacement\n" >> "$HOMEBOY_HARNESS_REPLACED"; }
+    trap first_exit_handler EXIT
+    homeboy_runner_harness_register_cleanup "$2"
+    trap replacement_exit_handler EXIT
+    homeboy_runner_harness_register_cleanup "$3"
+    exit 29
+' _ "$RUNNER_HARNESS_HELPER" "$HARNESS_REPLACED_FIRST" "$HARNESS_REPLACED_SECOND"
+HARNESS_REPLACED_EXIT=$?
+set -e
+if [ "$HARNESS_REPLACED_EXIT" -ne 29 ] || [ -e "$HARNESS_REPLACED_FIRST" ] || [ -e "$HARNESS_REPLACED_SECOND" ] || [ "$(wc -l < "$HARNESS_REPLACED_FILE" | tr -d ' ')" -ne 2 ]; then
+    echo "Expected harness to compose an EXIT trap installed after initial cleanup registration" >&2
+    exit 1
+fi
+assert_contains "$HARNESS_REPLACED_FILE" 'first'
+assert_contains "$HARNESS_REPLACED_FILE" 'replacement'
+
+HARNESS_DIR_ROOT="$TMP_DIR/harness-directory-root"
+HARNESS_DIR_SYMLINK="$TMP_DIR/harness-directory-symlink"
+mkdir -p "$HARNESS_DIR_ROOT"
+HOMEBOY_CACHE_DIR="$HARNESS_DIR_ROOT" bash -c '
+    source "$1"
+    homeboy_runner_harness_temp_dir OWNED
+    [ -d "$OWNED" ]
+    ! homeboy_runner_harness_register_cleanup / directory
+    ! homeboy_runner_harness_register_cleanup "$2" directory
+    ln -s "$OWNED" "$3"
+    ! homeboy_runner_harness_register_cleanup "$3" directory
+    mkdir "$2/homeboy-runner.unexpected"
+    ! homeboy_runner_harness_register_cleanup "$2/homeboy-runner.unexpected" directory
+    homeboy_runner_harness_cleanup
+    [ ! -e "$OWNED" ]
+' _ "$RUNNER_HARNESS_HELPER" "$HARNESS_DIR_ROOT" "$HARNESS_DIR_SYMLINK"
+
+HARNESS_REPLACEMENT_ROOT="$TMP_DIR/harness-replacement-root"
+mkdir -p "$HARNESS_REPLACEMENT_ROOT"
+HOMEBOY_CACHE_DIR="$HARNESS_REPLACEMENT_ROOT" bash -c '
+    source "$1"
+    homeboy_runner_harness_temp_dir MOVED
+    mv "$MOVED" "$2/original"
+    mkdir "$MOVED"
+    ! homeboy_runner_harness_cleanup_path directory "$MOVED"
+    [ -d "$MOVED" ] && [ -d "$2/original" ]
+    homeboy_runner_harness_temp_dir LINKED
+    mv "$LINKED" "$2/original-link"
+    ln -s "$2" "$LINKED"
+    ! homeboy_runner_harness_cleanup_path directory "$LINKED"
+    [ -L "$LINKED" ] && [ -d "$2/original-link" ]
+' _ "$RUNNER_HARNESS_HELPER" "$HARNESS_REPLACEMENT_ROOT"
+
+python3 - "$ROOT_DIR" <<'PY'
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+violations = []
+for path in root.rglob("*.sh"):
+    if "tests" in path.parts or ".git" in path.parts:
+        continue
+    if path == root / "scripts/lib/runner-harness.sh":
+        continue
+    lines = path.read_text(encoding="utf-8").splitlines()
+    first_registration = next((index for index, line in enumerate(lines) if re.search(r"homeboy_runner_harness_(temp|temp_dir|register_cleanup)\b", line)), None)
+    if first_registration is None:
+        continue
+    if any(re.search(r"\btrap\b.*\bEXIT\b", line) for line in lines[first_registration + 1:]):
+        violations.append(str(path.relative_to(root)))
+assert not violations, f"EXIT trap installed after harness cleanup registration: {violations}"
+PY
 homeboy_runner_harness_cleanup
 if [ -e "$HARNESS_TEMP" ]; then
     echo "Expected harness cleanup to remove temp file" >&2

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -283,6 +283,40 @@ HOMEBOY_CACHE_DIR="$HARNESS_REPLACEMENT_ROOT" bash -c '
     [ -L "$LINKED" ] && [ -d "$2/original-link" ]
 ' _ "$RUNNER_HARNESS_HELPER" "$HARNESS_REPLACEMENT_ROOT"
 
+GNU_STAT_BIN="$TMP_DIR/gnu-stat-bin"
+GNU_STAT_ROOT="$TMP_DIR/gnu-stat-root"
+mkdir -p "$GNU_STAT_BIN" "$GNU_STAT_ROOT"
+cat > "$GNU_STAT_BIN/stat" <<'EOF'
+#!/usr/bin/env bash
+# GNU stat accepts -f but emits filesystem data, not device/inode identity.
+printf 'filesystem-data\n'
+EOF
+chmod +x "$GNU_STAT_BIN/stat"
+PATH="$GNU_STAT_BIN:$PATH" HOMEBOY_CACHE_DIR="$GNU_STAT_ROOT" bash -c '
+    source "$1"
+    homeboy_runner_harness_temp_dir OWNED
+    homeboy_runner_harness_cleanup_path directory "$OWNED"
+    [ ! -e "$OWNED" ]
+' _ "$RUNNER_HARNESS_HELPER"
+
+HARNESS_SERIALIZATION_ROOT="$TMP_DIR/harness-serialization-root"
+HARNESS_UNRELATED_FILE="$TMP_DIR/harness-unrelated-file"
+mkdir -p "$HARNESS_SERIALIZATION_ROOT"
+printf 'retain\n' > "$HARNESS_UNRELATED_FILE"
+HOMEBOY_CACHE_DIR="$HARNESS_SERIALIZATION_ROOT" bash -c '
+    source "$1"
+    unsafe_path="$2/unsafe"$'"'"'\tfile\nfile'"'"'
+    : > "$unsafe_path"
+    ! homeboy_runner_harness_register_cleanup "$unsafe_path"
+    ! homeboy_runner_harness_temp BAD_TEMPLATE $'"'"'homeboy-runner.\tXXXXXX'"'"'
+    homeboy_runner_harness_temp SPACE_TEMPLATE "homeboy runner.XXXXXX"
+    [ -f "$SPACE_TEMPLATE" ]
+    homeboy_runner_harness_cleanup
+    [ ! -e "$SPACE_TEMPLATE" ]
+    [ -e "$unsafe_path" ]
+' _ "$RUNNER_HARNESS_HELPER" "$HARNESS_SERIALIZATION_ROOT"
+[ -e "$HARNESS_UNRELATED_FILE" ] || { echo "Unexpected cleanup removed unrelated file" >&2; exit 1; }
+
 python3 - "$ROOT_DIR" <<'PY'
 import pathlib
 import re


### PR DESCRIPTION
## Summary
- reconcile each planned nextest identity to exactly one final terminal outcome across batches
- normalize documented retry attempt suffixes without aliasing legitimate `#digits` test names, and fail closed on ambiguous identities
- preserve omitted planned skips and persist normalized failed test names through the existing sidecar schema
- compose runner EXIT handlers while preserving status and cleanup, and restrict recursive cleanup to identity-verified harness-owned temp directories
- add deterministic multi-batch, retry, leaky pass/fail, duplicate, ambiguity, sidecar merge, and cleanup regressions

## Verification
- `bash -n rust/scripts/test-runner.sh`
- `bash -n rust/tests/test-shard-inventory-smoke.sh`
- `bash rust/tests/test-shard-inventory-smoke.sh`
- `bash rust/tests/nextest-shard-real-smoke.sh`
- `git diff --check`
- iterative independent review: no actionable findings

`tests/runtime-helpers-smoke.sh` executes the new harness regressions successfully, then reaches an unrelated pre-existing assertion requiring `wordpress/scripts/bench/bench-runner-wp-codebox.sh` to reference `HOMEBOY_RUNTIME_RESOLVE_CONTEXT`. Real nextest protocol handling is exercised by the existing real smoke; retry and leaky terminal variants are deterministically modeled because that smoke does not induce retries or leaks.

Closes #2584.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode analyzed the shard artifacts and real nextest protocol, implemented the parser and harness repairs, and iteratively reviewed and verified the patch under human direction. Chris Huber remains responsible for every line.