### PR TITLE
fix(rust): make a widened changed-test selection attributable

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -842,12 +842,22 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
         cp "$SHARD_DATA" "$HOMEBOY_TEST_INVENTORY_FILE"
     fi
     if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = "1" ]; then
+        # Inventory-only is the shard *planner*. A changed-selection that widened
+        # to the full inventory here multiplies every downstream shard's work, so
+        # it must be announced at the point of planning rather than inferred later
+        # from an unexpectedly large plan (Extra-Chill/homeboy#12219).
+        if jq -e '.fallback_reason? // empty' "$SHARD_DATA" >/dev/null; then
+            echo "$(jq -r '.fallback_reason' "$SHARD_DATA") Test shard planning widened to the full inventory." >&2
+        fi
         cat "$SHARD_DATA"
         rm -f "$SHARD_DATA"
         exit 0
     fi
     if [ -n "${HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE:-}" ] && jq -e '.fallback_reason? // empty' "$SHARD_DATA" >/dev/null; then
-        echo "$(jq -r '.fallback_reason') Running the full test command." >&2
+        # `jq -r '.fallback_reason'` without a file argument reads stdin, not the
+        # shard data, so this diagnostic reported an empty reason and the widening
+        # looked unexplained on this path too.
+        echo "$(jq -r '.fallback_reason' "$SHARD_DATA") Running the full test command." >&2
         rm -f "$SHARD_DATA"
         unset HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE
         exec bash "$0" "$@"

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -356,7 +356,18 @@ def main():
     if args.changed_selection_file:
         resolved = resolve_changed_selection(args.changed_selection_file, current, args.project)
         if args.inventory_only:
-            output = current if "fallback_reason" in resolved else project_inventory(current, resolved["selected"])
+            if "fallback_reason" in resolved:
+                # Widening to the full inventory is the correct fail-safe, but it
+                # silently multiplies the planned work -- on Extra-Chill/homeboy
+                # it took a changed union of ~2.8k identities to the full 13.2k,
+                # which no shard budget could absorb. Discarding the reason here
+                # left a plan that looked deliberately full-scope and gave no
+                # indication the narrowing had been attempted and abandoned
+                # (Extra-Chill/homeboy#12219). Carry it on the inventory so the
+                # widening is attributable to the candidate that stopped matching.
+                output = dict(current, fallback_reason=resolved["fallback_reason"])
+            else:
+                output = project_inventory(current, resolved["selected"])
         else:
             output = {"inventory": current, **resolved}
     Path(args.output).write_text(json.dumps(output, indent=2) + "\n")

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -1357,6 +1357,117 @@ PY
   fi
 done
 
+# Shard planning runs the inventory in --inventory-only mode. When a changed-test
+# selection no longer matches, widening to the full inventory is the right
+# fail-safe -- but it multiplies every downstream shard's work, so it has to be
+# attributable. Discarding the reason produced a plan indistinguishable from a
+# deliberate full-scope run (Extra-Chill/homeboy#12219).
+cat > "$WORK_DIR/changed-selection-stale.json" <<'EOF'
+{
+  "schema": "homeboy/rust-changed-test-selection/v2",
+  "candidates": [
+    {"package": "shard-smoke", "target_kind": "test", "target": "deleted_integration_target", "module": null, "path": null}
+  ]
+}
+EOF
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_TEST_INVENTORY_ONLY=1 \
+HOMEBOY_TEST_INVENTORY_FILE="$WORK_DIR/widened-inventory.json" \
+HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORK_DIR/changed-selection-stale.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/widened.out" 2> "$WORK_DIR/widened.err"
+WIDENED_EXIT=$?
+set -e
+
+python3 - "$WORK_DIR/widened-inventory.json" "$WORK_DIR/widened.err" "$WIDENED_EXIT" <<'PY'
+import json
+import sys
+
+assert int(sys.argv[3]) == 0, "widening is a fail-safe, not a failure"
+inventory = json.load(open(sys.argv[1]))
+
+# The fail-safe itself is unchanged: planning still covers everything.
+assert len(inventory["tests"]) == 7, inventory["tests"]
+
+# ...but it now says why it widened, naming the candidate that stopped matching.
+reason = inventory.get("fallback_reason")
+assert reason, "the widened inventory must carry its fallback reason"
+assert "deleted_integration_target" in reason, reason
+
+# And the planner announces it, so an inflated plan is explained at the point of
+# planning instead of inferred later from an unexpectedly large shard.
+stderr = open(sys.argv[2], encoding="utf-8").read()
+assert "deleted_integration_target" in stderr, stderr
+assert "widened to the full inventory" in stderr, stderr
+PY
+printf 'PASS: a widened changed-selection is attributable in the shard plan\n'
+
+# The narrowing path must keep working: a selection that does match still
+# projects a smaller inventory and reports no fallback.
+cat > "$WORK_DIR/changed-selection-live.json" <<'EOF'
+{
+  "schema": "homeboy/rust-changed-test-selection/v2",
+  "candidates": [
+    {"package": "member-smoke", "target_kind": "lib", "target": "member_smoke", "module": null, "path": null}
+  ]
+}
+EOF
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_TEST_INVENTORY_ONLY=1 \
+HOMEBOY_TEST_INVENTORY_FILE="$WORK_DIR/narrowed-inventory.json" \
+HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORK_DIR/changed-selection-live.json" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/narrowed.out" 2> "$WORK_DIR/narrowed.err"
+
+python3 - "$WORK_DIR/narrowed-inventory.json" "$WORK_DIR/narrowed.err" <<'PY'
+import json
+import sys
+
+inventory = json.load(open(sys.argv[1]))
+assert "fallback_reason" not in inventory, inventory
+names = sorted(test["name"] for test in inventory["tests"])
+assert names == ["member::member_works"], names
+assert "widened to the full inventory" not in open(sys.argv[2], encoding="utf-8").read()
+PY
+printf 'PASS: a matching changed-selection still narrows the shard plan\n'
+
+# The replay path reported the same widening through `jq -r '.fallback_reason'`
+# with no file argument, so jq read stdin instead of the shard data and the
+# reason came out empty. Same widening, same silence, different line.
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_CHANGED_TEST_SELECTION_FILE="$WORK_DIR/changed-selection-stale.json" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/replay-widened-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/replay-widened.out" 2> "$WORK_DIR/replay-widened.err"
+
+python3 - "$WORK_DIR/replay-widened.err" <<'PY'
+import sys
+
+stderr = open(sys.argv[1], encoding="utf-8").read()
+assert "Running the full test command." in stderr, stderr
+# The reason must precede it rather than an empty string.
+assert "deleted_integration_target" in stderr, stderr
+PY
+printf 'PASS: the replay path names the reason it widened\n'
+
 printf 'pub fn changed_fixture() {}\n' >> "$PROJECT_DIR/src/lib.rs"
 if PATH="$BIN_DIR:$PATH" python3 "$EXTENSION_DIR/scripts/test-shard-inventory.py" --project "$PROJECT_DIR" --runner cargo --output "$WORK_DIR/stale-workspace.out" --manifest "$WORK_DIR/manifest.json" >/dev/null 2>&1; then
   printf 'Expected workspace change to reject the stale manifest\n' >&2


### PR DESCRIPTION
Part 2 of Extra-Chill/homeboy#12219. **Stacked on #2605** — review that one first; this PR's diff is the second commit only.

## What I found

I filed #12219 saying part 2 was a capacity/policy call — pick a knob: shard count, budget, `--test-threads`. **That was wrong, and I want to correct it.** It is a wiring defect, and the evidence is conclusive.

The shard planner artifact from [`31608292267`](https://github.com/Extra-Chill/homeboy/actions/runs/31608292267) (`homeboy-test-shard-plan-1` → `homeboy-test-inventory.json`):

```
total inventory tests: 13160
distinct packages: 35
   homeboy-core       2473
   homeboy-cli        2308
   homeboy-lab-runner 1823
   ...
fallback_reason: None
```

The full workspace. But that run's PR touched only `homeboy-core` and `homeboy-deploy` — a changed union of ~2772 identities. And the planner had resolved changed scope **correctly**:

```
Scope resolved: context=pr input=auto mode=changed base_ref=37bf2bb2e...
Rust test scope: Scoped to the exact union of changed Rust test identities.
```

So the gate announced it was scoped, then planned 4.7× the work it said it would. That inflation is what makes the shards unable to finish inside their budget — the budget was never the problem.

## Root cause

`resolve_changed_selection` returns `{"fallback_reason": ...}` when a candidate no longer matches, and widening to the full inventory is the **correct fail-safe**. But in `--inventory-only` mode — the mode the CI planner runs in — the reason was discarded:

```python
output = current if "fallback_reason" in resolved else project_inventory(current, resolved["selected"])
```

`current` is the unmodified full inventory. It carries no reason, so nothing downstream can tell a fail-safe widening from a deliberate full-scope plan. Reconstructing this took downloading and parsing the plan artifact.

Two more places lose the same signal:

- `test-runner.sh` surfaces `fallback_reason` **after** the `--inventory-only` early exit, so the planner never reaches it.
- On the replay path, `jq -r '.fallback_reason'` is called with **no file argument**, so jq reads stdin rather than the shard data. Demonstrated directly:

  ```
  $ echo "$(jq -r '.fallback_reason' data.json) Running the full test command."
  Changed test selection no longer matches X. Running the full test command.
  $ echo "$(jq -r '.fallback_reason' < /dev/null) Running the full test command."
   Running the full test command.
  ```

Same disease as part 1: a real finding is computed and then dropped, leaving a plausible-looking result that is wrong in a way nobody can see.

## Change

Carry `fallback_reason` on the widened inventory; announce it in `--inventory-only` before the early exit; pass `$SHARD_DATA` to the replay-path `jq`.

**This deliberately does not narrow anything.** Widening stays a fail-safe — planning still covers everything and the run still succeeds. It is now attributable to the candidate that stopped matching, which is the prerequisite for fixing *why* it stops matching. Narrowing by guessing at the matcher would risk silently dropping tests, which is the failure class this issue is about.

## Verification

Four new cases in `rust/tests/test-shard-inventory-smoke.sh`. **Each fix was reverted individually to confirm its test fails:**

| case | without the fix |
|---|---|
| `a widened changed-selection is attributable in the shard plan` | `AssertionError: the widened inventory must carry its fallback reason` |
| `the replay path names the reason it widened` | `AssertionError:  Running the full test command.` (empty reason, leading space) |
| `a matching changed-selection still narrows the shard plan` | guard — proves narrowing is untouched |

The widened case also asserts the fail-safe is intact: 7/7 tests still planned, exit 0.

Full suite:

```
PASS: nextest archive replaces workspace compilation for shard listing and execution
PASS: an absent declared nextest archive fails closed
PASS: a shard checkpoints partial progress before it can be killed
PASS: an incomplete shard reports truncation rather than a bare failure
PASS: a widened changed-selection is attributable in the shard plan
PASS: a matching changed-selection still narrows the shard plan
PASS: the replay path names the reason it widened
rust test shard inventory smoke ok
```

Also green: `parse-test-results-smoke.sh`, `rust-nextest-runner-smoke.sh`, `rust-runner-steps-direct-smoke.sh`, `zero-test-scope-fallback-smoke.sh`, `workspace-member-test-scope-smoke.sh`. `bash -n` and `ast.parse` clean.

The existing `set(first) == {schema, runner, ...}` inventory-shape assertion still passes: `fallback_reason` is added only when widening actually occurs.

## What this does not fix

Why the candidate stopped matching. With the reason now printed, the next run tells us — and that is the fix that actually restores coverage.

No PR CI in this repo (`homeboy.yml` is `push: main` only), so verification is local and deliberately detailed.