### PR TITLE
fix(wordpress): stop setup dirtying its own tracked source checkout

### DIFF
--- a/tests/wp-codebox-install-overrides-persist-smoke.mjs
+++ b/tests/wp-codebox-install-overrides-persist-smoke.mjs
@@ -39,6 +39,31 @@ const installedSettings = Object.fromEntries(installedManifest.settings.map((set
 assert.equal(installedSettings.wp_codebox_bin, cliPath);
 assert.equal(installedSettings.wp_codebox_core_module, coreModulePath);
 
+// Machine mode must write the same override values to a flat, machine-scoped
+// file without touching the tracked manifest, so setup in a linked extension
+// source checkout cannot dirty wordpress.json with machine-local paths.
+const manifestBefore = fs.readFileSync(manifestPath, 'utf8');
+const machineOverridesPath = path.join(tempDir, 'machine-overrides.json');
+const machineResult = spawnSync(process.execPath, [
+	path.join(rootDir, 'wordpress', 'scripts', 'build', 'persist-wp-codebox-overrides.mjs'),
+	'--machine',
+	machineOverridesPath,
+	manifestPath,
+], {
+	env: {
+		...process.env,
+		WP_CODEBOX_CLI: cliPath,
+		WP_CODEBOX_CORE_MODULE: coreModulePath,
+	},
+	encoding: 'utf8',
+});
+assert.equal(machineResult.status, 0, machineResult.stderr || machineResult.stdout);
+
+const machineOverrides = JSON.parse(fs.readFileSync(machineOverridesPath, 'utf8'));
+assert.equal(machineOverrides.wp_codebox_bin, cliPath);
+assert.equal(machineOverrides.wp_codebox_core_module, coreModulePath);
+assert.equal(fs.readFileSync(manifestPath, 'utf8'), manifestBefore, 'machine mode must not rewrite the manifest');
+
 const { resolveRuntimeProvider } = require('../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 const runtime = resolveRuntimeProvider('wp-codebox', {
 	repoRoot: rootDir,

--- a/wordpress/scripts/build/persist-wp-codebox-overrides.mjs
+++ b/wordpress/scripts/build/persist-wp-codebox-overrides.mjs
@@ -2,7 +2,25 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const manifestPath = path.resolve(process.argv[2] || path.join(process.cwd(), 'wordpress.json'));
+// Usage: persist-wp-codebox-overrides.mjs [--machine <file>] <manifest>
+//
+// Default (manifest) mode rewrites the `default` of the wp_codebox_bin /
+// wp_codebox_core_module settings in a wordpress.json-style manifest.
+//
+// `--machine <file>` instead writes the resolved override values to a flat,
+// machine-scoped JSON file ({ wp_codebox_bin?, wp_codebox_core_module? })
+// WITHOUT touching the tracked manifest. Setup uses this mode so that running
+// it in a linked, git-managed extension source checkout never dirties
+// wordpress.json with machine-local absolute paths.
+
+const argv = process.argv.slice(2);
+const machineIndex = argv.indexOf('--machine');
+let machineFile = '';
+if (machineIndex >= 0) {
+	machineFile = path.resolve(argv[machineIndex + 1]);
+	argv.splice(machineIndex, 2);
+}
+const manifestPath = path.resolve(argv[0] || path.join(process.cwd(), 'wordpress.json'));
 const env = process.env;
 
 const overrides = {
@@ -26,7 +44,6 @@ if (!Array.isArray(manifest.settings)) {
 	fail(`Manifest does not declare settings: ${manifestPath}`);
 }
 
-let changed = false;
 for (const [id, value] of Object.entries(overrides)) {
 	if (!value) {
 		continue;
@@ -35,6 +52,30 @@ for (const [id, value] of Object.entries(overrides)) {
 	if (!setting) {
 		fail(`Manifest is missing setting ${id}: ${manifestPath}`);
 	}
+}
+
+if (machineFile) {
+	const machineOverrides = {};
+	for (const [id, value] of Object.entries(overrides)) {
+		if (value) {
+			machineOverrides[id] = value;
+		}
+	}
+	if (Object.keys(machineOverrides).length > 0) {
+		fs.mkdirSync(path.dirname(machineFile), { recursive: true });
+		const tmpFile = `${machineFile}.tmp`;
+		fs.writeFileSync(tmpFile, `${JSON.stringify(machineOverrides, null, 2)}\n`);
+		fs.renameSync(tmpFile, machineFile);
+	}
+	process.exit(0);
+}
+
+let changed = false;
+for (const [id, value] of Object.entries(overrides)) {
+	if (!value) {
+		continue;
+	}
+	const setting = manifest.settings.find((entry) => entry && entry.id === id);
 	if (setting.default !== value) {
 		setting.default = value;
 		changed = true;

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -115,6 +115,15 @@ install_wp_codebox() {
         esac
     }
 
+    # Machine-scoped override file under the homeboy-managed cache install root.
+    # Setup persists the resolved wp_codebox_bin / wp_codebox_core_module here
+    # instead of rewriting the tracked wordpress.json manifest, so a linked
+    # extension source checkout never gets dirtied by machine-local paths.
+    wp_codebox_override_file() {
+        local install_root="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+        printf '%s\n' "${install_root}/wp-codebox-overrides.json"
+    }
+
     configure_explicit_overrides() {
         local explicit_bin=""
         local explicit_core_module=""
@@ -151,7 +160,10 @@ install_wp_codebox() {
         fi
 
         if [ "${configured_bin}" -eq 1 ] && { [ "${configured_core_module}" -eq 1 ] || resolve_core_module_from_known_locations; } && probe_wp_codebox_runtime "${HOMEBOY_WP_CODEBOX_BIN}" && probe_wp_codebox_native_runtime "$(wp_codebox_dependency_root "${HOMEBOY_WP_CODEBOX_BIN}")"; then
-            node "${EXTENSION_PATH}/scripts/build/persist-wp-codebox-overrides.mjs" "${EXTENSION_PATH}/wordpress.json"
+            # Persist machine-local overrides to the untracked cache override
+            # file rather than the tracked wordpress.json manifest so setup does
+            # not dirty a linked extension source checkout.
+            node "${EXTENSION_PATH}/scripts/build/persist-wp-codebox-overrides.mjs" --machine "$(wp_codebox_override_file)" "${EXTENSION_PATH}/wordpress.json"
             return 0
         fi
 
@@ -286,7 +298,23 @@ EOF
     fi
 
     git -C "${repo_dir}" fetch --quiet origin "${ref}"
-    git -C "${repo_dir}" checkout --quiet FETCH_HEAD
+
+    # ${repo_dir} is a homeboy-managed cache clone that homeboy itself cloned
+    # under ${install_root}, so it can never hold user work. Converge it the
+    # same deterministic way as the sibling scripts/update-wp-codebox-cache.sh:
+    # hard-reset to the fetched ref and drop untracked build residue (stale
+    # dist output, node_modules left by an earlier npm ci) that would poison a
+    # rebuild. This is safe ONLY for this owned cache; do not copy the pattern
+    # to the extension source checkout or any other repo that can hold user
+    # work.
+    git -C "${repo_dir}" reset --hard --quiet FETCH_HEAD || {
+        echo "Failed to reset WP Codebox cache checkout to FETCH_HEAD: ${repo_dir}" >&2
+        exit 1
+    }
+    git -C "${repo_dir}" clean -ffdx --quiet || {
+        echo "Failed to clean untracked build residue from WP Codebox cache checkout: ${repo_dir}" >&2
+        exit 1
+    }
 
     if [ ! -f "${repo_dir}/package-lock.json" ] && [ ! -f "${repo_dir}/npm-shrinkwrap.json" ]; then
         echo "WP Codebox source install requires an npm lockfile (package-lock.json or npm-shrinkwrap.json) for deterministic npm ci: ${source}" >&2
@@ -359,8 +387,20 @@ if [ -f "composer.json" ]; then
     fi
 fi
 
-# Install npm dependencies (Blueprint validation helpers, ESLint).
+# Install npm dependencies (Blueprint validation helpers, ESLint). npm ci is
+# lockfile-preserving by contract, but a version-skewed lockfile can still be
+# normalised in place. Snapshot the tracked lockfile before the install and
+# restore it if the install rewrote it, so setup never dirties a linked
+# extension source checkout. Only a modification this script itself just caused
+# is reverted — a deliberate pre-existing user edit is captured by the snapshot
+# and restored verbatim.
 if [ -f "package.json" ]; then
+    lockfile_snapshot=""
+    if [ -f "package-lock.json" ]; then
+        lockfile_snapshot="$(mktemp)"
+        cp "${EXTENSION_PATH}/package-lock.json" "${lockfile_snapshot}"
+    fi
+
     echo "Installing npm dependencies..."
     if [ -f "package-lock.json" ]; then
         npm ci --quiet --no-fund --no-audit 2>&1 || {
@@ -370,6 +410,14 @@ if [ -f "package.json" ]; then
         npm install --quiet --no-fund --no-audit 2>&1 || {
             echo "Warning: npm install failed — extension Node tooling may not be available"
         }
+    fi
+
+    if [ -n "${lockfile_snapshot}" ]; then
+        if ! cmp -s "${lockfile_snapshot}" "${EXTENSION_PATH}/package-lock.json"; then
+            echo "Restoring package-lock.json rewritten by npm; setup must not dirty the extension source checkout" >&2
+            cp "${lockfile_snapshot}" "${EXTENSION_PATH}/package-lock.json"
+        fi
+        rm -f "${lockfile_snapshot}"
     fi
 fi
 

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -319,9 +319,7 @@ function installedExtensionSettingDefaults(env) {
 			}
 			defaults[setting.id] = setting.default;
 		}
-		return defaults;
-	}
-	if (settings && typeof settings === 'object') {
+	} else if (settings && typeof settings === 'object') {
 		for (const [id, setting] of Object.entries(settings)) {
 			const value = setting && typeof setting === 'object' && Object.hasOwn(setting, 'default') ? setting.default : undefined;
 			if (value !== undefined && value !== '') {
@@ -329,7 +327,32 @@ function installedExtensionSettingDefaults(env) {
 			}
 		}
 	}
+	// Machine-scoped overrides persisted by setup into the untracked cache
+	// install root (not the tracked manifest) carry the same precedence the
+	// manifest default used to provide.
+	for (const [id, value] of Object.entries(readMachineOverrides(env))) {
+		if (value) {
+			defaults[id] = value;
+		}
+	}
 	return defaults;
+}
+
+function readMachineOverrides(env) {
+	const installRoot = env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.join(os.homedir(), '.cache', 'homeboy', 'wp-codebox');
+	const overrideFile = path.join(installRoot, 'wp-codebox-overrides.json');
+	try {
+		const parsed = JSON.parse(fs.readFileSync(overrideFile, 'utf8'));
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			return {
+				wp_codebox_bin: typeof parsed.wp_codebox_bin === 'string' ? parsed.wp_codebox_bin : '',
+				wp_codebox_core_module: typeof parsed.wp_codebox_core_module === 'string' ? parsed.wp_codebox_core_module : '',
+			};
+		}
+	} catch {
+		// Missing or malformed machine override files contribute nothing.
+	}
+	return {};
 }
 
 function readInstalledExtensionManifest(env) {

--- a/wordpress/scripts/lib/wp-codebox-paths.sh
+++ b/wordpress/scripts/lib/wp-codebox-paths.sh
@@ -69,6 +69,10 @@ homeboy_wp_codebox_resolve_bin() {
     if [ -n "$bin" ]; then
         candidates+=("$bin")
     fi
+    bin="$(homeboy_wp_codebox_machine_override wp_codebox_bin || true)"
+    if [ -n "$bin" ]; then
+        candidates+=("$bin")
+    fi
     if [ -n "${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}" ]; then
         candidates+=("$HOMEBOY_SETTINGS_WP_CODEBOX_BIN")
     fi
@@ -146,6 +150,25 @@ homeboy_wp_codebox_global_cli_candidates() {
 
 homeboy_wp_codebox_managed_install_root() {
     printf '%s\n' "${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+}
+
+# Machine-scoped override file written by setup (scripts/build/setup.sh) into
+# the untracked cache install root. Setup persists the wp_codebox_bin /
+# wp_codebox_core_module values it resolved for this machine here instead of
+# rewriting the tracked wordpress.json manifest. The resolver consumes this file
+# at the same precedence the manifest default used to provide.
+homeboy_wp_codebox_machine_override_file() {
+    printf '%s\n' "$(homeboy_wp_codebox_managed_install_root)/wp-codebox-overrides.json"
+}
+
+homeboy_wp_codebox_machine_override() {
+    local field="$1"
+    local override_file
+
+    override_file="$(homeboy_wp_codebox_machine_override_file)"
+    [ -f "${override_file}" ] || return 1
+
+    jq -r --arg field "${field}" '.[$field] // empty' "${override_file}" 2>/dev/null | head -n 1
 }
 
 homeboy_wp_codebox_managed_cli_candidates() {


### PR DESCRIPTION
Root-cause half of Extra-Chill/homeboy#12181. The reporting half is Extra-Chill/homeboy#12181's companion PR in the `homeboy` repo.

## Problem

`sudo homeboy upgrade --method binary` upgraded the controller fine but reported `extensions.status: partial`, `0 updated, 1 skipped`, after setup failed with:

```text
error: Your local changes to the following files would be overwritten by checkout:
    package-lock.json
Please commit your changes or stash them before you switch branches.
Aborting
```

Two defects caused it. Together they form a **self-sustaining trap**: setup dirties the extension source checkout, and the *next* upgrade's clean gate — which tolerates only `.source-url` and `.source-revision` — then refuses the extension outright, so it can never be refreshed again without manual intervention.

### 1. Bare `git checkout` on the WP Codebox cache clone

`install_wp_codebox()` ran `git checkout --quiet FETCH_HEAD` against `${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-$HOME/.cache/homeboy/wp-codebox}/source`. The preceding run's `npm ci` / `npm run build` leaves `package-lock.json` modified there, so the checkout aborts.

That directory is a **homeboy-managed cache that homeboy itself clones** — it can never hold user work. It now converges the same deterministic way as the sibling `scripts/build/update-wp-codebox-cache.sh` already did:

```bash
git -C "${repo_dir}" reset --hard --quiet FETCH_HEAD || { ...; exit 1; }
git -C "${repo_dir}" clean -ffdx --quiet       || { ...; exit 1; }
```

The hard reset is **scoped to that owned cache only** and commented as such, so nobody copies the pattern somewhere unsafe. No user checkout is ever reset, stashed, or cleaned.

### 2. Setup wrote machine-local values into tracked files

Both are tracked in git:

- `wordpress/wordpress.json` — `persist-wp-codebox-overrides.mjs` baked machine-local **absolute paths** into the versioned manifest.
- `wordpress/package-lock.json` — `npm ci` can rewrite it in place on lockfile normalisation.

Fixes:

- `persist-wp-codebox-overrides.mjs` gains a `--machine <file>` mode that writes the resolved overrides to an untracked, machine-scoped JSON file under the cache install root **without touching the manifest**. Setup now uses that mode. Manifest mode is unchanged for any caller that genuinely wants to target a manifest.
- The lockfile is snapshotted immediately before the install and restored **only if the install itself rewrote it**, so a deliberate pre-existing user edit is captured by the snapshot and restored verbatim rather than discarded.

## Resolution path is preserved

This is the part most likely to regress, so both override consumers were traced and updated to read the machine override at **exactly the precedence the manifest default previously provided**:

- `wordpress/scripts/lib/wp-codebox-paths.sh` — `homeboy_wp_codebox_resolve_bin()` consults the new `homeboy_wp_codebox_machine_override` after `HOMEBOY_WP_CODEBOX_BIN` and before `HOMEBOY_SETTINGS_WP_CODEBOX_BIN`. (`jq` was already a dependency of this file.) This file has no core-module resolver, so `bin` is its complete surface.
- `wordpress/scripts/fuzz/fuzz-runner.cjs` — `installedExtensionSettingDefaults()` layers the machine override over the manifest defaults it returns. Because the caller already checks `HOMEBOY_WP_CODEBOX_CORE_MODULE` and `HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE` *before* consulting `manifestDefaults`, an explicit user setting still wins. This is the path the doctor and test runner resolve `wp_codebox_core_module` through.

## Verification

This repo has no pull-request CI, so verification was local:

- `bash -n` across every tracked `wordpress/scripts/**/*.sh` — clean
- `node --check` on `persist-wp-codebox-overrides.mjs` and `fuzz-runner.cjs` — clean
- `node tests/wp-codebox-install-overrides-persist-smoke.mjs` — passes

The smoke test was extended to assert that machine mode writes the same override values **and leaves the manifest byte-identical**.