### PR TITLE
fix(wordpress): resolve symlinked sibling helpers

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -21,7 +21,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh scripts/test/changed-scope-test-routing-smoke.sh scripts/test/test-runner-file-routing-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
+      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh scripts/test/changed-scope-test-routing-smoke.sh scripts/test/test-runner-file-routing-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/installed-build-helper-resolution-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
       "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs"
     ],
     "test": [
@@ -30,6 +30,7 @@
       "bash scripts/build/update-wp-codebox-cache-smoke.sh",
       "bash scripts/test/wp-codebox-doctor-smoke.sh",
       "bash scripts/test/wp-codebox-cli-resolution-smoke.sh",
+      "bash tests/installed-build-helper-resolution-smoke.sh",
       "bash tests/installed-test-helper-resolution-smoke.sh",
       "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -62,7 +62,8 @@ homeboy_resolve_context --component-alias PLUGIN_PATH
 # is generic Node.js behavior and lives in the nodejs extension, which is
 # installed alongside this one. Resolve via an explicit runtime override first,
 # then the sibling extension path.
-LOCAL_WORKSPACE_DEPS_HELPER="${HOMEBOY_RUNTIME_LOCAL_WORKSPACE_DEPS:-${EXTENSION_PATH}/../nodejs/scripts/lib/local-workspace-deps.sh}"
+EXTENSION_COLLECTION_PATH="$(dirname "$EXTENSION_PATH")"
+LOCAL_WORKSPACE_DEPS_HELPER="${HOMEBOY_RUNTIME_LOCAL_WORKSPACE_DEPS:-${EXTENSION_COLLECTION_PATH}/nodejs/scripts/lib/local-workspace-deps.sh}"
 
 # Output functions
 print_status() {

--- a/wordpress/tests/installed-build-helper-resolution-smoke.sh
+++ b/wordpress/tests/installed-build-helper-resolution-smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORDPRESS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_RUNNER="${WORDPRESS_ROOT}/scripts/build/build.sh"
+FIXTURE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+mkdir -p \
+    "${FIXTURE_ROOT}/extension-sources/wordpress" \
+    "${FIXTURE_ROOT}/extensions/nodejs/scripts/lib"
+ln -s "${FIXTURE_ROOT}/extension-sources/wordpress" "${FIXTURE_ROOT}/extensions/wordpress"
+touch "${FIXTURE_ROOT}/extensions/nodejs/scripts/lib/local-workspace-deps.sh"
+
+EXTENSION_PATH="${FIXTURE_ROOT}/extensions/wordpress"
+export EXTENSION_PATH
+unset HOMEBOY_RUNTIME_LOCAL_WORKSPACE_DEPS || true
+eval "$(awk '/^EXTENSION_COLLECTION_PATH=/{print; next} /^LOCAL_WORKSPACE_DEPS_HELPER=/{print; exit}' "$BUILD_RUNNER")"
+
+EXPECTED="${FIXTURE_ROOT}/extensions/nodejs/scripts/lib/local-workspace-deps.sh"
+if [ "$LOCAL_WORKSPACE_DEPS_HELPER" != "$EXPECTED" ] || [ ! -f "$LOCAL_WORKSPACE_DEPS_HELPER" ]; then
+    printf 'FAIL: symlinked extension resolved helper to %s\n' "$LOCAL_WORKSPACE_DEPS_HELPER" >&2
+    exit 1
+fi
+
+printf '%s\n' 'installed build helper resolution smoke passed'


### PR DESCRIPTION
## Summary

- derive the installed extension collection from the lexical parent of `EXTENSION_PATH`
- resolve the shared Node.js workspace helper beside a symlinked WordPress extension
- preserve explicit `HOMEBOY_RUNTIME_LOCAL_WORKSPACE_DEPS` override precedence
- register a symlinked-install regression in WordPress lint and test self-checks

## Verification

- `bash wordpress/tests/installed-build-helper-resolution-smoke.sh`
- `bash wordpress/tests/installed-test-helper-resolution-smoke.sh`
- `shellcheck wordpress/tests/installed-build-helper-resolution-smoke.sh`
- `bash -n wordpress/scripts/build/build.sh wordpress/tests/installed-build-helper-resolution-smoke.sh`
- `jq empty wordpress/homeboy.json`
- independent review found no findings

Closes #2615.

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode was used to reproduce the failed component build, inspect installed symlink resolution, implement the owning extension fix, run verification, and review the final diff. Chris Huber reviewed and remains responsible for every line.
