### PR TITLE
fix(rust): scope shard inventory to changed tests

### DIFF
--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -198,11 +198,113 @@ if [[ "$OUTPUT" != *"Replaying Rust nextest shard: 2 runnable identities"* || "$
     exit 1
 fi
 
+SCOPED_INVENTORY="$WORKDIR/scoped-inventory.json"
+HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_TEST_SCOPE_KIND='rust_changed_union' \
+HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORKDIR/changed-selection.json" \
+HOMEBOY_TEST_INVENTORY_ONLY=1 \
+HOMEBOY_TEST_INVENTORY_FILE="$SCOPED_INVENTORY" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+bash "$SCRIPT_DIR/test-runner.sh" >/dev/null
+python3 - "$SCOPED_INVENTORY" "$WORKDIR/scoped-manifest.json" <<'PY'
+import hashlib
+import json
+import sys
+
+inventory = json.load(open(sys.argv[1]))
+assert inventory["schema"] == "homeboy/test-inventory/v1", inventory
+assert {test["name"] for test in inventory["tests"]} == {
+    "core::daemon::daemon_test::inline_scope_runs",
+    "integration_scope_runs",
+}, inventory
+fingerprint_record = {key: value for key, value in inventory.items() if key != "inventory_fingerprint"}
+expected = hashlib.sha256(json.dumps(fingerprint_record, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+assert inventory["inventory_fingerprint"] == expected, inventory
+selected_tests = inventory["tests"][:1]
+shard_record = dict(fingerprint_record, tests=selected_tests)
+shard_fingerprint = hashlib.sha256(json.dumps(shard_record, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+manifest = {key: inventory[key] for key in ("runner", "runner_fingerprint", "workspace_fingerprint")}
+manifest["schema"] = "homeboy/test-shard-manifest/v1"
+manifest["inventory_fingerprint"] = shard_fingerprint
+manifest["tests"] = [test["id"] for test in selected_tests]
+json.dump(manifest, open(sys.argv[2], "w"))
+PY
+
+# A manifest planned from a scoped inventory remains authoritative during
+# replay even though replay enumerates the complete current inventory.
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_RUST_TEST_RUNNER=nextest \
+    HOMEBOY_TEST_SHARD_MANIFEST="$WORKDIR/scoped-manifest.json" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+if [[ "$OUTPUT" != *"inline_scope_runs"* || "$OUTPUT" == *"integration_scope_runs"* || "$OUTPUT" == *"second_inline_scope_runs"* ]]; then
+    printf 'Expected scoped inventory shard manifest to replay its exact subset. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
 # Renames and deletions can leave a candidate absent from the current inventory.
 # They must widen safely instead of returning a green zero-test result.
 cat > "$WORKDIR/changed-selection.json" <<'EOF'
 {"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"rust-changed-scope-smoke","target_kind":"lib","target":"renamed_or_deleted","module":"core::deleted_test","path":"src/core/deleted_test.rs"}]}
 EOF
+
+FULL_FALLBACK_INVENTORY="$WORKDIR/full-fallback-inventory.json"
+HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_TEST_SCOPE_KIND='rust_changed_union' \
+HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORKDIR/changed-selection.json" \
+HOMEBOY_TEST_INVENTORY_ONLY=1 \
+HOMEBOY_TEST_INVENTORY_FILE="$FULL_FALLBACK_INVENTORY" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+bash "$SCRIPT_DIR/test-runner.sh" >/dev/null
+python3 - "$FULL_FALLBACK_INVENTORY" <<'PY'
+import json
+import sys
+
+inventory = json.load(open(sys.argv[1]))
+assert inventory["schema"] == "homeboy/test-inventory/v1", inventory
+assert {test["name"] for test in inventory["tests"]} == {
+    "core::daemon::daemon_test::inline_scope_runs",
+    "core::service::service_test::second_inline_scope_runs",
+    "integration_scope_runs",
+}, inventory
+PY
+
+set +e
+HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORKDIR/scoped-manifest.json" \
+HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORKDIR/changed-selection.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+bash "$SCRIPT_DIR/test-runner.sh" >"$WORKDIR/conflicting-selection.out" 2>&1
+CONFLICTING_SELECTION_EXIT=$?
+set -e
+if [ "$CONFLICTING_SELECTION_EXIT" -eq 0 ] || ! grep -q 'are mutually exclusive' "$WORKDIR/conflicting-selection.out"; then
+    printf 'Expected shard manifest and changed selection to fail as conflicting configuration\n' >&2
+    exit 1
+fi
 OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -758,6 +758,10 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
         echo "Remove arguments after -- and encode selection in HOMEBOY_TEST_SHARD_MANIFEST." >&2
         exit 2
     fi
+    if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ] && [ -n "${HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE:-}" ]; then
+        echo "Error: HOMEBOY_TEST_SHARD_MANIFEST and HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE are mutually exclusive." >&2
+        exit 2
+    fi
     SHARD_TOOL="${EXTENSION_PATH}/scripts/test-shard-inventory.py"
     SHARD_DATA="$(mktemp)"
     SHARD_ARGS=(--project "$PROJECT_PATH" --runner "$SELECTED_RUNNER" --output "$SHARD_DATA")
@@ -771,6 +775,9 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
             exec bash "$0" "$@"
         fi
         SHARD_ARGS+=(--changed-selection-file "$HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE")
+    fi
+    if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = "1" ]; then
+        SHARD_ARGS+=(--inventory-only)
     fi
     if ! python3 "$SHARD_TOOL" "${SHARD_ARGS[@]}"; then
         rm -f "$SHARD_DATA"

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -20,6 +20,19 @@ def digest(value):
     return hashlib.sha256(value.encode()).hexdigest()
 
 
+def set_inventory_fingerprint(record):
+    record = dict(record)
+    record.pop("inventory_fingerprint", None)
+    record["inventory_fingerprint"] = digest(json.dumps(record, sort_keys=True, separators=(",", ":")))
+    return record
+
+
+def project_inventory(current, tests):
+    projected = {key: value for key, value in current.items() if key != "inventory_fingerprint"}
+    projected["tests"] = tests
+    return set_inventory_fingerprint(projected)
+
+
 def run(command, cwd):
     return subprocess.run(command, cwd=cwd, text=True, stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE, check=False)
@@ -161,8 +174,7 @@ def inventory(project, runner):
         "workspace_fingerprint": workspace_fingerprint(workspace_root),
         "tests": tests,
     }
-    record["inventory_fingerprint"] = digest(json.dumps(record, sort_keys=True, separators=(",", ":")))
-    return record
+    return set_inventory_fingerprint(record)
 
 
 def legacy_inventory_fingerprint(current):
@@ -205,10 +217,14 @@ def validate(manifest_path, current):
     missing = [identity for identity in selected if identity not in known]
     if missing:
         fail(f"shard manifest contains unresolvable test identity: {missing[0]}")
-    if manifest.get("inventory_fingerprint") != current.get("inventory_fingerprint"):
+    manifest_fingerprint = manifest.get("inventory_fingerprint")
+    selected_ids = set(selected)
+    selected_current = [test for test in current["tests"] if test["id"] in selected_ids]
+    scoped_fingerprint = project_inventory(current, selected_current)["inventory_fingerprint"]
+    if manifest_fingerprint not in {current.get("inventory_fingerprint"), scoped_fingerprint}:
         legacy_fingerprint, legacy_ids = legacy_inventory_fingerprint(current)
-        if manifest.get("inventory_fingerprint") != legacy_fingerprint:
-            fail("stale shard manifest: inventory_fingerprint does not match the current or compatible legacy inventory")
+        if manifest_fingerprint != legacy_fingerprint:
+            fail("stale shard manifest: inventory_fingerprint does not match the current, scoped, or compatible legacy inventory")
         legacy_missing = [identity for identity in selected if identity not in legacy_ids]
         if legacy_missing:
             fail(f"legacy shard manifest selects tests outside the legacy inventory: {legacy_missing[0]}")
@@ -289,14 +305,22 @@ def main():
     parser.add_argument("--output", required=True)
     parser.add_argument("--manifest")
     parser.add_argument("--changed-selection-file")
+    parser.add_argument("--inventory-only", action="store_true")
     args = parser.parse_args()
+    if args.manifest and args.changed_selection_file:
+        fail("shard manifest and changed test selection are mutually exclusive")
+    if args.inventory_only and args.manifest:
+        fail("inventory-only mode does not accept a shard manifest")
     current = inventory(args.project, args.runner)
     output = current
     if args.manifest:
         output = {"inventory": current, "selected": validate(args.manifest, current)}
     if args.changed_selection_file:
         resolved = resolve_changed_selection(args.changed_selection_file, current, args.project)
-        output = {"inventory": current, **resolved}
+        if args.inventory_only:
+            output = current if "fallback_reason" in resolved else project_inventory(current, resolved["selected"])
+        else:
+            output = {"inventory": current, **resolved}
     Path(args.output).write_text(json.dumps(output, indent=2) + "\n")
 
 


### PR DESCRIPTION
## Summary

- emit inventory-only evidence for the resolved Rust changed-test closure
- recompute scoped inventory fingerprints and validate per-shard projected fingerprints during replay
- fall back to the complete inventory when changed selection is stale
- reject simultaneous changed-selection and shard-manifest selectors

Closes #2587.

This is the consumer-side repair required by Extra-Chill/homeboy#12007. The Action planner must also fingerprint each shard projection before that producer can pass sharded CI.

## Verification

- `bash scripts/rust-changed-scope-smoke.sh`
- `bash tests/test-shard-inventory-smoke.sh`
- `bash tests/nextest-shard-real-smoke.sh`
- `bash tests/env-provider-smoke.sh`
- `bash tests/fingerprint-policy-flow-smoke.sh`
- `bash tests/zero-test-scope-fallback-smoke.sh`
- `bash ../tests/lint-findings-clean-pass-contract-smoke.sh`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode diagnosed the cross-repository inventory/replay contract, implemented the adapter changes, and added end-to-end coverage. Chris Huber reviewed and is responsible for every line.