### PR TITLE
fix(rust): classify Cargo inventory outcomes

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -805,8 +805,11 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
     SHARD_TOTAL="$(jq '.selected | length' "$SHARD_DATA")"
     SHARD_PASSED=0
     SHARD_FAILED=0
-    SHARD_SKIPPED="$(jq '[.selected[] | select(.expected_outcome == "skipped")] | length' "$SHARD_DATA")"
+    SHARD_SKIPPED=0
     if [ "$SELECTED_RUNNER" = "nextest" ]; then
+        # Nextest intentionally omits planned ignored tests from its event
+        # stream. Cargo replays and counts each ignored identity directly.
+        SHARD_SKIPPED="$(jq '[.selected[] | select(.expected_outcome == "skipped")] | length' "$SHARD_DATA")"
         if ! NEXTEST_MAX_BYTES="$(rust_nextest_filter_max_bytes)"; then
             SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
             rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -71,7 +71,7 @@ def cargo_metadata_roots(project, context):
 
 
 def cargo_inventory(workspace_root, packages):
-    tests = []
+    tests = {}
     command = ["cargo", "test", "--workspace", "--no-run", "--message-format=json"]
     result = run(command, workspace_root)
     if result.returncode:
@@ -88,17 +88,31 @@ def cargo_inventory(workspace_root, packages):
         target = message.get("target", {})
         kinds = target.get("kind", [])
         listed = run([message["executable"], "--list"], workspace_root)
-        if listed.returncode:
+        ignored = run([message["executable"], "--list", "--ignored"], workspace_root)
+        if listed.returncode or ignored.returncode:
             fail(f"could not list tests for {target.get('name', 'unknown target')}: {listed.stderr.strip()}")
         package = packages.get(message.get("package_id"))
         if not package:
             fail("cargo emitted a test executable without a resolvable package")
         target_kind = kinds[0] if kinds else "unknown"
+        ignored_names = {
+            line.partition(": ")[0]
+            for line in ignored.stdout.splitlines()
+            if line.partition(": ")[1] and line.partition(": ")[0]
+        }
         for test_line in listed.stdout.splitlines():
             name, separator, _kind = test_line.partition(": ")
             if separator and name:
-                tests.append({"id": f"{package}::{target_kind}::{target['name']}::{name}", "package": package, "target": target["name"], "target_kind": target_kind, "name": name})
-    return tests
+                test_id = f"{package}::{target_kind}::{target['name']}::{name}"
+                tests[test_id] = {
+                    "id": test_id,
+                    "package": package,
+                    "target": target["name"],
+                    "target_kind": target_kind,
+                    "name": name,
+                    "expected_outcome": "skipped" if name in ignored_names else "executed",
+                }
+    return list(tests.values())
 
 
 def nextest_inventory(workspace_root):
@@ -163,6 +177,7 @@ def inventory(project, runner):
                 "target": "doc",
                 "target_kind": "doc",
                 "name": name,
+                "expected_outcome": "executed",
             })
     tests.sort(key=lambda item: item["id"])
     if len({item["id"] for item in tests}) != len(tests):

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -33,22 +33,30 @@ printf '#[cfg(test)]\nmod tests { #[test] fn member_works() {} }\n' > "$PROJECT_
 
 cat > "$BIN_DIR/test-lib" <<'EOF'
 #!/usr/bin/env bash
+if [[ " $* " == *' --ignored '* ]]; then
+  printf '%s\n' 'unit::ignored: test'
+  exit 0
+fi
 printf '%s\n' 'unit::alpha: test' 'unit::beta: test' 'unit::ignored: test'
 EOF
 cat > "$BIN_DIR/test-api" <<'EOF'
 #!/usr/bin/env bash
+[[ " $* " == *' --ignored '* ]] && exit 0
 printf '%s\n' 'api::works: test'
 EOF
 cat > "$BIN_DIR/test-member" <<'EOF'
 #!/usr/bin/env bash
+[[ " $* " == *' --ignored '* ]] && exit 0
 printf '%s\n' 'member::member_works: test'
 EOF
 cat > "$BIN_DIR/test-proc-macro" <<'EOF'
 #!/usr/bin/env bash
+[[ " $* " == *' --ignored '* ]] && exit 0
 printf '%s\n' 'macros::expands: test'
 EOF
 cat > "$BIN_DIR/test-rlib" <<'EOF'
 #!/usr/bin/env bash
+[[ " $* " == *' --ignored '* ]] && exit 0
 printf '%s\n' 'rlib::works: test'
 EOF
 cat > "$BIN_DIR/bench-audit-self" <<'EOF'
@@ -285,7 +293,7 @@ assert first == second, "inventory must be deterministic"
 assert set(first) == {"schema", "runner", "runner_fingerprint", "workspace_fingerprint", "inventory_fingerprint", "tests"}, first
 assert first["schema"] == "homeboy/test-inventory/v1", first
 assert nextest["schema"] == "homeboy/test-inventory/v1", nextest
-assert all(set(test) == {"id", "package", "target", "target_kind", "name"} for test in first["tests"]), first
+assert all(set(test) == {"id", "package", "target", "target_kind", "name", "expected_outcome"} for test in first["tests"]), first
 assert [test["id"] for test in first["tests"]] == [
     "member-smoke::lib::member_smoke::member::member_works",
     "shard-smoke::lib::shard_smoke::unit::alpha",
@@ -294,6 +302,9 @@ assert [test["id"] for test in first["tests"]] == [
     "shard-smoke::proc-macro::macros::macros::expands",
     "shard-smoke::rlib::rlib_fixture::rlib::works",
     "shard-smoke::test::api::api::works",
+], first
+assert [test["expected_outcome"] for test in first["tests"]] == [
+    "executed", "executed", "executed", "skipped", "executed", "executed", "executed",
 ], first
 assert nextest["runner"] == "nextest", nextest
 assert nextest["runner_fingerprint"] != first["runner_fingerprint"], nextest


### PR DESCRIPTION
## Summary
- enumerate Cargo normal and ignored test identities with explicit `executed`/`skipped` outcomes
- keep deterministic inventory ordering and exact Cargo replay counts
- preserve the v1 inventory schema and fingerprints

References Extra-Chill/homeboy#11751.

## Verification
- `python3 -m py_compile rust/scripts/test-shard-inventory.py`
- `bash -n rust/scripts/test-runner.sh`
- `bash rust/tests/test-shard-inventory-smoke.sh`
- actual Cargo inventory producer end-to-end against `rust/tests/fixtures/nextest-shard-real` (7 sorted identities with runnable and ignored outcomes)
- `git diff --check`

AI assistance: openai/gpt-5.6-terra via OpenCode implemented and verified the Cargo inventory outcome contract. Chris Huber remains responsible for every line.