### PR TITLE
feat(opencode): classify immediate server failures

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -227,6 +227,16 @@ const OPENCODE_PROVIDER_PREFLIGHT = {
 		guidance: 'Refresh Codex OAuth credentials before launching OpenCode, for example by signing in with Codex locally so ~/.codex/auth.json contains current tokens, then pass the updated AI_PROVIDER_OPENAI_CODEX_* secret environment values to the OpenCode executor.',
 	},
 };
+const OPENCODE_IMMEDIATE_FAILURE_PATTERNS = [
+	{
+		id: 'unexpected_server_error',
+		error_contains_any: ['Unexpected server error. Check server logs for details.'],
+		retryable: true,
+		error_ref_pattern: 'err_[A-Fa-f0-9]{1,64}\\b',
+		log_lookup: 'opencode debug paths; tail -n 200 "$HOME/.local/share/opencode/log/opencode.log"',
+		fallback_action: 'OpenCode has no error-reference lookup command. Inspect the runtime log manually for <provider-error-ref>, then select another configured provider while the service is investigated.',
+	},
+];
 
 function providerContract(options = {}) {
 	const contractFields = agentTaskProviderContractFields();
@@ -247,6 +257,7 @@ function providerContract(options = {}) {
 		workspace_tools: OPENCODE_WORKSPACE_TOOLS,
 		provider_defaults: OPENCODE_PROVIDER_DEFAULTS,
 		provider_preflight: OPENCODE_PROVIDER_PREFLIGHT,
+		immediate_failure_patterns: OPENCODE_IMMEDIATE_FAILURE_PATTERNS,
 		lifecycle: {
 			completion: 'synchronous_process',
 			cancellation: 'provider_signal',

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,8 +9,17 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.2.4',
+		version: '1.3.0',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
+		requires: {
+			homeboy: '>=0.345.0',
+		},
+		compatibility: {
+			immediate_failure_patterns: {
+				owner: 'Extra-Chill/homeboy#12293',
+				requirement: 'Homeboy core support for agent-task executor immediate_failure_patterns.',
+			},
+		},
 		contract_producers: [
 			{
 				id: 'opencode.agent-task-result',

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,8 +2,17 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
+  "requires": {
+    "homeboy": ">=0.345.0"
+  },
+  "compatibility": {
+    "immediate_failure_patterns": {
+      "owner": "Extra-Chill/homeboy#12293",
+      "requirement": "Homeboy core support for agent-task executor immediate_failure_patterns."
+    }
+  },
   "contract_producers": [
     {
       "id": "opencode.agent-task-result",
@@ -223,6 +232,18 @@
           "guidance": "Refresh Codex OAuth credentials before launching OpenCode, for example by signing in with Codex locally so ~/.codex/auth.json contains current tokens, then pass the updated AI_PROVIDER_OPENAI_CODEX_* secret environment values to the OpenCode executor."
         }
       },
+      "immediate_failure_patterns": [
+        {
+          "id": "unexpected_server_error",
+          "error_contains_any": [
+            "Unexpected server error. Check server logs for details."
+          ],
+          "retryable": true,
+          "error_ref_pattern": "err_[A-Fa-f0-9]{1,64}\\b",
+          "log_lookup": "opencode debug paths; tail -n 200 \"$HOME/.local/share/opencode/log/opencode.log\"",
+          "fallback_action": "OpenCode has no error-reference lookup command. Inspect the runtime log manually for <provider-error-ref>, then select another configured provider while the service is investigated."
+        }
+      ],
       "lifecycle": {
         "completion": "synchronous_process",
         "cancellation": "provider_signal"

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -138,9 +138,31 @@ assert.equal(provider.capabilities.includes('browser_runtime'), false);
 const manifest = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'opencode.json'), 'utf8'));
 assert.equal(manifest.id, 'opencode');
 assert.equal(manifest.name, 'OpenCode');
+assert.deepEqual(manifest.requires, { homeboy: '>=0.345.0' });
+assert.deepEqual(manifest.compatibility, {
+	immediate_failure_patterns: {
+		owner: 'Extra-Chill/homeboy#12293',
+		requirement: 'Homeboy core support for agent-task executor immediate_failure_patterns.',
+	},
+});
 assert.equal(manifest.agent_task_executors.length, 1);
 assert.equal(manifest.agent_task_executors[0].capabilities.includes('nested_orchestrator'), true);
 assert.equal(Object.hasOwn(manifest.agent_task_executors[0].provider_defaults.codex, 'model'), false);
+const [unexpectedServerError] = manifest.agent_task_executors[0].immediate_failure_patterns;
+assert.deepEqual(unexpectedServerError, {
+	id: 'unexpected_server_error',
+	error_contains_any: ['Unexpected server error. Check server logs for details.'],
+	retryable: true,
+	error_ref_pattern: 'err_[A-Fa-f0-9]{1,64}\\b',
+	log_lookup: 'opencode debug paths; tail -n 200 "$HOME/.local/share/opencode/log/opencode.log"',
+	fallback_action: 'OpenCode has no error-reference lookup command. Inspect the runtime log manually for <provider-error-ref>, then select another configured provider while the service is investigated.',
+});
+const errorRefPattern = new RegExp(unexpectedServerError.error_ref_pattern, 'g');
+assert.deepEqual(
+	'Unexpected server error. Check server logs for details. err_3a6d31e2 err_FACE'.match(errorRefPattern),
+	['err_3a6d31e2', 'err_FACE']
+);
+assert.equal('Unexpected server error. Check server logs for details. err_not-hex'.match(errorRefPattern), null);
 const packageJson = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'package.json'), 'utf8'));
 assert.equal(packageJson.name, 'homeboy-agent-runtime-opencode');
 assert.equal(packageJson.homeboy.agent_runtime_manifest, 'opencode.json');


### PR DESCRIPTION
## Summary
- declare the observed OpenCode immediate server-error signature and bounded `err_*` reference extraction
- provide valid runtime log inspection and transparent fallback guidance
- require Homeboy `>=0.345.0` for the new provider contract
- bump the OpenCode runtime manifest to `1.3.0` and regenerate the checked-in manifest

Companion to Extra-Chill/homeboy#12293 and its Homeboy core PR.

## Verification
- `npm run check:runtime-manifest`
- `npm run test:opencode-agent-task-executor-boundary`
- `node tests/agent-task-provider-contract-smoke.mjs`
- `git diff --check`

## AI Assistance
OpenAI `gpt-5.6-sol` via OpenCode general coding agents implemented and independently reviewed the adapter declaration, diagnostics, compatibility floor, generated manifest, and boundary tests. Chris Huber directed the work and owns every line.