### PR TITLE
Fix Rust nextest shard thread setting

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -90,7 +90,10 @@ rust_cargo_test_threads() {
 # changes until a caller asks. See Extra-Chill/homeboy#11751 W1-9.
 rust_nextest_shard_threads() {
     local value
-    value="${HOMEBOY_RUST_NEXTEST_SHARD_THREADS:-$(rust_cargo_test_threads || true)}"
+    value="${HOMEBOY_RUST_NEXTEST_SHARD_THREADS:-$(homeboy_setting rust_nextest_shard_threads '.rust_nextest_shard_threads' '')}"
+    if [ -z "$value" ]; then
+        value="$(rust_cargo_test_threads || true)"
+    fi
     case "$value" in
         '') printf '1' ;;
         *[!0-9]*) printf '1' ;;

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -528,6 +528,7 @@ HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_SKIP_LINT=1 \
 HOMEBOY_RUST_TEST_RUNNER=nextest \
 HOMEBOY_RUST_NEXTEST_SHARD_THREADS=0 \
+HOMEBOY_SETTINGS_JSON='{"rust_nextest_shard_threads":7,"rust_cargo_test_threads":3}' \
 HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
 HOMEBOY_FAKE_NEXTEST_LOG="$WORK_DIR/nextest-threads.log" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
@@ -546,7 +547,49 @@ if grep -F -- '--test-threads 1' "${WORK_DIR}/nextest-threads.log" >/dev/null; t
   printf 'FAIL: an explicit thread count must replace the serial default\n' >&2
   exit 1
 fi
-printf 'PASS: shard replay honours a configured thread count\n'
+printf 'PASS: shard replay environment override wins over merged settings\n'
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_SETTINGS_JSON='{"rust_nextest_shard_threads":0,"rust_cargo_test_threads":1}' \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_LOG="$WORK_DIR/nextest-setting-threads.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/setting-threads-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/setting-threads-runner.out"
+grep -F -- '--test-threads num-cpus' "$WORK_DIR/nextest-setting-threads.log" >/dev/null || {
+  printf 'FAIL: merged nextest zero-thread setting must select num-cpus parallelism\n' >&2
+  exit 1
+}
+printf 'PASS: shard replay reads its merged nextest thread setting\n'
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_RUST_TEST_RUNNER=nextest \
+HOMEBOY_SETTINGS_JSON='{"rust_cargo_test_threads":3}' \
+HOMEBOY_TEST_SHARD_MANIFEST="$WORK_DIR/nextest-manifest.json" \
+HOMEBOY_FAKE_NEXTEST_LOG="$WORK_DIR/nextest-fallback-threads.log" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
+HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/fallback-threads-results.json" \
+HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
+HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
+PATH="$BIN_DIR:$PATH" \
+bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/fallback-threads-runner.out"
+grep -F -- '--test-threads 3' "$WORK_DIR/nextest-fallback-threads.log" >/dev/null || {
+  printf 'FAIL: absent nextest setting must preserve the Cargo thread fallback\n' >&2
+  exit 1
+}
+printf 'PASS: shard replay preserves the Cargo thread fallback\n'
 
 # A prebuilt nextest archive makes shard replay execution-only: listing and
 # running must both read the archive instead of recompiling the workspace, and


### PR DESCRIPTION
## Summary

- read the declared `rust_nextest_shard_threads` merged extension setting during shard replay
- preserve environment override precedence
- preserve `rust_cargo_test_threads` as the compatibility fallback when no nextest-specific value exists
- cover all three precedence paths through executable runner smoke tests

## Root cause

`rust/rust.json` declared the setting, but `rust_nextest_shard_threads()` only read `HOMEBOY_RUST_NEXTEST_SHARD_THREADS` before falling directly back to the Cargo thread setting. Portable component configuration therefore had no effect, and Homeboy's process-isolated nextest shards remained serial.

Consumer evidence: https://github.com/Extra-Chill/homeboy/actions/runs/31890640923
Consumer repair: https://github.com/Extra-Chill/homeboy/pull/12537

## Verification

- `bash rust/tests/test-shard-inventory-smoke.sh`
- `bash -n rust/scripts/test-runner.sh rust/tests/test-shard-inventory-smoke.sh`
- `git diff --check`

Closes #2633.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the consumer configuration into the Rust runner, implemented the setting precedence repair, and added execution-level coverage. Chris Huber directed and reviewed the work.
