### PR TITLE
Make nextest shard replay parallelism configurable

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -180,6 +180,13 @@
       "description": "Optional Cargo libtest thread count. Set to 1 for suites that mutate process-global environment and need deterministic serial execution. Zero preserves Cargo's default parallelism."
     },
     {
+      "id": "rust_nextest_shard_threads",
+      "label": "Nextest shard threads",
+      "type": "integer",
+      "default": 1,
+      "description": "Thread count for nextest shard replay, which hard-coded 1 before it was configurable. Zero selects nextest's num-cpus parallelism. nextest runs every test in its own process, so process-global state is already isolated and serial replay is only the conservative default. Override per run with HOMEBOY_RUST_NEXTEST_SHARD_THREADS."
+    },
+    {
       "id": "clippy_all",
       "label": "Enable clippy::all",
       "type": "boolean",

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -70,6 +70,35 @@ rust_cargo_test_threads() {
     esac
 }
 
+# Shard replay parallelism.
+#
+# The `--test-threads 1` here was hard-coded and did NOT come from the
+# `rust_cargo_test_threads` setting, whose own default is 0 (nextest's default
+# parallelism). So the setting said "parallel" while shard replay ran serial
+# regardless, and nothing could change it without editing this file.
+#
+# Serializing test FUNCTIONS also does not buy what it looks like it buys.
+# homeboy-core/src/test_support.rs documents the outcome directly: the HOME
+# repoint "is held for this guard's entire lifetime, but that only serializes
+# writers. Readers never take it -- including worker threads a test spawns inside
+# itself, which is why running the suite with --test-threads=1 did not stop the
+# failures". The hazard was fixed properly instead, by a process-local
+# `set_home_root_override` read under a mutex (Extra-Chill/homeboy#7505, #11266),
+# and nextest already runs every test in its own process.
+#
+# This makes the value configurable and keeps 1 as the shard default, so nothing
+# changes until a caller asks. See Extra-Chill/homeboy#11751 W1-9.
+rust_nextest_shard_threads() {
+    local value
+    value="${HOMEBOY_RUST_NEXTEST_SHARD_THREADS:-$(rust_cargo_test_threads || true)}"
+    case "$value" in
+        '') printf '1' ;;
+        *[!0-9]*) printf '1' ;;
+        0) printf 'num-cpus' ;;
+        *) printf '%s' "$value" ;;
+    esac
+}
+
 rust_test_scope_json() {
     python3 - "${HOMEBOY_TEST_SCOPE_KIND:-workspace}" "${HOMEBOY_TEST_SCOPE_MESSAGE:-}" "${HOMEBOY_TEST_RUNNER_ARGS:-}" <<'PY'
 import json
@@ -984,7 +1013,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
                 rust_nextest_cleanup 1
                 exit 1
             fi
-            homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run "${NEXTEST_RUN_SOURCE_ARGS[@]}" --test-threads 1 --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
+            homeboy_run_step_capture SHARD_OUTPUT NEXTEST_BATCH_EXIT "cargo nextest run" -- env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run "${NEXTEST_RUN_SOURCE_ARGS[@]}" --test-threads "$(rust_nextest_shard_threads)" --no-fail-fast --no-tests fail --message-format libtest-json-plus --message-format-version 0.1 -E "$NEXTEST_FILTER" || true
             if ! NEXTEST_BATCH_FAILED_NAMES="$(mktemp)"; then
                 SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
                 rust_emit_shard_result failed "$SHARD_TOTAL" 0 0 0 0 "$((SHARD_ELAPSED*1000))"

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -509,6 +509,45 @@ assert all(" --workspace " in line for line in lines), lines
 assert all("test(=member::member_works)" in line for line in lines[1:]), lines
 PY
 
+# Shard replay parallelism is configurable but still defaults to serial.
+#
+# `--test-threads 1` was hard-coded here and did not come from
+# `rust_cargo_test_threads`, whose default is 0. Serializing test functions also
+# does not fix the hazard it was credited with: homeboy-core/src/test_support.rs
+# records that `--test-threads=1` "did not stop the failures", because readers
+# and a test's own worker threads never take the lock. nextest runs each test in
+# its own process, so the default stays 1 only out of caution (homeboy#11751 W1-9).
+grep -F -- '--test-threads 1' "${WORK_DIR}/nextest-selection.log" >/dev/null || {
+  printf 'FAIL: shard replay must default to serial execution\n' >&2
+  exit 1
+}
+printf 'PASS: shard replay defaults to serial execution\n'
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_RUST_NEXTEST_SHARD_THREADS=0 \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_LOG="$WORK_DIR/nextest-threads.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/threads-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/threads-runner.out"
+grep -F -- '--test-threads num-cpus' "${WORK_DIR}/nextest-threads.log" >/dev/null || {
+  printf 'FAIL: zero threads must select nextest num-cpus parallelism\n' >&2
+  exit 1
+}
+if grep -F -- '--test-threads 1' "${WORK_DIR}/nextest-threads.log" >/dev/null; then
+  printf 'FAIL: an explicit thread count must replace the serial default\n' >&2
+  exit 1
+fi
+printf 'PASS: shard replay honours a configured thread count\n'
+
 # A prebuilt nextest archive makes shard replay execution-only: listing and
 # running must both read the archive instead of recompiling the workspace, and
 # they must agree on the source so membership is validated against the binaries


### PR DESCRIPTION
Extra-Chill/homeboy#11751 **W1-9**: *"`rust_cargo_test_threads: 1` serializes tests nextest already isolates by process."*

## First, a correction to the item

**The setting is not the cause.** `rust_cargo_test_threads` defaults to **0** — nextest's num-cpus parallelism. Shard replay hard-coded `--test-threads 1` in `test-runner.sh` and never consulted it:

```bash
cargo nextest run ... --test-threads 1 --no-fail-fast ...
```

So the setting said *parallel* while replay ran *serial*, and nothing could change it without editing the script. Anyone reading the config would conclude the opposite of what CI does.

## The case for parallel is stronger than the epic states

The epic argues nextest's per-process isolation makes the serialization unnecessary. The repo says something sharper — `homeboy-core/src/test_support.rs`:

> `home_lock()` is held for this guard's entire lifetime, but that only serializes **writers**. Readers never take it — including worker threads a test spawns inside itself, **which is why running the suite with `--test-threads=1` did not stop the failures: serializing test functions does nothing for threads within a test.**

`--test-threads=1` was **already proven not to fix** the hazard it is credited with. The hazard was then fixed properly — a process-local `set_home_root_override` read under a mutex (Extra-Chill/homeboy#7505, #11266), across ~**2,380** `with_isolated_home` call sites — and nextest runs every test in its own process, which isolates that override perfectly.

## Why I did not flip the default anyway

**Extra-Chill/homeboy's suite is red.** 39 of 60 completed shards failed across the last 100 runs (#12113). Introducing parallelism into a red suite makes any new flake indistinguishable from an existing failure, and would hand #12113 a moving target.

So this converts the decision from a code change into a setting. Pull the lever and measure once the suite is green — `rust_nextest_shard_threads: 0`, or `HOMEBOY_RUST_NEXTEST_SHARD_THREADS=0` for a single run.

## Behaviour

| value | result |
|---|---|
| unset | `--test-threads 1` — identical to today |
| `0` | `--test-threads num-cpus` |
| `N` | `--test-threads N` |
| non-numeric | `1` — fail-safe, never fails the run |

Falls back to `rust_cargo_test_threads` when the new setting is absent, so an existing serial-by-config consumer keeps its behaviour.

## Tests

- shard replay **defaults to serial** — pinning that this PR changes nothing by default
- a configured `0` produces `--test-threads num-cpus` **and no longer emits `--test-threads 1`**, so a future regression to the hard-coded value is caught

All extension self-checks pass.

Refs Extra-Chill/homeboy#11751