### PR TITLE
Declare the WP Codebox remote recipe provider

### DIFF
--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -18,6 +18,13 @@ override through the provider contract or task conversion options:
   runtime id, model fields, and provider-plugin guidance consumed by the WP
   Codebox runtime contract.
 
+`recipe_run_providers` declares `wordpress.wp-codebox.recipe-run` for Homeboy's
+generic remote recipe-run command. It uses the runtime CLI descriptor's canonical
+`wp-codebox` executable with argv `recipe-run --recipe {recipe} --artifacts
+{artifacts} --json`; Homeboy resolves the executable on the selected runner and
+owns workspace materialization, run persistence, and artifact promotion. This
+provider requires Homeboy support from [#12131](https://github.com/Extra-Chill/homeboy/issues/12131).
+
 The JavaScript executor consumes these manifest fields as product policy. Callers
 can supply generic manifest values through the runtime package contract.
 

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -2,8 +2,24 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "wp-codebox",
   "name": "WP Codebox",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
+  "recipe_run_providers": [
+    {
+      "id": "wordpress.wp-codebox.recipe-run",
+      "version": "1.5.2",
+      "executable": "wp-codebox",
+      "command": [
+        "wp-codebox",
+        "recipe-run",
+        "--recipe",
+        "{recipe}",
+        "--artifacts",
+        "{artifacts}",
+        "--json"
+      ]
+    }
+  ],
   "contract_producers": [
     {
       "id": "wp-codebox.agent-task-result",

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
@@ -8,6 +8,9 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const runtimeManifest = JSON.parse(
+	readFileSync(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'wp-codebox.json'), 'utf8')
+);
 process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const {
 	WP_CODEBOX_BACKEND,
@@ -48,6 +51,23 @@ assert.equal(WP_CODEBOX_WORKSPACE_MOUNT_KIND, 'homeboy-runtime-workspace');
 
 const cliDescriptor = wpCodeboxCliDescriptor();
 assert.equal(cliDescriptor.schema, 'wp-codebox/cli-descriptor/v1');
+const recipeRunProvider = runtimeManifest.recipe_run_providers.find(
+	(provider) => provider.id === 'wordpress.wp-codebox.recipe-run'
+);
+assert.deepEqual(recipeRunProvider, {
+	id: 'wordpress.wp-codebox.recipe-run',
+	version: runtimeManifest.version,
+	executable: cliDescriptor.executable,
+	command: [
+		cliDescriptor.executable,
+		cliDescriptor.commands.recipe_run,
+		'--recipe',
+		'{recipe}',
+		'--artifacts',
+		'{artifacts}',
+		'--json',
+	],
+});
 assert.deepEqual(cliDescriptor.commands, {
 	run_agent_task: 'run-agent-task',
 	recipe_run: 'recipe-run',


### PR DESCRIPTION
## Summary

- declare `wordpress.wp-codebox.recipe-run` through the generic recipe provider manifest contract
- render the canonical argv-only WP Codebox recipe invocation
- tie the provider executable to the authoritative WP Codebox CLI descriptor
- document the required Homeboy substrate

Closes #2595.

Depends on Extra-Chill/homeboy#12141 for the generic remote recipe provider command and manifest discovery.

## Verification

```text
node tests/wp-codebox-adapter-contract-smoke.mjs
node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js
node tests/agent-task-provider-contract-smoke.mjs
node tests/extension-shape-lint-toolchain-probes.test.mjs
git diff --check
```

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode designed the generic Homeboy and product-extension split, implemented this provider declaration through a coding subagent, reviewed the manifest and executable contract, and ran verification. Chris Huber reviewed the resulting changes and remains responsible for every line.
