### PR TITLE
Render bounded WordPress timeout diagnostics

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -22,7 +22,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh scripts/test/changed-scope-test-routing-smoke.sh scripts/test/test-runner-file-routing-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/installed-build-helper-resolution-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
-      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs"
+      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/lib/wp-codebox-timeout-diagnostics.mjs scripts/lib/wp-codebox-phpunit-timeout.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs"
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
@@ -36,6 +36,9 @@
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
       "node tests/wp-codebox-phpunit-aggregate-smoke.mjs",
       "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
+      "node tests/wp-codebox-timeout-diagnostics-smoke.mjs",
+      "node tests/wp-codebox-phpunit-timeout-diagnostics-smoke.mjs",
+      "node tests/wp-codebox-phpunit-timeout-options-smoke.mjs",
       "node tests/wp-codebox-phpunit-target-activation-smoke.mjs",
       "node tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs",
       "node tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs",

--- a/wordpress/scripts/lib/wp-codebox-phpunit-timeout.mjs
+++ b/wordpress/scripts/lib/wp-codebox-phpunit-timeout.mjs
@@ -1,0 +1,13 @@
+export const DEFAULT_WP_CODEBOX_PHPUNIT_TIMEOUT_SECONDS = 1440;
+
+export function configuredWpCodeboxPhpunitTimeoutSeconds(environment = process.env, settings = {}) {
+  const value = environment.HOMEBOY_WORDPRESS_PHPUNIT_TIMEOUT_SECONDS
+    || settings.wp_codebox_phpunit_timeout_seconds
+    || environment.HOMEBOY_TASK_TIMEOUT_SECONDS
+    || DEFAULT_WP_CODEBOX_PHPUNIT_TIMEOUT_SECONDS;
+  const seconds = Number(value);
+  if (!Number.isSafeInteger(seconds) || seconds < 1) {
+    throw new Error('WP Codebox PHPUnit timeout must be a positive integer number of seconds.');
+  }
+  return seconds;
+}

--- a/wordpress/scripts/lib/wp-codebox-timeout-diagnostics.mjs
+++ b/wordpress/scripts/lib/wp-codebox-timeout-diagnostics.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+import { open, readFile } from 'node:fs/promises';
+import { StringDecoder } from 'node:string_decoder';
+
+export const WP_CODEBOX_TIMEOUT_DIAGNOSTICS_SCHEMA = 'homeboy/wp-codebox-timeout-diagnostics/v1';
+export const WP_CODEBOX_TIMEOUT_DIAGNOSTICS_MAX_BYTES = 8192;
+
+const TEXT_EXCERPT_BYTES = 1024;
+const FIELD_BYTES = 512;
+const INPUT_BYTES = 128 * 1024;
+const MAX_REDACTED_RECORD_BYTES = 128 * 1024;
+
+export function wpCodeboxTimeoutDiagnostics({
+  phase,
+  elapsedSeconds,
+  budgetSeconds,
+  selected = [],
+  termination = {},
+  artifacts = [],
+  payload,
+  stderr = '',
+  secretValues = secretValuesFromEnvironment(process.env),
+} = {}) {
+  const recipeRun = asObject(payload);
+  const executions = Array.isArray(recipeRun?.executions) ? recipeRun.executions : [];
+  const completed = executions.filter((execution) => integerExitCode(execution) !== undefined).length;
+  const last = executions.at(-1);
+  const diagnostic = {
+    schema: WP_CODEBOX_TIMEOUT_DIAGNOSTICS_SCHEMA,
+    phase: boundedText(phase, FIELD_BYTES, secretValues) || 'wp-codebox-recipe-run',
+    elapsed_seconds: finiteNonNegative(elapsedSeconds),
+    budget_seconds: finiteNonNegative(budgetSeconds),
+    selected: {
+      count: selected.length,
+      items: selected.slice(0, 20).map((value) => boundedText(value, FIELD_BYTES, secretValues)).filter(Boolean),
+    },
+    execution: {
+      count: executions.length,
+      count_complete: recipeRun?.execution_count_complete !== false,
+      completed_count: completed,
+      last: executionSummary(last, executions.length - 1, secretValues),
+    },
+    termination: {
+      result: boundedText(termination.result, FIELD_BYTES, secretValues) || 'timeout',
+      signal: boundedText(termination.signal, FIELD_BYTES, secretValues) || undefined,
+      code: Number.isInteger(termination.code) ? termination.code : undefined,
+    },
+    artifact_refs: artifacts.slice(0, 20).map((artifact) => boundedText(artifact, FIELD_BYTES, secretValues)).filter(Boolean),
+    excerpts: boundedText(stderr, TEXT_EXCERPT_BYTES, secretValues) || undefined,
+  };
+  removeUndefined(diagnostic.termination);
+  removeUndefined(diagnostic);
+
+  // Every projected field is independently bounded. This final guard keeps the
+  // record safe if a future caller adds a larger field.
+  let serialized = JSON.stringify(diagnostic);
+  if (Buffer.byteLength(serialized) > WP_CODEBOX_TIMEOUT_DIAGNOSTICS_MAX_BYTES) {
+    delete diagnostic.excerpts;
+    diagnostic.selected.items = diagnostic.selected.items.slice(0, 5);
+    diagnostic.artifact_refs = diagnostic.artifact_refs.slice(0, 5);
+    serialized = JSON.stringify(diagnostic);
+  }
+  if (Buffer.byteLength(serialized) > WP_CODEBOX_TIMEOUT_DIAGNOSTICS_MAX_BYTES) {
+    throw new Error('WP Codebox timeout diagnostic exceeded its publication byte ceiling.');
+  }
+  return diagnostic;
+}
+
+function executionSummary(execution, index, secretValues) {
+  if (!asObject(execution)) {
+    return undefined;
+  }
+  return withoutUndefined({
+    index,
+    command: boundedText(execution.command, FIELD_BYTES, secretValues),
+    status: boundedText(execution.status, FIELD_BYTES, secretValues),
+    exit_code: integerExitCode(execution),
+    stdout: outputState(execution.stdout),
+    stderr: outputState(execution.stderr),
+  });
+}
+
+function outputState(value) {
+  if (typeof value === 'string') {
+    return { kind: 'text', bytes: Buffer.byteLength(value) };
+  }
+  if (isByteMap(value)) {
+    return { kind: 'byte_map_omitted' };
+  }
+  if (value !== undefined && value !== null) {
+    return { kind: 'non_text_omitted' };
+  }
+  return undefined;
+}
+
+function isByteMap(value) {
+  if (!asObject(value) || Array.isArray(value)) {
+    return false;
+  }
+  const entries = Object.entries(value);
+  return entries.length > 0 && entries.every(([key, entry]) => /^\d+$/.test(key) && Number.isInteger(entry) && entry >= 0 && entry <= 255);
+}
+
+function boundedText(value, maxBytes, secretValues) {
+  if (typeof value !== 'string' || value === '') {
+    return '';
+  }
+  const text = redactTimeoutText(value, secretValues);
+  const bytes = Buffer.from(text);
+  return bytes.byteLength <= maxBytes ? text : `${bytes.subarray(0, Math.max(0, maxBytes - 14)).toString('utf8')}...[truncated]`;
+}
+
+export function redactTimeoutText(value, secretValues = secretValuesFromEnvironment(process.env)) {
+  if (typeof value !== 'string' || value === '') {
+    return '';
+  }
+  let text = value;
+  for (const secret of secretValues) {
+    text = text.replaceAll(secret, '[REDACTED]');
+  }
+  text = text
+    .replace(/((?:authorization|proxy-authorization)\s*:\s*)(?:[a-z]+\s+)?[^"\r\n]+(?:\r?\n[ \t]+[^"\r\n]+)*/gi, '$1[REDACTED]')
+    .replace(/((?:set-cookie|cookie)\s*:\s*)[^"\r\n]+(?:\r?\n[ \t]+[^"\r\n]+)*/gi, '$1[REDACTED]')
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/@:]+(?::[^\s/@]*)?@/gi, '$1[REDACTED]@')
+    .replace(/((?:api[_-]?key|secret|password|credential|session|cookie|auth(?:orization)?)\s*[=:]\s*|token\s*=\s*)(?!\[REDACTED\])[^"\r\n]*(?:\r?\n[ \t]+[^"\r\n]+)*/gi, '$1[REDACTED]');
+  return text;
+}
+
+// Hold a complete logical record until it can be redacted. A record that exceeds
+// the bounded buffer is omitted rather than publishing a prefix or continuation
+// that could be part of a credential split across stream chunks.
+export function createTimeoutLineRedactor(secretValues = secretValuesFromEnvironment(process.env), maxRecordBytes = MAX_REDACTED_RECORD_BYTES) {
+  const decoder = new StringDecoder('utf8');
+  let pending = '';
+  let omitting = false;
+  const omitted = () => '[REDACTED OVERLONG LINE]\n';
+  const flushLine = (line) => redactTimeoutText(line, secretValues);
+  const consume = (input, end = false) => {
+    let output = '';
+    pending += input;
+    while (true) {
+      const newline = pending.indexOf('\n');
+      if (newline === -1) {
+        if (!omitting && Buffer.byteLength(pending) > maxRecordBytes) {
+          pending = '';
+          omitting = true;
+        }
+        break;
+      }
+      const line = pending.slice(0, newline + 1);
+      pending = pending.slice(newline + 1);
+      if (omitting || Buffer.byteLength(line) > maxRecordBytes) {
+        output += omitted();
+      } else {
+        output += flushLine(line);
+      }
+      omitting = false;
+    }
+    if (end) {
+      if (omitting || Buffer.byteLength(pending) > maxRecordBytes) {
+        output += omitted();
+      } else if (pending) {
+        output += flushLine(pending);
+      }
+      pending = '';
+      omitting = false;
+    }
+    return output;
+  };
+  return {
+    write(chunk) { return consume(decoder.write(chunk)); },
+    end() { return consume(decoder.end(), true); },
+  };
+}
+
+function secretValuesFromEnvironment(environment) {
+  return Object.entries(environment)
+    .filter(([key, value]) => /(?:auth|cookie|credential|key|nonce|passw|secret|session|token)/i.test(key) && typeof value === 'string' && value.length >= 4)
+    .map(([, value]) => value)
+    .sort((left, right) => right.length - left.length);
+}
+
+function integerExitCode(execution) {
+  const value = execution?.exitCode ?? execution?.exit_code;
+  return Number.isInteger(value) ? value : undefined;
+}
+
+function finiteNonNegative(value) {
+  return Number.isFinite(Number(value)) && Number(value) >= 0 ? Number(value) : undefined;
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+}
+
+function withoutUndefined(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function removeUndefined(value) {
+  for (const key of Object.keys(value)) {
+    if (value[key] === undefined) {
+      delete value[key];
+    }
+  }
+}
+
+if (import.meta.filename === process.argv[1]) {
+  const [phase, elapsedSeconds, budgetSeconds, selected, terminationPath, outputPath, stderrPath, artifactsDirectory] = process.argv.slice(2);
+  const [payloadInput, stderr, terminationText] = await Promise.all([
+    readBoundedText(outputPath),
+    readBoundedText(stderrPath),
+    readFile(terminationPath, 'utf8').catch(() => '{}'),
+  ]);
+  let payload;
+  let termination;
+  try { payload = payloadInput.truncated ? recipeRunProjection(payloadInput.text) : JSON.parse(payloadInput.text); } catch { payload = recipeRunProjection(payloadInput.text); }
+  try { termination = JSON.parse(terminationText); } catch {}
+  const artifacts = ['recipe-run.json', 'wp-codebox.stderr', 'recipe.json', 'termination.json']
+    .map((name) => `artifact://${artifactsDirectory}/${name}`);
+  process.stdout.write(`${JSON.stringify(wpCodeboxTimeoutDiagnostics({
+    phase,
+    elapsedSeconds,
+    budgetSeconds,
+    selected: selected ? [selected] : [],
+    termination,
+    artifacts,
+    payload,
+    stderr,
+  }))}\n`);
+}
+
+export async function readBoundedText(filePath, maxBytes = INPUT_BYTES) {
+  let handle;
+  try {
+    handle = await open(filePath, 'r');
+    const stat = await handle.stat();
+    const bytes = Math.min(stat.size, maxBytes);
+    const buffer = Buffer.alloc(bytes);
+    await handle.read(buffer, 0, bytes, 0);
+    return { text: buffer.toString('utf8'), truncated: stat.size > maxBytes };
+  } catch {
+    return { text: '', truncated: false };
+  } finally {
+    await handle?.close();
+  }
+}
+
+export function recipeRunProjection(text) {
+  const execution = {};
+  const command = jsonStringField(text, 'command');
+  const status = jsonStringField(text, 'status');
+  const exitCode = numberField(text, 'exitCode') ?? numberField(text, 'exit_code');
+  if (command) { execution.command = command; }
+  if (status) { execution.status = status; }
+  if (exitCode !== undefined) { execution.exitCode = exitCode; }
+  if (/"stdout"\s*:\s*\{\s*"\d+"\s*:/s.test(text)) { execution.stdout = { 0: 0 }; }
+  else if (/"stdout"\s*:\s*"/s.test(text)) { execution.stdout = ''; }
+  if (/"stderr"\s*:\s*"/s.test(text)) { execution.stderr = ''; }
+  return {
+    executions: Object.keys(execution).length > 0 ? [execution] : [],
+    execution_count_complete: false,
+  };
+}
+
+function jsonStringField(text, name) {
+  const match = new RegExp(`"${name}"\\s*:\\s*("(?:\\\\.|[^"\\\\])*")`, 's').exec(text);
+  if (!match) { return ''; }
+  try { return JSON.parse(match[1]); } catch { return ''; }
+}
+
+function numberField(text, name) {
+  const match = new RegExp(`"${name}"\\s*:\\s*(-?\\d+)`, 's').exec(text);
+  return match ? Number(match[1]) : undefined;
+}

--- a/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
@@ -188,6 +188,11 @@ FAKE_CODEBOX_HANG="${TMPDIR}/fake-wp-codebox-hang.cjs"
 cat > "$FAKE_CODEBOX_HANG" <<'JS'
 #!/usr/bin/env node
 'use strict';
+const fs = require('fs');
+const { spawn } = require('child_process');
+const descendant = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1e9);'], { stdio: 'inherit' });
+fs.writeFileSync(process.env.FIXTURE_PIDS_PATH, JSON.stringify({ descendant: descendant.pid }));
+process.on('SIGTERM', () => process.exit(0));
 setTimeout(() => {}, 10000);
 JS
 
@@ -198,6 +203,7 @@ HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX_HANG" \
 HOMEBOY_WORDPRESS_HOST_SMOKE_TIMEOUT_SECONDS=1 \
 HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="tests/alpha-smoke.php" \
+FIXTURE_PIDS_PATH="${TMPDIR}/host-timeout-pids.json" \
 FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/direct-timeout.out" 2>&1
 timeout_exit=$?
@@ -210,6 +216,21 @@ fi
 assert_contains "${TMPDIR}/direct-timeout.out" "HOST_SMOKE_TIMEOUT:tests/alpha-smoke.php:phase=wp-codebox-recipe-run"
 assert_contains "${TMPDIR}/direct-timeout.out" "HOST_SMOKE_FAIL:tests/alpha-smoke.php:exit=124"
 assert_contains "${TMPDIR}/direct-timeout.out" "artifacts="
+assert_contains "${TMPDIR}/direct-timeout.out" '"schema":"homeboy/wp-codebox-timeout-diagnostics/v1"'
+assert_contains "${TMPDIR}/direct-timeout.out" '"phase":"wp-codebox-recipe-run"'
+assert_contains "${TMPDIR}/direct-timeout.out" '"selected":{"count":1,"items":["tests/alpha-smoke.php"]}'
+assert_contains "${TMPDIR}/direct-timeout.out" '"termination":{"result":"timeout"'
+host_descendant_pid="$(node -e 'process.stdout.write(String(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).descendant))' "${TMPDIR}/host-timeout-pids.json")"
+for _ in $(seq 1 200); do
+    if ! kill -0 "$host_descendant_pid" 2>/dev/null; then
+        break
+    fi
+    sleep 0.025
+done
+if kill -0 "$host_descendant_pid" 2>/dev/null; then
+    echo "Expected timeout descendant ${host_descendant_pid} to be reaped" >&2
+    exit 1
+fi
 
 # --- Routing: the dispatcher routes *-smoke.php to this real-WP smoke backend
 # purely by file type (no test_backend toggle). A --file smoke run goes straight

--- a/wordpress/scripts/test/test-runner-host-smoke-wp.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke-wp.sh
@@ -41,6 +41,7 @@ TARGET_SMOKE_FILE="${HOMEBOY_WORDPRESS_HOST_SMOKE_FILE:-}"
 TARGET_SMOKE_FILES="${HOMEBOY_WORDPRESS_HOST_SMOKE_FILES:-}"
 HOST_SMOKE_TIMEOUT_SECONDS="${HOMEBOY_WORDPRESS_HOST_SMOKE_TIMEOUT_SECONDS:-120}"
 HOST_SMOKE_EXCERPT_BYTES="${HOMEBOY_WORDPRESS_HOST_SMOKE_EXCERPT_BYTES:-65536}"
+WP_CODEBOX_TIMEOUT_DIAGNOSTICS="${SCRIPT_DIR}/../lib/wp-codebox-timeout-diagnostics.mjs"
 
 homeboy_wordpress_host_smoke_abs() {
     local raw_path="$1"
@@ -152,13 +153,14 @@ run_one_smoke() {
     local smoke_file="$1"
     local rel_path="${smoke_file#"${PLUGIN_PATH}/"}"
     local sandbox_smoke_path="/wordpress/wp-content/plugins/${PLUGIN_SLUG}/${rel_path}"
-    local wrapper_file recipe_file output_file stderr_file artifacts_dir status started_at elapsed
+    local wrapper_file recipe_file output_file stderr_file termination_file artifacts_dir status started_at elapsed
 
     artifacts_dir="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-smoke-artifacts.XXXXXX")"
     wrapper_file="${artifacts_dir}/wrapper.php"
     recipe_file="${artifacts_dir}/recipe.json"
     output_file="${artifacts_dir}/recipe-run.json"
     stderr_file="${artifacts_dir}/wp-codebox.stderr"
+    termination_file="${artifacts_dir}/termination.json"
 
     homeboy_wordpress_smoke_wrapper "$sandbox_smoke_path" > "$wrapper_file"
     echo "HOST_SMOKE_PROGRESS:${rel_path}:phase=wrapper-created artifacts=${artifacts_dir}"
@@ -178,7 +180,7 @@ run_one_smoke() {
     set +e
     started_at="$(date +%s)"
     echo "HOST_SMOKE_PROGRESS:${rel_path}:phase=wp-codebox-recipe-run timeout=${HOST_SMOKE_TIMEOUT_SECONDS}s artifacts=${artifacts_dir}"
-    homeboy_wordpress_smoke_run_with_timeout "$output_file" "$stderr_file" \
+    homeboy_wordpress_smoke_run_with_timeout "$output_file" "$stderr_file" "$termination_file" \
         "${WP_CODEBOX_COMMAND[@]}" recipe-run --recipe "$recipe_file" --artifacts "$artifacts_dir" --json
     status=$?
     elapsed=$(( $(date +%s) - started_at ))
@@ -187,7 +189,7 @@ run_one_smoke() {
 
     if [ "$status" -eq 124 ]; then
         echo "HOST_SMOKE_TIMEOUT:${rel_path}:phase=wp-codebox-recipe-run elapsed=${elapsed}s timeout=${HOST_SMOKE_TIMEOUT_SECONDS}s artifacts=${artifacts_dir}"
-        homeboy_wordpress_smoke_print_failure_output "$rel_path" "$output_file" "$stderr_file" "$artifacts_dir"
+        node "$WP_CODEBOX_TIMEOUT_DIAGNOSTICS" wp-codebox-recipe-run "$elapsed" "$HOST_SMOKE_TIMEOUT_SECONDS" "$rel_path" "$termination_file" "$output_file" "$stderr_file" "$artifacts_dir"
         return 124
     fi
 
@@ -207,28 +209,56 @@ run_one_smoke() {
 homeboy_wordpress_smoke_run_with_timeout() {
     local output_file="$1"
     local stderr_file="$2"
-    shift 2
+    local termination_file="$3"
+    shift 3
 
     node -e '
         const fs = require("node:fs");
-        const { spawnSync } = require("node:child_process");
-        const [timeoutSeconds, stdoutFile, stderrFile, ...command] = process.argv.slice(1);
-        const result = spawnSync(command[0], command.slice(1), {
-            encoding: "utf8",
-            maxBuffer: 50 * 1024 * 1024,
-            timeout: Number(timeoutSeconds) * 1000,
+        const { spawn } = require("node:child_process");
+        const { pathToFileURL } = require("node:url");
+        const [timeoutSeconds, stdoutFile, stderrFile, terminationFile, redactorModule, ...command] = process.argv.slice(1);
+        (async () => {
+        const { createTimeoutLineRedactor } = await import(pathToFileURL(redactorModule));
+        const stdout = fs.createWriteStream(stdoutFile);
+        const stderr = fs.createWriteStream(stderrFile);
+        const stdoutRedactor = createTimeoutLineRedactor();
+        const stderrRedactor = createTimeoutLineRedactor();
+        const child = spawn(command[0], command.slice(1), { stdio: ["ignore", "pipe", "pipe"], detached: true });
+        let timedOut = false;
+        let childError;
+        let timeoutClosed = false;
+        let killEscalated = false;
+        const killGroup = (signal) => {
+            try { process.kill(-child.pid, signal); }
+            catch (error) { if (error.code !== "ESRCH") { try { child.kill(signal); } catch {} } }
+        };
+        const timer = setTimeout(() => {
+            timedOut = true;
+            killGroup("SIGTERM");
+            // This begins at timeout, not at leader close: descendants can hold
+            // inherited pipes open after their parent exits.
+            setTimeout(() => {
+                killEscalated = true;
+                killGroup("SIGKILL");
+                if (timeoutClosed) process.exit(124);
+            }, 5000);
+        }, Number(timeoutSeconds) * 1000);
+        child.stdout.on("data", (chunk) => stdout.write(stdoutRedactor.write(chunk)));
+        child.stderr.on("data", (chunk) => stderr.write(stderrRedactor.write(chunk)));
+        child.on("error", (error) => { childError = error; });
+        child.on("close", (code, signal) => {
+            clearTimeout(timer);
+            stdout.end(stdoutRedactor.end());
+            stderr.end(stderrRedactor.end());
+            Promise.all([new Promise((done) => stdout.on("finish", done)), new Promise((done) => stderr.on("finish", done))]).then(() => {
+                fs.writeFileSync(terminationFile, JSON.stringify({ result: timedOut ? "timeout" : "exited", signal: signal || undefined, code }));
+                if (timedOut) { timeoutClosed = true; if (killEscalated) process.exit(124); return; }
+                if (childError) { fs.appendFileSync(stderrFile, `${childError.message}\n`); process.exit(1); }
+                process.exit(code === null ? 1 : code);
+            });
         });
-        fs.writeFileSync(stdoutFile, result.stdout || "");
-        fs.writeFileSync(stderrFile, result.stderr || "");
-        if (result.error && result.error.code === "ETIMEDOUT") {
-            process.exit(124);
-        }
-        if (result.error) {
-            fs.appendFileSync(stderrFile, `${result.error.message}\n`);
-            process.exit(1);
-        }
-        process.exit(result.status === null ? 1 : result.status);
-    ' "$HOST_SMOKE_TIMEOUT_SECONDS" "$output_file" "$stderr_file" "$@"
+        })().catch((error) => { fs.appendFileSync(stderrFile, `${error.message}\n`); process.exit(1); });
+    ' "$HOST_SMOKE_TIMEOUT_SECONDS" "$output_file" "$stderr_file" "$termination_file" "$WP_CODEBOX_TIMEOUT_DIAGNOSTICS" "$@"
 }
 
 homeboy_wordpress_smoke_print_failure_output() {

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -6,12 +6,14 @@ import { createWriteStream } from 'node:fs';
 import { access, copyFile, lstat, mkdir, mkdtemp, readdir, readFile, realpath, rename, rm, unlink, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import path from 'node:path';
-import { StringDecoder } from 'node:string_decoder';
 import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { createTimeoutLineRedactor, recipeRunProjection, readBoundedText, wpCodeboxTimeoutDiagnostics } from '../lib/wp-codebox-timeout-diagnostics.mjs';
+import { configuredWpCodeboxPhpunitTimeoutSeconds } from '../lib/wp-codebox-phpunit-timeout.mjs';
 
 const settings = parseSettings(process.env.HOMEBOY_SETTINGS_JSON);
+const phpunitTimeoutSeconds = configuredWpCodeboxPhpunitTimeoutSeconds(process.env, settings);
 const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMPONENT_PATH');
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const extensionRoot = path.resolve(scriptDirectory, '../..');
@@ -109,17 +111,17 @@ try {
   if (databaseService?.boundary) {
     executionArgs.push('--approve-external-service-writes', '--policy', JSON.stringify(databaseService.policy));
   }
-  const execution = await runCaptured(executionArgs);
+  const execution = await runCaptured(executionArgs, phpunitTimeoutSeconds);
   const artifactStatus = await handoffArtifacts(runArtifacts, execution);
   if (execution.status !== 0 || !['passed', 'skipped'].includes(artifactStatus)) {
-    process.exitCode = execution.status || 1;
+    process.exitCode = execution.timedOut ? 124 : (execution.status || 1);
   } else {
     process.stdout.write('WP Codebox test run complete.\n');
   }
 } finally {
   await rm(directory, { recursive: true, force: true });
 }
-async function runCaptured(args) {
+async function runCaptured(args, timeoutSeconds) {
   const logsDirectory = path.join(runArtifacts, 'logs');
   const stdoutPath = path.join(logsDirectory, 'recipe-run.stdout.log');
   const stderrPath = path.join(logsDirectory, 'recipe-run.stderr.log');
@@ -128,14 +130,27 @@ async function runCaptured(args) {
 
   return new Promise((resolve, reject) => {
     const [command, ...prefix] = wpCodeboxCommand();
-    const child = spawn(command, [...prefix, ...args], { cwd: componentPath, stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(command, [...prefix, ...args], { cwd: componentPath, stdio: ['ignore', 'pipe', 'pipe'], detached: true });
     const stdoutFile = createWriteStream(stdoutPath);
     const stderrFile = createWriteStream(stderrPath);
-    const stdoutRedactor = createLineRedactor(secretValues);
-    const stderrRedactor = createLineRedactor(secretValues);
+    const stdoutRedactor = createTimeoutLineRedactor(secretValues);
+    const stderrRedactor = createTimeoutLineRedactor(secretValues);
     let childError;
+    let timedOut = false;
+    const startedAt = Date.now();
+    let stdoutPreview = Buffer.alloc(0);
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killChildGroup(child, 'SIGTERM');
+      // Do not clear or unref this timer when the leader exits: a descendant
+      // can ignore SIGTERM after the CLI has been reaped.
+      setTimeout(() => killChildGroup(child, 'SIGKILL'), 5000);
+    }, timeoutSeconds * 1000);
 
     child.stdout.on('data', (chunk) => {
+      if (stdoutPreview.byteLength < 128 * 1024) {
+        stdoutPreview = Buffer.concat([stdoutPreview, chunk.subarray(0, (128 * 1024) - stdoutPreview.byteLength)]);
+      }
       chunk = stdoutRedactor.write(chunk);
       stdoutFile.write(chunk);
     });
@@ -144,7 +159,8 @@ async function runCaptured(args) {
       stderrFile.write(chunk);
     });
     child.on('error', (error) => { childError = error; });
-    child.on('close', (status) => {
+    child.on('close', (status, signal) => {
+      clearTimeout(timer);
       const stdoutTail = stdoutRedactor.end();
       const stderrTail = stderrRedactor.end();
       stdoutFile.write(stdoutTail);
@@ -159,10 +175,30 @@ async function runCaptured(args) {
           reject(childError);
           return;
         }
-        resolve({ status: status ?? 1, stdoutPath, stderrPath });
+        resolve({
+          status: status ?? 1,
+          stdoutPath,
+          stderrPath,
+          stdoutPreview: stdoutPreview.toString('utf8'),
+          timedOut,
+          elapsedSeconds: Math.ceil((Date.now() - startedAt) / 1000),
+          termination: { result: timedOut ? 'timeout' : 'exited', signal, code: status },
+        });
       }, reject);
     });
   });
+}
+function killChildGroup(child, signal) {
+  if (!child || typeof child.pid !== 'number') {
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if (error?.code !== 'ESRCH') {
+      try { child.kill(signal); } catch {}
+    }
+  }
 }
 function configuredSecretValues() {
   const configured = settings.bench_env && typeof settings.bench_env === 'object' ? settings.bench_env : {};
@@ -177,34 +213,6 @@ function redactSecrets(text, secretValues = configuredSecretValues()) {
     text = text.replaceAll(secret, '[REDACTED]');
   }
   return text;
-}
-function createLineRedactor(secretValues) {
-  const decoder = new StringDecoder('utf8');
-  let pending = '';
-  const overlap = Math.max(0, ...secretValues.map((secret) => secret.length - 1));
-  const redact = (text) => redactSecrets(text, secretValues);
-  return {
-    write(chunk) {
-      pending += decoder.write(chunk);
-      const boundary = pending.lastIndexOf('\n') + 1;
-      // JSON recipe responses can be a single line larger than a pipe buffer.
-      // Flush bounded chunks so a crashed PHPUnit run cannot deadlock at 64 KiB.
-      if (boundary === 0) {
-        if (pending.length < 8192) { return ''; }
-        // Keep enough input to redact a secret split across the flush boundary.
-        const buffered = pending.slice(0, Math.max(0, pending.length - overlap));
-        pending = pending.slice(buffered.length);
-        return redact(buffered);
-      }
-      const completeLines = pending.slice(0, boundary);
-      pending = pending.slice(boundary);
-      return redact(completeLines);
-    },
-    end() {
-      pending += decoder.end();
-      return redact(pending);
-    },
-  };
 }
 
 function run(args) {
@@ -653,6 +661,15 @@ async function publishPhpunitArtifacts(artifactDirectory, status) {
     { name: 'recipe-run-steps.json', kind: 'recipe-run-steps', role: 'recipe-run-step-ledger', semantic_key: 'recipe_run_steps', content_type: 'application/json', copy: true },
     { name: 'test-failures.json', kind: 'test-failures', role: 'structured-test-failures', semantic_key: 'test_failures', content_type: 'application/json' },
   ];
+  for (const file of [
+    { name: 'wp-codebox-timeout-diagnostics.json', kind: 'wp-codebox-timeout-diagnostics', role: 'timeout-diagnostics', semantic_key: 'timeout_diagnostics', content_type: 'application/json', copy: true },
+    { name: 'recipe-run.json', kind: 'recipe-run-payload', role: 'raw-recipe-run-payload', semantic_key: 'recipe_run_payload', content_type: 'application/json', copy: true },
+  ]) {
+    try {
+      await access(path.join(artifactDirectory, 'files', file.name));
+      files.push(file);
+    } catch {}
+  }
   await withInvocationArtifactLock(invocationArtifacts, async () => {
     await assertDirectoryTree(invocationArtifacts, ['wp-codebox-phpunit', 'files']);
     await assertDirectoryTree(artifactDirectory, ['files']);
@@ -944,16 +961,39 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   await copyFile(execution.stdoutPath, path.join(logsDirectory, 'recipe-run.stdout.log'));
   await copyFile(execution.stderrPath, path.join(logsDirectory, 'recipe-run.stderr.log'));
 
-  const stdout = await readFile(execution.stdoutPath, 'utf8');
-  const stderr = await readFile(execution.stderrPath, 'utf8');
+  const stdoutInput = execution.timedOut ? { text: execution.stdoutPreview || (await readBoundedText(execution.stdoutPath)).text, truncated: true } : { text: await readFile(execution.stdoutPath, 'utf8'), truncated: false };
+  const stderrInput = execution.timedOut ? await readBoundedText(execution.stderrPath) : { text: await readFile(execution.stderrPath, 'utf8'), truncated: false };
+  const stdout = stdoutInput.text;
+  const stderr = stderrInput.text;
   let preservedOutput = '';
-  try { preservedOutput = await readFile(phpunitOutputPath, 'utf8'); } catch {}
+  try { preservedOutput = execution.timedOut ? (await readBoundedText(phpunitOutputPath)).text : await readFile(phpunitOutputPath, 'utf8'); } catch {}
   // The recipe-run JSON payload carries the step ledger the raw log concatenation
   // discards. Preserve it as first-class structured evidence so a run that never
   // reaches the PHPUnit step still names the stage that stopped it.
-  const recipeRun = parseRecipeRunPayload(stdout);
+  const recipeRun = execution.timedOut
+    ? { ...recipeRunProjection(stdout), payload: null, phpunitIndexes: [], parse_status: 'bounded_timeout_projection' }
+    : parseRecipeRunPayload(stdout);
   const recipeRunSteps = buildRecipeRunStepsLedger(recipeRun);
   await writeFile(recipeRunStepsPath, `${JSON.stringify(recipeRunSteps, null, 2)}\n`);
+  const timeoutEvidence = execution.timedOut ? wpCodeboxTimeoutDiagnostics({
+    phase: 'wp-codebox-phpunit-recipe-run',
+    elapsedSeconds: execution.elapsedSeconds,
+    budgetSeconds: phpunitTimeoutSeconds,
+    selected: [selectedTestFile, ...changedTestFiles].filter(Boolean),
+    termination: execution.termination,
+    artifacts: [
+      'artifact://files/recipe-run.json',
+      'artifact://files/recipe-run-steps.json',
+      'artifact://files/phpunit-output.log',
+    ],
+    payload: recipeRun,
+    stderr,
+    secretValues: configuredSecretValues(),
+  }) : null;
+  if (timeoutEvidence) {
+    await atomicCopy(execution.stdoutPath, path.join(filesDirectory, 'recipe-run.json'));
+    await writeFile(path.join(filesDirectory, 'wp-codebox-timeout-diagnostics.json'), `${JSON.stringify(timeoutEvidence, null, 2)}\n`);
+  }
   if (managedRuntimeServices.length > 0) {
     await writeFile(managedRuntimeServicesPath, `${JSON.stringify(managedRuntimeServices, null, 2)}\n`);
   }
@@ -961,7 +1001,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   // A failed bootstrap stage means PHPUnit never got to run. Trust that over an
   // optimistic structured sidecar: reporting a pass because the sidecar claims
   // one is exactly how a red run shows up green.
-  const stageLog = await readPhpunitStageLog(artifactDirectory);
+  const stageLog = await readPhpunitStageLog(artifactDirectory, execution.timedOut);
   const stageFailure = (stageLog || '')
     .split('\n')
     .map((line) => line.trim())
@@ -975,7 +1015,9 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   const preservedOutputReferenced = validResults && Array.isArray(results.rawLogReferences) && results.rawLogReferences.some((reference) => reference?.path === 'files/phpunit-output.log' && reference?.kind === 'phpunit-output');
   const preservedOutputMatches = structuredExecution && preservedOutputReferenced && phpunitSummaryMatches(preservedAggregate, results.summary);
   const referencedOutput = structuredExecution ? await readMatchingPhpunitOutput(artifactDirectory, results) : '';
-  const output = redactSecrets( structuredExecution
+  const output = execution.timedOut
+    ? `${JSON.stringify(timeoutEvidence)}\n`
+    : redactSecrets( structuredExecution
     ? ((preservedOutputMatches && preservedOutput) || referencedOutput || stageLog || structuredPhpunitOutputUnavailable(results, recipeRun))
     : extractPhpunitOutput(stdout, stderr, recipeRun) );
   await writeFile(phpunitOutputPath, output);
@@ -1003,6 +1045,10 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
       { kind: 'test-execution-diagnosis', uri: 'artifact://files/phpunit-execution-diagnosis.json' },
       { kind: 'recipe-run-steps', uri: 'artifact://files/recipe-run-steps.json' },
     ];
+    if (timeoutEvidence) {
+      evidenceReferences.push({ kind: 'wp-codebox-timeout-diagnostics', uri: 'artifact://files/wp-codebox-timeout-diagnostics.json' });
+      evidenceReferences.push({ kind: 'recipe-run-payload', uri: 'artifact://files/recipe-run.json' });
+    }
     if (managedRuntimeServices.length > 0) {
       evidenceReferences.push({ kind: 'managed-runtime-services', uri: 'artifact://files/managed-runtime-services.json' });
     }
@@ -1017,6 +1063,9 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   process.stdout.write('Full PHPUnit output: artifact://files/phpunit-output.log\n');
   process.stdout.write('PHPUnit execution diagnosis: artifact://files/phpunit-execution-diagnosis.json\n');
   process.stdout.write('Recipe run step ledger: artifact://files/recipe-run-steps.json\n');
+  if (timeoutEvidence) {
+    process.stdout.write(`${JSON.stringify(timeoutEvidence)}\n`);
+  }
   if (stageFailure) {
     process.stdout.write(`BOOTSTRAP FAILURE: ${stageFailure.replace(/^STAGE_(FAIL|FATAL|DIE):/, '')}\n`);
   }
@@ -1184,7 +1233,7 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, 
     stage_markers: markers.slice(0, 60),
   };
 }
-async function readPhpunitStageLog(artifactDirectory) {
+async function readPhpunitStageLog(artifactDirectory, bounded = false) {
   const stageRoot = path.join(artifactDirectory, 'files', 'phpunit');
   const candidates = [path.join(stageRoot, '.pg-test-result.txt')];
   try {
@@ -1195,7 +1244,7 @@ async function readPhpunitStageLog(artifactDirectory) {
     }
   } catch {}
   for (const candidate of candidates) {
-    try { return await readFile(candidate, 'utf8'); } catch {}
+    try { return bounded ? (await readBoundedText(candidate)).text : await readFile(candidate, 'utf8'); } catch {}
   }
   return null;
 }

--- a/wordpress/tests/wp-codebox-phpunit-timeout-diagnostics-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-timeout-diagnostics-smoke.mjs
@@ -1,0 +1,103 @@
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-timeout-'));
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const component = path.join(root, 'sample-plugin');
+const artifacts = path.join(root, 'artifacts');
+const invocationArtifacts = path.join(root, 'invocation-artifacts');
+const cli = path.join(root, 'wp-codebox');
+
+function pidAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+async function waitForReaped(pid, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidAlive(pid)) { return true; }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return false;
+}
+
+await mkdir(component, { recursive: true });
+await mkdir(invocationArtifacts, { recursive: true });
+await writeFile(path.join(component, 'sample-plugin.php'), '<?php\n/* Plugin Name: Sample Plugin */\n');
+await writeFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
+await writeFile(cli, `#!/usr/bin/env node
+import fs from 'node:fs';
+import { spawn } from 'node:child_process';
+const args = process.argv.slice(2);
+if (args[0] === 'recipe' && args[1] === 'build') {
+  fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
+  process.exit(0);
+}
+const byteMap = Object.fromEntries(Array.from({ length: 131072 }, (_, index) => [index, index % 256]));
+const artifacts = args[args.indexOf('--artifacts') + 1];
+const runtime = artifacts + '/runtime-fixture';
+fs.mkdirSync(runtime + '/files/phpunit', { recursive: true });
+fs.writeFileSync(artifacts + '/latest-runtime.json', JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+fs.writeFileSync(runtime + '/files/phpunit-output.log', 'x'.repeat(2 * 1024 * 1024));
+fs.writeFileSync(runtime + '/files/phpunit/.pg-test-result.txt', 'STAGE_FAIL:bootstrap ' + 'y'.repeat(2 * 1024 * 1024));
+process.stdout.write(JSON.stringify({ executions: [{ command: 'phpunit Authorization: Bearer fixture-bearer-secret', status: 'running', stdout: byteMap }] }));
+process.stderr.write('Cookie: session=fixture-cookie-secret\\nrequest=https://user:fixture-url-secret@example.test/private\\n');
+const descendant = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1e9);'], { stdio: 'inherit' });
+fs.writeFileSync(process.env.FIXTURE_PIDS_PATH, JSON.stringify({ descendant: descendant.pid }));
+process.on('SIGTERM', () => process.exit(0));
+setTimeout(() => {}, 10000);
+`);
+await chmod(cli, 0o755);
+
+try {
+  const startedAt = Date.now();
+  const run = spawnSync(runner, [], {
+    env: {
+      ...process.env,
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'sample-plugin',
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
+      HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts,
+      HOMEBOY_SETTINGS_JSON: '{}',
+      HOMEBOY_WORDPRESS_PHPUNIT_TIMEOUT_SECONDS: '1',
+      HOMEBOY_TEST_FAILURES_FILE: path.join(root, 'test-failures.json'),
+      FIXTURE_PIDS_PATH: path.join(root, 'pids.json'),
+    },
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+  assert.equal(run.status, 124, run.stderr);
+  assert.ok(Date.now() - startedAt < 10000, 'timeout return must remain bounded while descendant holds inherited pipes');
+  assert.match(run.stdout, /"schema":"homeboy\/wp-codebox-timeout-diagnostics\/v1"/);
+  assert.doesNotMatch(run.stdout, /fixture-bearer-secret|fixture-cookie-secret|fixture-url-secret|"131071"/);
+
+  const runDirectory = (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
+  const runtimeFiles = path.join(artifacts, runDirectory, 'runtime-fixture', 'files');
+  const timeoutEvidence = JSON.parse(await readFile(path.join(runtimeFiles, 'wp-codebox-timeout-diagnostics.json'), 'utf8'));
+  assert.equal(timeoutEvidence.phase, 'wp-codebox-phpunit-recipe-run');
+  assert.equal(timeoutEvidence.budget_seconds, 1);
+  assert.equal(timeoutEvidence.execution.last.stdout.kind, 'byte_map_omitted');
+  assert.equal(timeoutEvidence.execution.count_complete, false);
+  assert.doesNotMatch(JSON.stringify(timeoutEvidence), /fixture-bearer-secret|fixture-cookie-secret|fixture-url-secret|"131071"/);
+
+  const payload = await readFile(path.join(runtimeFiles, 'recipe-run.json'), 'utf8');
+  assert.equal(payload, '[REDACTED OVERLONG LINE]\n');
+  assert.doesNotMatch(payload, /fixture-bearer-secret|fixture-cookie-secret|fixture-url-secret/);
+  const manifest = JSON.parse(await readFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), 'utf8'));
+  assert.ok(manifest.artifacts.some((artifact) => artifact.kind === 'wp-codebox-timeout-diagnostics'));
+  assert.ok(manifest.artifacts.some((artifact) => artifact.kind === 'recipe-run-payload'));
+  assert.ok(Buffer.byteLength(await readFile(path.join(runtimeFiles, 'phpunit-output.log'))) <= 8192);
+  const diagnosis = JSON.parse(await readFile(path.join(runtimeFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.ok(diagnosis.stage_markers[0].length <= 128 * 1024, 'timeout diagnosis must not materialize the multi-megabyte stage log');
+  const pids = JSON.parse(await readFile(path.join(root, 'pids.json'), 'utf8'));
+  assert.equal(await waitForReaped(pids.descendant), true, 'TERM-ignoring descendant must be reaped');
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox PHPUnit timeout diagnostics smoke passed.');

--- a/wordpress/tests/wp-codebox-phpunit-timeout-options-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-timeout-options-smoke.mjs
@@ -1,0 +1,17 @@
+import { strict as assert } from 'node:assert';
+
+import {
+  DEFAULT_WP_CODEBOX_PHPUNIT_TIMEOUT_SECONDS,
+  configuredWpCodeboxPhpunitTimeoutSeconds,
+} from '../scripts/lib/wp-codebox-phpunit-timeout.mjs';
+
+assert.equal(configuredWpCodeboxPhpunitTimeoutSeconds({}, {}), DEFAULT_WP_CODEBOX_PHPUNIT_TIMEOUT_SECONDS);
+assert.equal(configuredWpCodeboxPhpunitTimeoutSeconds({ HOMEBOY_TASK_TIMEOUT_SECONDS: '1200' }, {}), 1200);
+assert.equal(configuredWpCodeboxPhpunitTimeoutSeconds({}, { wp_codebox_phpunit_timeout_seconds: 900 }), 900);
+assert.equal(configuredWpCodeboxPhpunitTimeoutSeconds({ HOMEBOY_TASK_TIMEOUT_SECONDS: '1200' }, { wp_codebox_phpunit_timeout_seconds: 900 }), 900);
+assert.equal(configuredWpCodeboxPhpunitTimeoutSeconds({ HOMEBOY_WORDPRESS_PHPUNIT_TIMEOUT_SECONDS: '600', HOMEBOY_TASK_TIMEOUT_SECONDS: '1200' }, { wp_codebox_phpunit_timeout_seconds: 900 }), 600);
+for (const value of ['0', '-1', '1.5', 'nope']) {
+  assert.throws(() => configuredWpCodeboxPhpunitTimeoutSeconds({ HOMEBOY_WORDPRESS_PHPUNIT_TIMEOUT_SECONDS: value }, {}), /positive integer/);
+}
+
+console.log('WP Codebox PHPUnit timeout option smoke passed.');

--- a/wordpress/tests/wp-codebox-timeout-diagnostics-smoke.mjs
+++ b/wordpress/tests/wp-codebox-timeout-diagnostics-smoke.mjs
@@ -1,0 +1,99 @@
+import { strict as assert } from 'node:assert';
+
+import {
+  WP_CODEBOX_TIMEOUT_DIAGNOSTICS_MAX_BYTES,
+  WP_CODEBOX_TIMEOUT_DIAGNOSTICS_SCHEMA,
+  createTimeoutLineRedactor,
+  wpCodeboxTimeoutDiagnostics,
+} from '../scripts/lib/wp-codebox-timeout-diagnostics.mjs';
+
+// This mirrors a JSON-serialized Buffer that was retained in a timed-out
+// recipe-run response: enough numeric entries to exceed one megabyte without
+// putting a giant fixture file in the repository.
+const byteMap = Object.fromEntries(Array.from({ length: 131072 }, (_, index) => [index, index % 256]));
+const payload = {
+  success: false,
+  executions: [{
+    command: 'wordpress.run-php api_token=fixture-secret-value',
+    status: 'running',
+    stdout: byteMap,
+    stderr: 'provider token=fixture-secret-value timed out after waiting for WordPress',
+  }],
+};
+
+assert.ok(Buffer.byteLength(JSON.stringify(payload)) > 1024 * 1024);
+
+const diagnostic = wpCodeboxTimeoutDiagnostics({
+  phase: 'wp-codebox-recipe-run',
+  elapsedSeconds: 1500,
+  budgetSeconds: 1500,
+  selected: ['tests/wordpress-timeout-smoke.php'],
+  termination: { result: 'timeout', signal: 'SIGTERM' },
+  artifacts: ['artifact:///tmp/run/recipe-run.json', 'artifact:///tmp/run/wp-codebox.stderr'],
+  payload,
+  stderr: 'provider token=fixture-secret-value timed out after waiting for WordPress',
+  secretValues: ['fixture-secret-value'],
+});
+
+const serialized = JSON.stringify(diagnostic);
+assert.equal(diagnostic.schema, WP_CODEBOX_TIMEOUT_DIAGNOSTICS_SCHEMA);
+assert.equal(diagnostic.phase, 'wp-codebox-recipe-run');
+assert.deepEqual(diagnostic.selected, { count: 1, items: ['tests/wordpress-timeout-smoke.php'] });
+assert.deepEqual(diagnostic.execution, {
+  count: 1,
+  count_complete: true,
+  completed_count: 0,
+  last: {
+    index: 0,
+    command: 'wordpress.run-php api_token=[REDACTED]',
+    status: 'running',
+    stdout: { kind: 'byte_map_omitted' },
+    stderr: { kind: 'text', bytes: Buffer.byteLength(payload.executions[0].stderr) },
+  },
+});
+assert.deepEqual(diagnostic.termination, { result: 'timeout', signal: 'SIGTERM' });
+assert.deepEqual(diagnostic.artifact_refs, ['artifact:///tmp/run/recipe-run.json', 'artifact:///tmp/run/wp-codebox.stderr']);
+assert.match(diagnostic.excerpts, /token=\[REDACTED\]/);
+assert.doesNotMatch(serialized, /fixture-secret-value|"0":0|"131071"|byteMap/);
+assert.ok(Buffer.byteLength(serialized) <= WP_CODEBOX_TIMEOUT_DIAGNOSTICS_MAX_BYTES);
+
+const redactionDiagnostic = wpCodeboxTimeoutDiagnostics({
+  stderr: [
+    'Authorization: Bearer bearer-secret',
+    'Proxy-Authorization: Basic basic-secret',
+    'Cookie: session=cookie-secret; theme=dark',
+    'Set-Cookie: session=cookie-secret',
+    '  Path=/; HttpOnly',
+    'request=https://user:url-secret@example.test/private',
+    'credential: multiline-secret',
+    '  continuation-value',
+    'environment=environment-secret',
+  ].join('\n'),
+  secretValues: ['bearer-secret', 'basic-secret', 'cookie-secret', 'url-secret', 'multiline-secret\ncontinuation-value', 'environment-secret'],
+});
+const redacted = JSON.stringify(redactionDiagnostic);
+assert.doesNotMatch(redacted, /bearer-secret|basic-secret|cookie-secret|url-secret|multiline-secret|continuation-value|environment-secret/);
+assert.match(redacted, /Authorization:\[REDACTED\]/);
+assert.match(redacted, /Cookie:\[REDACTED\]/);
+assert.match(redacted, /https:\/\/\[REDACTED\]@example\.test/);
+
+const priorEnvironmentSecret = process.env.FIXTURE_SESSION_SECRET;
+process.env.FIXTURE_SESSION_SECRET = 'environment-derived-secret';
+const environmentDiagnostic = wpCodeboxTimeoutDiagnostics({ stderr: 'session=environment-derived-secret' });
+assert.doesNotMatch(JSON.stringify(environmentDiagnostic), /environment-derived-secret/);
+if (priorEnvironmentSecret === undefined) {
+  delete process.env.FIXTURE_SESSION_SECRET;
+} else {
+  process.env.FIXTURE_SESSION_SECRET = priorEnvironmentSecret;
+}
+
+const spanningCredential = `Bearer ${'s'.repeat(9000)}`;
+const streamRedactor = createTimeoutLineRedactor();
+assert.equal(streamRedactor.write(`Authorization: ${spanningCredential.slice(0, 4096)}`), '');
+assert.equal(streamRedactor.write(`${spanningCredential.slice(4096)}\n`), 'Authorization:[REDACTED]\n');
+assert.doesNotMatch(streamRedactor.end(), /s/);
+const overlongRedactor = createTimeoutLineRedactor();
+assert.equal(overlongRedactor.write(`Cookie: session=${'x'.repeat(128 * 1024)}`), '');
+assert.equal(overlongRedactor.end(), '[REDACTED OVERLONG LINE]\n');
+
+console.log('WP Codebox timeout diagnostics smoke passed.');


### PR DESCRIPTION
## Summary

- add bounded semantic timeout diagnostics for WordPress host-smoke and PHPUnit WP Codebox paths
- terminate and reap complete process groups with bounded TERM-to-KILL escalation
- stream redacted timeout artifacts without byte-map, overlong-record, or cross-chunk credential leakage
- preserve phase, budget, selected scope, count completeness, termination, and artifact references
- cover megabyte payloads, inherited-stdio descendants, timeout configuration precedence, and common credential classes

Closes #2625.

## Verification

- `node wordpress/tests/wp-codebox-timeout-diagnostics-smoke.mjs`
- `node wordpress/tests/wp-codebox-phpunit-timeout-options-smoke.mjs`
- `node wordpress/tests/wp-codebox-phpunit-timeout-diagnostics-smoke.mjs`
- `node wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs`
- `HOMEBOY_RUNTIME_RESOLVE_CONTEXT=/Users/chubes/Developer/homeboy/crates/homeboy-extension/src/runtime/resolve-context.sh bash wordpress/scripts/test/host-smoke-wp-runner-smoke.sh`
- Node/Bash syntax checks, manifest validation, and `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and tested the timeout diagnostics and process supervision repair. Four independent OpenCode general review passes identified and drove fixes for uncovered PHPUnit paths, redaction gaps, unbounded reads, process-tree hangs, and cross-chunk credential leakage. Chris Huber reviewed and remains responsible for every line.
