### PR TITLE
Expose WP Codebox recipe provider to Homeboy

### DIFF
--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -18,12 +18,13 @@ override through the provider contract or task conversion options:
   runtime id, model fields, and provider-plugin guidance consumed by the WP
   Codebox runtime contract.
 
-`recipe_run_providers` declares `wordpress.wp-codebox.recipe-run` for Homeboy's
-generic remote recipe-run command. It uses the runtime CLI descriptor's canonical
-`wp-codebox` executable with argv `recipe-run --recipe {recipe} --artifacts
-{artifacts} --json`; Homeboy resolves the executable on the selected runner and
-owns workspace materialization, run persistence, and artifact promotion. This
-provider requires Homeboy support from [#12131](https://github.com/Extra-Chill/homeboy/issues/12131).
+The installed WordPress extension manifest declares
+`wordpress.wp-codebox.recipe-run` for Homeboy's generic remote recipe-run command.
+It uses the runtime CLI descriptor's canonical `wp-codebox` executable with argv
+`recipe-run --recipe {recipe} --artifacts {artifacts} --json`; Homeboy resolves the
+executable on the selected runner and owns workspace materialization, run
+persistence, and artifact promotion. This provider requires Homeboy support from
+[#12131](https://github.com/Extra-Chill/homeboy/issues/12131).
 
 The JavaScript executor consumes these manifest fields as product policy. Callers
 can supply generic manifest values through the runtime package contract.

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -4,22 +4,6 @@
   "name": "WP Codebox",
   "version": "1.5.2",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
-  "recipe_run_providers": [
-    {
-      "id": "wordpress.wp-codebox.recipe-run",
-      "version": "1.5.2",
-      "executable": "wp-codebox",
-      "command": [
-        "wp-codebox",
-        "recipe-run",
-        "--recipe",
-        "{recipe}",
-        "--artifacts",
-        "{artifacts}",
-        "--json"
-      ]
-    }
-  ],
   "contract_producers": [
     {
       "id": "wp-codebox.agent-task-result",

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -8,6 +8,9 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const wordpressManifest = JSON.parse(
+	readFileSync(path.join(rootDir, 'wordpress', 'homeboy.json'), 'utf8')
+);
 const runtimeManifest = JSON.parse(
 	readFileSync(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'wp-codebox.json'), 'utf8')
 );
@@ -51,12 +54,14 @@ assert.equal(WP_CODEBOX_WORKSPACE_MOUNT_KIND, 'homeboy-runtime-workspace');
 
 const cliDescriptor = wpCodeboxCliDescriptor();
 assert.equal(cliDescriptor.schema, 'wp-codebox/cli-descriptor/v1');
-const recipeRunProvider = runtimeManifest.recipe_run_providers.find(
+const recipeRunProviders = wordpressManifest.recipe_run_providers.filter(
 	(provider) => provider.id === 'wordpress.wp-codebox.recipe-run'
 );
+assert.equal(recipeRunProviders.length, 1);
+const [recipeRunProvider] = recipeRunProviders;
 assert.deepEqual(recipeRunProvider, {
 	id: 'wordpress.wp-codebox.recipe-run',
-	version: runtimeManifest.version,
+	version: '1.5.2',
 	executable: cliDescriptor.executable,
 	command: [
 		cliDescriptor.executable,
@@ -68,6 +73,7 @@ assert.deepEqual(recipeRunProvider, {
 		'--json',
 	],
 });
+assert.equal(runtimeManifest.recipe_run_providers, undefined);
 assert.deepEqual(cliDescriptor.commands, {
 	run_agent_task: 'run-agent-task',
 	recipe_run: 'recipe-run',

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -2,6 +2,22 @@
   "id": "wordpress",
   "changelog_target": "docs/CHANGELOG.md",
   "version_targets": [{ "file": "wordpress.json", "pattern": "\"version\":\\s*\"([0-9.]+)\"" }],
+  "recipe_run_providers": [
+    {
+      "id": "wordpress.wp-codebox.recipe-run",
+      "version": "1.5.2",
+      "executable": "wp-codebox",
+      "command": [
+        "wp-codebox",
+        "recipe-run",
+        "--recipe",
+        "{recipe}",
+        "--artifacts",
+        "{artifacts}",
+        "--json"
+      ]
+    }
+  ],
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",


### PR DESCRIPTION
## Summary

- move `wordpress.wp-codebox.recipe-run` to the installed WordPress extension manifest Homeboy discovers
- remove the unreachable duplicate from the shared WP Codebox runtime manifest
- preserve the provider ID, version, executable, and argv-only command contract
- test the actual installed manifest shape and exactly-one declaration

Fixes #2599.

## Verification

- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `node agent-runtimes/wp-codebox/tests/wp-codebox-adapter-boundary.test.js`
- `node tests/agent-task-provider-contract-smoke.mjs`
- `node tests/extension-shape-lint-toolchain-probes.test.mjs`
- `git diff --check`

## Compatibility

Provider behavior is unchanged; only its declaration moves to the owning installed extension layer required by Homeboy discovery. The shared runtime manifest no longer advertises an unreachable duplicate.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the cross-layer discovery mismatch, directed and reviewed a direct general coding subagent, and ran verification. Chris Huber reviewed the resulting diff and remains responsible for every line.