### PR TITLE
fix(rust): resolve stale changed-test targets by source

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -269,6 +269,16 @@ def validate(manifest_path, current):
     return [known[identity] for identity in selected]
 
 
+def matching_tests(current, package, target_kind, target, module):
+    return [
+        test for test in current["tests"]
+        if test["package"] == package
+        and test["target_kind"] == target_kind
+        and test["target"] == target
+        and (module is None or test["name"] == module or test["name"].startswith(f"{module}::"))
+    ]
+
+
 def resolve_changed_selection(selection_path, current, project):
     try:
         selection = json.loads(Path(selection_path).read_text())
@@ -303,33 +313,38 @@ def resolve_changed_selection(selection_path, current, project):
                 if source == manifest_parent or manifest_parent in source.parents:
                     package = metadata_package["name"]
                     break
-        matches = [
-            test for test in current["tests"]
-            if test["package"] == package
-            and test["target_kind"] == target_kind
-            and test["target"] == target
-            and (module is None or test["name"] == module or test["name"].startswith(f"{module}::"))
-        ]
-        # A renamed explicit integration target can retain the same source path
-        # while its target name changes. Resolve that current target through
-        # Cargo metadata before deciding that the candidate is stale.
+        matches = matching_tests(current, package, target_kind, target, module)
+        # Changed-scope candidates describe the source that led to selection;
+        # their package/target fields may predate Cargo target renames or kind
+        # changes. Rebind a failed candidate to Cargo's current target identity
+        # by source path, preserving the exact current inventory record.
         if not matches and isinstance(path, str) and path:
             for metadata_package in metadata["packages"]:
                 if metadata_package["name"] != package:
                     continue
                 for metadata_target in metadata_package["targets"]:
-                    if target_kind in metadata_target["kind"] and (
-                        target_kind == "lib" or Path(metadata_target["src_path"]).resolve() == source
-                    ):
-                        target = metadata_target["name"]
-                        matches = [
-                            test for test in current["tests"]
-                            if test["package"] == package
-                            and test["target_kind"] == target_kind
-                            and test["target"] == target
-                            and (module is None or test["name"] == module or test["name"].startswith(f"{module}::"))
-                        ]
+                    kinds = metadata_target["kind"]
+                    manifest_parent = Path(metadata_package["manifest_path"]).resolve().parent
+                    is_lib_source = (
+                        "lib" in kinds
+                        and source.is_relative_to(manifest_parent / "src")
+                        and not source.is_relative_to(manifest_parent / "src" / "bin")
+                    )
+                    if Path(metadata_target["src_path"]).resolve() != source and not is_lib_source:
+                        continue
+                    for current_kind in kinds:
+                        current_matches = matching_tests(
+                            current, package, current_kind, metadata_target["name"], module
+                        )
+                        if current_matches:
+                            target_kind = current_kind
+                            target = metadata_target["name"]
+                            matches = current_matches
+                            break
+                    if matches:
                         break
+                if matches:
+                    break
         if not matches:
             return {"fallback_reason": f"Changed test selection no longer matches {package}::{target_kind}::{target}."}
         selected.update({test["id"]: test for test in matches})

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -25,9 +25,10 @@ PY
 
 PROJECT_DIR="$WORK_DIR/project"
 BIN_DIR="$WORK_DIR/bin"
-mkdir -p "$PROJECT_DIR/src" "$PROJECT_DIR/member/src" "$BIN_DIR" "$WORK_DIR/annotations"
+mkdir -p "$PROJECT_DIR/src/bin" "$PROJECT_DIR/member/src" "$BIN_DIR" "$WORK_DIR/annotations"
 printf '[package]\nname = "shard-smoke"\nversion = "0.1.0"\nedition = "2021"\n\n[workspace]\nmembers = ["member"]\n' > "$PROJECT_DIR/Cargo.toml"
 printf 'pub fn fixture() {}\n' > "$PROJECT_DIR/src/lib.rs"
+printf 'fn main() {}\n' > "$PROJECT_DIR/src/bin/current_bin.rs"
 printf '[package]\nname = "member-smoke"\nversion = "0.1.0"\nedition = "2021"\n' > "$PROJECT_DIR/member/Cargo.toml"
 printf '#[cfg(test)]\nmod tests { #[test] fn member_works() {} }\n' > "$PROJECT_DIR/member/src/lib.rs"
 
@@ -59,6 +60,11 @@ cat > "$BIN_DIR/test-rlib" <<'EOF'
 [[ " $* " == *' --ignored '* ]] && exit 0
 printf '%s\n' 'rlib::works: test'
 EOF
+cat > "$BIN_DIR/test-bin" <<'EOF'
+#!/usr/bin/env bash
+[[ " $* " == *' --ignored '* ]] && exit 0
+printf '%s\n' 'bin::works: test'
+EOF
 cat > "$BIN_DIR/bench-audit-self" <<'EOF'
 #!/usr/bin/env bash
 if [ -n "${HOMEBOY_BENCH_LIST_LOG:-}" ]; then
@@ -68,7 +74,7 @@ printf '%s\n' "thread 'main' panicked at src/bin/bench-audit-self.rs:44:40:" >&2
 printf '%s\n' 'CARGO_MANIFEST_DIR not set (run via cargo): NotPresent' >&2
 exit 101
 EOF
-chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member" "$BIN_DIR/test-proc-macro" "$BIN_DIR/test-rlib" "$BIN_DIR/bench-audit-self"
+chmod +x "$BIN_DIR/test-lib" "$BIN_DIR/test-api" "$BIN_DIR/test-member" "$BIN_DIR/test-proc-macro" "$BIN_DIR/test-rlib" "$BIN_DIR/test-bin" "$BIN_DIR/bench-audit-self"
 
 cat > "$BIN_DIR/cargo" <<'EOF'
 #!/usr/bin/env bash
@@ -76,7 +82,7 @@ set -euo pipefail
 if [ "${1:-}" = '--version' ]; then printf 'cargo 1.80.0\n'; exit 0; fi
 if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = '--version' ]; then printf 'cargo-nextest 0.9.0\n'; exit 0; fi
 if [ "${1:-}" = 'metadata' ]; then
-  printf '{"packages":[{"id":"shard-smoke 0.1.0 (path+file:///fixture)","name":"shard-smoke"},{"id":"member-smoke 0.1.0 (path+file:///fixture/member)","name":"member-smoke"}],"workspace_root":"%s"}\n' "$PWD"
+  printf '{"packages":[{"id":"shard-smoke 0.1.0 (path+file:///fixture)","name":"shard-smoke","manifest_path":"%s/Cargo.toml","targets":[{"name":"shard_smoke","kind":["lib"],"src_path":"%s/src/lib.rs"},{"name":"api","kind":["test"],"src_path":"%s/tests/api.rs"},{"name":"current_bin","kind":["bin"],"src_path":"%s/src/bin/current_bin.rs"}]},{"id":"member-smoke 0.1.0 (path+file:///fixture/member)","name":"member-smoke","manifest_path":"%s/member/Cargo.toml","targets":[{"name":"member_smoke","kind":["lib"],"src_path":"%s/member/src/lib.rs"}]}],"workspace_root":"%s"}\n' "$PWD" "$PWD" "$PWD" "$PWD" "$PWD" "$PWD" "$PWD"
   exit 0
 fi
 if [ "${1:-}" = 'nextest' ] && [ "${2:-}" = 'list' ]; then
@@ -131,6 +137,9 @@ if [[ " $* " == *' --workspace '* && " $* " == *' --no-run '* ]]; then
   printf '{"reason":"compiler-artifact","package_id":"member-smoke 0.1.0 (path+file:///fixture/member)","target":{"name":"member_smoke","kind":["lib"]},"profile":{"test":true},"executable":"%s/test-member"}\n' "$(dirname "$0")"
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"macros","kind":["proc-macro"]},"profile":{"test":true},"executable":"%s/test-proc-macro"}\n' "$(dirname "$0")"
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"rlib_fixture","kind":["rlib"]},"profile":{"test":true},"executable":"%s/test-rlib"}\n' "$(dirname "$0")"
+  if [ "${HOMEBOY_INCLUDE_CURRENT_BIN:-}" = 1 ]; then
+    printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"current_bin","kind":["bin"]},"profile":{"test":true},"executable":"%s/test-bin"}\n' "$(dirname "$0")"
+  fi
   printf '{"reason":"compiler-artifact","package_id":"shard-smoke 0.1.0 (path+file:///fixture)","target":{"name":"bench-audit-self","kind":["bin"]},"profile":{"test":false},"executable":"%s/bench-audit-self"}\n' "$(dirname "$0")"
   exit 0
 fi
@@ -195,6 +204,22 @@ fi
 printf 'test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n'
 EOF
 chmod +x "$BIN_DIR/cargo"
+
+# #12219: producer candidates can retain a prior lib target shape when the
+# current source is an executable target. Rebind by the source path and retain
+# the exact current inventory identity instead of widening to every test.
+printf '%s\n' '{"schema":"homeboy/rust-changed-test-selection/v2","candidates":[{"package":"shard-smoke","target_kind":"lib","target":"prior_lib_target","module":null,"path":"src/bin/current_bin.rs"}]}' > "$WORK_DIR/renamed-target-selection.json"
+HOMEBOY_INCLUDE_CURRENT_BIN=1 PATH="$BIN_DIR:$PATH" python3 "$EXTENSION_DIR/scripts/test-shard-inventory.py" --project "$PROJECT_DIR" --runner cargo --output "$WORK_DIR/renamed-target-inventory.json" --changed-selection-file "$WORK_DIR/renamed-target-selection.json" --inventory-only
+python3 - "$WORK_DIR/renamed-target-inventory.json" <<'PY'
+import json
+import sys
+
+inventory = json.load(open(sys.argv[1]))
+assert "fallback_reason" not in inventory, inventory
+assert [test["id"] for test in inventory["tests"]] == [
+    "shard-smoke::bin::current_bin::bin::works",
+], inventory
+PY
 
 cat > "$WORK_DIR/runner-prelude.sh" <<'EOF'
 homeboy_runner_init() {


### PR DESCRIPTION
## Summary

Fixes the Rust changed-test matcher used by the #12219 shard planner. A stale producer target tuple now resolves through its retained source path and current Cargo metadata to the exact current inventory identity, avoiding an unnecessary full-inventory fallback.

Closes Extra-Chill/homeboy#12219

## Evidence

- **Source relationship:** producer candidate source path -> current Cargo metadata target -> current test-inventory identity.
- **Change kind:** focused Rust matcher correction; no policy, scheduling, or capacity change.
- **Runtime evidence boundary:** only failed changed-selection candidates with a retained source path are rebound. Exact direct matches are unchanged; candidates without a current inventory-backed target or module match still retain the existing attributable `fallback_reason` and full-inventory fail-closed widening.
- **Regression:** a stale `lib` candidate for `src/bin/current_bin.rs` selects only `shard-smoke::bin::current_bin::bin::works`, not the full inventory.

## Verification

All commands used the caller-declared `/opt/homebrew/bin/bash` 5.3 because macOS `/bin/bash` 3 cannot run the runner's associative-array contract.

- `/opt/homebrew/bin/bash rust/tests/test-shard-inventory-smoke.sh` (1 total, 1 passed, 0 failed, 0 ignored)
- `/opt/homebrew/bin/bash rust/scripts/rust-changed-scope-smoke.sh` (1 total, 1 passed, 0 failed, 0 ignored)
- `/opt/homebrew/bin/bash rust/tests/zero-test-scope-fallback-smoke.sh` (4 total, 4 passed, 0 failed, 0 ignored)
- `/opt/homebrew/bin/bash rust/tests/env-provider-smoke.sh` (1 total, 1 passed, 0 failed, 0 ignored)
- `/opt/homebrew/bin/bash rust/tests/fingerprint-policy-flow-smoke.sh` (1 total, 1 passed, 0 failed, 0 ignored)
- `/opt/homebrew/bin/bash rust/tests/nextest-shard-real-smoke.sh` (1 total, 1 passed, 0 failed, 0 ignored)
- `/opt/homebrew/bin/bash ../tests/lint-findings-clean-pass-contract-smoke.sh` (1 total, 1 passed, 0 failed, 0 ignored; behavioral helper checks skipped because `HOMEBOY_CORE_DIR` is unavailable)

## AI Assistance

OpenAI GPT-5.6 Terra via OpenCode reviewed the promoted candidate against the #12219 evidence, ran the declared Bash 5 gates, and prepared this PR. Human review remains responsible for approval.