### PR TITLE
fix(opencode): pin run workspace directory

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -1169,7 +1169,7 @@ function resolveCommandSpec(config = {}, options = {}) {
 	return { command: configuredCommand.trim(), args: configuredArgs };
 }
 
-function opencodeRunArgs(request = {}, config = {}, commandSpec = {}) {
+function opencodeRunArgs(request = {}, config = {}, commandSpec = {}, cwd = '') {
 	const model = config.model || request.executor?.model || request.model;
 	const format = config.format || 'json';
 	return [
@@ -1180,6 +1180,10 @@ function opencodeRunArgs(request = {}, config = {}, commandSpec = {}) {
 		...(config.agent ? ['--agent', config.agent] : []),
 		...(config.variant ? ['--variant', config.variant] : []),
 		...(config.title ? ['--title', config.title] : []),
+		// OpenCode's location is the authority for relative native tool paths.
+		// Pass the same canonical directory as the child cwd so it cannot fall
+		// back to an inherited location and prefix a workspace path twice.
+		...(isWorkspaceDirectory(cwd) ? ['--dir', cwd] : []),
 		`${request.instructions}${requiredOutputInstructions(request)}`,
 	];
 }
@@ -1193,13 +1197,22 @@ function requiredOutputInstructions(request = {}) {
 }
 
 function resolveOpenCodeCwd(request = {}, config = {}) {
-	return config.cwd
+	const candidate = config.cwd
 		|| config.workspace_root
 		|| config.workspaceRoot
 		|| request.workspace_path
 		|| request.workspace?.path
 		|| request.workspace?.root
 		|| process.cwd();
+	return concretePath(candidate);
+}
+
+function isWorkspaceDirectory(candidate) {
+	try {
+		return isAbsolutePath(candidate) && fs.statSync(candidate).isDirectory();
+	} catch {
+		return false;
+	}
 }
 
 function openCodeWorkspacePermissionPreflight(commandSpec = {}, primaryAgent, cwd, env, allowedTools) {
@@ -1272,7 +1285,7 @@ async function executeOpenCodeAgentTask(request = {}, options = {}) {
 	}
 
 	const cwd = resolveOpenCodeCwd(request, config);
-	const args = opencodeRunArgs(request, config, commandSpec);
+	const args = opencodeRunArgs(request, config, commandSpec, cwd);
 	const spawnExtra = { env: { ...opencodeSpawnEnv(request, options), PWD: cwd } };
 	const toolPermissions = agentTaskPolicyToolPermissions(request.policy, {
 		native: OPENCODE_NATIVE_WORKSPACE_PERMISSIONS,

--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,7 +9,7 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.3.0',
+		version: '1.3.1',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
 		requires: {
 			homeboy: '>=0.345.0',

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "requires": {
     "homeboy": ">=0.345.0"

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -85,14 +85,14 @@ function concretePath(candidate) {
 	}
 }
 
-function resolvedOpenCodeAgent(opencode, cwd, configContent) {
-	const result = spawnSync(opencode, ['debug', 'agent', 'build', '--pure'], {
-		cwd,
-		encoding: 'utf8',
-		env: { ...process.env, OPENCODE_CONFIG_CONTENT: configContent },
-	});
+function installedOpenCodeBinary() {
+	const result = spawnSync('opencode', ['--version'], { encoding: 'utf8' });
+	if (result.error?.code === 'ENOENT') {
+		console.log('Skipping OpenCode file resolver integration: opencode binary is unavailable.');
+		return null;
+	}
 	assert.equal(result.status, 0, result.stderr);
-	return JSON.parse(result.stdout);
+	return result.spawnfile || 'opencode';
 }
 
 (async () => {
@@ -283,8 +283,8 @@ process.exit(0);
 	fs.writeFileSync(modelCliPath, `#!/usr/bin/env node
 const assert = require('node:assert/strict');
 assert.equal(process.cwd(), ${JSON.stringify(realModelWorkspace)});
-assert.equal(process.env.PWD, ${JSON.stringify(modelWorkspace)});
-assert.deepEqual(process.argv.slice(2, 7), ['run', '--format', 'json', '--model', 'opencode-go/kimi-k2.7-code']);
+assert.equal(process.env.PWD, ${JSON.stringify(realModelWorkspace)});
+assert.deepEqual(process.argv.slice(2, 9), ['run', '--format', 'json', '--model', 'opencode-go/kimi-k2.7-code', '--dir', ${JSON.stringify(realModelWorkspace)}]);
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
 assert.equal(config.$schema, 'https://opencode.ai/config.json');
 assert.equal(config.model, 'opencode-go/kimi-k2.7-code');
@@ -364,12 +364,20 @@ assert.equal(config.agent.title.disable, true);
 
 	const permissionWorkspaces = [
 		{
-			label: 'controller-scratch',
+			label: 'relative-long-attempt-workspace',
 			attemptRoot: path.join(root, 'controller-scratch', 'cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874'),
-			workspace: path.join(root, 'controller-scratch', 'cook-detached-37abbb52-d638495c-b270-46fdc965fc9c-attempt-1-fb890874', 'workspace'),
+			workspace: path.join(root, 'controller-scratch', 'cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874', 'workspace'),
 			workspacePermissionRoot: path.join(root, 'controller-scratch', 'cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874', 'workspace'),
-			workspaceConfig: 'cwd',
+			workspaceConfig: 'relative-cwd',
 			allowAttemptRoot: true,
+			workspaceSiblingAction: 'allow',
+		},
+		{
+			label: 'canonical-permission-root',
+			workspace: path.join(root, 'canonical-permission-root', 'workspace'),
+			workspacePermissionRoot: path.join(root, 'canonical-permission-root'),
+			workspaceConfig: 'cwd',
+			workspaceSiblingAction: 'allow',
 		},
 		{
 			label: 'unrelated-attempt-root',
@@ -426,6 +434,8 @@ assert.equal(config.agent.title.disable, true);
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 assert.equal(process.cwd(), ${JSON.stringify(concreteWorkspace)});
+assert.equal(process.argv.at(-3), '--dir');
+assert.equal(process.argv.at(-2), ${JSON.stringify(concreteWorkspace)});
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
 for (const pattern of ${JSON.stringify(workspacePatterns)}) {
   assert.equal(config.permission.external_directory[pattern], 'allow');
@@ -477,6 +487,9 @@ process.exit(0);
 		};
 		if (permissionWorkspace.workspaceConfig === 'cwd') {
 			workspaceRequest.executor.config.cwd = permissionWorkspace.workspace;
+		} else if (permissionWorkspace.workspaceConfig === 'relative-cwd') {
+			workspaceRequest.executor.config.cwd = path.relative(process.cwd(), permissionWorkspace.workspace);
+			assert.equal(path.isAbsolute(workspaceRequest.executor.config.cwd), false);
 		} else {
 			workspaceRequest.workspace_path = permissionWorkspace.workspace;
 		}
@@ -518,7 +531,10 @@ process.exit(0);
 		}
 		assert.equal(externalDirectoryAction(generatedConfig, 'build', concreteWorkspace), 'allow');
 		assert.equal(externalDirectoryAction(generatedConfig, 'build', path.join(concreteWorkspace, 'src', 'index.js')), 'allow');
-		assert.equal(externalDirectoryAction(generatedConfig, 'build', `${concreteWorkspace}-sibling`), 'deny');
+		assert.equal(
+			externalDirectoryAction(generatedConfig, 'build', `${concreteWorkspace}-sibling`),
+			permissionWorkspace.workspaceSiblingAction || 'deny'
+		);
 		assert.equal(externalDirectoryAction(generatedConfig, 'build', path.join(root, 'controller-scratch')), 'deny');
 		assert.equal(
 			readAction(generatedConfig, 'build', concreteWorkspace, path.join(root, 'outside-workspace', 'index.js')),
@@ -544,20 +560,40 @@ process.exit(0);
 				'allow'
 			);
 		}
-		if (permissionWorkspace.label === 'controller-scratch') {
-			const opencode = spawnSync('opencode', ['--version'], { encoding: 'utf8' });
-			if (opencode.status === 0) {
-				const resolvedAgent = resolvedOpenCodeAgent(opencode.spawnfile || 'opencode', concreteWorkspace, JSON.stringify(generatedConfig));
-				const externalDirectoryRules = resolvedAgent.permission.filter((rule) => rule.permission === 'external_directory');
-				// OpenCode asks for this parent-directory glob, not the calling tool's glob.
-				const exactAttemptRequest = path.join(concreteAttemptRoot, '*');
-				assert.equal(externalDirectoryRules.findLast((rule) => rule.pattern === exactAttemptRequest)?.action, 'allow');
-				for (const workspacePattern of workspacePatterns) {
-					assert.equal(externalDirectoryRules.findLast((rule) => rule.pattern === workspacePattern)?.action, 'allow');
-				}
-				assert.equal(externalDirectoryRules.findLast((rule) => rule.pattern === path.join(root, 'controller-scratch', 'unrelated-attempt', '*'))?.action || 'deny', 'deny');
-			}
-		}
+	}
+
+	const resolverWorkspace = concretePath(permissionWorkspaces[0].workspace);
+	const resolverFile = path.join(resolverWorkspace, 'crates', 'opencode-resolver-fixture', 'src', 'lib.rs');
+	const resolverRelativeFile = 'crates/opencode-resolver-fixture/src/lib.rs';
+	const resolverContent = 'pub const OPENCODE_RESOLVER_FIXTURE: &str = "workspace-relative";\n';
+	fs.mkdirSync(path.dirname(resolverFile), { recursive: true });
+	fs.writeFileSync(resolverFile, resolverContent);
+	const opencode = installedOpenCodeBinary();
+	if (opencode) {
+		const search = spawnSync(opencode, ['debug', 'file', 'search', 'opencode-resolver-fixture', '--pure'], {
+			cwd: resolverWorkspace,
+			encoding: 'utf8',
+		});
+		assert.equal(search.status, 0, search.stderr);
+		const searchResults = search.stdout.trim().split(/\r?\n/).filter(Boolean);
+		assert.equal(searchResults.includes(resolverRelativeFile), true, search.stdout);
+		assert.equal(searchResults.some((result) => path.isAbsolute(result) || result === '..' || result.startsWith('../')), false, search.stdout);
+
+		const read = spawnSync(opencode, ['debug', 'file', 'read', resolverRelativeFile, '--pure'], {
+			cwd: resolverWorkspace,
+			encoding: 'utf8',
+		});
+		assert.equal(read.status, 0, read.stderr);
+		const resolvedFile = JSON.parse(read.stdout);
+		assert.equal(Buffer.from(resolvedFile.content, resolvedFile.encoding).toString('utf8'), resolverContent);
+
+		const outsideFile = path.join(path.dirname(resolverWorkspace), 'opencode-resolver-outside.txt');
+		fs.writeFileSync(outsideFile, 'outside workspace');
+		const escapedRead = spawnSync(opencode, ['debug', 'file', 'read', '../opencode-resolver-outside.txt', '--pure'], {
+			cwd: resolverWorkspace,
+			encoding: 'utf8',
+		});
+		assert.notEqual(escapedRead.status, 0, 'OpenCode file resolver escaped the configured workspace root.');
 	}
 
 	const preflightWorkspace = path.join(root, 'controller-scratch', 'cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874', 'workspace');


### PR DESCRIPTION
## Summary

- canonicalize the assigned OpenCode cwd and pass it explicitly through `opencode run --dir`
- preserve an independently broader canonical permission root without changing escape denials
- exercise long attempt-workspace relative search/read resolution through the installed OpenCode resolver

## Verification

- `npm run generate:runtime-manifest`
- `npm run check:runtime-manifest`
- `npm run test:opencode-agent-task-executor-boundary`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `git diff --check`

Closes #2613

Related: Extra-Chill/homeboy#12379

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the duplicated active-location resolution, implemented and independently reviewed explicit workspace pinning, and added mock-boundary plus installed-resolver regression coverage. Chris Huber reviewed and owns every line.