### PR TITLE
feat(rust): resolve changed test identity unions

### DIFF
--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -152,7 +152,7 @@ if [[ "$OUTPUT" != *"1 passed"* ]]; then
 fi
 
 cat > "$WORKDIR/changed-selection.json" <<'EOF'
-{"schema":"homeboy/rust-changed-test-selection/v1","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"lib","target":"rust_changed_scope_smoke","module":"core::daemon::daemon_test"},{"package":"rust-changed-scope-smoke","target_kind":"test","target":"integration_scope","module":null}]}
+{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"lib","target":"rust_changed_scope_smoke","module":"core::daemon::daemon_test"},{"package":"rust-changed-scope-smoke","target_kind":"test","target":"integration_scope","module":null}]}
 EOF
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
@@ -193,7 +193,7 @@ fi
 # Renames and deletions can leave a candidate absent from the current inventory.
 # They must widen safely instead of returning a green zero-test result.
 cat > "$WORKDIR/changed-selection.json" <<'EOF'
-{"schema":"homeboy/rust-changed-test-selection/v1","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"test","target":"renamed_or_deleted","module":null}]}
+{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"test","target":"renamed_or_deleted","module":null}]}
 EOF
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -17,6 +17,14 @@ cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
 name = "rust-changed-scope-smoke"
 version = "0.1.0"
 edition = "2021"
+
+[lib]
+name = "renamed_lib"
+path = "src/lib.rs"
+
+[[test]]
+name = "renamed_integration"
+path = "tests/integration_scope.rs"
 EOF
 
 cat > "$PROJECT_DIR/src/lib.rs" <<'EOF'
@@ -45,7 +53,7 @@ EOF
 cat > "$PROJECT_DIR/tests/integration_scope.rs" <<'EOF'
 #[test]
 fn integration_scope_runs() {
-    assert_eq!(rust_changed_scope_smoke::value(), 1);
+    assert_eq!(renamed_lib::value(), 1);
 }
 EOF
 
@@ -152,7 +160,7 @@ if [[ "$OUTPUT" != *"1 passed"* ]]; then
 fi
 
 cat > "$WORKDIR/changed-selection.json" <<'EOF'
-{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"lib","target":"rust_changed_scope_smoke","module":"core::daemon::daemon_test"},{"package":"rust-changed-scope-smoke","target_kind":"test","target":"integration_scope","module":null}]}
+{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"stale-producer-name","target_kind":"lib","target":"rust_changed_scope_smoke","module":"core::daemon::daemon_test","path":"src/core/daemon.rs"},{"package":"stale-producer-name","target_kind":"test","target":"integration_scope","module":null,"path":"tests/integration_scope.rs"}]}
 EOF
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
@@ -193,7 +201,7 @@ fi
 # Renames and deletions can leave a candidate absent from the current inventory.
 # They must widen safely instead of returning a green zero-test result.
 cat > "$WORKDIR/changed-selection.json" <<'EOF'
-{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"test","target":"renamed_or_deleted","module":null}]}
+{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"test","target":"renamed_or_deleted","module":null,"path":"tests/deleted.rs"}]}
 EOF
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -151,6 +151,67 @@ if [[ "$OUTPUT" != *"1 passed"* ]]; then
     exit 1
 fi
 
+cat > "$WORKDIR/changed-selection.json" <<'EOF'
+{"schema":"homeboy/rust-changed-test-selection/v1","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"lib","target":"rust_changed_scope_smoke","module":"core::daemon::daemon_test"},{"package":"rust-changed-scope-smoke","target_kind":"test","target":"integration_scope","module":null}]}
+EOF
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_TEST_SCOPE_KIND='rust_changed_union' \
+    HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORKDIR/changed-selection.json" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+if [[ "$OUTPUT" != *"inline_scope_runs ... ok"* || "$OUTPUT" != *"integration_scope_runs ... ok"* || "$OUTPUT" == *"second_inline_scope_runs ... ok"* ]]; then
+    printf 'Expected exact mixed changed-scope union membership. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+OUTPUT=$( 
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_RUST_TEST_RUNNER=nextest \
+    HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES=180 \
+    HOMEBOY_TEST_SCOPE_KIND='rust_changed_union' \
+    HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORKDIR/changed-selection.json" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+if [[ "$OUTPUT" != *"Replaying Rust nextest shard: 2 runnable identities"* || "$OUTPUT" != *"inline_scope_runs"* || "$OUTPUT" != *"integration_scope_runs"* ]]; then
+    printf 'Expected ARG_MAX-safe nextest batches for the exact union. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+# Renames and deletions can leave a candidate absent from the current inventory.
+# They must widen safely instead of returning a green zero-test result.
+cat > "$WORKDIR/changed-selection.json" <<'EOF'
+{"schema":"homeboy/rust-changed-test-selection/v1","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"test","target":"renamed_or_deleted","module":null}]}
+EOF
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_TEST_SCOPE_KIND='rust_changed_union' \
+    HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORKDIR/changed-selection.json" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+if [[ "$OUTPUT" != *"second_inline_scope_runs ... ok"* || "$OUTPUT" != *"integration_scope_runs ... ok"* ]]; then
+    printf 'Expected unmatched changed selection to run the full suite. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -179,7 +179,7 @@ if [[ "$OUTPUT" != *"inline_scope_runs ... ok"* || "$OUTPUT" != *"integration_sc
     exit 1
 fi
 
-OUTPUT=$( 
+OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
@@ -201,7 +201,7 @@ fi
 # Renames and deletions can leave a candidate absent from the current inventory.
 # They must widen safely instead of returning a green zero-test result.
 cat > "$WORKDIR/changed-selection.json" <<'EOF'
-{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"test","target":"renamed_or_deleted","module":null,"path":"tests/deleted.rs"}]}
+{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"lib","target":"renamed_or_deleted","module":"core::deleted_test","path":"src/core/deleted_test.rs"}]}
 EOF
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
@@ -217,6 +217,43 @@ OUTPUT=$(
 )
 if [[ "$OUTPUT" != *"second_inline_scope_runs ... ok"* || "$OUTPUT" != *"integration_scope_runs ... ok"* ]]; then
     printf 'Expected unmatched changed selection to run the full suite. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+# New producers pass only the additive selection-file variable. An older
+# consumer ignores it and retains its normal full-suite behavior.
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_TEST_SCOPE_KIND='rust_changed_union' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+if [[ "$OUTPUT" != *"second_inline_scope_runs ... ok"* || "$OUTPUT" != *"integration_scope_runs ... ok"* ]]; then
+    printf 'Expected missing selection file to preserve old-consumer full suite behavior. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+# Old producers do not set the additive selection-file variable. A new
+# consumer must preserve the ordinary full-suite command rather than treating
+# an absent selection as zero selected tests.
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_TEST_SCOPE_KIND='workspace' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+if [[ "$OUTPUT" != *"second_inline_scope_runs ... ok"* || "$OUTPUT" != *"integration_scope_runs ... ok"* ]]; then
+    printf 'Expected absent old-producer selection to preserve the full suite. Output:\n%s\n' "$OUTPUT" >&2
     exit 1
 fi
 

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -671,10 +671,11 @@ else
     echo "Running cargo test..."
 fi
 
-# Shard manifests are Rust-owned because Cargo target identities and their
-# resolution are runner-specific. Normal and changed-scope paths do not enter
-# this branch.
-if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEBOY_TEST_INVENTORY_ONLY:-}" ]; then
+# Shard manifests and changed-source selections are Rust-owned because Cargo
+# target identities and their resolution are runner-specific. Changed selections
+# resolve against the current inventory, then reuse the exact replay and
+# ARG_MAX-safe batching path below.
+if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEBOY_TEST_INVENTORY_ONLY:-}" ]; then
     if [ "$#" -gt 0 ]; then
         echo "Error: test shard inventory and replay do not support passthrough arguments." >&2
         echo "Remove arguments after -- and encode selection in HOMEBOY_TEST_SHARD_MANIFEST." >&2
@@ -685,6 +686,9 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEB
     SHARD_ARGS=(--project "$PROJECT_PATH" --runner "$SELECTED_RUNNER" --output "$SHARD_DATA")
     if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ]; then
         SHARD_ARGS+=(--manifest "$HOMEBOY_TEST_SHARD_MANIFEST")
+    fi
+    if [ -n "${HOMEBOY_RUST_CHANGED_TEST_SELECTION:-}" ]; then
+        SHARD_ARGS+=(--changed-selection-json "$HOMEBOY_RUST_CHANGED_TEST_SELECTION")
     fi
     if ! python3 "$SHARD_TOOL" "${SHARD_ARGS[@]}"; then
         rm -f "$SHARD_DATA"

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -675,7 +675,7 @@ fi
 # target identities and their resolution are runner-specific. Changed selections
 # resolve against the current inventory, then reuse the exact replay and
 # ARG_MAX-safe batching path below.
-if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEBOY_TEST_INVENTORY_ONLY:-}" ]; then
+if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEBOY_TEST_INVENTORY_ONLY:-}" ]; then
     if [ "$#" -gt 0 ]; then
         echo "Error: test shard inventory and replay do not support passthrough arguments." >&2
         echo "Remove arguments after -- and encode selection in HOMEBOY_TEST_SHARD_MANIFEST." >&2
@@ -687,8 +687,13 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION:-
     if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ]; then
         SHARD_ARGS+=(--manifest "$HOMEBOY_TEST_SHARD_MANIFEST")
     fi
-    if [ -n "${HOMEBOY_RUST_CHANGED_TEST_SELECTION:-}" ]; then
-        SHARD_ARGS+=(--changed-selection-json "$HOMEBOY_RUST_CHANGED_TEST_SELECTION")
+    if [ -n "${HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE:-}" ]; then
+        if [ ! -f "$HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE" ] || [ "$(wc -c < "$HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE")" -gt 1048576 ]; then
+            echo "Rust changed-test selection is unavailable or exceeds its 1 MiB bound; running the full test command." >&2
+            unset HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE
+            exec bash "$0" "$@"
+        fi
+        SHARD_ARGS+=(--changed-selection-file "$HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE")
     fi
     if ! python3 "$SHARD_TOOL" "${SHARD_ARGS[@]}"; then
         rm -f "$SHARD_DATA"
@@ -702,7 +707,13 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION:-
         rm -f "$SHARD_DATA"
         exit 0
     fi
-    if [ -z "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ]; then
+    if [ -n "${HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE:-}" ] && jq -e '.fallback_reason? // empty' "$SHARD_DATA" >/dev/null; then
+        echo "$(jq -r '.fallback_reason') Running the full test command." >&2
+        rm -f "$SHARD_DATA"
+        unset HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE
+        exec bash "$0" "$@"
+    fi
+    if [ -z "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ] && [ -z "${HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE:-}" ]; then
         rm -f "$SHARD_DATA"
         exit 0
     fi

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -207,10 +207,10 @@ def validate(manifest_path, current):
     return [known[identity] for identity in selected]
 
 
-def resolve_changed_selection(selection_raw, current):
+def resolve_changed_selection(selection_path, current, project):
     try:
-        selection = json.loads(selection_raw)
-    except json.JSONDecodeError as error:
+        selection = json.loads(Path(selection_path).read_text())
+    except (OSError, json.JSONDecodeError) as error:
         fail(f"invalid changed test selection: {error}")
     if selection.get("schema") != CHANGED_SELECTION_SCHEMA:
         fail("unsupported changed test selection schema")
@@ -219,6 +219,11 @@ def resolve_changed_selection(selection_raw, current):
         fail("changed test selection must contain a non-empty candidates array")
 
     selected = {}
+    metadata_result = run(["cargo", "metadata", "--no-deps", "--format-version=1"], project)
+    if metadata_result.returncode:
+        fail(f"cargo metadata failed while resolving changed test selection: {metadata_result.stderr.strip()}")
+    metadata = json.loads(metadata_result.stdout)
+    workspace_root = Path(metadata["workspace_root"]).resolve()
     for candidate in candidates:
         if not isinstance(candidate, dict):
             fail("changed test selection candidates must be objects")
@@ -226,6 +231,7 @@ def resolve_changed_selection(selection_raw, current):
         target_kind = candidate.get("target_kind")
         target = candidate.get("target")
         module = candidate.get("module")
+        path = candidate.get("path")
         if not all(isinstance(value, str) and value for value in (package, target_kind, target)):
             fail("changed test selection candidate has an invalid package or target identity")
         if module is not None and (not isinstance(module, str) or not module):
@@ -237,10 +243,31 @@ def resolve_changed_selection(selection_raw, current):
             and test["target"] == target
             and (module is None or test["name"] == module or test["name"].startswith(f"{module}::"))
         ]
+        # A renamed explicit integration target can retain the same source path
+        # while its target name changes. Resolve that current target through
+        # Cargo metadata before deciding that the candidate is stale.
+        if not matches and isinstance(path, str) and path:
+            source = (workspace_root / path).resolve()
+            for metadata_package in metadata["packages"]:
+                if metadata_package["name"] != package:
+                    continue
+                for metadata_target in metadata_package["targets"]:
+                    if target_kind in metadata_target["kind"] and (
+                        target_kind == "lib" or Path(metadata_target["src_path"]).resolve() == source
+                    ):
+                        target = metadata_target["name"]
+                        matches = [
+                            test for test in current["tests"]
+                            if test["package"] == package
+                            and test["target_kind"] == target_kind
+                            and test["target"] == target
+                            and (module is None or test["name"] == module or test["name"].startswith(f"{module}::"))
+                        ]
+                        break
         if not matches:
-            fail(f"changed test selection has no inventory match for {package}::{target_kind}::{target}")
+            return {"fallback_reason": f"Changed test selection no longer matches {package}::{target_kind}::{target}."}
         selected.update({test["id"]: test for test in matches})
-    return [selected[key] for key in sorted(selected)]
+    return {"selected": [selected[key] for key in sorted(selected)]}
 
 
 def main():
@@ -249,14 +276,15 @@ def main():
     parser.add_argument("--runner", choices=("cargo", "nextest"), required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--manifest")
-    parser.add_argument("--changed-selection-json")
+    parser.add_argument("--changed-selection-file")
     args = parser.parse_args()
     current = inventory(args.project, args.runner)
     output = current
     if args.manifest:
         output = {"inventory": current, "selected": validate(args.manifest, current)}
-    if args.changed_selection_json:
-        output = {"inventory": current, "selected": resolve_changed_selection(args.changed_selection_json, current)}
+    if args.changed_selection_file:
+        resolved = resolve_changed_selection(args.changed_selection_file, current, args.project)
+        output = {"inventory": current, **resolved}
     Path(args.output).write_text(json.dumps(output, indent=2) + "\n")
 
 

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 SCHEMA = "homeboy/test-inventory/v1"
 MANIFEST_SCHEMA = "homeboy/test-shard-manifest/v1"
-CHANGED_SELECTION_SCHEMA = "homeboy/rust-changed-test-selection/v1"
+CHANGED_SELECTION_SCHEMA = "homeboy/rust-changed-test-selection/v2"
 
 
 def fail(message):

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 SCHEMA = "homeboy/test-inventory/v1"
 MANIFEST_SCHEMA = "homeboy/test-shard-manifest/v1"
+CHANGED_SELECTION_SCHEMA = "homeboy/rust-changed-test-selection/v1"
 
 
 def fail(message):
@@ -206,17 +207,56 @@ def validate(manifest_path, current):
     return [known[identity] for identity in selected]
 
 
+def resolve_changed_selection(selection_raw, current):
+    try:
+        selection = json.loads(selection_raw)
+    except json.JSONDecodeError as error:
+        fail(f"invalid changed test selection: {error}")
+    if selection.get("schema") != CHANGED_SELECTION_SCHEMA:
+        fail("unsupported changed test selection schema")
+    candidates = selection.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        fail("changed test selection must contain a non-empty candidates array")
+
+    selected = {}
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            fail("changed test selection candidates must be objects")
+        package = candidate.get("package")
+        target_kind = candidate.get("target_kind")
+        target = candidate.get("target")
+        module = candidate.get("module")
+        if not all(isinstance(value, str) and value for value in (package, target_kind, target)):
+            fail("changed test selection candidate has an invalid package or target identity")
+        if module is not None and (not isinstance(module, str) or not module):
+            fail("changed test selection candidate has an invalid module")
+        matches = [
+            test for test in current["tests"]
+            if test["package"] == package
+            and test["target_kind"] == target_kind
+            and test["target"] == target
+            and (module is None or test["name"] == module or test["name"].startswith(f"{module}::"))
+        ]
+        if not matches:
+            fail(f"changed test selection has no inventory match for {package}::{target_kind}::{target}")
+        selected.update({test["id"]: test for test in matches})
+    return [selected[key] for key in sorted(selected)]
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--project", required=True)
     parser.add_argument("--runner", choices=("cargo", "nextest"), required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--manifest")
+    parser.add_argument("--changed-selection-json")
     args = parser.parse_args()
     current = inventory(args.project, args.runner)
     output = current
     if args.manifest:
         output = {"inventory": current, "selected": validate(args.manifest, current)}
+    if args.changed_selection_json:
+        output = {"inventory": current, "selected": resolve_changed_selection(args.changed_selection_json, current)}
     Path(args.output).write_text(json.dumps(output, indent=2) + "\n")
 
 

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -236,6 +236,13 @@ def resolve_changed_selection(selection_path, current, project):
             fail("changed test selection candidate has an invalid package or target identity")
         if module is not None and (not isinstance(module, str) or not module):
             fail("changed test selection candidate has an invalid module")
+        if isinstance(path, str) and path:
+            source = (workspace_root / path).resolve()
+            for metadata_package in metadata["packages"]:
+                manifest_parent = Path(metadata_package["manifest_path"]).resolve().parent
+                if source == manifest_parent or manifest_parent in source.parents:
+                    package = metadata_package["name"]
+                    break
         matches = [
             test for test in current["tests"]
             if test["package"] == package
@@ -247,7 +254,6 @@ def resolve_changed_selection(selection_path, current, project):
         # while its target name changes. Resolve that current target through
         # Cargo metadata before deciding that the candidate is stale.
         if not matches and isinstance(path, str) and path:
-            source = (workspace_root / path).resolve()
             for metadata_package in metadata["packages"]:
                 if metadata_package["name"] != package:
                     continue

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -45,6 +45,18 @@ def runner_fingerprint(cwd, runner):
     return digest(f"{runner}\0{result.stdout.strip()}")
 
 
+def cargo_metadata_roots(project, context):
+    component_root = Path(project).resolve()
+    result = run(["cargo", "metadata", "--no-deps", "--format-version=1"], component_root)
+    if result.returncode:
+        fail(f"cargo metadata failed {context}: {result.stderr.strip()}")
+    metadata = json.loads(result.stdout)
+    workspace_root = Path(metadata["workspace_root"]).resolve()
+    if component_root != workspace_root and workspace_root not in component_root.parents:
+        fail(f"component root is outside Cargo workspace {context}")
+    return metadata, workspace_root, component_root
+
+
 def cargo_inventory(workspace_root, packages):
     tests = []
     command = ["cargo", "test", "--workspace", "--no-run", "--message-format=json"]
@@ -110,11 +122,7 @@ def nextest_inventory(workspace_root):
 
 
 def inventory(project, runner):
-    metadata_result = run(["cargo", "metadata", "--no-deps", "--format-version=1"], project)
-    if metadata_result.returncode:
-        fail(f"cargo metadata failed: {metadata_result.stderr.strip()}")
-    metadata = json.loads(metadata_result.stdout)
-    component_root = Path(project).resolve()
+    metadata, workspace_root, _component_root = cargo_metadata_roots(project, "while building inventory")
     packages = {package["id"]: package["name"] for package in metadata["packages"]}
     tests = nextest_inventory(workspace_root) if runner == "nextest" else cargo_inventory(workspace_root, packages)
     # cargo-nextest does not execute doctests, so its inventory contains only
@@ -219,11 +227,9 @@ def resolve_changed_selection(selection_path, current, project):
         fail("changed test selection must contain a non-empty candidates array")
 
     selected = {}
-    metadata_result = run(["cargo", "metadata", "--no-deps", "--format-version=1"], project)
-    if metadata_result.returncode:
-        fail(f"cargo metadata failed while resolving changed test selection: {metadata_result.stderr.strip()}")
-    metadata = json.loads(metadata_result.stdout)
-    workspace_root = Path(metadata["workspace_root"]).resolve()
+    metadata, _workspace_root, component_root = cargo_metadata_roots(
+        project, "while resolving changed test selection"
+    )
     for candidate in candidates:
         if not isinstance(candidate, dict):
             fail("changed test selection candidates must be objects")

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -114,7 +114,7 @@ def inventory(project, runner):
     if metadata_result.returncode:
         fail(f"cargo metadata failed: {metadata_result.stderr.strip()}")
     metadata = json.loads(metadata_result.stdout)
-    workspace_root = Path(metadata["workspace_root"]).resolve()
+    component_root = Path(project).resolve()
     packages = {package["id"]: package["name"] for package in metadata["packages"]}
     tests = nextest_inventory(workspace_root) if runner == "nextest" else cargo_inventory(workspace_root, packages)
     # cargo-nextest does not execute doctests, so its inventory contains only
@@ -237,7 +237,7 @@ def resolve_changed_selection(selection_path, current, project):
         if module is not None and (not isinstance(module, str) or not module):
             fail("changed test selection candidate has an invalid module")
         if isinstance(path, str) and path:
-            source = (workspace_root / path).resolve()
+            source = (component_root / path).resolve()
             for metadata_package in metadata["packages"]:
                 manifest_parent = Path(metadata_package["manifest_path"]).resolve().parent
                 if source == manifest_parent or manifest_parent in source.parents:


### PR DESCRIPTION
## Summary
- resolve declared changed Rust package, target, and module candidates against the current inventory
- replay only exact selected identities using existing validation and ARG_MAX-safe batching

References Extra-Chill/homeboy#11751.

## Verification
- `bash rust/scripts/rust-changed-scope-smoke.sh`
- `python3 -m py_compile rust/scripts/test-shard-inventory.py`
- `bash -n rust/scripts/test-runner.sh`
- `git diff --check`

AI assistance: openai/gpt-5.6-sol via OpenCode implemented and verified the generic Rust runner selection path. Chris Huber remains responsible for every line.