### PR TITLE
fix(opencode): deny unmatched external paths

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -416,6 +416,9 @@ function permissionWithExternalDirectoryAllowances(permission, patterns) {
 	return {
 		...rules,
 		external_directory: {
+			// Noninteractive runs cannot answer permission prompts. Deny unmatched
+			// paths explicitly, then let the exact task-owned paths below override it.
+			'*': 'deny',
 			...externalDirectory,
 			// OpenCode resolves matching rules in order, so these task-owned paths
 			// deliberately supersede inherited catch-all rules.

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -214,6 +214,10 @@ assert.equal(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN, 'access-token-mu
 assert.equal(process.env.UNDECLARED_SECRET, undefined);
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
 assert.equal(config.agent.title.disable, true);
+assert.equal(config.permission.external_directory['*'], 'deny');
+assert.equal(config.permission.external_directory[${JSON.stringify(concretePath(executorWorkspace))}], 'allow');
+assert.equal(config.agent.build.permission.external_directory['*'], 'deny');
+assert.equal(config.agent.build.permission.external_directory[${JSON.stringify(concretePath(executorWorkspace))}], 'allow');
 if (instruction === 'Prove two attached runtime tools without leaking secrets.') {
   assert.equal(typeof config.mcp, 'object');
   assert.equal(config.mcp['fixture.mcp'].command[0], process.execPath);
@@ -322,6 +326,7 @@ assert.equal(config.agent.title.disable, true);
 	  edit: { '*': 'allow' },
 	  bash: { '*': 'allow', 'git push *': 'deny' },
 	  external_directory: {
+	    '*': 'deny',
 	    '/unrelated/**': 'deny',
 	    ${JSON.stringify(realModelWorkspace)}: 'allow',
 	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
@@ -340,6 +345,7 @@ assert.equal(config.agent.title.disable, true);
 	  edit: { '*': 'allow' },
 	  bash: { '*': 'allow', 'git push *': 'deny' },
 	  external_directory: {
+	    '*': 'deny',
 	    ${JSON.stringify(realModelWorkspace)}: 'allow',
 	    ${JSON.stringify(path.join(realModelWorkspace, '**'))}: 'allow'
 	  }


### PR DESCRIPTION
## Summary

- make unmatched external-directory requests explicit deny for noninteractive OpenCode runs
- retain ordered exact allows for the canonical task workspace and declared permission root
- prevent speculative invalid paths from entering the permission-prompt auto-rejection path

## Verification

- `npm run test:opencode-agent-task-executor-boundary` from source checkout
- `homeboy runtime refresh --source <candidate-worktree> opencode --placement local`
- `npm run test:opencode-agent-task-executor-boundary` from the installed runtime generation
- `npm run check:runtime-manifest`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- real Cook `cook-detached-3aacb9f1-a51c-489c-a7ba-0ef714f034a9`: OpenCode completed a 25+ step SSI implementation, produced and promoted an 8-file patch, and passed the repository `npm test` gate without policy termination
- `git diff --check`

Closes #2631

Related: #2613, Extra-Chill/homeboy#12379, Automattic/static-site-importer#827

## AI assistance

OpenAI gpt-5.6-sol via OpenCode isolated the noninteractive permission-prompt failure, implemented and tested ordered default-deny policy, and inspected live Cook evidence. OpenAI gpt-5.6-terra via OpenCode supplied the real provider execution proof. Chris Huber reviewed and owns every line.