### PR TITLE
fix(wordpress): explain stale database secret setup

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -477,7 +477,7 @@ function resolveDatabaseService(configuration, environment) {
       throw new Error('wp_codebox_database_service.secret_env must map provider fields to environment variable names');
     }
     if (typeof environment[name] !== 'string' || (field !== 'password' && environment[name].trim() === '')) {
-      throw new Error(`wp_codebox_database_service secret environment variable is unavailable: ${name}`);
+      throw new Error(`wp_codebox_database_service secret environment variable is unavailable: ${name}. Export the configured variable, or refresh the installed WordPress extension/rig package with homeboy init; inspect the active install with homeboy extension show wordpress and readlink ~/.config/homeboy/extensions/wordpress.`);
     }
   }
   const secretEnv = [...new Set(Object.values(value.secret_env))];

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -323,7 +323,7 @@ try {
   expectPreflightFailure({
     database_type: 'mysql',
     wp_codebox_database_service: { provider: 'external', allowed_hosts: ['database.internal.example'], secret_env: { host: 'MISSING_PROVIDER_HOST', username: 'PROVIDER_ADMIN_USER', password: 'PROVIDER_ADMIN_PASSWORD' } },
-  }, /secret environment variable is unavailable: MISSING_PROVIDER_HOST/, secretValues);
+  }, /secret environment variable is unavailable: MISSING_PROVIDER_HOST.*homeboy init.*homeboy extension show wordpress.*readlink/, secretValues);
   expectPreflightFailure({
     database_type: 'mysql',
     wp_codebox_database_service: { provider: 'external', allowed_hosts: ['database.internal.example'], secret_env: ['PROVIDER_ADMIN_HOST'] },


### PR DESCRIPTION
## Summary
- make missing WordPress database-service secret failures identify both valid causes: an unexported configured variable or a stale installed extension/rig package
- include concrete refresh and inspection commands in the adapter error
- lock the actionable remediation into the database-service smoke test

## Root cause
The failing installed adapter reported the secret check at line 347, while current `origin/main` performs it around line 477 and already contains the #2458 propagation support. This points to stale installed WordPress extension/rig content, not a missing database-service implementation in current source. Previously the error named only the missing variable and gave no way to distinguish or repair stale installation state.

## Verification
- `cd wordpress && composer install --no-interaction`
- `cd wordpress && npm install --ignore-scripts`
- `cd wordpress && npm run test:wp-codebox-database-service`
- `cd wordpress && npm run test:wp-codebox-phpunit-evidence`
- `node --check wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs`
- `node --check wordpress/tests/wp-codebox-database-service-smoke.mjs`
- `git diff --check`

Repository-wide ESLint remains red on the existing baseline, including the pre-existing adapter finding at line 1070; this PR adds no new lint finding.

Closes #2611