### PR TITLE
feat(wordpress): emit a test inventory so the suite can be sharded

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -81,6 +81,7 @@
       "bash scripts/lint/phpcs-warnings-gate-smoke.sh",
       "bash scripts/test/parse-test-failures-sidecar-smoke.sh",
       "bash scripts/test/parse-wp-codebox-artifacts-smoke.sh",
+      "bash scripts/test/test-inventory-smoke.sh",
       "bash scripts/validation/validate-playground-blueprint-smoke.sh",
       "node tests/audit-fanout-runtime-adapter.test.js",
       "node tests/block-quality-smoke.js",

--- a/wordpress/scripts/test/test-inventory-smoke.sh
+++ b/wordpress/scripts/test/test-inventory-smoke.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extra-Chill/homeboy#12394 — WordPress test inventory producer.
+#
+# Sharded execution needs the suite enumerated without running it. Homeboy core
+# re-derives both fingerprints itself and refuses anything that does not match,
+# so the producer's only job is to agree with core exactly. Two properties carry
+# that agreement and are asserted here:
+#
+#   * the workspace fingerprint responds to declared files and ignores
+#     everything else, including skipped directories;
+#   * `inventory_fingerprint` is the sha256 of
+#     `json.dumps(record_without_that_key, sort_keys=True, separators=(",",":"))`,
+#     which is the byte layout core reproduces by hand.
+#
+# Enumeration must also match what the runner would actually execute. A file the
+# runner cannot route must not appear, or a shard would claim a test that never
+# runs and the aggregate totals would not reconcile.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PRODUCER="${SCRIPT_DIR}/test-inventory.py"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+plugin="${WORKDIR}/plugin"
+mkdir -p "${plugin}/tests/nested" "${plugin}/inc" "${plugin}/vendor/pkg/tests" "${plugin}/node_modules/x"
+printf '{}\n' > "${plugin}/composer.json"
+printf '<?php\n' > "${plugin}/inc/Runtime.php"
+
+# Routable by the runner: host PHP smoke, JS smoke, shell smoke, node test, PHPUnit.
+printf '<?php\n' > "${plugin}/tests/alpha-smoke.php"
+printf '<?php\n' > "${plugin}/tests/nested/beta-smoke.php"
+printf '// js\n'  > "${plugin}/tests/gamma-smoke.js"
+printf '# sh\n'   > "${plugin}/tests/delta-smoke.sh"
+printf '// node\n' > "${plugin}/tests/epsilon.test.js"
+printf '<?php\n'  > "${plugin}/tests/ZetaTest.php"
+printf '<?php\n'  > "${plugin}/tests/test-eta.php"
+
+# Not routable, and must not be enumerated: a fixture, a support file, and
+# anything inside a skipped directory.
+printf '<?php\n' > "${plugin}/tests/fixture-data.php"
+printf '<?php\n' > "${plugin}/vendor/pkg/tests/vendor-smoke.php"
+printf '// dep\n' > "${plugin}/node_modules/x/dep-smoke.js"
+
+run_producer() {
+    python3 "$PRODUCER" \
+        --project "$plugin" \
+        --extension-path "$EXTENSION_PATH" \
+        --runner wordpress \
+        --package fixture-plugin \
+        --output "$1" 2>/dev/null
+}
+
+run_producer "${WORKDIR}/inventory.json" || fail "producer exited non-zero"
+inventory="${WORKDIR}/inventory.json"
+
+python3 - "$inventory" <<'PY' || fail "inventory contract assertions failed"
+import hashlib, json, sys
+
+doc = json.load(open(sys.argv[1]))
+
+assert doc["schema"] == "homeboy/test-inventory/v1", doc["schema"]
+assert doc["runner"] == "wordpress", doc["runner"]
+for key in ("runner_fingerprint", "workspace_fingerprint", "inventory_fingerprint"):
+    value = doc[key]
+    assert len(value) == 64 and value == value.lower(), f"{key}={value!r}"
+    int(value, 16)
+
+# Core rebuilds the canonical form without `inventory_fingerprint` and with no
+# `fallback_reason`, so the producer must not emit one.
+assert "fallback_reason" not in doc, "producer must not emit fallback_reason"
+
+ids = [t["id"] for t in doc["tests"]]
+assert len(ids) == len(set(ids)), "test ids must be unique"
+
+expected = {
+    "tests/alpha-smoke.php": ("smoke", "host-php-smoke"),
+    "tests/nested/beta-smoke.php": ("smoke", "host-php-smoke"),
+    "tests/gamma-smoke.js": ("smoke", "host-js-smoke"),
+    "tests/delta-smoke.sh": ("smoke", "host-shell-smoke"),
+    "tests/epsilon.test.js": ("test", "node-test"),
+    "tests/ZetaTest.php": ("test", "phpunit"),
+    "tests/test-eta.php": ("test", "phpunit"),
+}
+assert set(ids) == set(expected), f"enumerated {sorted(ids)}"
+
+by_id = {t["id"]: t for t in doc["tests"]}
+for test_id, (kind, target) in expected.items():
+    entry = by_id[test_id]
+    assert entry["target_kind"] == kind, (test_id, entry)
+    assert entry["target"] == target, (test_id, entry)
+    assert entry["expected_outcome"] == "executed", entry
+    assert entry["package"] == "fixture-plugin", entry
+    assert entry["name"] and entry["name"] == test_id.rsplit("/", 1)[-1], entry
+
+# The fingerprint identity core re-derives.
+record = {k: v for k, v in doc.items() if k != "inventory_fingerprint"}
+canonical = json.dumps(record, sort_keys=True, separators=(",", ":"))
+assert hashlib.sha256(canonical.encode()).hexdigest() == doc["inventory_fingerprint"], \
+    "inventory_fingerprint is not the canonical digest core will recompute"
+
+print(f"PASS: enumerated {len(ids)} routable tests, fingerprints are canonical")
+PY
+
+# Determinism: identical input must produce an identical document, or a shard
+# plan cannot be replayed.
+run_producer "${WORKDIR}/again.json" || fail "second producer run exited non-zero"
+cmp -s "$inventory" "${WORKDIR}/again.json" || fail "producer is not deterministic"
+printf 'PASS: producer is deterministic across runs\n'
+
+before_ws="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["workspace_fingerprint"])' "$inventory")"
+
+# A skipped directory must not move the workspace fingerprint.
+printf '<?php\n// noise\n' > "${plugin}/vendor/pkg/Ignored.php"
+run_producer "${WORKDIR}/skipped.json" || fail "producer failed after vendor write"
+after_skip="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["workspace_fingerprint"])' "${WORKDIR}/skipped.json")"
+[ "$before_ws" = "$after_skip" ] || fail "vendor/ is skipped but changed the workspace fingerprint"
+printf 'PASS: skipped directories do not move the workspace fingerprint\n'
+
+# An undeclared extension must not move it either.
+printf 'notes\n' > "${plugin}/inc/notes.md"
+run_producer "${WORKDIR}/md.json" || fail "producer failed after markdown write"
+after_md="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["workspace_fingerprint"])' "${WORKDIR}/md.json")"
+[ "$before_ws" = "$after_md" ] || fail "markdown is undeclared but changed the workspace fingerprint"
+printf 'PASS: undeclared extensions do not move the workspace fingerprint\n'
+
+# A declared source file must move it, or the fingerprint proves nothing.
+printf '<?php\n// changed\n' > "${plugin}/inc/Runtime.php"
+run_producer "${WORKDIR}/changed.json" || fail "producer failed after php edit"
+after_php="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["workspace_fingerprint"])' "${WORKDIR}/changed.json")"
+[ "$before_ws" != "$after_php" ] || fail "a declared PHP source edit did not move the workspace fingerprint"
+printf 'PASS: declared source edits move the workspace fingerprint\n'
+
+# An empty enumeration is refused: it cannot be told apart from a broken
+# producer, and sharding nothing would report a green suite that ran no tests.
+empty="${WORKDIR}/empty"
+mkdir -p "${empty}"
+printf '{}\n' > "${empty}/composer.json"
+if python3 "$PRODUCER" --project "$empty" --extension-path "$EXTENSION_PATH" \
+    --runner wordpress --output "${WORKDIR}/empty.json" >/dev/null 2>&1; then
+    fail "producer accepted a component with no tests"
+fi
+printf 'PASS: an empty enumeration is refused\n'
+
+# An undeclared runner has no version command and therefore no identity.
+if python3 "$PRODUCER" --project "$plugin" --extension-path "$EXTENSION_PATH" \
+    --runner not-declared --output "${WORKDIR}/bad-runner.json" >/dev/null 2>&1; then
+    fail "producer accepted an undeclared runner"
+fi
+printf 'PASS: an undeclared runner is refused\n'
+
+printf 'All WordPress test inventory checks passed.\n'

--- a/wordpress/scripts/test/test-inventory.py
+++ b/wordpress/scripts/test/test-inventory.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Emit a `homeboy/test-inventory/v1` document for a WordPress component.
+
+Sharded test execution needs an enumeration of the suite that is produced
+*without running it*, bound to a fingerprint of the workspace and of the runner.
+Homeboy core owns the binding and re-derives both fingerprints itself before
+accepting anything this script writes, so the only way a document is accepted is
+by computing them exactly the way core does.
+
+Two details are load-bearing and easy to get wrong:
+
+* The canonical JSON that feeds `inventory_fingerprint` is
+  `json.dumps(record, sort_keys=True, separators=(",", ":"))` with the default
+  `ensure_ascii=True`, over the record *without* `inventory_fingerprint`.
+  Core reproduces that byte layout by hand in `canonical_inventory_json`,
+  including the ASCII escaping, so a differently-encoded equivalent document is
+  rejected. This is also why the producer is Python rather than PHP or shell:
+  matching Python's `json.dumps` is the contract.
+
+* The workspace fingerprint concatenates `f"{relative_path}\\0{text}\\0"` over
+  the selected files in sorted order, where `text` has been read with universal
+  newlines. Core normalizes CRLF and lone CR to LF for the same reason.
+
+The file selection, skip list, root markers and runner identity are read from
+the extension manifest's `test.inventory` block, so this script and the
+declaration Homeboy validates against cannot drift apart.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCHEMA = "homeboy/test-inventory/v1"
+
+
+def fail(message):
+    raise SystemExit(f"WordPress test inventory error: {message}")
+
+
+def digest(value):
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def load_inventory_config(extension_path):
+    manifest = Path(extension_path) / "wordpress.json"
+    try:
+        declared = json.loads(manifest.read_text())
+    except OSError as error:
+        fail(f"could not read {manifest}: {error}")
+    except json.JSONDecodeError as error:
+        fail(f"{manifest} is not valid JSON: {error}")
+
+    config = declared.get("test", {}).get("inventory")
+    if not config:
+        fail("wordpress.json declares no test.inventory block")
+    return config
+
+
+def workspace_root(project, config):
+    """Mirror core's `inventory_workspace_root`.
+
+    Walk upward for the first ancestor holding a declared marker; with none
+    found the component path is its own root. Core resolves this identically,
+    and a mismatch means the workspace fingerprints cannot agree.
+    """
+    start = Path(project).resolve()
+    markers = config.get("root_markers") or []
+    for candidate in [start, *start.parents]:
+        if any((candidate / marker).exists() for marker in markers):
+            return candidate
+    return start
+
+
+def selected_for_fingerprint(path, config):
+    names = set(config.get("fingerprint_names") or [])
+    extensions = set(config.get("fingerprint_extensions") or [])
+    if path.name in names:
+        return True
+    return path.suffix[1:] in extensions if path.suffix else False
+
+
+def workspace_fingerprint(root, config):
+    skip = set(config.get("fingerprint_skip_dirs") or [])
+    selected = []
+    for directory, subdirectories, files in os.walk(root):
+        subdirectories[:] = [name for name in subdirectories if name not in skip]
+        for name in files:
+            path = Path(directory) / name
+            if path.is_file() and selected_for_fingerprint(path, config):
+                selected.append(path)
+
+    content = []
+    for path in sorted(selected, key=lambda item: str(item.relative_to(root))):
+        try:
+            # `read_text` applies universal newlines, which is what core's
+            # CRLF/CR normalization reproduces.
+            text = path.read_text(errors="replace")
+        except OSError as error:
+            fail(f"could not read {path} for the workspace fingerprint: {error}")
+        content.append(f"{path.relative_to(root)}\0{text}\0")
+    return digest("".join(content))
+
+
+def runner_fingerprint(root, config, runner):
+    declared = next(
+        (entry for entry in config.get("runners") or [] if entry.get("id") == runner),
+        None,
+    )
+    if not declared:
+        fail(f"wordpress.json declares no inventory runner named {runner!r}")
+    argv = declared.get("version_command") or []
+    if not argv:
+        fail(f"inventory runner {runner!r} declares no version_command")
+    try:
+        result = subprocess.run(
+            argv, cwd=root, text=True, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=False,
+        )
+    except OSError as error:
+        fail(f"could not fingerprint {runner} runner: {error}")
+    if result.returncode:
+        fail(f"could not fingerprint {runner} runner: {result.stderr.strip()}")
+    return digest(f"{runner}\0{result.stdout.strip()}")
+
+
+def within_tests_tree(relative):
+    """Match the runner's own `tests/` and `wordpress/tests/` prefixes."""
+    parts = relative.split("/")
+    if parts[0] == "tests":
+        return True
+    return len(parts) > 1 and parts[0] == "wordpress" and parts[1] == "tests"
+
+
+def classify(relative):
+    """Return (target_kind, target) or None, mirroring the runner's matchers.
+
+    These predicates are the ones `test-runner.sh` uses to route a changed-scope
+    selection, so the inventory enumerates exactly the population the runner
+    would execute. A file the runner cannot route must not appear here: a shard
+    would then claim a test that never runs, and the aggregate totals would not
+    reconcile.
+    """
+    name = relative.rsplit("/", 1)[-1]
+    in_tests = within_tests_tree(relative)
+
+    if in_tests and name.endswith("-smoke.php"):
+        return "smoke", "host-php-smoke"
+    if in_tests and name.endswith("-smoke.js"):
+        return "smoke", "host-js-smoke"
+    if in_tests and name.endswith("-smoke.sh"):
+        return "smoke", "host-shell-smoke"
+    for suffix in (".test.js", ".test.cjs", ".test.mjs", ".test.jsx", ".test.ts", ".test.tsx"):
+        if name.endswith(suffix):
+            return "test", "node-test"
+    if name.endswith("Test.php") or name.startswith("test-") and name.endswith(".php"):
+        return "test", "phpunit"
+    return None
+
+
+def enumerate_tests(root, package, config):
+    skip = set(config.get("fingerprint_skip_dirs") or [])
+    tests = {}
+    for directory, subdirectories, files in os.walk(root):
+        subdirectories[:] = [name for name in subdirectories if name not in skip]
+        for name in files:
+            relative = str((Path(directory) / name).relative_to(root))
+            classified = classify(relative)
+            if not classified:
+                continue
+            target_kind, target = classified
+            # The path is the id: it is what HOMEBOY_CHANGED_TEST_FILES already
+            # carries, so a shard manifest slice can be replayed through the
+            # existing changed-scope routing without a second selector format.
+            tests[relative] = {
+                "id": relative,
+                "package": package,
+                "target": target,
+                "target_kind": target_kind,
+                "name": name,
+                "expected_outcome": "executed",
+            }
+    return [tests[key] for key in sorted(tests)]
+
+
+def build_inventory(runner, runner_digest, workspace_digest, tests):
+    record = {
+        "schema": SCHEMA,
+        "runner": runner,
+        "runner_fingerprint": runner_digest,
+        "workspace_fingerprint": workspace_digest,
+        "tests": tests,
+    }
+    # Core hashes the record without `inventory_fingerprint`, and deliberately
+    # excludes `fallback_reason` from the canonical form, so this producer never
+    # emits one.
+    record["inventory_fingerprint"] = digest(
+        json.dumps(record, sort_keys=True, separators=(",", ":"))
+    )
+    return record
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True, help="component source path")
+    parser.add_argument("--extension-path", required=True, help="extension root holding wordpress.json")
+    parser.add_argument("--runner", default="wordpress", help="declared runner identity")
+    parser.add_argument("--package", default="", help="package label recorded on each test")
+    parser.add_argument("--output", required=True, help="file to write the inventory to")
+    args = parser.parse_args()
+
+    config = load_inventory_config(args.extension_path)
+    root = workspace_root(args.project, config)
+    package = args.package or Path(args.project).resolve().name
+
+    tests = enumerate_tests(root, package, config)
+    if not tests:
+        # Core refuses an empty inventory, and it is right to: an empty
+        # enumeration cannot be distinguished from a broken producer, and
+        # sharding nothing would report a green suite that ran no tests.
+        fail(f"no test files found under {root}")
+
+    inventory = build_inventory(
+        args.runner,
+        runner_fingerprint(root, config, args.runner),
+        workspace_fingerprint(root, config),
+        tests,
+    )
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(inventory))
+    print(f"WordPress test inventory: {len(tests)} tests -> {output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -48,6 +48,34 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Component path: ${COMPONENT_PATH:-$(pwd)}"
 fi
 
+# Inventory-only mode enumerates the suite without running any of it, so that
+# Homeboy can plan bounded shards. It must return before any runner is selected:
+# a producer that executed tests would defeat the point, and core deliberately
+# withholds the changed-scope environment here because an inventory is a
+# complete enumeration rather than a changed-test execution.
+#
+# The document is written by a Python producer, not by this shell, because the
+# `inventory_fingerprint` contract is literally Python's
+# `json.dumps(..., sort_keys=True, separators=(",", ":"))` byte layout, which
+# core reproduces by hand when it re-derives the fingerprint. (#12394)
+if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = "1" ]; then
+    if [ -z "${HOMEBOY_TEST_INVENTORY_FILE:-}" ]; then
+        echo "Error: HOMEBOY_TEST_INVENTORY_ONLY is set without HOMEBOY_TEST_INVENTORY_FILE." >&2
+        exit 2
+    fi
+    INVENTORY_TOOL="${SCRIPT_DIR}/test-inventory.py"
+    if [ ! -f "$INVENTORY_TOOL" ]; then
+        echo "Error: WordPress test inventory producer is missing: ${INVENTORY_TOOL}" >&2
+        exit 2
+    fi
+    exec python3 "$INVENTORY_TOOL" \
+        --project "$PLUGIN_PATH" \
+        --extension-path "$EXTENSION_PATH" \
+        --runner "${HOMEBOY_WORDPRESS_INVENTORY_RUNNER:-wordpress}" \
+        --package "${HOMEBOY_COMPONENT_ID:-wordpress}" \
+        --output "$HOMEBOY_TEST_INVENTORY_FILE"
+fi
+
 # WordPress tests run through the selected runtime backend against real
 # WordPress. The default suite is PHPUnit. Standalone smoke scripts are
 # diagnostic/operator targets and run only when selected explicitly with --file,

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1064,6 +1064,13 @@
       "file_extensions": ["php"],
       "inline_tests": false
     },
+    "inventory": {
+      "root_markers": ["composer.json", "readme.txt", "style.css"],
+      "fingerprint_names": ["composer.json", "composer.lock", "package.json", "package-lock.json"],
+      "fingerprint_extensions": ["php", "js", "jsx", "ts", "tsx", "sh"],
+      "fingerprint_skip_dirs": [".git", "vendor", "node_modules", "build", "dist", "target", ".homeboy-action"],
+      "runners": [{ "id": "wordpress", "version_command": ["php", "--version"] }]
+    },
     "secret_env_projections": [
       {
         "when": {


### PR DESCRIPTION
Step 2c of Extra-Chill/homeboy#12394. Producer only — shard-manifest replay is a separate PR.

Requires the seam from Extra-Chill/homeboy#12396 and the runner-allowlist fix in Extra-Chill/homeboy#12423.

## Why

Sharded test execution needs the suite enumerated *without running it*. Only the Rust extension implemented a `homeboy/test-inventory/v1` producer, so WordPress components could not shard at all — which is why Data Machine PR #3173 spent 25 minutes timing out instead of running in bounded parallel shards, and why Extra-Chill/homeboy#12365 ended where it did.

## The contract

Homeboy core re-derives both fingerprints itself and refuses anything that does not match, so the producer's only real job is to agree with core exactly. Two details carry that:

- **`inventory_fingerprint`** is the sha256 of `json.dumps(record_without_that_key, sort_keys=True, separators=(",", ":"))` with the default `ensure_ascii=True`. Core reproduces that byte layout *by hand* in `canonical_inventory_json`. This is why the producer is Python rather than PHP or shell — matching Python's `json.dumps` is the contract, not an implementation preference.
- **The workspace fingerprint** concatenates `"{relpath}\0{text}\0"` over selected files in sorted order, read with universal newlines — which is what core's CRLF/lone-CR normalization reproduces.

## Verified against core, not asserted

Ran core's own `workspace_fingerprint` and `canonical_inventory_json` over this producer's output for the real Data Machine checkout:

```
XCHECK core root      = /var/lib/datamachine/workspace/data-machine
XCHECK core ws_fp     = eb9a153713c03488e45f98bbd52ea3bc6fbbe7ddb04dc089fa70f826c7d18f84
XCHECK producer ws_fp = eb9a153713c03488e45f98bbd52ea3bc6fbbe7ddb04dc089fa70f826c7d18f84
XCHECK core canon fp  = 8a0bd4bd7942ed14e6cb185ba20f2a1d9552680e3e4e2fb4593c5d1e033ab7f2
XCHECK producer inv fp= 8a0bd4bd7942ed14e6cb185ba20f2a1d9552680e3e4e2fb4593c5d1e033ab7f2
```

Both agree exactly. **467 tests enumerated in 0.8s.**

## Enumeration matches what the runner executes

`classify()` mirrors `test-runner.sh`'s own routing predicates — `tests/**/*-smoke.php`, `-smoke.js`, `-smoke.sh`, `*.test.{js,cjs,mjs,jsx,ts,tsx}`, `*Test.php`, `test-*.php`, under `tests/` or `wordpress/tests/`.

A file the runner cannot route is deliberately **absent**: a shard would otherwise claim a test that never runs, and the aggregate totals would not reconcile.

Test ids are component-relative paths — what `HOMEBOY_CHANGED_TEST_FILES` already carries — so a shard slice replays through the existing changed-scope routing instead of needing a second selector format.

## Single source of truth

Selection, skip list, root markers and runner identity all come from the `test.inventory` block that Homeboy validates against, read from `wordpress.json` at runtime. The producer and the declaration cannot drift apart.

## Refusals

An empty enumeration is **refused**, not emitted — it cannot be told apart from a broken producer, and sharding nothing would report a green suite that ran no tests. An undeclared runner is refused for the same reason: no version command means no identity.

## Coverage

`wordpress/scripts/test/test-inventory-smoke.sh`, registered in `wordpress/homeboy.json` self-checks:

```
PASS: enumerated 7 routable tests, fingerprints are canonical
PASS: producer is deterministic across runs
PASS: skipped directories do not move the workspace fingerprint
PASS: undeclared extensions do not move the workspace fingerprint
PASS: declared source edits move the workspace fingerprint
PASS: an empty enumeration is refused
PASS: an undeclared runner is refused
```

The three fingerprint-sensitivity checks matter most: a fingerprint that never changes, or changes on irrelevant files, silently breaks shard-plan validity rather than failing loudly.

Determinism is pinned by `cmp` on two consecutive runs — a shard plan cannot be replayed otherwise.
