### PR TITLE
Preflight OpenCode workspace permissions

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -87,6 +87,7 @@ const OPENCODE_CAPABILITIES = [
 	'run_scoped_scratch',
 	'runtime_tool_attachment',
 	'workspace_permission_root/v1',
+	'workspace_permission_preflight/v1',
 ];
 
 const OPENCODE_COMMAND = 'node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs';
@@ -353,7 +354,11 @@ function opencodeExternalDirectoryPatterns(request = {}, config = {}) {
 function opencodeWorkspaceReadPatterns(request = {}, config = {}) {
 	return opencodeWorkspacePermissionRoots(request, config)
 		.filter(isAbsolutePath)
-		.map((workspaceRoot) => path.join(concretePath(workspaceRoot), '**'));
+		.flatMap((workspaceRoot) => {
+			const workspace = concretePath(workspaceRoot);
+			// OpenCode may request the workspace itself before it requests a child.
+			return [workspace, path.join(workspace, '**')];
+		});
 }
 
 function opencodeWorkspacePermissionRoot(request = {}, config = {}) {
@@ -1186,6 +1191,57 @@ function resolveOpenCodeCwd(request = {}, config = {}) {
 		|| process.cwd();
 }
 
+function openCodeWorkspacePermissionPreflight(commandSpec = {}, primaryAgent, cwd, env, allowedTools) {
+	if (!isOpenCodeCommand(commandSpec) || !isAbsolutePath(cwd)) {
+		return null;
+	}
+	const result = spawnSync(commandSpec.command, [
+		...arrayValue(commandSpec.args),
+		'debug', 'agent', primaryAgent, '--pure',
+	], {
+		cwd,
+		env,
+		encoding: 'utf8',
+		maxBuffer: 1024 * 1024,
+	});
+	if (result.status !== 0 || result.error) {
+		return 'OpenCode could not resolve the configured agent permission contract.';
+	}
+	try {
+		const resolvedAgent = JSON.parse(result.stdout);
+		return hasOpenCodeWorkspacePermissionContract(resolvedAgent, cwd, allowedTools) ? null
+			: 'OpenCode resolved an agent without the required workspace coding permissions.';
+	} catch {
+		return 'OpenCode returned an invalid resolved agent permission contract.';
+	}
+}
+
+function isOpenCodeCommand(commandSpec = {}) {
+	return typeof commandSpec.command === 'string' && /^opencode(?:\.exe)?$/i.test(path.basename(commandSpec.command));
+}
+
+function hasOpenCodeWorkspacePermissionContract(agent, cwd, allowedTools = Object.values(OPENCODE_NATIVE_WORKSPACE_PERMISSIONS).flat()) {
+	const permissions = openCodePermissionRules(agent?.permission);
+	const requiredExternalDirectoryPatterns = [concretePath(cwd), path.join(concretePath(cwd), '**')];
+	return requiredExternalDirectoryPatterns.every((pattern) => permissions.some((rule) => (
+		rule?.permission === 'external_directory' && rule.pattern === pattern && rule.action === 'allow'
+	))) && allowedTools.every((tool) => permissions.some((rule) => (
+			rule?.permission === tool && rule.pattern === '*' && rule.action === 'allow'
+		)));
+}
+
+function openCodePermissionRules(permission) {
+	if (Array.isArray(permission)) {
+		return permission;
+	}
+	return Object.entries(objectValue(permission)).flatMap(([name, rules]) => {
+		if (typeof rules === 'string') {
+			return [{ permission: name, pattern: '*', action: rules }];
+		}
+		return Object.entries(objectValue(rules)).map(([pattern, action]) => ({ permission: name, pattern, action }));
+	});
+}
+
 async function executeOpenCodeAgentTask(request = {}, options = {}) {
 	const validationError = validateOpenCodeRequest(request);
 	if (validationError) {
@@ -1207,6 +1263,26 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 	const cwd = resolveOpenCodeCwd(request, config);
 	const args = opencodeRunArgs(request, config, commandSpec);
 	const spawnExtra = { env: { ...opencodeSpawnEnv(request, options), PWD: cwd } };
+	const toolPermissions = agentTaskPolicyToolPermissions(request.policy, {
+		native: OPENCODE_NATIVE_WORKSPACE_PERMISSIONS,
+		workspace: OPENCODE_WORKSPACE_TOOLS,
+	});
+	const workspacePermissionError = openCodeWorkspacePermissionPreflight(
+		commandSpec,
+		config.agent || 'build',
+		cwd,
+		spawnExtra.env,
+		toolPermissions.native
+	);
+	if (workspacePermissionError) {
+		return outcome(request, {
+			status: 'provider_error',
+			failure_classification: 'provider_setup',
+			failure_code: 'agent_task.opencode_workspace_permission_preflight_failed',
+			summary: 'OpenCode workspace permission preflight failed.',
+			diagnostics: [{ class: 'opencode.workspace_permission_preflight', classification: 'provider_setup', message: workspacePermissionError }],
+		});
+	}
 	const timeoutSeconds = timeoutSecondsFromLimits(request.limits, config.timeout_seconds);
 	const runtimeLogPaths = openCodeRuntimeLogPaths(request, config);
 	const progressEventPath = openCodeProgressEventPath(request, config);
@@ -1568,6 +1644,7 @@ module.exports = {
 	OPENCODE_WORKSPACE_TOOLS,
 	OPENCODE_WORKSPACE_MATERIALIZATION,
 	executeOpenCodeAgentTask,
+	openCodeWorkspacePermissionPreflight,
 	outcome,
 	providerContract,
 	validationFailure,

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -118,7 +118,8 @@
         "nested_orchestrator",
         "run_scoped_scratch",
         "runtime_tool_attachment",
-        "workspace_permission_root/v1"
+        "workspace_permission_root/v1",
+        "workspace_permission_preflight/v1"
       ],
       "workspace_materialization": {
         "cwd": "git_checkout",

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -132,6 +132,7 @@ assert.equal(provider.capabilities.includes('run_scoped_scratch'), true);
 assert.equal(provider.capabilities.includes('runtime_tool_attachment'), true);
 assert.equal(provider.capabilities.includes('live_progress_events'), true);
 assert.equal(provider.capabilities.includes('workspace_permission_root/v1'), true);
+assert.equal(provider.capabilities.includes('workspace_permission_preflight/v1'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'opencode.json'), 'utf8'));
@@ -285,6 +286,7 @@ assert.equal(config.agent.title.disable, true);
 	  bash: { '*': 'allow', 'git push *': 'deny' },
 	  external_directory: {
 	    '/unrelated/**': 'deny',
+	    ${JSON.stringify(realModelWorkspace)}: 'allow',
 	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
 	  }
 	});
@@ -301,6 +303,7 @@ assert.equal(config.agent.title.disable, true);
 	  edit: { '*': 'allow' },
 	  bash: { '*': 'allow', 'git push *': 'deny' },
 	  external_directory: {
+	    ${JSON.stringify(realModelWorkspace)}: 'allow',
 	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
 	  }
 	});
@@ -387,7 +390,9 @@ assert.equal(config.agent.title.disable, true);
 		const concreteWorkspace = concretePath(permissionWorkspace.workspace);
 		const concretePermissionRoot = concretePath(permissionWorkspace.workspacePermissionRoot || permissionWorkspace.workspace);
 		const workspacePatterns = [...new Set([
+			concretePermissionRoot,
 			path.join(concretePermissionRoot, '**'),
+			concreteWorkspace,
 			path.join(concreteWorkspace, '**'),
 		])];
 		const concreteAttemptRoot = permissionWorkspace.attemptRoot && concretePath(permissionWorkspace.attemptRoot);
@@ -486,6 +491,13 @@ process.exit(0);
 		assert.equal(nativeToolAction(generatedConfig, 'build', 'edit', 'src/index.js'), 'allow');
 		assert.equal(nativeToolAction(generatedConfig, 'build', 'bash', 'git status --short'), 'allow');
 		assert.equal(nativeToolAction(generatedConfig, 'build', 'bash', 'git push origin trunk'), 'deny');
+		for (const tool of ['read', 'glob', 'grep', 'edit', 'bash']) {
+			assert.equal(nativeToolAction(generatedConfig, 'build', tool, 'src/index.js'), 'allow');
+		}
+		assert.equal(externalDirectoryAction(generatedConfig, 'build', concreteWorkspace), 'allow');
+		assert.equal(externalDirectoryAction(generatedConfig, 'build', path.join(concreteWorkspace, 'src', 'index.js')), 'allow');
+		assert.equal(externalDirectoryAction(generatedConfig, 'build', `${concreteWorkspace}-sibling`), 'deny');
+		assert.equal(externalDirectoryAction(generatedConfig, 'build', path.join(root, 'controller-scratch')), 'deny');
 		assert.equal(
 			readAction(generatedConfig, 'build', concreteWorkspace, path.join(root, 'outside-workspace', 'index.js')),
 			'deny'
@@ -525,6 +537,51 @@ process.exit(0);
 			}
 		}
 	}
+
+	const preflightWorkspace = path.join(root, 'controller-scratch', 'cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874', 'workspace');
+	fs.mkdirSync(preflightWorkspace, { recursive: true });
+	spawnSync('git', ['init'], { cwd: preflightWorkspace, encoding: 'utf8' });
+	spawnSync('git', ['commit', '--allow-empty', '-m', 'initial'], {
+		cwd: preflightWorkspace,
+		encoding: 'utf8',
+		env: { ...process.env, GIT_AUTHOR_NAME: 'Homeboy Test', GIT_AUTHOR_EMAIL: 'homeboy@example.test', GIT_COMMITTER_NAME: 'Homeboy Test', GIT_COMMITTER_EMAIL: 'homeboy@example.test' },
+	});
+	const concretePreflightWorkspace = concretePath(preflightWorkspace);
+	const preflightOpenCode = path.join(root, 'opencode');
+	const preflightRunMarker = path.join(root, 'opencode-preflight-run-marker');
+	fs.writeFileSync(preflightOpenCode, `#!/usr/bin/env node
+const fs = require('node:fs');
+const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
+const permission = Object.entries(config.agent.build.permission).flatMap(([name, rules]) => Object.entries(rules).map(([pattern, action]) => ({ permission: name, pattern, action })));
+if (process.argv[2] === 'debug') {
+  const omitted = process.env.HOMEBOY_TEST_OMIT_WORKSPACE_ROOT;
+  const omittedPermission = process.env.HOMEBOY_TEST_OMIT_PERMISSION;
+  process.stdout.write(JSON.stringify({ permission: permission.filter((rule) => !(omitted && rule.permission === 'external_directory' && rule.pattern === omitted) && rule.permission !== omittedPermission) }));
+  process.exit(0);
+}
+if (process.argv[2] === 'run') fs.appendFileSync(${JSON.stringify(preflightRunMarker)}, 'run\\n');
+process.exit(0);
+`);
+	fs.chmodSync(preflightOpenCode, 0o755);
+	const preflightRequest = (taskId, policy = { write: 'patch' }, runtimeEnv = {}) => ({
+		...request,
+		task_id: taskId,
+		policy,
+		workspace_path: preflightWorkspace,
+		executor: { ...request.executor, config: { ...request.executor.config, runtime_bin: preflightOpenCode, command_args: [], runtime_env: runtimeEnv } },
+	});
+	const preflightFailure = await executeOpenCodeAgentTask(preflightRequest('opencode-workspace-preflight-failure', { write: 'patch' }, { HOMEBOY_TEST_OMIT_WORKSPACE_ROOT: concretePreflightWorkspace }), { env: fixtureEnv });
+	assert.equal(preflightFailure.status, 'provider_error');
+	assert.equal(preflightFailure.failure_code, 'agent_task.opencode_workspace_permission_preflight_failed');
+	assert.equal(preflightFailure.diagnostics[0].class, 'opencode.workspace_permission_preflight');
+	assert.equal(fs.existsSync(preflightRunMarker), false);
+	const preflightReadOnly = await executeOpenCodeAgentTask(preflightRequest('opencode-workspace-preflight-readonly', { write: 'none' }, { HOMEBOY_TEST_OMIT_PERMISSION: 'edit' }), { env: fixtureEnv });
+	assert.equal(preflightReadOnly.status, 'succeeded', JSON.stringify(preflightReadOnly.diagnostics));
+	const preflightReadWriteMissingEdit = await executeOpenCodeAgentTask(preflightRequest('opencode-workspace-preflight-readwrite-missing-edit', { write: 'patch' }, { HOMEBOY_TEST_OMIT_PERMISSION: 'edit' }), { env: fixtureEnv });
+	assert.equal(preflightReadWriteMissingEdit.failure_code, 'agent_task.opencode_workspace_permission_preflight_failed');
+	const preflightReadWrite = await executeOpenCodeAgentTask(preflightRequest('opencode-workspace-preflight-readwrite'), { env: fixtureEnv });
+	assert.equal(preflightReadWrite.status, 'succeeded', JSON.stringify(preflightReadWrite.diagnostics));
+	assert.equal(fs.readFileSync(preflightRunMarker, 'utf8'), 'run\nrun\n');
 
 	const scratchAttempts = [
 		{ id: 'run-2250-attempt-1', status: 0 },


### PR DESCRIPTION
## Summary

- allow the exact assigned workspace root as well as descendants without broadening to sibling scratch paths
- resolve the generated OpenCode agent permission contract before substantive execution
- fail early with typed provider-setup diagnostics when exact workspace or required tool permissions are missing
- preserve read-only versus read-write tool requirements and non-terminal handling of individual denied calls
- add controller-scratch and end-to-end executor coverage

Addresses Extra-Chill/homeboy#7720 at the owning OpenCode adapter layer.

## Verification

- `npm run test:opencode-agent-task-executor-boundary`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `npm run check:runtime-manifest`
- `git diff --check`

## Compatibility

Sibling and parent scratch paths remain denied. Read-only tasks do not require write permissions. Custom wrapper commands that do not identify as OpenCode retain generated-config coverage but skip the native debug preflight.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the current adapter and prior fixes, directed and reviewed a direct general coding subagent, tightened exact-workspace and end-to-end preflight coverage, and ran verification. Chris Huber reviewed the resulting diff and remains responsible for every line.