### PR TITLE
Use daemon-backed runner maintenance

### DIFF
--- a/scripts/bootstrap-standard-extensions.sh
+++ b/scripts/bootstrap-standard-extensions.sh
@@ -15,8 +15,7 @@ usage() {
     cat <<'USAGE'
 Usage: scripts/bootstrap-standard-extensions.sh [options]
 
-Install the standard Homeboy extension set on the local machine or an SSH
-reachable remote runner.
+Install the standard Homeboy extension set locally or on a Homeboy runner.
 
 Options:
   --target <runner-id>        Runner ID such as example-runner. Omit for local bootstrap.
@@ -118,7 +117,7 @@ REMOTE_SCRIPT
 if [ -n "$TARGET" ]; then
     RUNNER_ID="$TARGET"
     CONTROLLER_HOMEBOY_BIN="${HOMEBOY_CONTROLLER_BIN:-homeboy}"
-    RUNNER_ARGS=(runner exec "$RUNNER_ID" --script-file - --raw --env "HOMEBOY_BIN=$HOMEBOY_BIN" --env "REPO=$REPO" --env "EXTENSIONS=$EXTENSIONS" --env "REPLACE_EXISTING=$REPLACE_EXISTING" --ssh)
+    RUNNER_ARGS=(runner exec "$RUNNER_ID" --script-file - --raw --env "HOMEBOY_BIN=$HOMEBOY_BIN" --env "REPO=$REPO" --env "EXTENSIONS=$EXTENSIONS" --env "REPLACE_EXISTING=$REPLACE_EXISTING")
 
     if [ "$DRY_RUN" -eq 1 ]; then
         RUNNER_ARGS+=(--dry-run)

--- a/tests/bootstrap-standard-extensions-smoke.sh
+++ b/tests/bootstrap-standard-extensions-smoke.sh
@@ -11,7 +11,22 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-OUTPUT="$($SCRIPT --target local --extensions "nodejs rust" --repo "https://example.com/extensions.git" --homeboy /opt/homeboy/bin/homeboy --dry-run)"
+FAKE_HOMEBOY="$TMP_DIR/homeboy"
+LOG_FILE="$TMP_DIR/homeboy.log"
+cat > "$FAKE_HOMEBOY" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$HOMEBOY_FAKE_LOG"
+case "$1 $2" in
+    "extension install") exit 0 ;;
+    "extension show") exit 0 ;;
+    "extension list") printf 'nodejs\nrust\n' ; exit 0 ;;
+    *) cat ;;
+esac
+FAKE
+chmod +x "$FAKE_HOMEBOY"
+
+OUTPUT="$(HOMEBOY_CONTROLLER_BIN="$FAKE_HOMEBOY" HOMEBOY_FAKE_LOG="$LOG_FILE" "$SCRIPT" --target local --extensions "nodejs rust" --repo "https://example.com/extensions.git" --homeboy /opt/homeboy/bin/homeboy --dry-run)"
 
 case "$OUTPUT" in
     *'INSTALL_ARGS=(extension install "$REPO" --id "$EXTENSION_ID")'*'"$HOMEBOY_BIN" "${INSTALL_ARGS[@]}"'*) ;;
@@ -50,21 +65,26 @@ case "$HELP_OUTPUT" in
         ;;
 esac
 
-FAKE_HOMEBOY="$TMP_DIR/homeboy"
-LOG_FILE="$TMP_DIR/homeboy.log"
-cat > "$FAKE_HOMEBOY" <<'FAKE'
-#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$*" >> "$HOMEBOY_FAKE_LOG"
-case "$1 $2" in
-    "extension install") exit 0 ;;
-    "extension show") exit 0 ;;
-    "extension list") printf 'nodejs\nrust\n' ; exit 0 ;;
-    *) exit 2 ;;
+: > "$LOG_FILE"
+HOMEBOY_CONTROLLER_BIN="$FAKE_HOMEBOY" HOMEBOY_FAKE_LOG="$LOG_FILE" "$SCRIPT" --target homeboy-lab --extensions "nodejs rust" --repo "https://example.com/extensions.git" --homeboy /opt/homeboy/bin/homeboy --dry-run >/dev/null
+TARGET_CALL="$(<"$LOG_FILE")"
+case "$TARGET_CALL" in
+    *"runner exec homeboy-lab --script-file - --raw --env HOMEBOY_BIN=/opt/homeboy/bin/homeboy --env REPO=https://example.com/extensions.git --env EXTENSIONS=nodejs rust --env REPLACE_EXISTING=0 --dry-run"*) ;;
+    *)
+        echo "Targeted dry-run did not preserve runner and environment arguments" >&2
+        echo "$TARGET_CALL" >&2
+        exit 1
+        ;;
 esac
-FAKE
-chmod +x "$FAKE_HOMEBOY"
+case "$TARGET_CALL" in
+    *"--ssh"*)
+        echo "Targeted dry-run unexpectedly requested diagnostic SSH" >&2
+        echo "$TARGET_CALL" >&2
+        exit 1
+        ;;
+esac
 
+: > "$LOG_FILE"
 HOMEBOY_FAKE_LOG="$LOG_FILE" "$SCRIPT" --extensions "nodejs rust" --repo "https://example.com/extensions.git" --homeboy "$FAKE_HOMEBOY" >/dev/null
 
 EXPECTED_LOG="$TMP_DIR/expected.log"

--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -142,9 +142,16 @@ case "$DRY_RUN_OUTPUT" in
         ;;
 esac
 case "$DRY_RUN_OUTPUT" in
-    *"--env REQUESTED_REF=fixture-ref"*"--env CACHE_DIR="*"--env NPM_BIN=npm --ssh --dry-run example-runner"*) ;;
+    *"--env REQUESTED_REF=fixture-ref"*"--env CACHE_DIR="*"--env NPM_BIN=npm --dry-run example-runner"*) ;;
     *)
-        echo "Dry-run did not preserve runner environment, SSH dispatch, and target" >&2
+        echo "Dry-run did not preserve daemon-backed runner environment and target" >&2
+        echo "$DRY_RUN_OUTPUT" >&2
+        exit 1
+        ;;
+esac
+case "$DRY_RUN_OUTPUT" in
+    *"--ssh"*)
+        echo "Dry-run unexpectedly requested diagnostic SSH" >&2
         echo "$DRY_RUN_OUTPUT" >&2
         exit 1
         ;;

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -156,7 +156,7 @@ if [ -z "$TARGET" ]; then
     exit 0
 fi
 
-RUNNER_ARGS=(runner exec --script-file - --raw --env "SOURCE=$SOURCE" --env "REQUESTED_REF=$REF" --env "CACHE_DIR=$CACHE_DIR" --env "NPM_BIN=$NPM_BIN" --ssh)
+RUNNER_ARGS=(runner exec --script-file - --raw --env "SOURCE=$SOURCE" --env "REQUESTED_REF=$REF" --env "CACHE_DIR=$CACHE_DIR" --env "NPM_BIN=$NPM_BIN")
 
 if [ "$DRY_RUN" -eq 1 ]; then
     RUNNER_ARGS+=(--dry-run)


### PR DESCRIPTION
## Summary

- stop forcing diagnostic SSH for targeted WP Codebox cache refresh
- stop forcing diagnostic SSH for standard extension bootstrap
- preserve daemon-backed runner arguments and local no-target behavior
- add focused smoke coverage for both maintenance helpers

Closes #2594.

## Verification

```text
bash -n wordpress/scripts/build/update-wp-codebox-cache.sh wordpress/scripts/build/update-wp-codebox-cache-smoke.sh scripts/bootstrap-standard-extensions.sh tests/bootstrap-standard-extensions-smoke.sh
bash wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
bash tests/bootstrap-standard-extensions-smoke.sh
git diff --check
```

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the connected-daemon failure, deduplicated historical transport issues, implemented the maintenance repair through a coding subagent, reviewed the diff, and ran verification. Chris Huber reviewed the resulting changes and remains responsible for every line.
