### PR TITLE
fix(wordpress): preserve PHPUnit failure output

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -172,16 +172,17 @@ function configuredSecretValues() {
     .map(([, value]) => value)
     .sort((left, right) => right.length - left.length);
 }
+function redactSecrets(text, secretValues = configuredSecretValues()) {
+  for (const secret of secretValues) {
+    text = text.replaceAll(secret, '[REDACTED]');
+  }
+  return text;
+}
 function createLineRedactor(secretValues) {
   const decoder = new StringDecoder('utf8');
   let pending = '';
   const overlap = Math.max(0, ...secretValues.map((secret) => secret.length - 1));
-  const redact = (text) => {
-    for (const secret of secretValues) {
-      text = text.replaceAll(secret, '[REDACTED]');
-    }
-    return text;
-  };
+  const redact = (text) => redactSecrets(text, secretValues);
   return {
     write(chunk) {
       pending += decoder.write(chunk);
@@ -945,14 +946,14 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
 
   const stdout = await readFile(execution.stdoutPath, 'utf8');
   const stderr = await readFile(execution.stderrPath, 'utf8');
+  let preservedOutput = '';
+  try { preservedOutput = await readFile(phpunitOutputPath, 'utf8'); } catch {}
   // The recipe-run JSON payload carries the step ledger the raw log concatenation
   // discards. Preserve it as first-class structured evidence so a run that never
   // reaches the PHPUnit step still names the stage that stopped it.
   const recipeRun = parseRecipeRunPayload(stdout);
   const recipeRunSteps = buildRecipeRunStepsLedger(recipeRun);
   await writeFile(recipeRunStepsPath, `${JSON.stringify(recipeRunSteps, null, 2)}\n`);
-  const output = extractPhpunitOutput(stdout, stderr, recipeRun);
-  await writeFile(phpunitOutputPath, output);
   if (managedRuntimeServices.length > 0) {
     await writeFile(managedRuntimeServicesPath, `${JSON.stringify(managedRuntimeServices, null, 2)}\n`);
   }
@@ -966,16 +967,26 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     .map((line) => line.trim())
     .find((line) => /^(STAGE_FAIL|STAGE_FATAL|STAGE_DIE):/.test(line)) || '';
 
-  const aggregate = phpunitAggregate(output);
   let results;
   try { results = json(await readFile(testResultsPath, 'utf8'), null); } catch { results = null; }
   const validResults = validTestResults(results);
+  const structuredExecution = validResults && results.summary.total > 0 && !stageFailure;
+  const preservedAggregate = phpunitAggregate(preservedOutput);
+  const preservedOutputReferenced = validResults && Array.isArray(results.rawLogReferences) && results.rawLogReferences.some((reference) => reference?.path === 'files/phpunit-output.log' && reference?.kind === 'phpunit-output');
+  const preservedOutputMatches = structuredExecution && preservedOutputReferenced && preservedAggregate?.total === results.summary.total && preservedAggregate.failed === results.summary.failed;
+  const output = redactSecrets( structuredExecution
+    ? ((preservedOutputMatches && preservedOutput) || stageLog || structuredPhpunitOutputUnavailable(results, recipeRun))
+    : extractPhpunitOutput(stdout, stderr, recipeRun) );
+  await writeFile(phpunitOutputPath, output);
+  const aggregate = phpunitAggregate(output);
   if (!validResults) {
     results = { schema: 'wp-codebox/test-results/v1', status: 'unknown', summary: aggregate || emptyTestSummary(), suites: [], rawLogReferences: [] };
   }
   if (results && typeof results === 'object') {
     const summary = isObject(results.summary) ? results.summary : {};
-    if (aggregate) {
+    if (stageFailure) {
+      results.summary = emptyTestSummary();
+    } else if (aggregate) {
       results.summary = { ...summary, ...aggregate };
     }
     results.status = stageFailure ? 'failed' : normalizedTestStatus(results, aggregate, execution.status, validResults);
@@ -1067,7 +1078,6 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, 
     if (executed > 0) {
       return { cause: 'tests_executed', detail: `PHPUnit executed ${executed} test(s).`, remediation: 'No execution diagnosis is required.' };
     }
-    const failedRecipeStep = (recipeRunSteps?.executions || []).find((step) => Number.isInteger(step.exit_code) && step.exit_code !== 0);
     if (recipeRunSteps?.parse_status === 'unparseable') {
       return {
         cause: 'recipe_run_payload_unparseable',
@@ -1082,6 +1092,7 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, 
         remediation: 'Inspect artifact://files/recipe-run-steps.json and logs/recipe-run.stderr.log for why the recipe dispatched no steps.',
       };
     }
+    const failedRecipeStep = (recipeRunSteps?.executions || []).find((step) => Number.isInteger(step.exit_code) && step.exit_code !== 0);
     if (failedRecipeStep) {
       return {
         cause: 'recipe_step_failed',
@@ -1290,6 +1301,20 @@ function noPhpunitExecutionBanner(recipeRun) {
     'Test execution never started; the setup output below is retained for the record.',
     'Structured step ledger: artifact://files/recipe-run-steps.json',
     ...steps,
+    '============================================================',
+    '',
+  ].join('\n');
+}
+function structuredPhpunitOutputUnavailable(results, recipeRun) {
+  const summary = results.summary;
+  const setupOutput = recipeRun.executions.flatMap((execution) => [execution?.stdout, execution?.stderr]).filter((value) => typeof value === 'string' && value !== '').join('');
+  if (setupOutput) {
+    return setupOutput;
+  }
+  return [
+    '============================================================',
+    'WP_CODEBOX_PHPUNIT_OUTPUT: UNAVAILABLE',
+    `Structured results report ${summary.total} test(s), ${summary.failed} failed, but no raw PHPUnit output artifact was retained.`,
     '============================================================',
     '',
   ].join('\n');

--- a/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
@@ -37,13 +37,16 @@ const artifactRoot = args[args.indexOf('--artifacts') + 1];
 const runtime = path.join(artifactRoot, 'runtime-fixture');
 fs.mkdirSync(path.join(runtime, 'files'), { recursive: true });
 fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
-fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify({
+const fixture = JSON.parse(process.env.RECIPE_RUN_FIXTURE || '{}');
+fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify(fixture.testResults || {
   schema: 'wp-codebox/test-results/v1',
   status: 'skipped',
   summary: { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 },
   suites: [],
 }));
-const fixture = JSON.parse(process.env.RECIPE_RUN_FIXTURE || '{}');
+if (typeof fixture.phpunitOutput === 'string') {
+  fs.writeFileSync(path.join(runtime, 'files', 'phpunit-output.log'), fixture.phpunitOutput);
+}
 if (typeof fixture.stageLog === 'string') {
   fs.mkdirSync(path.join(runtime, 'files', 'phpunit'), { recursive: true });
   fs.writeFileSync(path.join(runtime, 'files', 'phpunit', '.pg-test-result.txt'), fixture.stageLog);
@@ -68,6 +71,7 @@ async function runScenario(name, fixture) {
       HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
       HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts,
       HOMEBOY_SETTINGS_JSON: '{}',
+      FIXTURE_SECRET_TOKEN: fixture.secretValue || '',
     },
     encoding: 'utf8',
     maxBuffer: 2 * 1024 * 1024,
@@ -135,6 +139,86 @@ try {
   const results = JSON.parse(await readFile(path.join(setupOnly.publishedFiles, 'test-results.json'), 'utf8'));
   assert.equal(results.status, 'failed');
   assert.ok(results.evidenceReferences.some((entry) => entry.kind === 'recipe-run-steps' && entry.uri === 'artifact://files/recipe-run-steps.json'));
+
+  // PHPUnit can execute inside the sandbox without appearing as a top-level
+  // recipe execution. Preserve its authoritative artifact instead of replacing
+  // the failure trace with a false no-execution banner.
+  const structuredFailure = await runScenario('structured-failure', {
+    executions: setupOnlyFixture.executions,
+    phpunitOutput: 'There was 1 failure:\n1) SampleTest::test_failure\nsecret=fixture-phpunit-secret\nFailed asserting that false is true.\nTests: 23, Assertions: 40, Failures: 1.\n',
+    secretValue: 'fixture-phpunit-secret',
+    stageLog: 'PLUGIN_DETECTED sample-plugin/sample-plugin.php\nSCOPED_TEST_FILES requested=1 matched=1\nDISCOVERY: found=1\n',
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'failed',
+      summary: { total: 23, passed: 22, failed: 1, skipped: 0, unknown: 0 },
+      suites: [],
+      rawLogReferences: [{ path: 'files/phpunit-output.log', kind: 'phpunit-output' }],
+    },
+  });
+  assert.equal(structuredFailure.run.status, 1, structuredFailure.run.stderr);
+  const structuredOutput = await readFile(path.join(structuredFailure.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.match(structuredOutput, /SampleTest::test_failure/);
+  assert.doesNotMatch(structuredOutput, /NO_PHPUNIT_EXECUTION/);
+  assert.doesNotMatch(structuredOutput, /fixture-phpunit-secret/);
+  assert.match(structuredOutput, /secret=\[REDACTED\]/);
+  const structuredDiagnosis = JSON.parse(await readFile(path.join(structuredFailure.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.equal(structuredDiagnosis.executed_tests, 23);
+  assert.equal(structuredDiagnosis.cause, 'tests_executed');
+
+  const staleOutput = await runScenario('stale-output', {
+    executions: setupOnlyFixture.executions,
+    phpunitOutput: 'OK (99 tests, 99 assertions)\n',
+  });
+  const staleRetainedOutput = await readFile(path.join(staleOutput.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.match(staleRetainedOutput, /NO_PHPUNIT_EXECUTION/);
+  assert.doesNotMatch(staleRetainedOutput, /OK \(99 tests/);
+
+  const bootstrapFailure = await runScenario('bootstrap-failure-with-stale-output', {
+    executions: setupOnlyFixture.executions,
+    phpunitOutput: 'OK (99 tests, 99 assertions)\n',
+    stageLog: 'STAGE_FAIL:activation: plugin activation failed\n',
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'passed',
+      summary: { total: 99, passed: 99, failed: 0, skipped: 0, unknown: 0 },
+      suites: [],
+    },
+  });
+  const bootstrapOutput = await readFile(path.join(bootstrapFailure.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.doesNotMatch(bootstrapOutput, /OK \(99 tests/);
+  const bootstrapResults = JSON.parse(await readFile(path.join(bootstrapFailure.publishedFiles, 'test-results.json'), 'utf8'));
+  assert.equal(bootstrapResults.status, 'failed');
+  assert.equal(bootstrapResults.summary.total, 0);
+
+  const structuredWithoutRawOutput = await runScenario('structured-without-raw-output', {
+    executions: [],
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'failed',
+      summary: { total: 3, passed: 2, failed: 1, skipped: 0, unknown: 0 },
+      suites: [],
+    },
+  });
+  const unavailableOutput = await readFile(path.join(structuredWithoutRawOutput.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.match(unavailableOutput, /WP_CODEBOX_PHPUNIT_OUTPUT: UNAVAILABLE/);
+  assert.doesNotMatch(unavailableOutput, /NO_PHPUNIT_EXECUTION/);
+
+  const stalePositiveOutput = await runScenario('stale-positive-output', {
+    executions: setupOnlyFixture.executions,
+    phpunitOutput: 'OK (99 tests, 99 assertions)\n',
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'failed',
+      summary: { total: 3, passed: 2, failed: 1, skipped: 0, unknown: 0 },
+      suites: [],
+    },
+  });
+  const stalePositiveRetained = await readFile(path.join(stalePositiveOutput.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.doesNotMatch(stalePositiveRetained, /OK \(99 tests/);
+  const stalePositiveResults = JSON.parse(await readFile(path.join(stalePositiveOutput.publishedFiles, 'test-results.json'), 'utf8'));
+  assert.equal(stalePositiveResults.summary.total, 3);
+  assert.equal(stalePositiveResults.summary.failed, 1);
 
   // A recipe step that exited non-zero names the step and its exit code ahead
   // of the generic missing-PHPUnit cause.


### PR DESCRIPTION
## Summary

- preserve WP Codebox's bound raw PHPUnit artifact when structured results prove execution
- require matching current result counts and an explicit raw-log reference before trusting the file
- redact configured secrets before durable publication
- ignore stale output on zero-test and bootstrap-failure paths
- retain explicit diagnostics when structured execution lacks raw output

## Verification

- `node wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs`
- `node wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs`
- `node wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs`
- ESLint and Node syntax checks for changed implementation/test files
- independent review found no remaining findings

Closes #2617.

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode was used to reconcile contradictory CI artifacts, trace the evidence overwrite, implement provenance and redaction guards, add regressions, and review the final diff. Chris Huber reviewed and remains responsible for every line.
