### PR TITLE
test(opencode): isolate installed boundary workspace

### DIFF
--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -171,6 +171,20 @@ assert.equal(JSON.stringify({ manifest, packageJson }).includes('WP Codebox'), f
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-opencode-provider-contract-'));
 try {
+	const executorWorkspace = path.join(root, 'executor-workspace');
+	fs.mkdirSync(executorWorkspace, { recursive: true });
+	spawnSync('git', ['init'], { cwd: executorWorkspace, encoding: 'utf8' });
+	spawnSync('git', ['commit', '--allow-empty', '-m', 'initial'], {
+		cwd: executorWorkspace,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Homeboy Test',
+			GIT_AUTHOR_EMAIL: 'homeboy@example.test',
+			GIT_COMMITTER_NAME: 'Homeboy Test',
+			GIT_COMMITTER_EMAIL: 'homeboy@example.test',
+		},
+	});
 	const runtimesRoot = path.join(root, 'agent-runtimes');
 	const runtimePath = path.join(runtimesRoot, 'opencode');
 	fs.mkdirSync(runtimesRoot, { recursive: true });
@@ -234,6 +248,7 @@ process.exit(0);
 				command_args: [mockCliPath],
 			},
 		},
+		workspace: { root: executorWorkspace },
 		instructions: 'Prove the OpenCode provider boundary without leaking secrets.',
 		artifacts_path: path.join(root, 'default-artifacts'),
 	};


### PR DESCRIPTION
## Summary

- initialize an explicit temporary Git workspace for the OpenCode executor boundary fixture
- bind the initial executor request to that workspace so patch capture does not depend on the test launcher directory
- preserve the real Git workspace requirement while making source and installed-runtime verification equivalent

## Verification

- `npm run test:opencode-agent-task-executor-boundary` from source checkout
- `homeboy runtime refresh --source <candidate-worktree> opencode --placement local`
- `npm run test:opencode-agent-task-executor-boundary` from `~/.config/homeboy/agent-runtimes/opencode`
- `npm run check:runtime-manifest`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `git diff --check`

Closes #2629

Related: Extra-Chill/homeboy#12379

## AI assistance

OpenAI gpt-5.6-sol via OpenCode compared source and installed runtime behavior, isolated the implicit Git workspace dependency, implemented the fixture correction, and ran source plus installed-generation verification. Chris Huber reviewed and owns every line.