### PR TITLE
fix(wordpress): enforce managed PHPUnit selection

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -22,7 +22,8 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh scripts/test/changed-scope-test-routing-smoke.sh scripts/test/test-runner-file-routing-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/installed-build-helper-resolution-smoke.sh tests/installed-agent-runtime-resolution-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
-      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/lib/agent-runtime-paths.cjs scripts/agent/homeboy-opencode-agent-task-executor.cjs scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/lib/wp-codebox-timeout-diagnostics.mjs scripts/lib/wp-codebox-phpunit-timeout.mjs scripts/lib/wp-codebox-runtime-crash.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs"
+      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh scripts/test/changed-scope-test-routing-smoke.sh scripts/test/test-runner-file-routing-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/installed-build-helper-resolution-smoke.sh tests/installed-agent-runtime-resolution-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
+      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/lib/agent-runtime-paths.cjs scripts/agent/homeboy-opencode-agent-task-executor.cjs scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/lib/wp-codebox-timeout-diagnostics.mjs scripts/lib/wp-codebox-phpunit-timeout.mjs scripts/lib/wp-codebox-runtime-crash.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs tests/wp-codebox-phpunit-managed-selection-smoke.mjs"
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
@@ -46,6 +47,7 @@
       "node tests/wp-codebox-runtime-crash-detector-smoke.mjs",
       "node tests/wp-codebox-phpunit-runtime-crash-smoke.mjs",
       "node tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs",
+      "node tests/wp-codebox-phpunit-managed-selection-smoke.mjs",
       "bash scripts/test/changed-scope-test-routing-smoke.sh",
       "bash scripts/test/test-runner-file-routing-smoke.sh",
       "bash scripts/test/wp-codebox-mount-translation-smoke.sh",

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -451,9 +451,13 @@ function phpunitChangedTestFiles() {
   const scoped = process.env.HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES;
   const raw = scoped === undefined || scoped === '' ? process.env.HOMEBOY_CHANGED_TEST_FILES || '' : scoped;
   const entries = raw.split('\n').map((entry) => entry.trim()).filter(Boolean);
-  const selected = scoped === undefined || scoped === ''
-    ? entries.filter((entry) => /(?:Test\.php|\/test-[^/]*\.php)$/.test(`/${entry}`))
-    : entries;
+  const selected = entries.filter((entry) => /(?:Test\.php|\/test-[^/]*\.php)$/.test(`/${entry}`));
+  if (scoped !== undefined && scoped !== '') {
+    const rejected = entries.filter((entry) => !selected.includes(entry));
+    if (rejected.length > 0) {
+      throw new Error(`HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES contains non-PHPUnit paths: ${rejected.join(', ')}`);
+    }
+  }
   return [...new Set(selected)];
 }
 function canonicalMounts(value) {

--- a/wordpress/tests/wp-codebox-phpunit-managed-selection-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-managed-selection-smoke.mjs
@@ -26,6 +26,10 @@ await writeFile(cli, `#!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
 const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  process.stdout.write('0.21.0\\n');
+  process.exit(0);
+}
 if (args[0] === 'recipe' && args[1] === 'build') {
   fs.copyFileSync(args[args.indexOf('--options') + 1], process.env.CAPTURED_OPTIONS);
   fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');

--- a/wordpress/tests/wp-codebox-phpunit-managed-selection-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-managed-selection-smoke.mjs
@@ -1,0 +1,125 @@
+/**
+ * Regression: a managed changed-test scope must reach WP Codebox as explicit
+ * sandbox paths, retain nonzero counts, and remain fail-closed.
+ *
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-managed-selection-'));
+const component = path.join(root, 'sample-plugin');
+const cli = path.join(root, 'wp-codebox');
+
+await mkdir(path.join(component, 'tests/Unit/Deep'), { recursive: true });
+await writeFile(path.join(component, 'sample-plugin.php'), '<?php\n/* Plugin Name: Sample Plugin */\n');
+await writeFile(path.join(component, 'tests/Unit/FirstTest.php'), '<?php\nuse PHPUnit\\Framework\\TestCase;\nfinal class FirstTest extends TestCase {}\n');
+await writeFile(path.join(component, 'tests/Unit/Deep/SecondTest.php'), '<?php\nuse PHPUnit\\Framework\\TestCase;\nfinal class SecondTest extends TestCase {}\n');
+await writeFile(path.join(component, 'tests/standalone-smoke.php'), '<?php\necho "standalone smoke";\n');
+
+await writeFile(cli, `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+const args = process.argv.slice(2);
+if (args[0] === 'recipe' && args[1] === 'build') {
+  fs.copyFileSync(args[args.indexOf('--options') + 1], process.env.CAPTURED_OPTIONS);
+  fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
+  process.exit(0);
+}
+const artifactRoot = args[args.indexOf('--artifacts') + 1];
+const runtime = path.join(artifactRoot, 'runtime-fixture');
+fs.mkdirSync(path.join(runtime, 'files', 'phpunit'), { recursive: true });
+fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+const scenario = process.env.SELECTION_SCENARIO || 'passed';
+const failed = scenario === 'command-failed';
+const total = scenario === 'passed' ? 2 : 0;
+fs.writeFileSync(path.join(runtime, 'files', 'phpunit', '.pg-test-result.txt'), [
+  'PLUGIN_DETECTED sample-plugin.php',
+  'PLUGIN_ACTIVATE sample-plugin/sample-plugin.php',
+  'PLUGIN_ACTIVATE_OK sample-plugin/sample-plugin.php stage=activation',
+  'SCOPED_TEST_FILES requested=2 matched=2',
+  'DISCOVERY: dirs=/wordpress/wp-content/plugins/sample-plugin/tests files=2 suffixes=Test.php prefixes=test- excludes=0 found=2',
+  '',
+].join('\\n'));
+fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify({
+  schema: 'wp-codebox/test-results/v1',
+  status: failed ? 'failed' : (total > 0 ? 'passed' : 'skipped'),
+  summary: { total, passed: total, failed: 0, skipped: 0, unknown: 0 },
+  suites: [],
+}));
+const stdout = total > 0 ? 'OK (2 tests, 2 assertions)\\n' : 'Tests: 0, Assertions: 0.\\n';
+process.stdout.write(JSON.stringify({
+  success: !failed,
+  executions: [{ command: 'wordpress.phpunit', exitCode: failed ? 2 : 0, stdout, stderr: failed ? 'runner failed\\n' : '' }],
+}));
+process.exitCode = failed ? 2 : 0;
+`);
+await chmod(cli, 0o755);
+
+function execute(name, changed, scenario = 'passed') {
+  const artifacts = path.join(root, `${name}-artifacts`);
+  const capturedOptions = path.join(root, `${name}-options.json`);
+  const run = spawnSync('bash', [runner], {
+    env: {
+      ...process.env,
+      CAPTURED_OPTIONS: capturedOptions,
+      SELECTION_SCENARIO: scenario,
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'sample-plugin',
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({ phpunit_no_tests: 'fail', wp_codebox_phpunit_bootstrap_mode: 'managed' }),
+      HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES: changed,
+    },
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return { artifacts, capturedOptions, run };
+}
+
+async function artifactResults(artifacts) {
+  const runDirectory = (await readdir(artifacts)).find((entry) => entry.startsWith('wp-codebox-phpunit.'));
+  assert.ok(runDirectory, 'expected a WP Codebox run artifact directory');
+  return JSON.parse(await readFile(path.join(artifacts, runDirectory, 'runtime-fixture/files/test-results.json'), 'utf8'));
+}
+
+try {
+  const selected = 'tests/Unit/FirstTest.php\ntests/Unit/Deep/SecondTest.php';
+  const passed = execute('passed', selected);
+  assert.equal(passed.run.status, 0, passed.run.stderr || passed.run.stdout);
+  const options = JSON.parse(await readFile(passed.capturedOptions, 'utf8'));
+  assert.deepEqual(options.changedTestFiles, [
+    '/wordpress/wp-content/plugins/sample-plugin/tests/Unit/FirstTest.php',
+    '/wordpress/wp-content/plugins/sample-plugin/tests/Unit/Deep/SecondTest.php',
+  ]);
+  assert.equal(options.bootstrapMode, 'managed');
+  assert.deepEqual((await artifactResults(passed.artifacts)).summary, {
+    total: 2,
+    passed: 2,
+    failed: 0,
+    skipped: 0,
+    unknown: 0,
+  });
+
+  const invalid = execute('standalone-script', `${selected}\ntests/standalone-smoke.php`);
+  assert.notEqual(invalid.run.status, 0, 'a standalone PHP script must not enter the PHPUnit scope');
+  assert.match(`${invalid.run.stdout}${invalid.run.stderr}`, /contains non-PHPUnit paths: tests\/standalone-smoke\.php/);
+
+  const zero = execute('zero', selected, 'zero');
+  assert.notEqual(zero.run.status, 0, 'a genuine zero-test result must fail closed');
+  assert.equal((await artifactResults(zero.artifacts)).status, 'failed');
+  assert.match(zero.run.stdout, /PHPUNIT_ZERO_TESTS/);
+
+  const commandFailed = execute('command-failed', selected, 'command-failed');
+  assert.notEqual(commandFailed.run.status, 0, 'a PHPUnit command failure must remain a failure');
+  assert.equal((await artifactResults(commandFailed.artifacts)).status, 'failed');
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log('WP Codebox PHPUnit managed selection smoke passed.');


### PR DESCRIPTION
## Summary
- validate the final managed PHPUnit changed-file scope so only canonical PHPUnit files can reach WP Codebox
- add an end-to-end adapter regression proving multiple selected files survive sandbox remapping and report nonzero counts
- retain fail-closed behavior for genuine zero-test results and command failures

## Root cause
Workflow run 31914303314 selected three valid PHPUnit files, but the preserved recipe options and command log showed `changed-tests-json=[]`. The installed WordPress extension revision in that run predated the current changed-scope handoff/remapping fixes, so WP Codebox widened to the configured managed suite instead of executing the selection. Its project bootstrap then loaded a standalone test stub after WordPress and fatally redeclared `get_site_option()` before PHPUnit produced a structured response. The resulting failed sidecar contained zero counts, which Homeboy correctly rejected as `test runner reported zero executed tests`.

The execution seam fixed here is the adapter's final `HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES` boundary. The adapter now applies the canonical PHPUnit filename predicate even to the pre-scoped environment and fails before recipe construction if a standalone PHP script or other non-PHPUnit path leaks into that scope. Valid selected files continue through the existing host-to-sandbox remapping and are passed to `wordpress.phpunit` as explicit sandbox paths.

Standalone `*-smoke.php` scripts remain owned by the generic outer test router and are never treated as PHPUnit classes. The regression covers that boundary without repository-specific names or bypasses. PHPUnit files stay in the managed runtime; no separate plain-unit execution mode is introduced because the selected files are already representable through the existing managed/project bootstrap contract once the explicit selection reaches WP Codebox.

## Fail-closed guarantees
- a non-PHPUnit path in the explicit PHPUnit scope fails instead of being dropped into an empty/full-suite scope
- a valid selection that reports zero executed tests remains failed
- a nonzero recipe/PHPUnit command exit remains failed
- no test skipping or repository-specific exception was added

## Tests
- `node tests/wp-codebox-phpunit-managed-selection-smoke.mjs`
- `node tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs`
- `node tests/wp-codebox-phpunit-target-activation-smoke.mjs`
- `node tests/wp-codebox-phpunit-aggregate-smoke.mjs`
- `node tests/wp-codebox-phpunit-evidence-smoke.mjs`
- `node tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs`
- `node tests/wp-codebox-phpunit-multisite-smoke.mjs`
- `bash scripts/test/changed-scope-test-routing-smoke.sh`
- `bash scripts/test/test-runner-file-routing-smoke.sh`
- `bash scripts/test/full-suite-no-phpunit-smoke.sh`
- `npx eslint scripts/test/wp-codebox-phpunit-adapter.mjs --no-warn-ignored`
- syntax and JSON checks for the changed adapter, regression, and manifests

## Workflow evidence
- Extra-Chill/extrachill-events run 31914303314, job 95083835649
- downloaded artifact `managed-phpunit-evidence` (artifact 9254560809)
- recipe options showed no changed test files
- `logs/commands.log` showed `changed-tests-json=[]` and the pre-PHPUnit `get_site_option()` redeclaration fatal
- the workflow's separate isolated unit step passed before the managed run, but that separate command was not part of the managed adapter's structured result

Closes #2637