### PR TITLE
Make WP Codebox runner readiness authoritative

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-provider-readiness.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-provider-readiness.cjs
@@ -5,6 +5,8 @@ const fs = require('node:fs');
 const {
   wpCodeboxRuntimeReadinessDiagnostics,
 } = require('../../lib/wp-codebox-runtime-readiness');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
 
 const REQUEST_SCHEMA = 'homeboy/agent-task-provider-readiness-request/v1';
 const RESULT_SCHEMA = 'homeboy/agent-task-provider-readiness-result/v1';
@@ -16,6 +18,12 @@ function main() {
   }
 
   const config = request.effective_config;
+  const runnerReadiness = path.join(__dirname, 'homeboy-wp-codebox-runner-readiness.cjs');
+  const runner = spawnSync(process.execPath, [runnerReadiness], { encoding: 'utf8', env: process.env });
+  if (runner.status !== 0) {
+    throw new Error(runner.stderr || 'WP Codebox runner readiness command failed.');
+  }
+  const runnerResult = JSON.parse(runner.stdout);
   const diagnostics = wpCodeboxRuntimeReadinessDiagnostics({
     runtime_overlays: config.runtime_overlays || config.wp_codebox_runtime_overlays || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || [],
@@ -24,8 +32,14 @@ function main() {
   });
   process.stdout.write(JSON.stringify({
     schema: RESULT_SCHEMA,
-    ready: diagnostics.length === 0,
-    message: diagnostics[0]?.message || 'WP Codebox provider runtime is ready.',
+    ready: runnerResult.ready && diagnostics.length === 0,
+    classification: runnerResult.classification,
+    retryable: runnerResult.retryable,
+    remediation: runnerResult.remediation,
+    reason: runnerResult.ready ? (diagnostics[0]?.message || runnerResult.reason) : runnerResult.reason,
+    cache_key: runnerResult.cache_key,
+    identity: runnerResult.identity,
+    message: runnerResult.ready ? (diagnostics[0]?.message || 'WP Codebox provider runtime is ready.') : runnerResult.reason,
     diagnostics,
   }));
 }

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const RESULT_SCHEMA = 'homeboy/agent-task-provider-readiness-result/v1';
+const REPAIR_COMMAND = 'homeboy extension setup wordpress';
+const paths = path.resolve(__dirname, '../../../../wordpress/scripts/lib/wp-codebox-paths.sh');
+
+function resolve() {
+  const result = spawnSync('bash', ['-c', [
+    'source "$1"',
+    'override="${HOMEBOY_WP_CODEBOX_BIN:-${WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}}"',
+    'if [ -n "$override" ]; then',
+    '  if homeboy_wp_codebox_bin_is_present "$override"; then printf "explicit_override\\t%s\\n" "$override"; exit 0; fi',
+    '  printf "configured_binary_missing\\t%s\\n" "$override"; exit 2',
+    'fi',
+    'if homeboy_wp_codebox_managed_cache_is_incomplete; then',
+    '  printf "managed_cache_incomplete\\t%s\\n" "$(homeboy_wp_codebox_managed_cli_candidates | head -1)"; exit 2',
+    'fi',
+    'bin="$(homeboy_wp_codebox_resolve_bin "${HOMEBOY_SETTINGS_JSON:-}")" || exit 1',
+    'printf "resolved\\t%s\\n" "$bin"',
+  ].join('\n'), 'wp-codebox-runner-readiness', paths], {
+    encoding: 'utf8',
+    env: process.env,
+  });
+  const [source = '', executable = ''] = result.stdout.trim().split('\t');
+  return { status: result.status, source, executable, stderr: result.stderr.trim() };
+}
+
+function version(executable) {
+  const command = /\.(?:c|m)?js$/.test(executable) ? process.execPath : executable;
+  const args = command === executable ? ['--version'] : [executable, '--version'];
+  const result = spawnSync(command, args, { encoding: 'utf8', env: process.env });
+  return result.status === 0 ? (result.stdout.trim() || result.stderr.trim()) : '';
+}
+
+function main() {
+  const resolved = resolve();
+  if (resolved.status !== 0 || !resolved.executable) {
+    const reason = resolved.source === 'configured_binary_missing'
+      ? `Configured WP Codebox binary is missing: ${resolved.executable}.`
+      : resolved.source === 'managed_cache_incomplete'
+        ? `Managed WP Codebox cache is incomplete; built CLI entrypoint is missing: ${resolved.executable}.`
+        : resolved.stderr || 'WP Codebox executable could not be resolved.';
+    process.stdout.write(JSON.stringify({
+      schema: RESULT_SCHEMA,
+      ready: false,
+      classification: resolved.source || 'wp_codebox_unavailable',
+      retryable: false,
+      remediation: REPAIR_COMMAND,
+      reason,
+      cache_key: '',
+      identity: { executable: resolved.executable, source: resolved.source },
+    }));
+    return;
+  }
+  const selectedVersion = version(resolved.executable);
+  if (!selectedVersion) {
+    process.stdout.write(JSON.stringify({
+      schema: RESULT_SCHEMA,
+      ready: false,
+      classification: 'wp_codebox_version_probe_failed',
+      retryable: false,
+      remediation: REPAIR_COMMAND,
+      reason: `Resolved WP Codebox executable did not answer --version: ${resolved.executable}.`,
+      cache_key: '',
+      identity: { executable: resolved.executable, source: resolved.source },
+    }));
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    schema: RESULT_SCHEMA,
+    ready: true,
+    classification: 'ready',
+    retryable: false,
+    remediation: '',
+    reason: 'WP Codebox runner is ready.',
+    cache_key: '',
+    identity: { executable: resolved.executable, source: resolved.source, version: selectedVersion },
+  }));
+}
+
+main();

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -234,6 +234,11 @@
           "{{runtime_path}}/scripts/agent/homeboy-codebox-provider-readiness.cjs"
         ],
         "env_allowlist": [
+          "HOMEBOY_WP_CODEBOX_BIN",
+          "WP_CODEBOX_BIN",
+          "HOMEBOY_SETTINGS_WP_CODEBOX_BIN",
+          "HOMEBOY_SETTINGS_JSON",
+          "HOMEBOY_WP_CODEBOX_INSTALL_DIR",
           "HOMEBOY_WP_CODEBOX_CORE_MODULE",
           "WP_CODEBOX_CORE_MODULE"
         ],
@@ -398,15 +403,17 @@
       },
       "runner_readiness": [
         {
-          "id": "wp-codebox.executable",
-          "label": "WP Codebox executable",
-          "executable": {
-            "env": ["HOMEBOY_WP_CODEBOX_BIN"],
-            "candidates": ["wp-codebox"],
-            "version_command": ["--version"],
-            "install_hint": "Install WP Codebox or set the generic runtime_bin executor config; HOMEBOY_WP_CODEBOX_BIN remains a legacy compatibility env alias."
+          "id": "wp-codebox.runner",
+          "label": "WP Codebox managed runner",
+          "invocation": {
+            "schema": "homeboy/command-invocation/v1",
+            "argv": [
+              "node",
+              "{{runtime_path}}/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs"
+            ],
+            "display": "node {{runtime_path}}/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs"
           },
-          "remediation": "Install WP Codebox or set the generic runtime_bin executor config; HOMEBOY_WP_CODEBOX_BIN remains a legacy compatibility env alias."
+          "remediation": "homeboy extension setup wordpress"
         }
       ],
       "runner_sources": [
@@ -416,7 +423,7 @@
           "path": "~/.cache/homeboy/wp-codebox/source",
           "remote_url": "https://github.com/Automattic/wp-codebox.git",
           "git_ref": "main",
-          "remediation": "Refresh the managed WP Codebox source cache before dispatching WP Codebox-backed runner workloads."
+          "remediation": "homeboy extension setup wordpress"
         }
       ],
       "workspace_tools": {

--- a/tests/wp-codebox-runner-readiness-smoke.mjs
+++ b/tests/wp-codebox-runner-readiness-smoke.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const readiness = path.join(root, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs');
+const manifest = JSON.parse(fs.readFileSync(path.join(root, 'agent-runtimes/wp-codebox/wp-codebox.json'), 'utf8'));
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-wp-codebox-runner-readiness-'));
+const run = (env) => {
+  const result = spawnSync(process.execPath, [readiness], { encoding: 'utf8', env: { ...process.env, ...env } });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+};
+const executable = (file, version) => {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(version)});\n`);
+  fs.chmodSync(file, 0o755);
+};
+
+try {
+  const declaration = manifest.agent_task_executors[0].runner_readiness[0];
+  assert.deepEqual(declaration.invocation.argv, ['node', '{{runtime_path}}/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs']);
+  assert.equal(declaration.remediation, 'homeboy extension setup wordpress');
+  const stalePath = path.join(temp, 'stale-path');
+  const stale = path.join(stalePath, 'wp-codebox');
+  executable(stale, '0.12.27');
+  const incomplete = path.join(temp, 'incomplete');
+  fs.mkdirSync(path.join(incomplete, 'source/packages/cli'), { recursive: true });
+
+  const dangling = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: incomplete, HOMEBOY_WP_CODEBOX_BIN: path.join(temp, 'missing'), PATH: `${stalePath}:${process.env.PATH}` });
+  assert.equal(dangling.ready, false);
+  assert.equal(dangling.classification, 'configured_binary_missing');
+  assert.equal(dangling.remediation, 'homeboy extension setup wordpress');
+
+  const incompleteResult = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: incomplete, HOMEBOY_WP_CODEBOX_BIN: '', PATH: `${stalePath}:${process.env.PATH}` });
+  assert.equal(incompleteResult.ready, false);
+  assert.equal(incompleteResult.classification, 'managed_cache_incomplete');
+  assert.match(incompleteResult.reason, /built CLI entrypoint is missing/);
+
+  const healthy = path.join(temp, 'healthy');
+  const managedCli = path.join(healthy, 'source/packages/cli/dist/index.js');
+  executable(managedCli, '0.19.0');
+  const managed = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: healthy, HOMEBOY_WP_CODEBOX_BIN: '', PATH: `${stalePath}:${process.env.PATH}` });
+  assert.equal(managed.ready, true);
+  assert.equal(managed.identity.executable, managedCli);
+  assert.equal(managed.identity.source, 'resolved');
+  assert.equal(managed.identity.version, '0.19.0');
+
+  const override = path.join(temp, 'override');
+  executable(override, 'external-1.0');
+  const explicit = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: incomplete, HOMEBOY_WP_CODEBOX_BIN: override, PATH: `${stalePath}:${process.env.PATH}` });
+  assert.equal(explicit.ready, true);
+  assert.equal(explicit.identity.executable, override);
+  assert.equal(explicit.identity.source, 'explicit_override');
+  assert.equal(explicit.identity.version, 'external-1.0');
+} finally {
+  fs.rmSync(temp, { recursive: true, force: true });
+}
+
+console.log('wp-codebox runner readiness smoke passed');

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -283,15 +283,22 @@ assert.equal(Object.hasOwn(runtime.agent_task_executors[0], 'deprecated_compatib
 assert.equal(runtime.agent_task_executors[0].upstream_primitive_requirements.some((requirement) => requirement.id === 'run-agent-task' && requirement.schema === 'wp-codebox/run-agent-task/v1'), true);
 assert.deepEqual(provider.provider_runtime_invocation, providerRuntimeInvocationContract());
 assert.deepEqual(provider.runner_readiness, [{
-  id: 'wp-codebox.executable',
-  label: 'WP Codebox executable',
-  executable: {
-    env: ['HOMEBOY_WP_CODEBOX_BIN'],
-    candidates: ['wp-codebox'],
-    version_command: ['--version'],
-    install_hint: 'Install WP Codebox or set the generic runtime_bin executor config; HOMEBOY_WP_CODEBOX_BIN remains a legacy compatibility env alias.',
+  id: 'wp-codebox.runner',
+  label: 'WP Codebox managed runner',
+  invocation: {
+    schema: 'homeboy/command-invocation/v1',
+    argv: ['node', '{{runtime_path}}/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs'],
+    display: 'node {{runtime_path}}/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs',
   },
-  remediation: 'Install WP Codebox or set the generic runtime_bin executor config; HOMEBOY_WP_CODEBOX_BIN remains a legacy compatibility env alias.',
+  remediation: 'homeboy extension setup wordpress',
+}]);
+assert.deepEqual(provider.runner_sources, [{
+  id: 'wp-codebox.source',
+  label: 'WP Codebox source cache',
+  path: '~/.cache/homeboy/wp-codebox/source',
+  remote_url: 'https://github.com/Automattic/wp-codebox.git',
+  git_ref: 'main',
+  remediation: 'homeboy extension setup wordpress',
 }]);
 assert.deepEqual(secretEnvRequirementForProvider(runtime.agent_task_executors[0], 'codex').env, codexSecretEnv);
 assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);


### PR DESCRIPTION
## Summary

- add extension-owned authoritative WP Codebox runner readiness
- reject dangling managed binaries and incomplete managed caches before stale PATH fallback
- preserve valid explicit external overrides
- surface `homeboy extension setup wordpress` as the direct repair
- compose runner readiness into agent-task provider readiness

Closes #2593.

Depends on Extra-Chill/homeboy#12142 for runner doctor command-readiness execution.

## Verification

```text
node tests/wp-codebox-runner-readiness-smoke.mjs
node wordpress/tests/codebox-agent-task-executor-boundary.test.js
node tests/wp-codebox-runtime-readiness-controller-smoke.mjs
node tests/extension-shape-lint.mjs
git diff --check
```

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode correlated live runner status, doctor, executable, and setup evidence, designed the extension-owned readiness contract, implemented it through a coding subagent, reviewed the cross-repository boundary, and ran verification. Chris Huber reviewed the resulting changes and remains responsible for every line.
