### PR TITLE
fix(wordpress): name the stage that stopped a zero-test WP Codebox PHPUnit run

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -6,7 +6,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
-      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs"
+      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs"
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
@@ -20,6 +20,7 @@
       "node tests/wp-codebox-phpunit-aggregate-smoke.mjs",
       "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
       "node tests/wp-codebox-phpunit-target-activation-smoke.mjs",
+      "node tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs",
       "bash scripts/test/wp-codebox-mount-translation-smoke.sh",
       "bash scripts/build/build-clean-vendor-smoke.sh",
       "bash scripts/build/build-helper-smoke.sh",

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -582,6 +582,7 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
     { name: 'test-results.json', kind: 'test-results', role: 'structured-test-results', semantic_key: 'test_results', content_type: 'application/json', copy: true },
     { name: 'phpunit-output.log', kind: 'phpunit-output', role: 'raw-test-output', semantic_key: 'phpunit_output', content_type: 'text/plain', copy: true },
     { name: 'phpunit-execution-diagnosis.json', kind: 'phpunit-execution-diagnosis', role: 'test-execution-diagnosis', semantic_key: 'phpunit_execution_diagnosis', content_type: 'application/json', copy: true },
+    { name: 'recipe-run-steps.json', kind: 'recipe-run-steps', role: 'recipe-run-step-ledger', semantic_key: 'recipe_run_steps', content_type: 'application/json', copy: true },
     { name: 'test-failures.json', kind: 'test-failures', role: 'structured-test-failures', semantic_key: 'test_failures', content_type: 'application/json' },
   ];
   await withInvocationArtifactLock(invocationArtifacts, async () => {
@@ -868,6 +869,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   const logsDirectory = path.join(artifactDirectory, 'logs');
   const testResultsPath = path.join(filesDirectory, 'test-results.json');
   const phpunitOutputPath = path.join(filesDirectory, 'phpunit-output.log');
+  const recipeRunStepsPath = path.join(filesDirectory, 'recipe-run-steps.json');
   const managedRuntimeServicesPath = path.join(filesDirectory, 'managed-runtime-services.json');
   await mkdir(filesDirectory, { recursive: true });
   await mkdir(logsDirectory, { recursive: true });
@@ -876,7 +878,13 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
 
   const stdout = await readFile(execution.stdoutPath, 'utf8');
   const stderr = await readFile(execution.stderrPath, 'utf8');
-  const output = extractPhpunitOutput(stdout, stderr);
+  // The recipe-run JSON payload carries the step ledger the raw log concatenation
+  // discards. Preserve it as first-class structured evidence so a run that never
+  // reaches the PHPUnit step still names the stage that stopped it.
+  const recipeRun = parseRecipeRunPayload(stdout);
+  const recipeRunSteps = buildRecipeRunStepsLedger(recipeRun);
+  await writeFile(recipeRunStepsPath, `${JSON.stringify(recipeRunSteps, null, 2)}\n`);
+  const output = extractPhpunitOutput(stdout, stderr, recipeRun);
   await writeFile(phpunitOutputPath, output);
   if (managedRuntimeServices.length > 0) {
     await writeFile(managedRuntimeServicesPath, `${JSON.stringify(managedRuntimeServices, null, 2)}\n`);
@@ -915,6 +923,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
       { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
       { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
       { kind: 'test-execution-diagnosis', uri: 'artifact://files/phpunit-execution-diagnosis.json' },
+      { kind: 'recipe-run-steps', uri: 'artifact://files/recipe-run-steps.json' },
     ];
     if (managedRuntimeServices.length > 0) {
       evidenceReferences.push({ kind: 'managed-runtime-services', uri: 'artifact://files/managed-runtime-services.json' });
@@ -923,12 +932,13 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     await writeFile(testResultsPath, `${JSON.stringify(results, null, 2)}\n`);
   }
 
-  const diagnosis = await phpunitExecutionDiagnosis(artifactDirectory, results, execution, stageLog);
+  const diagnosis = await phpunitExecutionDiagnosis(artifactDirectory, results, execution, stageLog, recipeRunSteps);
   await writeFile(path.join(filesDirectory, 'phpunit-execution-diagnosis.json'), `${JSON.stringify(diagnosis, null, 2)}\n`);
 
   process.stdout.write('Structured PHPUnit evidence: artifact://files/test-results.json\n');
   process.stdout.write('Full PHPUnit output: artifact://files/phpunit-output.log\n');
   process.stdout.write('PHPUnit execution diagnosis: artifact://files/phpunit-execution-diagnosis.json\n');
+  process.stdout.write('Recipe run step ledger: artifact://files/recipe-run-steps.json\n');
   if (stageFailure) {
     process.stdout.write(`BOOTSTRAP FAILURE: ${stageFailure.replace(/^STAGE_(FAIL|FATAL|DIE):/, '')}\n`);
   }
@@ -944,8 +954,12 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
 }
 // A selected test set must either execute or say why it did not. The sandbox
 // bootstrap logs stage markers to a diagnostic file; classify them so a zero
-// count names the failing seam instead of reporting an empty pass.
-async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, stageLog) {
+// count names the failing seam instead of reporting an empty pass. The
+// recipe-run step ledger supplies the stage identity for runs that never
+// reached the sandbox bootstrap at all (or that stopped inside a recipe step),
+// and is evaluated before the bootstrap_evidence_unavailable fallback so the
+// most specific stage wins.
+async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, stageLog, recipeRunSteps) {
   const summary = isObject(results?.summary) ? results.summary : {};
   const executed = Number.isInteger(summary.total) ? summary.total : 0;
   const markers = stageLog === null
@@ -986,7 +1000,43 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, 
     if (executed > 0) {
       return { cause: 'tests_executed', detail: `PHPUnit executed ${executed} test(s).`, remediation: 'No execution diagnosis is required.' };
     }
+    const failedRecipeStep = (recipeRunSteps?.executions || []).find((step) => Number.isInteger(step.exit_code) && step.exit_code !== 0);
+    if (recipeRunSteps?.parse_status === 'unparseable') {
+      return {
+        cause: 'recipe_run_payload_unparseable',
+        detail: 'The recipe-run JSON payload could not be parsed, so no execution step ledger is available.',
+        remediation: 'Read logs/recipe-run.stdout.log and logs/recipe-run.stderr.log for the raw recipe-run output; a crashed or truncated recipe-run may not have flushed its JSON summary.',
+      };
+    }
+    if (recipeRunSteps?.parse_status === 'no_executions') {
+      return {
+        cause: 'recipe_run_no_executions',
+        detail: 'The recipe-run payload parsed but declared no execution steps, so no sandbox step ran and PHPUnit never started.',
+        remediation: 'Inspect artifact://files/recipe-run-steps.json and logs/recipe-run.stderr.log for why the recipe dispatched no steps.',
+      };
+    }
+    if (failedRecipeStep) {
+      return {
+        cause: 'recipe_step_failed',
+        detail: `recipe step '${recipeStepName(failedRecipeStep)}' exited with code ${failedRecipeStep.exit_code} before PHPUnit executed.`,
+        remediation: 'Read the failing step trace in artifact://files/phpunit-output.log and its ledger entry in artifact://files/recipe-run-steps.json; fix the command, dependency, or configuration that step depends on.',
+      };
+    }
+    // A missing PHPUnit step is inferred from the ledger, so it must lose to
+    // any stage marker that names the seam directly. The bootstrap legitimately
+    // skips the PHPUnit invocation when discovery or the changed-file scope
+    // matched nothing, and `NO_TEST_FILES` / `SCOPED_TEST_FILES ... matched=0`
+    // is a sharper answer than "no step invoked PHPUnit". With no stage log
+    // there is no sharper answer, so the ledger wins there.
+    const phpunitStepNotExecuted = {
+      cause: 'phpunit_step_not_executed',
+      detail: `The recipe-run ledger recorded ${recipeRunSteps?.executions?.length ?? 0} execution step(s) but none invoked PHPUnit, so test execution never started.`,
+      remediation: 'Inspect artifact://files/recipe-run-steps.json for the step ledger and artifact://files/phpunit-output.log for the setup output that was retained.',
+    };
     if (stageLog === null) {
+      if (recipeRunSteps?.phpunit_executed === false) {
+        return phpunitStepNotExecuted;
+      }
       return {
         cause: 'bootstrap_evidence_unavailable',
         detail: 'The sandbox produced no PHPUnit stage log, so the run did not reach the bootstrap that records stage markers.',
@@ -1014,6 +1064,9 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, 
         remediation: 'Check wp_codebox_phpunit_test_root and the phpunit.xml testsuite directories against the mounted component.',
       };
     }
+    if (recipeRunSteps?.phpunit_executed === false) {
+      return phpunitStepNotExecuted;
+    }
     return {
       cause: 'suite_reported_no_tests',
       detail: 'The sandbox mounted, activated, and discovered the component but the assembled suite contained no test cases.',
@@ -1038,6 +1091,7 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, 
       { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
       { kind: 'recipe-options', uri: 'artifact://wp-codebox-phpunit-recipe-options.json' },
       { kind: 'recipe-provenance', uri: 'artifact://wp-codebox-phpunit-provenance.json' },
+      { kind: 'recipe-run-steps', uri: 'artifact://files/recipe-run-steps.json' },
     ],
     stage_markers: markers.slice(0, 60),
   };
@@ -1085,17 +1139,101 @@ function normalizedTestStatus(results, aggregate, executionStatus, validResults)
   }
   return results.status;
 }
-function extractPhpunitOutput(stdout, stderr) {
+function parseRecipeRunPayload(stdout) {
   const payload = json(stdout.trim(), null);
-  if (payload && Array.isArray(payload.executions)) {
-    const chunks = [];
-    for (const execution of payload.executions) {
-      if (typeof execution?.stdout === 'string') { chunks.push(execution.stdout); }
-      if (typeof execution?.stderr === 'string') { chunks.push(execution.stderr); }
-    }
-    if (chunks.length > 0) {
-      return chunks.join('');
-    }
+  if (payload === null) {
+    return { payload: null, executions: [], phpunitIndexes: [], parse_status: 'unparseable' };
+  }
+  const executions = isObject(payload) && Array.isArray(payload.executions) ? payload.executions : [];
+  const phpunitIndexes = [];
+  executions.forEach((execution, index) => { if (isPhpunitExecution(execution)) { phpunitIndexes.push(index); } });
+  return {
+    payload,
+    executions,
+    phpunitIndexes,
+    parse_status: executions.length > 0 ? 'executions' : 'no_executions',
+  };
+}
+// A PHPUnit invocation is identified by its recipe command name when the
+// payload carries one, and otherwise by the PHPUnit output signatures it
+// produced. Composer install and plugin activation payloads are setup JSON and
+// never match these signatures, so a ledger that records only those steps is
+// correctly reported as not having executed PHPUnit.
+function isPhpunitExecution(execution) {
+  if (!execution || typeof execution !== 'object') {
+    return false;
+  }
+  if (typeof execution.command === 'string' && /phpunit/i.test(execution.command)) {
+    return true;
+  }
+  const output = `${typeof execution.stdout === 'string' ? execution.stdout : ''}\n${typeof execution.stderr === 'string' ? execution.stderr : ''}`;
+  return /PHPUnit\s+\d+\.\d+|\bOK\s*\(\s*\d+\s+tests?|\bTests:\s*\d+,\s*Assertions:/i.test(output);
+}
+function integerExitCode(execution) {
+  const value = execution?.exitCode ?? execution?.exit_code;
+  return Number.isInteger(value) ? value : undefined;
+}
+function buildRecipeRunStepsLedger(recipeRun) {
+  const executions = recipeRun.executions.map((execution, index) => {
+    const stdout = typeof execution?.stdout === 'string' ? execution.stdout : '';
+    const stderr = typeof execution?.stderr === 'string' ? execution.stderr : '';
+    return clean({
+      index,
+      command: typeof execution?.command === 'string' && execution.command !== '' ? execution.command : undefined,
+      status: typeof execution?.status === 'string' && execution.status !== '' ? execution.status : undefined,
+      exit_code: integerExitCode(execution),
+      stdout_bytes: Buffer.byteLength(stdout),
+      stderr_bytes: Buffer.byteLength(stderr),
+      phpunit: recipeRun.phpunitIndexes.includes(index),
+    });
+  });
+  return {
+    schema: 'homeboy/wordpress-recipe-run-steps/v1',
+    parse_status: recipeRun.parse_status,
+    phpunit_executed: recipeRun.phpunitIndexes.length > 0,
+    phpunit_step_indexes: recipeRun.phpunitIndexes,
+    executions,
+  };
+}
+function recipeStepName(step) {
+  return step?.command || `step ${step?.index ?? '?'}`;
+}
+function noPhpunitExecutionBanner(recipeRun) {
+  const steps = recipeRun.executions.map((execution, index) => {
+    const command = recipeStepName({ ...execution, index });
+    const exitCode = integerExitCode(execution);
+    const stdoutBytes = typeof execution?.stdout === 'string' ? Buffer.byteLength(execution.stdout) : 0;
+    const stderrBytes = typeof execution?.stderr === 'string' ? Buffer.byteLength(execution.stderr) : 0;
+    return `  [${index}] ${command} (exit_code=${exitCode === undefined ? 'unset' : exitCode}, stdout=${stdoutBytes}B, stderr=${stderrBytes}B)`;
+  });
+  return [
+    '============================================================',
+    'WP_CODEBOX_RECIPE_RUN: NO_PHPUNIT_EXECUTION',
+    `The recipe-run payload reported ${recipeRun.executions.length} execution step(s), but none invoked PHPUnit.`,
+    'Test execution never started; the setup output below is retained for the record.',
+    'Structured step ledger: artifact://files/recipe-run-steps.json',
+    ...steps,
+    '============================================================',
+    '',
+  ].join('\n');
+}
+function extractPhpunitOutput(stdout, stderr, recipeRun) {
+  const parsed = recipeRun || parseRecipeRunPayload(stdout);
+  if (parsed.payload === null) {
+    return stdout + stderr;
+  }
+  const chunks = [];
+  for (const execution of parsed.executions) {
+    if (typeof execution?.stdout === 'string') { chunks.push(execution.stdout); }
+    if (typeof execution?.stderr === 'string') { chunks.push(execution.stderr); }
+  }
+  // A setup-only run must not read like a successful-but-empty PHPUnit run.
+  // Make the missing PHPUnit step explicit with a machine-greppable banner.
+  if (parsed.executions.length > 0 && parsed.phpunitIndexes.length === 0) {
+    return `${noPhpunitExecutionBanner(parsed)}${chunks.join('')}`;
+  }
+  if (chunks.length > 0) {
+    return chunks.join('');
   }
   return stdout + stderr;
 }

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -125,6 +125,7 @@ try {
       'wp-codebox-phpunit/files/test-results.json',
       'wp-codebox-phpunit/files/phpunit-output.log',
       'wp-codebox-phpunit/files/phpunit-execution-diagnosis.json',
+      'wp-codebox-phpunit/files/recipe-run-steps.json',
       'wp-codebox-phpunit/files/test-failures.json',
     ], testCase.name);
     const durableSummary = JSON.parse(await readFile(path.join(invocationArtifacts, 'wp-codebox-phpunit/files/test-results.json'), 'utf8')).summary;

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -123,6 +123,7 @@ try {
     { kind: 'structured-test-results', uri: 'artifact://files/test-results.json' },
     { kind: 'raw-phpunit-output', uri: 'artifact://files/phpunit-output.log' },
     { kind: 'test-execution-diagnosis', uri: 'artifact://files/phpunit-execution-diagnosis.json' },
+    { kind: 'recipe-run-steps', uri: 'artifact://files/recipe-run-steps.json' },
   ]);
   assert.deepEqual(JSON.parse(await readFile(resultsFile, 'utf8')), { total: 3, passed: 0, failed: 2, skipped: 1 });
   const invocationManifest = JSON.parse(await readFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), 'utf8'));
@@ -130,6 +131,7 @@ try {
     'wp-codebox-phpunit/files/test-results.json',
     'wp-codebox-phpunit/files/phpunit-output.log',
     'wp-codebox-phpunit/files/phpunit-execution-diagnosis.json',
+    'wp-codebox-phpunit/files/recipe-run-steps.json',
     'wp-codebox-phpunit/files/test-failures.json',
   ]);
   const publishedDirectory = path.join(invocationArtifacts, 'wp-codebox-phpunit/files');

--- a/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
@@ -1,0 +1,193 @@
+/**
+ * Regression: Extra-Chill/homeboy#11992. When the recipe-run ledger records only
+ * setup steps (composer install, plugin activation) and the PHPUnit step never
+ * executes, the run must name the stage that stopped before test execution
+ * instead of reporting a silently setup-only "zero tests" run. The recipe-run
+ * step ledger is preserved as structured evidence, the diagnosis derives a
+ * specific ledger cause, and the retained log carries an explicit banner.
+ *
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-recipe-run-ledger-'));
+const component = path.join(root, 'sample-plugin');
+const cli = path.join(root, 'wp-codebox');
+await mkdir(component, { recursive: true });
+await writeFile(path.join(component, 'sample-plugin.php'), '<?php\n/* Plugin Name: Sample Plugin */\n');
+
+// The stub stands in for WP Codebox: composer install and plugin activation run
+// cleanly, the PHPUnit step is absent from the ledger, and recipe-run exits
+// non-zero because the recipe never executed PHPUnit.
+await writeFile(cli, `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+const args = process.argv.slice(2);
+if (args[0] === 'recipe' && args[1] === 'build') {
+  fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
+  process.exit(0);
+}
+const artifactRoot = args[args.indexOf('--artifacts') + 1];
+const runtime = path.join(artifactRoot, 'runtime-fixture');
+fs.mkdirSync(path.join(runtime, 'files'), { recursive: true });
+fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify({
+  schema: 'wp-codebox/test-results/v1',
+  status: 'skipped',
+  summary: { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 },
+  suites: [],
+}));
+const fixture = JSON.parse(process.env.RECIPE_RUN_FIXTURE || '{}');
+if (typeof fixture.stageLog === 'string') {
+  fs.mkdirSync(path.join(runtime, 'files', 'phpunit'), { recursive: true });
+  fs.writeFileSync(path.join(runtime, 'files', 'phpunit', '.pg-test-result.txt'), fixture.stageLog);
+}
+process.stdout.write(JSON.stringify({ success: false, executions: fixture.executions || [] }) + '\\n');
+process.exitCode = fixture.exitCode === undefined ? 1 : fixture.exitCode;
+`);
+await chmod(cli, 0o755);
+
+async function runScenario(name, fixture) {
+  const artifacts = path.join(root, `${name}-artifacts`);
+  const invocationArtifacts = path.join(root, `${name}-invocation`);
+  await mkdir(invocationArtifacts, { recursive: true });
+  await writeFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
+  const run = spawnSync(runner, [], {
+    env: {
+      ...process.env,
+      RECIPE_RUN_FIXTURE: JSON.stringify(fixture),
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'sample-plugin',
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
+      HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts,
+      HOMEBOY_SETTINGS_JSON: '{}',
+    },
+    encoding: 'utf8',
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  const publishedFiles = path.join(invocationArtifacts, 'wp-codebox-phpunit', 'files');
+  return { run, publishedFiles, invocationArtifacts };
+}
+
+try {
+  const setupOnlyFixture = {
+    executions: [
+      {
+        command: 'composer.install',
+        status: 'completed',
+        exitCode: 0,
+        stdout: 'Installing phpunit/phpunit (9.6.34): Extracting archive\nGenerating autoload files\n',
+        stderr: '',
+      },
+      {
+        command: 'wordpress.activate',
+        status: 'completed',
+        exitCode: 0,
+        stdout: '{"activated":["data-machine","sample-plugin"]}\n',
+        stderr: '',
+      },
+    ],
+  };
+
+  const setupOnly = await runScenario('setup-only', setupOnlyFixture);
+  assert.equal(setupOnly.run.status, 1, setupOnly.run.stderr);
+  assert.match(setupOnly.run.stdout, /PHPUNIT_ZERO_TESTS cause=phpunit_step_not_executed/);
+
+  const diagnosis = JSON.parse(await readFile(path.join(setupOnly.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.equal(diagnosis.schema, 'homeboy/wordpress-phpunit-execution-diagnosis/v1');
+  assert.equal(diagnosis.executed_tests, 0);
+  assert.equal(diagnosis.cause, 'phpunit_step_not_executed', `unexpected zero-test cause: ${diagnosis.cause}`);
+  assert.notEqual(diagnosis.cause, 'bootstrap_evidence_unavailable');
+  assert.notEqual(diagnosis.cause, 'suite_reported_no_tests');
+  assert.ok(diagnosis.evidence.some((entry) => entry.kind === 'recipe-run-steps' && entry.uri === 'artifact://files/recipe-run-steps.json'));
+
+  // The recipe-run step ledger is preserved as first-class structured evidence.
+  const ledger = JSON.parse(await readFile(path.join(setupOnly.publishedFiles, 'recipe-run-steps.json'), 'utf8'));
+  assert.equal(ledger.schema, 'homeboy/wordpress-recipe-run-steps/v1');
+  assert.equal(ledger.parse_status, 'executions');
+  assert.equal(ledger.phpunit_executed, false);
+  assert.deepEqual(ledger.phpunit_step_indexes, []);
+  assert.deepEqual(ledger.executions.map(({ command, exit_code, stdout_bytes, phpunit }) => [command, exit_code, stdout_bytes, phpunit]), [
+    ['composer.install', 0, 82, false],
+    ['wordpress.activate', 0, 47, false],
+  ]);
+
+  const manifest = JSON.parse(await readFile(path.join(setupOnly.invocationArtifacts, 'homeboy-artifact-manifest.json'), 'utf8'));
+  const registered = manifest.artifacts.map((artifact) => artifact.path);
+  assert.ok(registered.includes('wp-codebox-phpunit/files/recipe-run-steps.json'), `ledger not registered: ${registered.join(', ')}`);
+  assert.ok(registered.includes('wp-codebox-phpunit/files/phpunit-output.log'), `output not registered: ${registered.join(', ')}`);
+
+  // The retained log makes the missing PHPUnit step explicit and greppable.
+  const output = await readFile(path.join(setupOnly.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.match(output, /WP_CODEBOX_RECIPE_RUN: NO_PHPUNIT_EXECUTION/);
+  assert.match(output, /composer\.install/);
+  assert.match(output, /Installing phpunit\/phpunit \(9\.6\.34\)/);
+
+  // The run still resolves to a failing status; a friendlier diagnosis does not
+  // turn a red run green.
+  const results = JSON.parse(await readFile(path.join(setupOnly.publishedFiles, 'test-results.json'), 'utf8'));
+  assert.equal(results.status, 'failed');
+  assert.ok(results.evidenceReferences.some((entry) => entry.kind === 'recipe-run-steps' && entry.uri === 'artifact://files/recipe-run-steps.json'));
+
+  // A recipe step that exited non-zero names the step and its exit code ahead
+  // of the generic missing-PHPUnit cause.
+  const activationFailedFixture = {
+    executions: [
+      { command: 'composer.install', status: 'completed', exitCode: 0, stdout: 'Generating autoload files\n', stderr: '' },
+      { command: 'wordpress.activate', status: 'failed', exitCode: 5, stdout: '', stderr: 'Fatal: unable to activate sample-plugin\n' },
+    ],
+  };
+  const activationFailed = await runScenario('activation-failed', activationFailedFixture);
+  assert.equal(activationFailed.run.status, 1, activationFailed.run.stderr);
+  const failedDiagnosis = JSON.parse(await readFile(path.join(activationFailed.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.equal(failedDiagnosis.cause, 'recipe_step_failed', `unexpected cause: ${failedDiagnosis.cause}`);
+  assert.match(failedDiagnosis.detail, /wordpress\.activate/);
+  assert.match(failedDiagnosis.detail, /exited with code 5/);
+  assert.notEqual(failedDiagnosis.cause, 'phpunit_step_not_executed');
+  const failedLedger = JSON.parse(await readFile(path.join(activationFailed.publishedFiles, 'recipe-run-steps.json'), 'utf8'));
+  assert.equal(failedLedger.executions[1].exit_code, 5);
+  assert.match(await readFile(path.join(activationFailed.publishedFiles, 'phpunit-output.log'), 'utf8'), /WP_CODEBOX_RECIPE_RUN: NO_PHPUNIT_EXECUTION/);
+
+  // Ordering: the ledger cause is INFERRED, so a stage marker that names the
+  // seam directly must win. The bootstrap legitimately skips the PHPUnit
+  // invocation when the changed-file scope matched nothing, which leaves the
+  // ledger with no PHPUnit step — reporting the generic "no step invoked
+  // PHPUnit" there would mask the precise reason the run selected no tests.
+  const scopeMismatch = await runScenario('scope-mismatch', {
+    executions: setupOnlyFixture.executions,
+    stageLog: [
+      'PLUGIN_DETECTED sample-plugin/sample-plugin.php',
+      'PLUGIN_ACTIVATE_OK sample-plugin/sample-plugin.php',
+      'DISCOVERY: found=12',
+      'SCOPED_TEST_FILES requested=7 matched=0',
+    ].join('\n'),
+  });
+  const scopeDiagnosis = JSON.parse(await readFile(path.join(scopeMismatch.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.equal(scopeDiagnosis.cause, 'changed_file_filter_mismatch', `stage marker must outrank the inferred ledger cause, got: ${scopeDiagnosis.cause}`);
+  // The ledger is still preserved even when a stage marker supplies the cause.
+  const scopeLedger = JSON.parse(await readFile(path.join(scopeMismatch.publishedFiles, 'recipe-run-steps.json'), 'utf8'));
+  assert.equal(scopeLedger.phpunit_executed, false);
+
+  // Same ordering rule for empty discovery.
+  const discoveryEmpty = await runScenario('discovery-empty', {
+    executions: setupOnlyFixture.executions,
+    stageLog: [
+      'PLUGIN_DETECTED sample-plugin/sample-plugin.php',
+      'PLUGIN_ACTIVATE_OK sample-plugin/sample-plugin.php',
+      'NO_TEST_FILES',
+    ].join('\n'),
+  });
+  const discoveryDiagnosis = JSON.parse(await readFile(path.join(discoveryEmpty.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.equal(discoveryDiagnosis.cause, 'phpunit_discovery_empty', `stage marker must outrank the inferred ledger cause, got: ${discoveryDiagnosis.cause}`);
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox PHPUnit recipe-run ledger smoke passed.');


### PR DESCRIPTION
Fixes the defect tracked in Extra-Chill/homeboy#11992. The issue is filed on `homeboy`; the fix lands here because the WP Codebox PHPUnit adapter owns the evidence.

## Problem

A managed WordPress test run spent ~60-68s, reported successful dependency resolution and plugin activation, then emitted **zero suites and zero tests with no PHPUnit error**. The retained `files/phpunit-output.log` contained *only* the composer-autoloader install JSON and the dependency-activation JSON. Homeboy rendered that as `test runner reported zero executed tests` — a summary that names no stage.

Two seams in `wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs` caused it:

- `extractPhpunitOutput` parsed the `recipe-run --json` payload and concatenated `executions[].stdout/stderr` into the raw log, **discarding the step ledger**. When no step invoked PHPUnit, the concatenation legitimately yielded setup-only output and nothing recorded that the PHPUnit step was absent.
- `phpunitExecutionDiagnosis` classified solely from the in-sandbox stage log (`files/phpunit/.pg-test-result.txt`). A run that never reached the bootstrap fell through to `bootstrap_evidence_unavailable`, whose remediation is "inspect the log" — the very log that is empty of PHPUnit.

## Change

**Preserve the recipe-run step ledger as first-class evidence.** New artifact `files/recipe-run-steps.json`, schema `homeboy/wordpress-recipe-run-steps/v1`, recording per-step `command`, `status`, `exit_code`, `stdout_bytes`/`stderr_bytes`, and which steps invoked PHPUnit. Registered in `publishPhpunitArtifacts`, in `results.evidenceReferences`, and in the diagnosis `evidence` array, so it reaches `HOMEBOY_INVOCATION_ARTIFACT_DIR` and `HOMEBOY_RUN_DIR` like its peers.

**Four new ledger-derived diagnosis causes**, so a zero-suite run names its stage:

| cause | fires when |
|---|---|
| `recipe_run_payload_unparseable` | the recipe-run JSON never parsed |
| `recipe_run_no_executions` | payload parsed but declared no steps |
| `recipe_step_failed` | a step exited non-zero — names the step and its exit code |
| `phpunit_step_not_executed` | steps ran but none invoked PHPUnit |

**An explicit banner in the raw log.** A setup-only run now leads with a machine-greppable `WP_CODEBOX_RECIPE_RUN: NO_PHPUNIT_EXECUTION` block listing each step and its exit code, instead of reading like a successful-but-empty PHPUnit run.

### Ordering matters here

`phpunit_step_not_executed` is *inferred* from the ledger, so it is deliberately ordered to **lose to any stage marker that names the seam directly**. The bootstrap legitimately skips the PHPUnit invocation when discovery or the changed-file scope matched nothing — reporting the generic "no step invoked PHPUnit" there would mask the precise `phpunit_discovery_empty` / `changed_file_filter_mismatch` answer. With no stage log there is no sharper answer, so the ledger wins. This ordering is pinned by two smoke assertions.

## No status softening

`normalizedTestStatus` is untouched: a zero-count run still resolves to `failed` unless `phpunit_no_tests` opts into skip, and the `stageFailure` precedence over an optimistic sidecar is preserved. A friendlier diagnosis cannot turn a red run green — asserted directly in the new smoke.

## Evidence

New `wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs`, registered in `wordpress/homeboy.json` under both `self_checks.test` and the `node --check` lint line. It drives the adapter through four fixtures — setup-only, failed recipe step, scope mismatch, empty discovery — and asserts the cause, the ledger contents, manifest registration, the log banner, and the failing status.

The two ordering assertions were verified non-vacuous: reverting only the ordering fix makes the smoke fail with `stage marker must outrank the inferred ledger cause, got: phpunit_step_not_executed`, and it passes again once restored.

All 23 self-checks in this extension touching phpunit / wp-codebox / artifacts / parse / `jq empty` / `node --check` pass locally. This repo has no PR CI (`homeboy.yml` is `push: main` only), so local verification is the gate.

No version bump: `wordpress.json` versions are owned by `release:` commits via `homeboy release`, not feature commits.

---
AI-assisted.