### PR TITLE
Fix referenced PHPUnit output publication

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -973,9 +973,10 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   const structuredExecution = validResults && results.summary.total > 0 && !stageFailure;
   const preservedAggregate = phpunitAggregate(preservedOutput);
   const preservedOutputReferenced = validResults && Array.isArray(results.rawLogReferences) && results.rawLogReferences.some((reference) => reference?.path === 'files/phpunit-output.log' && reference?.kind === 'phpunit-output');
-  const preservedOutputMatches = structuredExecution && preservedOutputReferenced && preservedAggregate?.total === results.summary.total && preservedAggregate.failed === results.summary.failed;
+  const preservedOutputMatches = structuredExecution && preservedOutputReferenced && phpunitSummaryMatches(preservedAggregate, results.summary);
+  const referencedOutput = structuredExecution ? await readMatchingPhpunitOutput(artifactDirectory, results) : '';
   const output = redactSecrets( structuredExecution
-    ? ((preservedOutputMatches && preservedOutput) || stageLog || structuredPhpunitOutputUnavailable(results, recipeRun))
+    ? ((preservedOutputMatches && preservedOutput) || referencedOutput || stageLog || structuredPhpunitOutputUnavailable(results, recipeRun))
     : extractPhpunitOutput(stdout, stderr, recipeRun) );
   await writeFile(phpunitOutputPath, output);
   const aggregate = phpunitAggregate(output);
@@ -983,11 +984,10 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     results = { schema: 'wp-codebox/test-results/v1', status: 'unknown', summary: aggregate || emptyTestSummary(), suites: [], rawLogReferences: [] };
   }
   if (results && typeof results === 'object') {
-    const summary = isObject(results.summary) ? results.summary : {};
     if (stageFailure) {
       results.summary = emptyTestSummary();
-    } else if (aggregate) {
-      results.summary = { ...summary, ...aggregate };
+    } else if (!structuredExecution && aggregate) {
+      results.summary = { ...results.summary, ...aggregate };
     }
     results.status = stageFailure ? 'failed' : normalizedTestStatus(results, aggregate, execution.status, validResults);
     const references = Array.isArray(results.rawLogReferences) ? results.rawLogReferences : [];
@@ -1198,6 +1198,58 @@ async function readPhpunitStageLog(artifactDirectory) {
     try { return await readFile(candidate, 'utf8'); } catch {}
   }
   return null;
+}
+async function readMatchingPhpunitOutput(artifactDirectory, results) {
+  const references = [
+    ...(Array.isArray(results.rawLogReferences) ? results.rawLogReferences : []),
+    ...(Array.isArray(results.suites) ? results.suites.flatMap((suite) => Array.isArray(suite?.rawLogReferences) ? suite.rawLogReferences : []) : []),
+  ];
+  const canonicalRoot = await realpath(artifactDirectory);
+  const seen = new Set();
+  for (const reference of references) {
+    if (!['phpunit-output', 'commands-log'].includes(reference?.kind) || typeof reference.path !== 'string' || seen.has(reference.path)) {
+      continue;
+    }
+    seen.add(reference.path);
+    if (path.isAbsolute(reference.path) || reference.path.includes('\\') || reference.path.split('/').includes('..')) {
+      continue;
+    }
+    const candidate = path.resolve(canonicalRoot, reference.path);
+    if (!candidate.startsWith(`${canonicalRoot}${path.sep}`)) {
+      continue;
+    }
+    try {
+      const stat = await lstat(candidate);
+      const canonical = await realpath(candidate);
+      if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 8 * 1024 * 1024 || !canonical.startsWith(`${canonicalRoot}${path.sep}`)) {
+        continue;
+      }
+      const output = await readFile(canonical, 'utf8');
+      const aggregate = reference.kind === 'commands-log' ? phpunitCommandLogAggregate(output) : phpunitAggregate(output);
+      if (phpunitSummaryMatches(aggregate, results.summary)) {
+        return output;
+      }
+    } catch {}
+  }
+  return '';
+}
+function phpunitCommandLogAggregate(output) {
+  const sections = [...output.matchAll(/(?:^|\n---\n)(\[[^\]\n]+\]\s+wordpress\.phpunit\b[\s\S]*?)(?=\n---\n\[[^\]\n]+\]\s+\S|$)/g)]
+    .map((match) => phpunitAggregate(match[1]))
+    .filter(Boolean);
+  if (sections.length === 0) {
+    return phpunitAggregate(output);
+  }
+  return sections.reduce((aggregate, section) => ({
+    total: aggregate.total + section.total,
+    passed: aggregate.passed + section.passed,
+    failed: aggregate.failed + section.failed,
+    skipped: aggregate.skipped + section.skipped,
+    assertions: aggregate.assertions + section.assertions,
+  }), { total: 0, passed: 0, failed: 0, skipped: 0, assertions: 0 });
+}
+function phpunitSummaryMatches(aggregate, summary) {
+  return aggregate !== null && ['total', 'passed', 'failed', 'skipped'].every((key) => aggregate[key] === summary[key]);
 }
 function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
@@ -51,6 +51,10 @@ if (typeof fixture.stageLog === 'string') {
   fs.mkdirSync(path.join(runtime, 'files', 'phpunit'), { recursive: true });
   fs.writeFileSync(path.join(runtime, 'files', 'phpunit', '.pg-test-result.txt'), fixture.stageLog);
 }
+if (typeof fixture.commandsLog === 'string') {
+  fs.mkdirSync(path.join(runtime, 'logs'), { recursive: true });
+  fs.writeFileSync(path.join(runtime, 'logs', 'commands.log'), fixture.commandsLog);
+}
 process.stdout.write(JSON.stringify({ success: false, executions: fixture.executions || [] }) + '\\n');
 process.exitCode = fixture.exitCode === undefined ? 1 : fixture.exitCode;
 `);
@@ -165,6 +169,124 @@ try {
   const structuredDiagnosis = JSON.parse(await readFile(path.join(structuredFailure.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
   assert.equal(structuredDiagnosis.executed_tests, 23);
   assert.equal(structuredDiagnosis.cause, 'tests_executed');
+
+  // WP Codebox's real failed-suite artifact shape stores stage markers in the
+  // phpunit diagnostic and TextUI's failure trace in the referenced command log.
+  const referencedCommandLog = await runScenario('referenced-command-log', {
+    executions: setupOnlyFixture.executions,
+    stageLog: 'STAGE_BEGIN:run_tests\nRUNNING 1 TEST FILES\n',
+    commandsLog: [
+      '[2026-08-14T00:00:00.000Z] wordpress.phpunit plugin-slug=sample-plugin',
+      'exitCode=1',
+      'PHPUnit 9.6.34 by Sebastian Bergmann and contributors.',
+      '',
+      'There were 4 failures:',
+      '',
+      '1) SampleTest::test_first',
+      'Failed asserting that false is true.',
+      '',
+      '2) SampleTest::test_second',
+      'Failed asserting that null is not null.',
+      '',
+      '3) SampleTest::test_third',
+      'Failed asserting that two strings are identical.',
+      '',
+      '4) SampleTest::test_fourth',
+      'Failed asserting that an array has the key expected.',
+      '',
+      'FAILURES!',
+      'Tests: 23, Assertions: 40, Failures: 4.',
+      '',
+    ].join('\n'),
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'failed',
+      summary: { total: 23, passed: 19, failed: 4, skipped: 0, unknown: 0 },
+      suites: [],
+      rawLogReferences: [
+        { path: 'logs/commands.log', kind: 'commands-log' },
+        { path: 'files/phpunit/.pg-test-result.txt', kind: 'phpunit-output' },
+      ],
+    },
+  });
+  const referencedOutput = await readFile(path.join(referencedCommandLog.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.match(referencedOutput, /SampleTest::test_first/);
+  assert.match(referencedOutput, /SampleTest::test_fourth/);
+  assert.match(referencedOutput, /Tests: 23, Assertions: 40, Failures: 4/);
+  assert.doesNotMatch(referencedOutput, /NO_PHPUNIT_EXECUTION/);
+  const referencedFailures = JSON.parse(await readFile(path.join(referencedCommandLog.publishedFiles, 'test-failures.json'), 'utf8'));
+  assert.equal(referencedFailures.failures.length, 4);
+
+  const staleSkippedCommandLog = await runScenario('stale-skipped-command-log', {
+    executions: setupOnlyFixture.executions,
+    stageLog: 'STAGE_BEGIN:run_tests\nRUNNING 1 TEST FILES\n',
+    commandsLog: '[2026-08-14T00:00:00.000Z] wordpress.phpunit\nexitCode=1\n1) StaleTest::test_failure\nTests: 23, Assertions: 40, Failures: 4.\n',
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'failed',
+      summary: { total: 23, passed: 18, failed: 4, skipped: 1, unknown: 0 },
+      suites: [],
+      rawLogReferences: [{ path: 'logs/commands.log', kind: 'commands-log' }],
+    },
+  });
+  const staleSkippedOutput = await readFile(path.join(staleSkippedCommandLog.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.doesNotMatch(staleSkippedOutput, /StaleTest::test_failure/);
+  const staleSkippedResults = JSON.parse(await readFile(path.join(staleSkippedCommandLog.publishedFiles, 'test-results.json'), 'utf8'));
+  assert.deepEqual(staleSkippedResults.summary, { total: 23, passed: 18, failed: 4, skipped: 1, unknown: 0 });
+
+  const staleSkippedPreserved = await runScenario('stale-skipped-preserved-output', {
+    executions: setupOnlyFixture.executions,
+    phpunitOutput: '1) StalePreservedTest::test_failure\nTests: 23, Assertions: 40, Failures: 4.\n',
+    stageLog: 'STAGE_BEGIN:run_tests\nRUNNING 1 TEST FILES\n',
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'failed',
+      summary: { total: 23, passed: 18, failed: 4, skipped: 1, unknown: 0 },
+      suites: [],
+      rawLogReferences: [{ path: 'files/phpunit-output.log', kind: 'phpunit-output' }],
+    },
+  });
+  const staleSkippedPreservedOutput = await readFile(path.join(staleSkippedPreserved.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.doesNotMatch(staleSkippedPreservedOutput, /StalePreservedTest::test_failure/);
+
+  const multiCommandLog = await runScenario('multi-command-log', {
+    executions: setupOnlyFixture.executions,
+    stageLog: 'STAGE_BEGIN:run_tests\nRUNNING 2 TEST FILES\n',
+    commandsLog: [
+      '[2026-08-14T00:00:00.000Z] wordpress.phpunit process-identity=one',
+      'exitCode=1',
+      'There was 1 failure:',
+      '',
+      '1) FirstTest::test_failure',
+      'Failed asserting that false is true.',
+      'FAILURES!',
+      'Tests: 10, Assertions: 15, Failures: 1.',
+      '---',
+      '[2026-08-14T00:00:01.000Z] wordpress.phpunit process-identity=two',
+      'exitCode=1',
+      'There was 1 failure:',
+      '',
+      '1) SecondTest::test_failure',
+      'Failed asserting that null is not null.',
+      'FAILURES!',
+      'Tests: 13, Assertions: 25, Failures: 1.',
+      '',
+    ].join('\n'),
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'failed',
+      summary: { total: 23, passed: 21, failed: 2, skipped: 0, unknown: 0 },
+      suites: [],
+      rawLogReferences: [{ path: 'logs/commands.log', kind: 'commands-log' }],
+    },
+  });
+  const multiOutput = await readFile(path.join(multiCommandLog.publishedFiles, 'phpunit-output.log'), 'utf8');
+  assert.match(multiOutput, /FirstTest::test_failure/);
+  assert.match(multiOutput, /SecondTest::test_failure/);
+  const multiResults = JSON.parse(await readFile(path.join(multiCommandLog.publishedFiles, 'test-results.json'), 'utf8'));
+  assert.deepEqual(multiResults.summary, { total: 23, passed: 21, failed: 2, skipped: 0, unknown: 0 });
+  const multiFailures = JSON.parse(await readFile(path.join(multiCommandLog.publishedFiles, 'test-failures.json'), 'utf8'));
+  assert.equal(multiFailures.failures.length, 2);
 
   const staleOutput = await runScenario('stale-output', {
     executions: setupOnlyFixture.executions,


### PR DESCRIPTION
## Summary
- resolve WP Codebox PHPUnit output and command-log references inside the current artifact root
- require full structured-summary agreement before promoting referenced or preserved output
- preserve aggregate structured results across multiple PHPUnit command sections
- regress the live 23-test/4-failure artifact shape, stale output, and multi-command suites

## Verification
- `npx eslint scripts/test/wp-codebox-phpunit-adapter.mjs`
- `node tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs`
- `node tests/wp-codebox-phpunit-evidence-smoke.mjs`
- `node tests/wp-codebox-phpunit-aggregate-smoke.mjs`
- `bash scripts/test/parse-test-failures-sidecar-smoke.sh`
- `bash scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- independent focused review: no findings

Repository-wide `npm run lint:js` still reports pre-existing failures in untouched files; the changed adapter passes focused ESLint.

Fixes #2617.

## AI Assistance
OpenAI GPT-5.6 Sol through OpenCode was used to trace the live WP Codebox artifact contract, implement the bounded raw-reference resolver, write regression coverage, and run verification. Chris Huber reviewed and remains responsible for every line.