### PR TITLE
fix(rust): leave durable evidence when a test shard is truncated

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -170,6 +170,29 @@ PY
     rm -f "$result_tmp"
 }
 
+# Persist shard progress after each batch so a shard that never reaches a
+# terminal emit still leaves structured counts behind.
+#
+# The shard's completeness invariant (executed vs total, below) and the
+# per-batch membership check in `rust_nextest_counts` both live on the happy
+# path. When the wall-clock test budget expires, the supervisor destroys this
+# process tree mid-loop and neither ever runs, so the shard dies having emitted
+# no result at all -- and the only surviving evidence is the per-test events
+# already streamed, which read exactly like an ordinary test failure. A shard
+# truncated at 21% of its plan is indistinguishable from one that simply had
+# failing tests (#12219).
+#
+# A signal trap cannot cover this: the observed containment sequence sends
+# SIGTERM and SIGKILL in the same millisecond, so there is no window in which a
+# handler is guaranteed to run. A checkpoint written after each completed batch
+# survives regardless of how the shard dies, and the terminal emit overwrites it
+# with the real outcome whenever the shard does finish.
+rust_checkpoint_shard_progress() {
+    local executed="$1" passed="$2" failed="$3" skipped="$4"
+    type homeboy_write_test_results >/dev/null 2>&1 || return 0
+    homeboy_write_test_results "$executed" "$passed" "$failed" "$skipped" "rust-shard"
+}
+
 rust_shard_cargo_counts() {
     python3 - "$1" <<'PY'
 import re
@@ -973,6 +996,12 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
             SHARD_SKIPPED=$((SHARD_SKIPPED + SKIPPED))
             [ "$NEXTEST_BATCH_EXIT" -eq 0 ] || SHARD_EXIT="$NEXTEST_BATCH_EXIT"
             rm -f "$SHARD_OUTPUT"
+            # Checkpoint after every completed batch. If the shard is killed
+            # before its terminal emit, this is the last word on how much of the
+            # plan actually ran (#12219).
+            SHARD_EXECUTED=$((SHARD_PASSED + SHARD_FAILED + SHARD_SKIPPED))
+            rust_checkpoint_shard_progress "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED"
+            echo "Rust shard progress: executed=${SHARD_EXECUTED}/${SHARD_TOTAL} passed=${SHARD_PASSED} failed=${SHARD_FAILED} skipped=${SHARD_SKIPPED}"
         done
         if rust_nextest_merge_failure_evidence "$NEXTEST_FAILED_NAMES"; then
             :
@@ -1002,13 +1031,28 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
             SHARD_PASSED=$((SHARD_PASSED + PASSED))
             SHARD_FAILED=$((SHARD_FAILED + FAILED))
             SHARD_SKIPPED=$((SHARD_SKIPPED + SKIPPED))
+            # Durability of shard progress must not depend on which runner the
+            # component selected (#12219). This path already pays for one cargo
+            # invocation per identity, so the checkpoint is negligible beside it.
+            SHARD_EXECUTED=$((SHARD_PASSED + SHARD_FAILED + SHARD_SKIPPED))
+            rust_checkpoint_shard_progress "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED"
         done < <(jq -r '.selected[] | [.package, .target, .target_kind, .name] | @tsv' "$SHARD_DATA")
     fi
     SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
     SHARD_EXECUTED=$((SHARD_PASSED + SHARD_FAILED + SHARD_SKIPPED))
     if [ "$SHARD_EXECUTED" -ne "$SHARD_TOTAL" ] || [ "$SHARD_FAILED" -ne 0 ] || [ "${SHARD_EXIT:-0}" -ne 0 ]; then
-        echo "Rust shard result: total=${SHARD_TOTAL} executed=${SHARD_EXECUTED} passed=${SHARD_PASSED} failed=${SHARD_FAILED} skipped=${SHARD_SKIPPED}" >&2
-        rust_emit_shard_result failed "$SHARD_TOTAL" "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED" "$((SHARD_ELAPSED*1000))"
+        SHARD_STATUS=failed
+        if [ "$SHARD_EXECUTED" -ne "$SHARD_TOTAL" ]; then
+            # An incomplete plan is a different finding from a red one, and the
+            # distinction is the entire signal: "failed" alone reads as "these
+            # tests are broken" when the truth may be that most of the shard
+            # never ran. Name the gap in both the log line and the emitted
+            # status so neither a human nor a consumer has to infer it (#12219).
+            SHARD_STATUS=truncated
+            echo "Rust shard truncated: executed ${SHARD_EXECUTED} of ${SHARD_TOTAL} planned identities; $((SHARD_TOTAL - SHARD_EXECUTED)) never ran" >&2
+        fi
+        echo "Rust shard result: status=${SHARD_STATUS} total=${SHARD_TOTAL} executed=${SHARD_EXECUTED} passed=${SHARD_PASSED} failed=${SHARD_FAILED} skipped=${SHARD_SKIPPED}" >&2
+        rust_emit_shard_result "$SHARD_STATUS" "$SHARD_TOTAL" "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED" "$((SHARD_ELAPSED*1000))"
         rm -f "$SHARD_DATA"
         exit 1
     fi

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -184,6 +184,11 @@ raise SystemExit(1 if mode in {"failure", "leaky-failure", "retry-failure"} and 
 PY
   exit $?
 fi
+if [ -n "${HOMEBOY_SILENT_TEST:-}" ] && [[ " $* " == *" ${HOMEBOY_SILENT_TEST} "* ]]; then
+  # A planned identity that produces no `test result:` line at all: the shape a
+  # shard sees when execution is cut short rather than reported as a failure.
+  exit 0
+fi
 if [ -n "${HOMEBOY_FAIL_TEST:-}" ] && [[ " $* " == *" ${HOMEBOY_FAIL_TEST} "* ]]; then
   printf 'test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out\n'
   exit 1
@@ -572,6 +577,117 @@ assert selected == ["member::member_works", "unit::alpha", "unit::beta", "api::w
 assert len(selected) == len(set(selected)), selected
 assert json.load(open(sys.argv[2])) == {"total": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"}
 PY
+
+# A shard killed by its wall-clock budget never reaches a terminal emit, so the
+# only thing that can report the gap is evidence already written to disk. Record
+# every result write and prove a partial checkpoint exists *before* completion:
+# that checkpoint is what a killed shard leaves behind (#12219).
+cat > "$WORK_DIR/checkpoint-writer.sh" <<'EOF'
+homeboy_write_test_results() {
+  python3 - "$HOMEBOY_TEST_RESULTS_FILE" "$HOMEBOY_CHECKPOINT_LOG" "$@" <<'PY'
+import json
+import sys
+path, log, executed, passed, failed, skipped, partial = sys.argv[1:]
+record = {"executed": int(executed), "passed": int(passed), "failed": int(failed), "skipped": int(skipped), "partial": partial}
+with open(path, "w") as handle:
+    json.dump(record, handle)
+with open(log, "a") as handle:
+    handle.write(json.dumps(record) + "\n")
+PY
+}
+EOF
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_RUST_NEXTEST_FILTER_MAX_BYTES=150 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_RUN_LOG="$WORK_DIR/checkpoint-nextest.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/checkpoint-writer.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/checkpoint-results.json" \
+HOMEBOY_CHECKPOINT_LOG="$WORK_DIR/checkpoint-log.jsonl" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/checkpoint-nextest.out"
+
+python3 - "$WORK_DIR/checkpoint-log.jsonl" "$WORK_DIR/checkpoint-nextest.out" <<'PY'
+import json
+import sys
+
+records = [json.loads(line) for line in open(sys.argv[1]) if line.strip()]
+assert records, "the shard must write results incrementally, not only at the end"
+
+# The last word is still the complete, correct shard outcome.
+assert records[-1] == {
+    "executed": 5, "passed": 4, "failed": 0, "skipped": 1, "partial": "rust-shard"
+}, records
+
+# At least one durable write predates completion. Had the budget expired there,
+# `executed < total` would already be on disk instead of nothing at all.
+partial_writes = [record for record in records[:-1] if record["executed"] < 5]
+assert partial_writes, records
+
+# Progress only moves forward, so a surviving checkpoint is always a lower bound
+# on what actually ran rather than a stale higher count.
+executed = [record["executed"] for record in records]
+assert executed == sorted(executed), executed
+
+# The same progress is legible in the log a human reads during triage.
+progress = [line for line in open(sys.argv[2]).read().splitlines() if line.startswith("Rust shard progress:")]
+assert len(progress) == len(records) - 1, progress
+assert progress[-1] == "Rust shard progress: executed=5/5 passed=4 failed=0 skipped=1", progress
+PY
+printf 'PASS: a shard checkpoints partial progress before it can be killed\n'
+
+# A shard that reaches its terminal check with an incomplete plan must say so.
+# "failed" alone is indistinguishable from a red suite, and the difference
+# between "these tests broke" and "most of these never ran" is the whole
+# diagnosis (#12219). The cargo shard path has no per-batch membership
+# enforcement, so this check is the only thing standing between an unrun shard
+# and a plausible-looking red one.
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_SILENT_TEST=unit::beta \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/manifest.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/truncated-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/truncated.out" 2> "$WORK_DIR/truncated.err"
+TRUNCATED_EXIT=$?
+set -e
+
+python3 - "$WORK_DIR/truncated.err" "$WORK_DIR/truncated-results.json" "$WORK_DIR/annotations/rust-test-shard.json" "$TRUNCATED_EXIT" <<'PY'
+import json
+import sys
+
+stderr = open(sys.argv[1], encoding="utf-8").read()
+assert int(sys.argv[4]) != 0, "a truncated shard must not report success"
+
+# The gap is named in full, so triage never has to compute total - executed.
+assert "Rust shard truncated: executed 6 of 7 planned identities; 1 never ran" in stderr, stderr
+assert "status=truncated" in stderr, stderr
+
+# Zero tests failed. Without the explicit truncation finding this shard would
+# present as a bare nonzero exit with nothing broken in it.
+results = json.load(open(sys.argv[2]))
+assert results == {"total": 6, "passed": 5, "failed": 0, "skipped": 1, "partial": "rust-shard"}, results
+
+# Consumers get the same distinction structurally, not just in prose.
+record = json.load(open(sys.argv[3]))[0]
+assert record["status"] == "truncated", record
+assert (record["total"], record["executed"], record["failed"]) == (7, 6, 0), record
+PY
+printf 'PASS: an incomplete shard reports truncation rather than a bare failure\n'
 
 # A nonzero batch exit remains aggregate evidence: every prevalidated batch
 # runs exactly once, and the final shard fails only after all outcomes exist.


### PR DESCRIPTION
Part 1 of Extra-Chill/homeboy#12219 — the invisibility half. The capacity half (making the plan fit the budget) is deliberately not in scope here.

## Problem

A shard killed by its wall-clock test budget emits **no result at all**. The only surviving evidence is the per-test events already streamed before the kill — which read exactly like an ordinary red suite.

From [`31608292267`](https://github.com/Extra-Chill/homeboy/actions/runs/31608292267), shard-2:

```
Replaying Rust nextest shard: 3283 runnable identities and 7 planned skipped identities
...
command_execution running for 1501s
homeboy review test containment grace expired; sending SIGKILL by pidfd.
command_execution failed after 1518s
```

That shard executed **697 of 3283** planned identities. The 2586 that never ran left no trace, and `gh run view --log-failed` surfaces only the handful of tests that happened to fail before the clock expired. A shard truncated at 21% of its plan is indistinguishable from one that simply had failing tests — I nearly misdiagnosed exactly this while triaging Extra-Chill/homeboy#12216.

## Why the existing guards miss it

The completeness invariant is already here and is correct:

```bash
if [ "$SHARD_EXECUTED" -ne "$SHARD_TOTAL" ] || ...
```

as is the per-batch membership check in `rust_nextest_counts` (`nextest executed membership does not match the shard manifest`).

**Both live on the happy path.** The supervisor destroys the process tree mid-batch-loop, so neither ever runs. The invariant that exists to catch an incomplete shard is bypassed by the one failure mode that produces one.

A signal trap does not fix this either — the observed containment sequence sends SIGTERM and SIGKILL in the same millisecond (`15:32:27.8387222` → `15:32:27.8392686`), so no handler is guaranteed a window.

## Change

**Checkpoint after every completed batch.** `rust_checkpoint_shard_progress` writes structured counts through the existing `homeboy_write_test_results` seam. It survives however the shard dies, and the terminal emit overwrites it with the real outcome whenever the shard does finish. Progress is also echoed per batch so the job log shows where execution stopped:

```
Rust shard progress: executed=5/5 passed=4 failed=0 skipped=1
```

Both runner paths checkpoint — durability should not depend on which runner a component selected.

**Name truncation when the shard does reach its terminal check.** Status becomes `truncated` rather than a bare `failed`, with the gap spelled out:

```
Rust shard truncated: executed 6 of 7 planned identities; 1 never ran
Rust shard result: status=truncated total=7 executed=6 passed=5 failed=0 skipped=1
```

The cargo shard path has no per-batch membership enforcement, so this check is the only thing separating an unrun shard from a plausible-looking red one.

## Verification

`rust/tests/test-shard-inventory-smoke.sh` — two new cases, **each verified to fail without its half of the fix**:

- `PASS: a shard checkpoints partial progress before it can be killed` — records every result write in the 4-batch scenario and asserts a partial write exists *before* completion, that progress is monotonic (so a surviving checkpoint is always a lower bound, never a stale higher count), and that the terminal write is still the correct complete outcome. Without the fix there is exactly one write and the assertion reports `[{'executed': 5, ...}]`.
- `PASS: an incomplete shard reports truncation rather than a bare failure` — drives the cargo shard path with a new `HOMEBOY_SILENT_TEST` stub mode (a planned identity that emits no `test result:` line, the shape of execution cut short rather than reported). Asserts the truncation line, `status=truncated` in both the log and the annotation, and that **zero tests failed** — without the explicit finding this shard is a bare nonzero exit with nothing broken in it. Without the fix: `AssertionError: Rust shard result: status=failed total=7 executed=6 ...`.

Full local run:

```
PASS: nextest archive replaces workspace compilation for shard listing and execution
PASS: an absent declared nextest archive fails closed
PASS: a shard checkpoints partial progress before it can be killed
PASS: an incomplete shard reports truncation rather than a bare failure
rust test shard inventory smoke ok
```

Also green: `parse-test-results-smoke.sh`, `rust-nextest-runner-smoke.sh`, `rust-runner-steps-direct-smoke.sh`, `zero-test-scope-fallback-smoke.sh`, `workspace-member-test-scope-smoke.sh`. `bash -n` clean.

`rust-changed-scope-smoke.sh` exits 101 both with and without this change — it requires a real `cargo-nextest` install this host lacks. Pre-existing, unrelated.

Existing assertions on `status == "failed"` for genuinely-failing shards are unaffected: those have `executed == total`, so they keep the `failed` status.

## Note

This repo has no PR CI (`homeboy.yml` is `push: main` only), so the verification above is local and deliberately detailed.