### PR TITLE
Avoid executing dependency entrypoints during PHPStan discovery

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -140,6 +140,7 @@ PHPSTAN_BASE_CONFIG="$PHPSTAN_DEFAULT_CONFIG"
 PHPSTAN_LEVEL_SOURCE="extension-default"
 COMPONENT_BASELINE="${PLUGIN_PATH}/phpstan-baseline.neon"
 COMPOSITE_AUTOLOAD=""
+COMPOSITE_AUTOLOAD_DIR=""
 DEPENDENCY_CONFIG=""
 SCOPED_CONTEXT_CONFIG=""
 
@@ -711,14 +712,21 @@ fi
 # (`class-wp-agent-materialized-identity.php`) rather than PSR-4, so no path
 # convention can derive the mapping — the declarations have to be indexed.
 #
-# Emits `<fqcn> => <file>` pairs by tokenizing each dependency source once.
+# Emits `<fqcn> => <declaration-only-file>` pairs by tokenizing each dependency
+# source once. The generated files preserve class bodies for PHPStan reflection
+# without executing plugin entrypoints or other top-level runtime bootstrap.
 # Tokenizing is used rather than a regex so commented-out or string-literal
 # occurrences of `class Foo` cannot poison the map.
 homeboy_emit_dependency_class_map_entries() {
     local dependency_path="$1"
+    local declaration_dir="$2"
 
     homeboy_resolve_phpstan_dependency_signature_files "$dependency_path" \
         | "${HOMEBOY_PHP_BIN:-php}" -r '
+            $declarationDir = $argv[1] ?? "";
+            if ($declarationDir === "" || (!is_dir($declarationDir) && !mkdir($declarationDir, 0700, true))) {
+                exit(1);
+            }
             $stdin = fopen("php://stdin", "r");
             while (false !== ($file = fgets($stdin))) {
                 $file = trim($file);
@@ -734,43 +742,112 @@ homeboy_emit_dependency_class_map_entries() {
                     continue;
                 }
                 $namespace = "";
+                $namespaceDepth = 0;
+                $imports = [];
+                $scopeDepth = 0;
                 $count = count($tokens);
                 for ($i = 0; $i < $count; $i++) {
                     $token = $tokens[$i];
                     if (!is_array($token)) {
+                        if ($token === "{") {
+                            $scopeDepth++;
+                        } elseif ($token === "}") {
+                            $scopeDepth--;
+                        }
                         continue;
                     }
                     if ($token[0] === T_NAMESPACE) {
                         $namespace = "";
+                        $imports = [];
                         for ($j = $i + 1; $j < $count; $j++) {
                             if (is_array($tokens[$j]) && in_array($tokens[$j][0], array(T_STRING, T_NAME_QUALIFIED), true)) {
                                 $namespace .= $tokens[$j][1];
                             } elseif ($tokens[$j] === ";" || $tokens[$j] === "{") {
+                                $namespaceDepth = $tokens[$j] === "{" ? $scopeDepth + 1 : $scopeDepth;
                                 break;
                             }
                         }
                         continue;
                     }
-                    if (!in_array($token[0], array(T_CLASS, T_INTERFACE, T_TRAIT), true)) {
+                    if ($token[0] === T_USE && $scopeDepth === $namespaceDepth) {
+                        $import = "";
+                        for ($j = $i; $j < $count; $j++) {
+                            $import .= is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j];
+                            if ($tokens[$j] === ";") {
+                                $imports[] = trim($import);
+                                $i = $j;
+                                break;
+                            }
+                        }
+                        continue;
+                    }
+                    $declarationTokens = array(T_CLASS, T_INTERFACE, T_TRAIT);
+                    if (defined("T_ENUM")) {
+                        $declarationTokens[] = T_ENUM;
+                    }
+                    if (!in_array($token[0], $declarationTokens, true)) {
                         continue;
                     }
                     // Skip anonymous classes and `::class` constant fetches.
                     if ($i > 0 && is_array($tokens[$i - 1]) && $tokens[$i - 1][0] === T_DOUBLE_COLON) {
                         continue;
                     }
+                    $name = "";
                     for ($j = $i + 1; $j < $count; $j++) {
                         if (is_array($tokens[$j]) && $tokens[$j][0] === T_STRING) {
-                            $fqcn = ($namespace !== "" ? $namespace . "\\" : "") . $tokens[$j][1];
-                            echo $fqcn . "\t" . $file . "\n";
+                            $name = $tokens[$j][1];
                             break;
                         }
                         if ($tokens[$j] === "(" || $tokens[$j] === "{") {
                             break;
                         }
                     }
+                    if ($name === "") {
+                        continue;
+                    }
+
+                    $start = $i;
+                    while ($start > 0 && is_array($tokens[$start - 1]) && in_array($tokens[$start - 1][0], array(T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, T_ABSTRACT, T_FINAL, defined("T_READONLY") ? T_READONLY : -1), true)) {
+                        $start--;
+                    }
+                    $declaration = "";
+                    $braceDepth = 0;
+                    $opened = false;
+                    for ($j = $start; $j < $count; $j++) {
+                        $piece = is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j];
+                        $declaration .= $piece;
+                        if ($piece === "{") {
+                            $braceDepth++;
+                            $opened = true;
+                        } elseif ($piece === "}") {
+                            $braceDepth--;
+                            if ($opened && $braceDepth === 0) {
+                                break;
+                            }
+                        }
+                    }
+                    if (!$opened || $braceDepth !== 0) {
+                        continue;
+                    }
+
+                    $fqcn = ($namespace !== "" ? $namespace . "\\" : "") . $name;
+                    $target = $declarationDir . "/" . sha1($file . "\0" . $fqcn) . ".php";
+                    $stub = "<?php\n";
+                    if ($namespace !== "") {
+                        $stub .= "namespace " . $namespace . ";\n";
+                    }
+                    if ($imports !== []) {
+                        $stub .= implode("\n", $imports) . "\n";
+                    }
+                    $stub .= $declaration . "\n";
+                    if (file_put_contents($target, $stub) === false) {
+                        continue;
+                    }
+                    echo $fqcn . "\t" . $target . "\n";
+                    $i = $j;
                 }
             }
-        ' 2>/dev/null
+        ' "$declaration_dir" 2>/dev/null
 }
 
 generate_composite_autoload() {
@@ -779,6 +856,8 @@ generate_composite_autoload() {
     local component_prefixed_autoload="${PLUGIN_PATH}/vendor_prefixed/autoload.php"
 
     tmpfile=$(homeboy_mktemp 'homeboy-phpstan-autoload.XXXXXX')
+    COMPOSITE_AUTOLOAD_DIR="${tmpfile}.d"
+    mkdir -p "$COMPOSITE_AUTOLOAD_DIR"
 
     {
         printf '%s\n' '<?php'
@@ -828,7 +907,7 @@ generate_composite_autoload() {
                     "$(printf '%s' "$fqcn" | jq -Rsa .)" \
                     "$(printf '%s' "$class_file" | jq -Rsa .)"
                 class_map_entries=$((class_map_entries + 1))
-            done < <(homeboy_emit_dependency_class_map_entries "$dependency_path")
+            done < <(homeboy_emit_dependency_class_map_entries "$dependency_path" "$COMPOSITE_AUTOLOAD_DIR")
         done <<< "$autoloaderless_dependencies"
         printf '%s\n' '];'
         printf '%s\n' 'if ($homeboyDependencyClassMap !== []) {'
@@ -849,10 +928,13 @@ generate_composite_autoload() {
 
 cleanup_composite_autoload() {
     [ -n "$COMPOSITE_AUTOLOAD" ] && rm -f "$COMPOSITE_AUTOLOAD"
+    [ -n "$COMPOSITE_AUTOLOAD_DIR" ] && rm -rf "$COMPOSITE_AUTOLOAD_DIR"
     COMPOSITE_AUTOLOAD=""
+    COMPOSITE_AUTOLOAD_DIR=""
 }
 
 COMPOSITE_AUTOLOAD=$(generate_composite_autoload)
+COMPOSITE_AUTOLOAD_DIR="${COMPOSITE_AUTOLOAD}.d"
 
 if [ -f "$COMPOSITE_AUTOLOAD" ]; then
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -1093,7 +1175,9 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
             $criticalIdentifiers = explode("|", $criticalPattern);
 
             $totals = $json["totals"] ?? [];
-            $errorCount = $totals["file_errors"] ?? 0;
+            $fileErrorCount = $totals["file_errors"] ?? 0;
+            $globalErrors = $json["errors"] ?? [];
+            $errorCount = $fileErrorCount + count($globalErrors);
             $fileCount = count($json["files"] ?? []);
 
             if ($errorCount === 0) exit;
@@ -1165,6 +1249,14 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
                     echo "\n";
 
                     $identifiers[$identifier] = ($identifiers[$identifier] ?? 0) + 1;
+                }
+            }
+
+            if (!$criticalOnly && $globalErrors !== []) {
+                echo "  PHPStan:\n";
+                foreach ($globalErrors as $message) {
+                    echo "    " . (is_string($message) ? $message : json_encode($message)) . "\n\n";
+                    $identifiers["internal"] = ($identifiers["internal"] ?? 0) + 1;
                 }
             }
 
@@ -1248,7 +1340,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         echo "$json_output" | php -r '
             require $argv[3];
             $json = json_decode(file_get_contents("php://stdin"), true);
-            if (!$json || empty($json["files"])) {
+            if (!$json || (empty($json["files"]) && empty($json["errors"]))) {
                 file_put_contents($argv[2], "[]");
                 exit;
             }
@@ -1288,6 +1380,24 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
                         "excerpt" => $readExcerpt($filePath, $line),
                     ];
                 }
+            }
+            foreach ($json["errors"] ?? [] as $globalIndex => $globalError) {
+                $message = is_string($globalError) ? $globalError : json_encode($globalError, JSON_UNESCAPED_SLASHES);
+                $code = stripos((string) $message, "internal error") !== false ? "phpstan.internal" : "phpstan.global";
+                $findings[] = [
+                    "id" => "phpstan::" . $code . "::" . $globalIndex,
+                    "tool" => "phpstan",
+                    "file" => null,
+                    "line" => null,
+                    "column" => null,
+                    "severity" => "error",
+                    "code" => $code,
+                    "rule" => $code,
+                    "category" => "phpstan",
+                    "message" => $message . " (" . $code . ")",
+                    "fixable" => false,
+                    "excerpt" => null,
+                ];
             }
             $findings = homeboy_assign_stable_lint_fingerprints($findings);
             file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -74,6 +74,10 @@ if [ "${PHPSTAN_EMIT_ERROR:-}" = "1" ]; then
     printf '{"totals":{"errors":1,"file_errors":1},"files":{"%s/main.php":{"errors":1,"messages":[{"message":"Call to an undefined function missing_function().","line":1,"identifier":"function.notFound"}]}}}\n' "${HOMEBOY_COMPONENT_PATH}"
     exit 1
 fi
+if [ "${PHPSTAN_EMIT_GLOBAL_ERROR:-}" = "1" ]; then
+    printf '%s\n' '{"totals":{"errors":1,"file_errors":0},"files":{},"errors":["Internal error: Failed opening required core/abstraction.php while analysing fixture/content.php"]}'
+    exit 1
+fi
 printf '%s\n' '{"totals":{"errors":0,"file_errors":0},"files":{}}'
 SH
 chmod +x "${EXTENSION_DIR}/vendor/bin/phpstan"
@@ -303,6 +307,46 @@ expected = {
 for key, value in expected.items():
     assert finding.get(key) == value, (key, finding)
 assert "source" not in finding, finding
+assert finding.get("fingerprint"), finding
+PY
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="phpstan-smoke" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+PHPSTAN_ARGS_FILE="$ARGS_FILE" \
+PHPSTAN_CALLS_FILE="$CALLS_FILE" \
+PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \
+PHPSTAN_AUTOLOAD_CAPTURE="$AUTOLOAD_CAPTURE" \
+PHPSTAN_EMIT_GLOBAL_ERROR=1 \
+_HOMEBOY_PHPSTAN_FINDINGS_FILE="$FINDINGS_FILE" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
+HOMEBOY_SUMMARY_MODE=1 \
+"$RUNNER" >"$OUTPUT_FILE"
+phpstan_global_error_status=$?
+set -e
+
+if [ "$phpstan_global_error_status" -eq 0 ]; then
+    echo "FAIL: PHPStan global error fixture should fail" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+assert_file_contains "$OUTPUT_FILE" "Failed opening required core/abstraction.php" "PHPStan global error is visible in summary output"
+python3 - "$FINDINGS_FILE" <<'PY'
+import json
+import sys
+
+findings = json.load(open(sys.argv[1], encoding="utf-8"))
+assert len(findings) == 1, findings
+finding = findings[0]
+assert finding["tool"] == "phpstan", finding
+assert finding["code"] == "phpstan.internal", finding
+assert finding["file"] is None, finding
+assert finding["line"] is None, finding
+assert "Failed opening required core/abstraction.php" in finding["message"], finding
 assert finding.get("fingerprint"), finding
 PY
 

--- a/wordpress/tests/phpstan-dependency-class-registration-smoke.sh
+++ b/wordpress/tests/phpstan-dependency-class-registration-smoke.sh
@@ -23,6 +23,7 @@ TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 DEPENDENCY_DIR="${TMP_ROOT}/fixture-dependency"
+DECLARATION_DIR="${TMP_ROOT}/declarations"
 mkdir -p "${DEPENDENCY_DIR}/src/Identity" "${DEPENDENCY_DIR}/vendor/acme" "${DEPENDENCY_DIR}/tests"
 
 cat > "${DEPENDENCY_DIR}/fixture-dependency.php" <<'PHP'
@@ -30,7 +31,14 @@ cat > "${DEPENDENCY_DIR}/fixture-dependency.php" <<'PHP'
 /**
  * Plugin Name: Fixture Dependency
  */
-require_once __DIR__ . '/src/Identity/class-fixture-identity.php';
+final class Fixture_Entrypoint_Class {
+    public function identity(): string {
+        return 'fixture';
+    }
+}
+
+$GLOBALS['fixture_dependency_bootstrapped'] = true;
+require_once 'core/abstraction.php';
 PHP
 
 # WordPress file naming, PSR-4-incompatible: no path convention derives the FQCN.
@@ -71,7 +79,7 @@ for helper in homeboy_resolve_phpstan_dependency_signature_files homeboy_emit_de
     fi
 done
 
-entries="$(homeboy_emit_dependency_class_map_entries "$DEPENDENCY_DIR")"
+entries="$(homeboy_emit_dependency_class_map_entries "$DEPENDENCY_DIR" "$DECLARATION_DIR")"
 
 if ! grep -qP '^FixtureAPI\\Core\\Identity\\Fixture_Materialized_Identity\t' <<< "$entries"; then
     echo "FAIL: namespaced dependency class must be indexed with its fully-qualified name" >&2
@@ -80,10 +88,22 @@ if ! grep -qP '^FixtureAPI\\Core\\Identity\\Fixture_Materialized_Identity\t' <<<
 fi
 
 mapped_file="$(grep -P '^FixtureAPI\\Core\\Identity\\Fixture_Materialized_Identity\t' <<< "$entries" | head -1 | cut -f2)"
-if [ "$mapped_file" != "${DEPENDENCY_DIR}/src/Identity/class-fixture-identity.php" ]; then
-    echo "FAIL: class must map to its declaring file, got: ${mapped_file}" >&2
+if [[ "$mapped_file" != "${DECLARATION_DIR}/"*.php ]]; then
+    echo "FAIL: class must map to a generated declaration file, got: ${mapped_file}" >&2
     exit 1
 fi
+
+entrypoint_file="$(grep -P '^Fixture_Entrypoint_Class\t' <<< "$entries" | head -1 | cut -f2)"
+if [ ! -f "$entrypoint_file" ]; then
+    echo "FAIL: entrypoint class must map to a generated declaration file" >&2
+    printf '%s\n' "$entries" >&2
+    exit 1
+fi
+
+# Loading a discovered class must not execute the dependency file. The original
+# entrypoint has a relative require that deterministically fatals outside its
+# runtime bootstrap context.
+php -r 'require $argv[1]; $instance = new Fixture_Entrypoint_Class(); exit($instance->identity() === "fixture" && empty($GLOBALS["fixture_dependency_bootstrapped"]) ? 0 : 1);' "$entrypoint_file"
 
 if grep -q 'Acme\\Vendored' <<< "$entries"; then
     echo "FAIL: vendored dependency classes must not be indexed" >&2


### PR DESCRIPTION
Closes #2635

## Root cause

The non-Composer dependency fallback tokenized dependency sources into a class map, but mapped each discovered class back to its original declaring file. PHPStan's autoloader then `require_once`d that file to reflect the class. When a class lived in a plugin entrypoint, symbol discovery executed the entrypoint's top-level bootstrap in PHPStan's analysis context. A relative runtime require consequently failed while the consumer template was being analyzed.

The summary parser also counted only `totals.file_errors` and transformed only `files[*].messages`. PHPStan's top-level `errors` array was therefore omitted from both console details and the lint findings sidecar, leaving Homeboy with exit 1 and zero findings.

## Generic boundary

- Keep the existing bounded dependency-source scan and token-based FQCN discovery.
- For dependencies without Composer autoloaders, generate temporary declaration-only class files that preserve namespaces, imports, class bodies, interfaces, traits, and enums.
- Point the fallback class map at those generated declarations instead of executable dependency files.
- Remove the generated declaration directory with the existing composite-autoloader cleanup.
- Convert top-level PHPStan errors into locationless `phpstan.internal` or `phpstan.global` findings and include them in summary output.

No consumer, plugin, or vendor is named or special-cased in the implementation.

## Regression coverage

`phpstan-dependency-class-registration-smoke.sh` now includes an autoloaderless dependency entrypoint that declares a class, mutates global runtime state, and performs a relative require of a missing file. The test loads the generated class-map target and proves the class remains reflectable while neither the bootstrap mutation nor the failing require executes.

`phpstan-scoped-smoke.sh` now emits a top-level PHPStan internal error with the reported relative-require signature and asserts that it remains visible in summary output and becomes a fingerprinted, locationless structured finding.

## Verification

- `bash scripts/ci/run-self-checks.sh wordpress lint`: 3 passed, 0 failed.
- `bash scripts/ci/run-self-checks.sh wordpress test`: 77 passed; six lint smokes initially lacked the CI-provided runtime-helper environment. Rerunning those six with the installed `HOMEBOY_RUNTIME_*` helper paths passed, covering all 83 declared checks.
- Focused dependency/diagnostic suites passed: class registration, signature shadowing, relative dependency path, validation dependencies, dependency-resolution regressions, dependency preflight, and scoped PHPStan diagnostics.
- `git diff --check` and `bash -n` passed. ShellCheck is not installed on the host.

## Community release-gate reproduction

The installed-extension canonical command reproduced the original opaque result before the patch: PHPStan exit 1, zero findings, and an infrastructure-failure verdict.

Running this branch's PHPStan runner over the same eight runtime files and the same declared validation dependencies completes dependency discovery without the bootstrap crash. PHPStan now reports eight ordinary consumer findings across three files (`argument.type`, `parameter.notFound`, `if.alwaysTrue`, and `property.nonObject`). The gate remains correctly failing on those actionable findings rather than skipping PHPStan or returning an internal/global error.