### PR TITLE
Run sharded Rust tests from a prebuilt nextest archive

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -750,6 +750,38 @@ fi
 
 # Shard manifests and changed-source selections are Rust-owned because Cargo
 # target identities and their resolution are runner-specific. Changed selections
+# A prebuilt `cargo nextest archive` makes list/run execution-only. Without it,
+# every shard recompiles the entire workspace to execute its own slice, so a
+# four-shard run performs five identical full-workspace debug compiles. The
+# archive carries its own workspace, so `--archive-file` replaces
+# `--workspace`/`--manifest-path` rather than joining them.
+rust_nextest_archive_args() {
+    [ -n "${HOMEBOY_RUST_NEXTEST_ARCHIVE:-}" ] || return 1
+    if [ ! -f "${HOMEBOY_RUST_NEXTEST_ARCHIVE}" ]; then
+        echo "Rust test error: HOMEBOY_RUST_NEXTEST_ARCHIVE does not exist: ${HOMEBOY_RUST_NEXTEST_ARCHIVE}" >&2
+        return 2
+    fi
+    printf '%s\n' --archive-file "${HOMEBOY_RUST_NEXTEST_ARCHIVE}"
+}
+
+# Preflight listing and execution take different workspace arguments without an
+# archive, and both are pinned by tests; only the archive case is shared.
+rust_nextest_list_source_args() {
+    local status
+    rust_nextest_archive_args && return 0
+    status=$?
+    [ "$status" -eq 2 ] && return 1
+    printf '%s\n' --workspace
+}
+
+rust_nextest_run_source_args() {
+    local status
+    rust_nextest_archive_args && return 0
+    status=$?
+    [ "$status" -eq 2 ] && return 1
+    printf '%s\n' --manifest-path "${PROJECT_PATH}/Cargo.toml" --workspace
+}
+
 # resolve against the current inventory, then reuse the exact replay and
 # ARG_MAX-safe batching path below.
 if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE:-}${HOMEBOY_TEST_INVENTORY_FILE:-}${HOMEBOY_TEST_INVENTORY_ONLY:-}" ]; then
@@ -854,6 +886,25 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
             rust_nextest_cleanup 1
             exit 1
         fi
+        # Resolve the test source once. Preflight and execution must agree on it:
+        # listing from the workspace while running from an archive (or the
+        # reverse) would validate membership against binaries that are not the
+        # ones executed.
+        NEXTEST_LIST_SOURCE_ARGS=()
+        while IFS= read -r NEXTEST_SOURCE_ARG; do
+            NEXTEST_LIST_SOURCE_ARGS+=("$NEXTEST_SOURCE_ARG")
+        done < <(rust_nextest_list_source_args) || true
+        NEXTEST_RUN_SOURCE_ARGS=()
+        while IFS= read -r NEXTEST_SOURCE_ARG; do
+            NEXTEST_RUN_SOURCE_ARGS+=("$NEXTEST_SOURCE_ARG")
+        done < <(rust_nextest_run_source_args) || true
+        if [ "${#NEXTEST_LIST_SOURCE_ARGS[@]}" -eq 0 ] || [ "${#NEXTEST_RUN_SOURCE_ARGS[@]}" -eq 0 ]; then
+            SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
+            rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
+            rust_nextest_cleanup 1
+            exit 1
+        fi
+
         # Capture filter argv values once. Preflight and execution consume the
         # same shell-owned bytes, never a mutable filter file.
         declare -A NEXTEST_FILTERS NEXTEST_FILTER_DIGESTS
@@ -869,7 +920,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
                 exit 1
             fi
             homeboy_runner_harness_register_cleanup "$NEXTEST_LIST_JSON"
-            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list --workspace --message-format json -E "$NEXTEST_FILTER" || true
+            homeboy_run_step_capture NEXTEST_LIST_OUTPUT NEXTEST_LIST_EXIT "cargo nextest list" -- rust_capture_stdout "$NEXTEST_LIST_JSON" cargo nextest list "${NEXTEST_LIST_SOURCE_ARGS[@]}" --message-format json -E "$NEXTEST_FILTER" || true
             if [ "$NEXTEST_LIST_EXIT" -ne 0 ] || ! rust_validate_nextest_membership "$NEXTEST_LIST_JSON" "$NEXTEST_BATCH"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"
@@ -900,7 +951,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
                 rust_nextest_cleanup 1
                 exit 1
             fi
-            homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run --manifest-path "${PROJECT_PATH}/Cargo.toml" --workspace --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
+            homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run "${NEXTEST_RUN_SOURCE_ARGS[@]}" --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
             if ! NEXTEST_BATCH_FAILED_NAMES="$(mktemp)"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -4,6 +4,7 @@
 import argparse
 import hashlib
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -115,8 +116,30 @@ def cargo_inventory(workspace_root, packages):
     return list(tests.values())
 
 
+def nextest_archive():
+    """Path to a prebuilt `cargo nextest archive`, when the caller supplies one.
+
+    Enumerating and running tests both compile every test binary in the
+    workspace. Sharded CI does that once per shard plus once for the inventory
+    -- five identical full-workspace debug compiles to execute a few dozen
+    tests. An archive is built once and reused, so `list` and `run` become
+    execution-only.
+    """
+    archive = os.environ.get("HOMEBOY_RUST_NEXTEST_ARCHIVE", "").strip()
+    if not archive:
+        return ""
+    if not os.path.isfile(archive):
+        fail(f"HOMEBOY_RUST_NEXTEST_ARCHIVE does not exist: {archive}")
+    return archive
+
+
 def nextest_inventory(workspace_root):
-    result = run(["cargo", "nextest", "list", "--workspace", "--run-ignored", "all", "--message-format", "json"], workspace_root)
+    archive = nextest_archive()
+    # `--archive-file` carries its own workspace, so it replaces `--workspace`
+    # in the same argv position rather than joining it.
+    source = ["--archive-file", archive] if archive else ["--workspace"]
+    command = ["cargo", "nextest", "list", *source, "--run-ignored", "all", "--message-format", "json"]
+    result = run(command, workspace_root)
     if result.returncode:
         fail(f"could not enumerate nextest tests: {result.stderr.strip()}")
     try:

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -479,6 +479,64 @@ assert all(" --workspace " in line for line in lines), lines
 assert all("test(=member::member_works)" in line for line in lines[1:]), lines
 PY
 
+# A prebuilt nextest archive makes shard replay execution-only: listing and
+# running must both read the archive instead of recompiling the workspace, and
+# they must agree on the source so membership is validated against the binaries
+# that actually execute.
+: > "$WORK_DIR/archive.tar.zst"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_RUST_NEXTEST_ARCHIVE="$WORK_DIR/archive.tar.zst" \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_LOG="$WORK_DIR/nextest-archive.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/archive-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/archive-runner.out"
+
+python3 - "$WORK_DIR/nextest-archive.log" "$WORK_DIR/archive.tar.zst" <<'PY_ARCHIVE'
+import sys
+
+lines = open(sys.argv[1]).read().splitlines()
+archive = sys.argv[2]
+replay = [line for line in lines if line.startswith(("list ", "run "))]
+assert len(replay) == 3, lines
+assert replay[1].startswith("list nextest list") and replay[2].startswith("run nextest run"), replay
+for line in replay[1:]:
+    assert f"--archive-file {archive}" in line, line
+    assert " --workspace " not in line, line
+    assert "--manifest-path" not in line, line
+PY_ARCHIVE
+printf 'PASS: nextest archive replaces workspace compilation for shard listing and execution\n'
+
+# A declared archive that is not present must fail closed rather than silently
+# falling back to a full-workspace compile, which would erase the saving and
+# hide the misconfiguration.
+if HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+  HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+  HOMEBOY_SKIP_LINT=1 \
+  HOMEBOY_RUST_TEST_RUNNER=nextest \
+  HOMEBOY_RUST_NEXTEST_ARCHIVE="$WORK_DIR/missing-archive.tar.zst" \
+  HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+  HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+  HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+  HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/missing-archive-results.json" \
+  HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+  HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+  HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+  PATH="$BIN_DIR:$PATH" \
+  bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/missing-archive.out" 2>&1; then
+  printf 'Expected a declared but absent nextest archive to fail closed\n' >&2
+  exit 1
+fi
+printf 'PASS: an absent declared nextest archive fails closed\n'
+
 # A small limit forces deterministic batches. Every filter stays below the
 # bound while the aggregate result remains the immutable manifest total.
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \


### PR DESCRIPTION
Half one of cutting the Test gate's compile prefix. **Inert until a caller sets the variable**, so it can land on its own.

## The problem, measured

`cargo nextest run -E <filter>` filters which tests **execute**. It does not reduce what gets **compiled** — with `--workspace`, every shard builds all of the workspace's test binaries to run its own slice.

Extra-Chill/homeboy CI, run `31570203797`, shard-1:

```
06:58:00  ./.homeboy-action starts
06:58:24  extension setup done
          ...7.8 minutes of silence...
07:06:12  Finished `test` profile ... in 0.31s
07:06:12  Starting 30 tests across 2 binaries (4702 tests and 76 binaries skipped)
07:06:16  Summary [4.046s] 30 tests run: 30 passed, 4702 skipped
```

**7.8 minutes of compilation to run 30 tests in 4 seconds.**

A four-shard run does this **five times** — once in `Plan candidate Test shards` for `nextest list`, once per shard — all compiling the same thing. Sharding currently splits execution (already only seconds) while duplicating compilation (all of the cost), so adding shards has been making it *worse*.

The upstream `binary` job's cargo cache cannot help: it builds `--release`, tests need `debug`.

## The change

`HOMEBOY_RUST_NEXTEST_ARCHIVE` points listing and execution at a prebuilt `cargo nextest archive`, making both execution-only.

Two properties worth calling out:

- **Listing and execution share one resolved source.** Listing from the workspace while running from an archive would validate shard membership against binaries other than the ones executed.
- **A declared but absent archive fails closed.** Falling back to a full compile would erase the saving while hiding the misconfiguration.

## Compatibility

Unset, both paths keep their **exact** existing argv — including the pre-existing asymmetry where preflight listing passes `--workspace` alone while execution passes `--manifest-path … --workspace`. I initially unified those and the smoke test's argv assertions caught it; they are preserved deliberately rather than tidied.

## Tests

Two new cases in `test-shard-inventory-smoke.sh`, using the existing stub harness (no real cargo-nextest needed):

- listing and execution both use `--archive-file` and neither uses `--workspace` or `--manifest-path`
- a declared-but-absent archive fails closed

Extension self-checks pass: `env-provider`, `fingerprint-policy-flow`, `zero-test-scope-fallback`, `test-shard-inventory`, `lint-findings-clean-pass-contract`.

`nextest-shard-real-smoke.sh` requires cargo-nextest exactly 0.9.140, which is not installed on this host; it fails identically on pristine `main`, verified by stashing.

## Next

The producer half goes in homeboy-action: build the archive once in `Plan candidate Test shards`, upload it, download it in the shards, set the variable. Estimated critical path **~32.5m → ~23m**.

Refs Extra-Chill/homeboy#10997