### PR TITLE
Measure unsharded nextest runs from libtest-json-plus

### DIFF
--- a/rust/docs/dev-loop.md
+++ b/rust/docs/dev-loop.md
@@ -82,6 +82,53 @@ The provider appends the matching Rust flag only when the linker binary is on
 Unsupported or unavailable requests are reported through `HOMEBOY_RUST_*_STATUS`
 environment metadata and do not force Cargo to run with a broken linker flag.
 
+## Test Runner Selection
+
+`rust_test_runner` chooses between `cargo` (default) and `nextest`. When
+`nextest` is selected but `cargo-nextest` is not installed, `rust_nextest_fallback`
+(default true) falls back to `cargo test`; set it false to fail with an install
+diagnostic instead.
+
+Sharded replay and unsharded runs count nextest differently because only one of
+them has a plan to count against:
+
+- **Sharded replay** reconciles the emitted `libtest-json-plus` identities
+  against the shard manifest and hard-errors on any mismatch. A shard that does
+  not execute exactly what was planned is a broken shard, not a test failure.
+- **Unsharded runs** have no manifest. `rust_nextest_measured_counts` (default
+  true) parses the same event stream into a Homeboy test result without
+  reconciliation. Both counters share `scripts/nextest_events_lib.py`, so they
+  cannot drift on how nextest encodes identity or which events are outcomes.
+
+`rust_nextest_measured_counts` does **not** select the runner — it only decides
+whether a run that already chose nextest is measured. It matters because nextest
+emits no `test result:` lines, so the cargo-test result adapter matches nothing:
+without it, an unsharded nextest run produces no structured counts at all. Set
+`HOMEBOY_RUST_NEXTEST_MEASURED_COUNTS=0` to opt back out.
+
+A measured run reports its counts directly:
+
+```
+Rust test runner: cargo nextest (measured counts from libtest-json-plus)
+Rust nextest result: total=482 passed=479 failed=0 skipped=3
+```
+
+When the stream carries no terminal test event — a compile failure, or a run
+killed before the first test — no test result is written at all. Homeboy reads a
+missing `test.results` as "no structured counts", which is the intended signal;
+an all-zero result would be indistinguishable from a suite that legitimately ran
+nothing and would report a broken build as a pass.
+
+Two invocation details differ from shard replay on purpose:
+
+- `--no-tests warn` (replay uses `fail`). Replay preflights exact membership, so
+  an empty match there is a broken plan. Unsharded, the filter is derived from
+  changed file paths, and an empty match is the scope-derivation gap the runner
+  absorbs by widening to the full suite — which requires a zero exit code.
+- Skip counts reflect only the skips nextest reported. nextest omits tests it
+  never ran from its default event stream, so unsharded skip counts do not
+  reconstruct `#[ignore]` membership the way a shard manifest can.
+
 ## Fast Local Profile
 
 For local iteration, use the narrowest command that proves the change:

--- a/rust/homeboy.json
+++ b/rust/homeboy.json
@@ -13,6 +13,8 @@
       "bash tests/fingerprint-policy-flow-smoke.sh",
       "bash tests/zero-test-scope-fallback-smoke.sh",
       "bash tests/test-shard-inventory-smoke.sh",
+      "bash tests/nextest-unsharded-counts-smoke.sh",
+      "bash scripts/rust-nextest-runner-smoke.sh",
       "bash tests/nextest-shard-real-smoke.sh",
       "bash ../tests/lint-findings-clean-pass-contract-smoke.sh"
     ]

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -131,6 +131,13 @@
       "description": "When cargo-nextest is selected but unavailable, fall back to cargo test. Set false or HOMEBOY_RUST_NEXTEST_FALLBACK=0 to fail with an install diagnostic instead."
     },
     {
+      "id": "rust_nextest_measured_counts",
+      "label": "Rust nextest measured counts",
+      "type": "boolean",
+      "default": true,
+      "description": "Measure unsharded cargo nextest runs by parsing libtest-json-plus events into Homeboy test results. Applies only when rust_test_runner is already nextest; it does not select the runner. nextest emits no 'test result:' lines, so without this an unsharded nextest run produces no structured counts at all. Set false or HOMEBOY_RUST_NEXTEST_MEASURED_COUNTS=0 to run nextest with its human-readable output and no measured result."
+    },
+    {
       "id": "rust_nextest_filter_max_bytes",
       "label": "Rust nextest filter maximum bytes",
       "type": "integer",

--- a/rust/scripts/nextest_events_lib.py
+++ b/rust/scripts/nextest_events_lib.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Shared reader for nextest ``libtest-json-plus`` event streams.
+
+``test-runner.sh`` counts nextest output in two places: shard replay, which
+reconciles what it read against a planned shard manifest, and unsharded runs,
+which have no manifest to reconcile against. The reading half is identical in
+both and lives here; only the reconciliation half is the shard's own.
+
+Splitting it this way is the point. A second parser written for the unsharded
+path would be free to drift from the shard path on what nextest even said --
+how identity is encoded, which events are outcomes, which lines are not JSON at
+all -- and the two counters would disagree about the same stream while both
+looked correct in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+
+# Terminal libtest outcomes. nextest emits lifecycle events ("queued",
+# "started", "running") on the same stream and those are not outcomes, so every
+# consumer has to filter against this set rather than against "has an event".
+PASSED_STATUSES = frozenset({"ok", "passed"})
+FAILED_STATUSES = frozenset({"failed", "fail"})
+SKIPPED_STATUSES = frozenset({"ignored", "skipped"})
+TERMINAL_STATUSES = PASSED_STATUSES | FAILED_STATUSES | SKIPPED_STATUSES
+
+# nextest's retry count is u32 and its attempt number is retry_count + 1.
+# Its TestInstanceId appends the decimal attempt only when it exceeds one.
+MAX_RETRY_ATTEMPT = 2**32
+
+
+class MalformedIdentity(Exception):
+    """An emitted event name is not a nextest test identity."""
+
+
+def emitted_identity(value):
+    """Split an emitted event name into ``(package, target, test)``.
+
+    libtest-json-plus omits Cargo's target kind and encodes its remaining
+    identity as ``package::target$test``. Callers reconcile that structured
+    projection rather than mutating either serialized identifier.
+    """
+    if not isinstance(value, str):
+        raise MalformedIdentity("nextest emitted a malformed test identity")
+    package_target, separator, test = value.rpartition("$")
+    package, target_separator, target = package_target.partition("::")
+    if not separator or not target_separator or not all((package, target, test)):
+        raise MalformedIdentity(f"nextest emitted a malformed test identity: {value!r}")
+    return package, target, test
+
+
+def retry_base_identity(emitted):
+    """Return the pre-retry identity for ``emitted``.
+
+    ``None`` means the name carries no attempt suffix at all. The string
+    ``"invalid"`` means it carries something shaped like one that nextest would
+    never have written, which is a different finding from carrying none and is
+    reported differently by the shard path.
+    """
+    package, target, test = emitted
+    base, marker, attempt_text = test.rpartition("#")
+    if not marker:
+        return None
+    if not base or not attempt_text.isdecimal():
+        return "invalid"
+    attempt = int(attempt_text)
+    if attempt < 2 or attempt > MAX_RETRY_ATTEMPT or attempt_text != str(attempt):
+        return "invalid"
+    return package, target, base
+
+
+def read_test_events(path):
+    """Yield ``(name, identity, status)`` for every ``type: test`` event.
+
+    ``identity`` is ``None`` when the emitted name is not a nextest identity.
+    Child processes inherit libtest JSON, so a captured stream legitimately
+    carries names no scheduler ever planned; deciding what to do with those is
+    the caller's, since the shard path answers it from its manifest and the
+    unsharded path has no manifest to answer it from.
+
+    Non-JSON lines are skipped rather than treated as corruption: the runner
+    captures stdout and stderr into one file, so nextest's own human-readable
+    progress output shares this stream with the JSON.
+    """
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") != "test":
+                continue
+            name = event.get("name")
+            try:
+                identity = emitted_identity(name)
+            except MalformedIdentity:
+                identity = None
+            yield name, identity, event.get("event")

--- a/rust/scripts/rust-nextest-runner-smoke.sh
+++ b/rust/scripts/rust-nextest-runner-smoke.sh
@@ -110,7 +110,16 @@ if [[ "$OUTPUT" != *"Running cargo nextest"* ]]; then
     exit 1
 fi
 
-EXPECTED_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n--workspace\n--test\nintegration_scope'
+if [[ "$OUTPUT" != *"Rust test runner: cargo nextest (measured counts from libtest-json-plus)"* ]]; then
+    printf 'Expected the measured nextest selection to be stated. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+# An unsharded nextest run is measured by default, so the scope args are
+# followed by the flags the libtest-json parser depends on. The scope args must
+# still come first and unchanged: measurement is appended to the selection, it
+# does not rewrite it.
+EXPECTED_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n--workspace\n--test\nintegration_scope\n--no-fail-fast\n--no-tests\nwarn\n--message-format\nlibtest-json-plus\n--message-format-version\n0.1'
 ACTUAL_ARGS="$(cat "$WORKDIR/cargo-args.txt")"
 if [ "$ACTUAL_ARGS" != "$EXPECTED_ARGS" ]; then
     printf 'Expected nextest command shape:\n%s\nActual:\n%s\n' "$EXPECTED_ARGS" "$ACTUAL_ARGS" >&2
@@ -139,6 +148,40 @@ assert record["runner"] == "nextest", record
 assert record["scope"] == "rust_integration", record
 assert record["args"] == ["--test", "integration_scope"], record
 PY
+
+# Measurement off returns the invocation to exactly what it was before measured
+# counts existed, so the escape hatch is a real one rather than a renamed
+# variant of the new command.
+OUTPUT=$(
+    PATH="$BIN_DIR:$PATH" \
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_RUST_TEST_RUNNER=nextest \
+    HOMEBOY_RUST_NEXTEST_MEASURED_COUNTS=0 \
+    HOMEBOY_TEST_SCOPE_KIND='rust_integration' \
+    HOMEBOY_TEST_RUNNER_ARGS=$'--test\nintegration_scope' \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$COMMAND_CAPTURE_HELPER" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    HOMEBOY_RUNTIME_SIDECAR_WRITER="$HELPER_DIR/sidecar-writer.sh" \
+    HOMEBOY_SIDECAR_DIR="$SIDECAR_DIR" \
+    HOMEBOY_FAKE_CARGO_ARGS="$WORKDIR/cargo-args.txt" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+
+if [[ "$OUTPUT" != *"unmeasured; rust_nextest_measured_counts is off"* ]]; then
+    printf 'Expected the disabled measurement to be stated. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+EXPECTED_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n--workspace\n--test\nintegration_scope'
+ACTUAL_ARGS="$(cat "$WORKDIR/cargo-args.txt")"
+if [ "$ACTUAL_ARGS" != "$EXPECTED_ARGS" ]; then
+    printf 'Expected legacy nextest command shape:\n%s\nActual:\n%s\n' "$EXPECTED_ARGS" "$ACTUAL_ARGS" >&2
+    exit 1
+fi
 
 cat > "$BIN_DIR/cargo" <<'EOF'
 #!/usr/bin/env bash

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -60,6 +60,29 @@ rust_nextest_fallback_enabled() {
     [ "$(homeboy_setting_bool rust_nextest_fallback true '.rust_nextest_fallback // .nextest_fallback')" = "true" ]
 }
 
+# Whether an unsharded nextest run is measured.
+#
+# This does NOT decide cargo vs nextest. `rust_test_runner` still does, and it
+# still defaults to cargo, so no existing component silently changes runner.
+# This only decides whether a run that ALREADY selected nextest gets counted.
+#
+# It defaults on because the status quo it replaces is worse than either
+# alternative: nextest emits no `test result:` lines, so the cargo-test adapter
+# in parse-test-results.sh matched nothing and an unsharded nextest run produced
+# no Homeboy test result at all. Turning this on for those components is purely
+# additive. The knob exists as an escape hatch if a future nextest release
+# changes its libtest-json projection.
+rust_nextest_measured_counts_enabled() {
+    if [ -n "${HOMEBOY_RUST_NEXTEST_MEASURED_COUNTS:-}" ]; then
+        case "${HOMEBOY_RUST_NEXTEST_MEASURED_COUNTS}" in
+            1|true|TRUE|yes|YES|on|ON) return 0 ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    [ "$(homeboy_setting_bool rust_nextest_measured_counts true '.rust_nextest_measured_counts')" = "true" ]
+}
+
 rust_cargo_test_threads() {
     local value
     value="${HOMEBOY_RUST_CARGO_TEST_THREADS:-$(homeboy_setting rust_cargo_test_threads '.rust_cargo_test_threads // .cargo_test_threads' '')}"
@@ -459,12 +482,23 @@ rust_capture_stdout() {
 }
 
 rust_nextest_counts() {
-    python3 - "$1" "$2" "$3" <<'PY'
+    python3 - "${EXTENSION_PATH}/scripts" "$1" "$2" "$3" <<'PY'
 import json
 import sys
 
-expected = json.load(open(sys.argv[2], encoding="utf-8"))["selected"]
-failed_names_file = sys.argv[3]
+sys.path.insert(0, sys.argv[1])
+
+from nextest_events_lib import (
+    FAILED_STATUSES,
+    PASSED_STATUSES,
+    SKIPPED_STATUSES,
+    TERMINAL_STATUSES,
+    read_test_events,
+    retry_base_identity,
+)
+
+expected = json.load(open(sys.argv[3], encoding="utf-8"))["selected"]
+failed_names_file = sys.argv[4]
 
 def planned_identity(item):
     values = (item.get("package"), item.get("target_kind"), item.get("target"), item.get("name"))
@@ -477,18 +511,6 @@ def planned_outcome(item):
     if outcome not in {"executed", "skipped"}:
         raise SystemExit("Rust test shard error: shard manifest contains an invalid planned nextest outcome")
     return outcome
-
-def emitted_identity(value):
-    # libtest-json-plus omits Cargo's target kind and encodes its remaining
-    # identity as package::target$test. Reconcile that structured projection,
-    # rather than mutating either serialized identifier.
-    if not isinstance(value, str):
-        raise SystemExit("Rust test shard error: nextest emitted a malformed test identity")
-    package_target, separator, test = value.rpartition("$")
-    package, target_separator, target = package_target.partition("::")
-    if not separator or not target_separator or not all((package, target, test)):
-        raise SystemExit(f"Rust test shard error: nextest emitted a malformed test identity: {value!r}")
-    return package, target, test
 
 planned_by_emitted = {}
 expected_identities = set()
@@ -506,35 +528,9 @@ for item in expected:
         raise SystemExit(f"Rust test shard error: nextest output identity is ambiguous: {package}::{target}${test}")
     planned_by_emitted[emitted] = planned
 
-# nextest's retry count is u32 and its attempt number is retry_count + 1.
-# Its TestInstanceId appends the decimal attempt only when it exceeds one.
-MAX_RETRY_ATTEMPT = 2**32
-
-def retry_base_identity(emitted):
-    package, target, test = emitted
-    base, marker, attempt_text = test.rpartition("#")
-    if not marker:
-        return None
-    if not base or not attempt_text.isdecimal():
-        return "invalid"
-    attempt = int(attempt_text)
-    if attempt < 2 or attempt > MAX_RETRY_ATTEMPT or attempt_text != str(attempt):
-        return "invalid"
-    return package, target, base
-
 outcomes = {}
-for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
-    try:
-        event = json.loads(line)
-    except json.JSONDecodeError:
-        continue
-    if not isinstance(event, dict):
-        continue
-    if event.get("type") != "test":
-        continue
-    try:
-        emitted = emitted_identity(event.get("name"))
-    except SystemExit:
+for name, emitted, status in read_test_events(sys.argv[2]):
+    if emitted is None:
         # Child processes inherit libtest JSON. Scheduler preflight, not their
         # diagnostics, is the authority for shard membership.
         continue
@@ -543,22 +539,21 @@ for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
     if exact:
         normalized = planned_by_emitted.get(retry_base) if retry_base != "invalid" and retry_base else None
         if normalized:
-            raise SystemExit(f"Rust test shard error: nextest retry suffix is ambiguous between planned identities: {event.get('name')}")
+            raise SystemExit(f"Rust test shard error: nextest retry suffix is ambiguous between planned identities: {name}")
         planned = exact
     elif retry_base == "invalid":
         base = emitted[0], emitted[1], emitted[2].rpartition("#")[0]
         if base in planned_by_emitted:
-            raise SystemExit(f"Rust test shard error: nextest emitted a malformed retry suffix: {event.get('name')}")
+            raise SystemExit(f"Rust test shard error: nextest emitted a malformed retry suffix: {name}")
         continue
     else:
         planned = planned_by_emitted.get(retry_base) if retry_base else None
     if not planned:
         continue
-    status = event.get("event")
-    if status not in {"ok", "passed", "failed", "fail", "ignored", "skipped"}:
+    if status not in TERMINAL_STATUSES:
         continue
     if planned in outcomes:
-        raise SystemExit(f"Rust test shard error: nextest emitted an unexpected or duplicate test identity: {event.get('name')}")
+        raise SystemExit(f"Rust test shard error: nextest emitted an unexpected or duplicate test identity: {name}")
     outcomes[planned] = status
 missing = expected_identities - outcomes.keys()
 unexpected_missing = missing - expected_skipped
@@ -566,19 +561,92 @@ if unexpected_missing:
     raise SystemExit(f"Rust test shard error: nextest executed membership does not match the shard manifest (missing={sorted(unexpected_missing)[:1]})")
 # Nextest intentionally omits ignored tests from its default event stream.
 # Their listed disposition is canonical execution policy, not a relaxed match.
-passed = sum(status in {"ok", "passed"} for status in outcomes.values())
+passed = sum(status in PASSED_STATUSES for status in outcomes.values())
 failed_names = sorted(
     f"{package}::{target}${test}"
     for (package, _target_kind, target, test), status in outcomes.items()
-    if status in {"failed", "fail"}
+    if status in FAILED_STATUSES
 )
 failed = len(failed_names)
-skipped = sum(status in {"ignored", "skipped"} for status in outcomes.values()) + len(missing)
+skipped = sum(status in SKIPPED_STATUSES for status in outcomes.values()) + len(missing)
 with open(failed_names_file, "w", encoding="utf-8") as handle:
     handle.write("\n".join(failed_names))
     if failed_names:
         handle.write("\n")
 print(f"{passed}\t{failed}\t{skipped}")
+PY
+}
+
+# Counts for an unsharded nextest run.
+#
+# The sharded counter above reconciles emitted identities against a planned
+# manifest and hard-errors on any mismatch. That is correct for replay and
+# impossible here: nothing planned this run, so there is no `selected` list to
+# reconcile against. What survives is the event stream itself, which already
+# carries every terminal outcome nextest observed. Reading it is the shared half
+# (nextest_events_lib); only the reconciliation is dropped.
+#
+# Prints "total\tpassed\tfailed\tskipped" -- the same tuple the cargo adapter
+# emits through parse-test-results.sh -- and writes failed identities one per
+# line to the second argument, in the same `package::target$test` form the shard
+# path writes, so `rust_nextest_merge_failure_evidence` consumes either.
+#
+# Returns 1 and prints nothing when the stream carried no terminal test event.
+# A compile failure, a crash before the first test, and a filter that matched
+# nothing all land there, and all three must reach the caller as "unmeasured"
+# rather than as a fabricated zero that would read as a pass.
+rust_nextest_unsharded_counts() {
+    python3 - "${EXTENSION_PATH}/scripts" "$1" "$2" <<'PY'
+import sys
+
+sys.path.insert(0, sys.argv[1])
+
+from nextest_events_lib import (
+    FAILED_STATUSES,
+    PASSED_STATUSES,
+    SKIPPED_STATUSES,
+    TERMINAL_STATUSES,
+    read_test_events,
+    retry_base_identity,
+)
+
+failed_names_file = sys.argv[3]
+
+outcomes = {}
+for name, emitted, status in read_test_events(sys.argv[2]):
+    # An unplanned identity is not evidence of anything wrong here. Child
+    # processes inherit libtest JSON, and with no manifest there is nothing to
+    # call it a mismatch against -- so it is simply not one of our tests.
+    if emitted is None or status not in TERMINAL_STATUSES:
+        continue
+    # Fold retry attempts onto the identity they retried. nextest appends the
+    # decimal attempt only above one, so `t` and `t#2` are one test with one
+    # outcome and the final attempt is the one nextest itself reports. Without
+    # this a flaky-then-green test would be counted twice, once red.
+    base = retry_base_identity(emitted)
+    if base is not None and base != "invalid":
+        emitted = base
+    outcomes[emitted] = status
+
+if not outcomes:
+    raise SystemExit(1)
+
+failed_names = sorted(
+    f"{package}::{target}${test}"
+    for (package, target, test), status in outcomes.items()
+    if status in FAILED_STATUSES
+)
+passed = sum(status in PASSED_STATUSES for status in outcomes.values())
+# nextest omits tests it never ran from its default event stream, so an
+# unsharded skip count reflects the skips nextest actually reported and does not
+# reconstruct `#[ignore]` membership the way a shard manifest can.
+skipped = sum(status in SKIPPED_STATUSES for status in outcomes.values())
+failed = len(failed_names)
+with open(failed_names_file, "w", encoding="utf-8") as handle:
+    handle.write("\n".join(failed_names))
+    if failed_names:
+        handle.write("\n")
+print(f"{passed + failed + skipped}\t{passed}\t{failed}\t{skipped}")
 PY
 }
 
@@ -1104,6 +1172,19 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
     exit 0
 fi
 
+# Unsharded measurement state. Resolved once, before the command is built, so a
+# widened re-run and the zero-test checks below all read the same decision.
+NEXTEST_MEASURED=0
+RUST_MEASURED_STATUS=unmeasured
+RUST_MEASURED_TOTAL=0
+RUST_MEASURED_PASSED=0
+RUST_MEASURED_FAILED=0
+RUST_MEASURED_SKIPPED=0
+RUST_MEASURED_FAILED_NAMES=""
+if [ "$SELECTED_RUNNER" = "nextest" ] && rust_nextest_measured_counts_enabled; then
+    NEXTEST_MEASURED=1
+fi
+
 TEST_ARGS=(
     test
     --manifest-path "${PROJECT_PATH}/Cargo.toml"
@@ -1149,6 +1230,19 @@ rust_append_scope_args "$SCOPE_JSON"
 echo "Rust test scope kind: ${SCOPE_KIND}"
 echo "Rust test package selection: ${WORKSPACE_SELECTION}"
 echo "Rust test invocation: cargo ${TEST_ARGS[*]}"
+# Which runner ran, and whether its result was measured, must be readable
+# straight from the log. "Measured" and "unmeasured" are different outcomes for
+# the same green exit code, and an operator should never have to infer which
+# one they got from the absence of a sidecar.
+if [ "$SELECTED_RUNNER" = "nextest" ]; then
+    if [ "$NEXTEST_MEASURED" = "1" ]; then
+        echo "Rust test runner: cargo nextest (measured counts from libtest-json-plus)"
+    else
+        echo "Rust test runner: cargo nextest (unmeasured; rust_nextest_measured_counts is off)"
+    fi
+else
+    echo "Rust test runner: cargo test"
+fi
 
 # Builds COMMAND_LABEL/COMMAND_BINARY from the current TEST_ARGS. Shared so a
 # widened re-run reuses the exact runner selection the first attempt used.
@@ -1171,10 +1265,74 @@ rust_build_test_command() {
         rust_nextest_args_from_cargo_args
         COMMAND_LABEL="cargo nextest run"
         COMMAND_BINARY=(cargo nextest "${NEXTEST_ARGS[@]}")
+        if [ "$NEXTEST_MEASURED" = "1" ]; then
+            # `--no-fail-fast` matches shard replay for the same reason: a
+            # stream truncated at the first failure cannot be counted.
+            #
+            # `--no-tests` deliberately does NOT match it. Shard replay
+            # preflights exact membership, so an empty match there is a broken
+            # plan and `fail` is the right answer. Unsharded, the filter is
+            # derived from changed file paths, and an empty match is the
+            # scope-derivation gap the widening below exists to absorb -- a
+            # `#[path]`-mounted module compiles a filter that matches nothing.
+            # `fail` would exit non-zero, the widening requires exit 0, and the
+            # run would go red for code that was never executed. That is exactly
+            # the false failure #10477 documents, so `warn` is used to keep the
+            # empty match measurable and let the widening do its job.
+            NEXTEST_ARGS+=(
+                --no-fail-fast
+                --no-tests warn
+                --message-format libtest-json-plus
+                --message-format-version 0.1
+            )
+            COMMAND_BINARY=(env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest "${NEXTEST_ARGS[@]}")
+        fi
     fi
 }
 
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/parse-test-results.sh"
+
+# Turn the captured nextest stream into a Homeboy test result.
+#
+# The written tuple is (total, passed, failed, skipped, partial) -- the same
+# shape and the same helper the cargo path reaches through
+# parse-test-results.sh, which ends in `homeboy_write_test_results` with those
+# five values. `partial` is empty because an unsharded run is the whole run;
+# only shard replay has a partial slice to label.
+#
+# When the stream carried no terminal test event the result is deliberately not
+# written. Homeboy reads a missing test.results as "no structured counts", and
+# that is the signal a compile failure or an aborted run has to reach. Writing
+# an all-zero result instead would be indistinguishable from a suite that
+# legitimately ran nothing, and would report a broken build as a pass.
+rust_measure_nextest_run() {
+    RUST_MEASURED_STATUS=unmeasured
+    RUST_MEASURED_TOTAL=0
+    RUST_MEASURED_PASSED=0
+    RUST_MEASURED_FAILED=0
+    RUST_MEASURED_SKIPPED=0
+    RUST_MEASURED_FAILED_NAMES=""
+
+    local failed_names counts
+    if ! homeboy_runner_harness_temp failed_names "homeboy-rust-nextest-failed.XXXXXX"; then
+        echo "Rust nextest counts unavailable: could not allocate a failed-name file." >&2
+        return 0
+    fi
+
+    if ! counts="$(rust_nextest_unsharded_counts "$TEST_TMPFILE" "$failed_names")"; then
+        echo "Rust nextest reported no structured test counts: the run emitted no test events." >&2
+        rm -f "$failed_names"
+        return 0
+    fi
+
+    IFS=$'\t' read -r RUST_MEASURED_TOTAL RUST_MEASURED_PASSED RUST_MEASURED_FAILED RUST_MEASURED_SKIPPED <<< "$counts"
+    RUST_MEASURED_STATUS=measured
+    RUST_MEASURED_FAILED_NAMES="$failed_names"
+    if type homeboy_write_test_results >/dev/null 2>&1; then
+        homeboy_write_test_results "$RUST_MEASURED_TOTAL" "$RUST_MEASURED_PASSED" "$RUST_MEASURED_FAILED" "$RUST_MEASURED_SKIPPED" ""
+    fi
+    echo "Rust nextest result: total=${RUST_MEASURED_TOTAL} passed=${RUST_MEASURED_PASSED} failed=${RUST_MEASURED_FAILED} skipped=${RUST_MEASURED_SKIPPED}"
+}
 
 rust_execute_test_run() {
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -1184,6 +1342,14 @@ rust_execute_test_run() {
     rust_emit_test_plan "$SELECTED_RUNNER" "$COMMAND_LABEL" "$SCOPE_JSON" "started" 0
     homeboy_run_step_capture TEST_TMPFILE TEST_EXIT "$COMMAND_LABEL" -- "${COMMAND_BINARY[@]}" "$@" || true
     rust_emit_test_plan "$SELECTED_RUNNER" "$COMMAND_LABEL" "$SCOPE_JSON" "completed" "$TEST_EXIT"
+
+    if [ "$NEXTEST_MEASURED" = "1" ]; then
+        # The cargo adapter keys on `test result:` lines, which a libtest-json
+        # stream never contains. Routing this run through it would parse nothing
+        # and write nothing.
+        rust_measure_nextest_run
+        return 0
+    fi
 
     # Parse test results for homeboy core (best-effort, non-blocking)
     if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
@@ -1195,6 +1361,16 @@ rust_execute_test_run() {
 # test binaries (unit, integration, doc-tests) and some legitimately have zero
 # tests, so only a zero total across every summary line counts.
 rust_run_executed_no_tests() {
+    if [ "$NEXTEST_MEASURED" = "1" ]; then
+        # A measured run states its own execution count, so ask it. Grepping
+        # "N passed" out of a libtest-json stream would find nothing on a run
+        # that passed hundreds of tests and widen every derived scope to the
+        # full suite -- the precise cost this whole path exists to avoid.
+        # An unmeasured stream did not execute anything we can account for,
+        # which on a green exit is the widening case too.
+        [ "$RUST_MEASURED_STATUS" != "measured" ] || [ "$RUST_MEASURED_TOTAL" -eq 0 ]
+        return
+    fi
     local total
     total=$( { grep -Eo '[0-9]+ passed' "$TEST_TMPFILE" || true; } | awk '{s+=$1} END {print s+0}' )
     [ "$total" -eq 0 ]
@@ -1232,10 +1408,31 @@ fi
 
 TEST_OUTPUT=$(cat "$TEST_TMPFILE")
 
+# A measured failure is a failure even if the runner exited zero. The counts are
+# the evidence and the exit code is a summary of it; when they disagree, trust
+# the evidence rather than let a red suite through on a green code.
+if [ "$NEXTEST_MEASURED" = "1" ] && [ "$TEST_EXIT" -eq 0 ] && [ "$RUST_MEASURED_FAILED" -gt 0 ]; then
+    echo "Rust nextest reported ${RUST_MEASURED_FAILED} failed test(s) with a zero exit code; treating the run as failed." >&2
+    TEST_EXIT=1
+fi
+
+# The cargo summary line does not exist in a libtest-json stream, so a measured
+# run reports the counts it derived instead of grepping for a line that is
+# structurally absent.
+rust_test_summary_line() {
+    if [ "$NEXTEST_MEASURED" = "1" ]; then
+        [ "$RUST_MEASURED_STATUS" = "measured" ] || return 0
+        printf 'test result: %s. %s passed; %s failed; %s ignored' \
+            "$([ "$RUST_MEASURED_FAILED" -eq 0 ] && printf 'ok' || printf 'FAILED')" \
+            "$RUST_MEASURED_PASSED" "$RUST_MEASURED_FAILED" "$RUST_MEASURED_SKIPPED"
+        return 0
+    fi
+    echo "$TEST_OUTPUT" | grep -E "^test result:" | tail -1 || true
+}
 
 if [ $TEST_EXIT -eq 0 ]; then
     # Extract test summary line
-    SUMMARY=$(echo "$TEST_OUTPUT" | grep -E "^test result:" | tail -1 || true)
+    SUMMARY=$(rust_test_summary_line)
     if [ -n "$SUMMARY" ]; then
         echo ""
         echo "$SUMMARY"
@@ -1245,7 +1442,7 @@ if [ $TEST_EXIT -eq 0 ]; then
     rm -f "$TEST_TMPFILE"
 else
     # Extract failure details
-    SUMMARY=$(echo "$TEST_OUTPUT" | grep -E "^test result:" | tail -1 || true)
+    SUMMARY=$(rust_test_summary_line)
     FAILURES=$(echo "$TEST_OUTPUT" | grep -E "^---- .* ----$|^test .* FAILED$" || true)
 
     if [ -n "$SUMMARY" ]; then
@@ -1253,7 +1450,12 @@ else
         echo "$SUMMARY"
     fi
 
-    if homeboy_test_failures_enabled; then
+    if [ "$NEXTEST_MEASURED" = "1" ]; then
+        # The identities came out of the event stream, so reuse the shard path's
+        # evidence writer rather than re-deriving them by scraping cargo-shaped
+        # text that a libtest-json run never produced.
+        rust_nextest_merge_failure_evidence "${RUST_MEASURED_FAILED_NAMES:-}" || true
+    elif homeboy_test_failures_enabled; then
         homeboy_runner_harness_temp TEST_FAILURES_TMP "homeboy-rust-test-failures.XXXXXX"
         python3 "${EXTENSION_PATH}/scripts/parse-test-failures.py" "$PROJECT_PATH" "$TEST_TMPFILE" "$TEST_FAILURES_TMP"
         homeboy_test_failures_merge_file "$TEST_FAILURES_TMP"
@@ -1272,13 +1474,22 @@ fi
 # A derived scope has already been widened to the full command by this point,
 # so reaching here on a changed-files run means the whole suite executed
 # nothing — a real configuration problem rather than a scoping gap.
-TOTAL_PASSED=$( { echo "$TEST_OUTPUT" | grep -Eo '[0-9]+ passed' || true; } | awk '{s+=$1} END {print s+0}' )
+#
+# A measured run already knows its own pass count. Grepping a libtest-json
+# stream for "N passed" would find nothing on a fully green suite and fire this
+# warning -- and, with HOMEBOY_CHANGED_TEST_FILES set, exit 1 on a run in which
+# every test passed.
+if [ "$NEXTEST_MEASURED" = "1" ]; then
+    TOTAL_PASSED="$RUST_MEASURED_PASSED"
+else
+    TOTAL_PASSED=$( { echo "$TEST_OUTPUT" | grep -Eo '[0-9]+ passed' || true; } | awk '{s+=$1} END {print s+0}' )
+fi
 if [ "$TOTAL_PASSED" -eq 0 ]; then
     TEST_FILE_COUNT=$(find "$PROJECT_PATH" -name "*test*" -name "*.rs" -not -path "*/target/*" 2>/dev/null | wc -l | tr -d ' ')
     if [ "$TEST_FILE_COUNT" -gt 0 ]; then
         echo ""
         echo "============================================"
-        echo "WARNING: cargo test ran 0 tests"
+        echo "WARNING: ${COMMAND_LABEL} ran 0 tests"
         echo "============================================"
         echo ""
         echo "Found ${TEST_FILE_COUNT} test files but no tests were executed."

--- a/rust/tests/nextest-unsharded-counts-smoke.sh
+++ b/rust/tests/nextest-unsharded-counts-smoke.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# Smoke-test the unsharded nextest counts path against fixture
+# libtest-json-plus output.
+#
+# Fixtures rather than a live nextest run: what is under test is the projection
+# from an event stream to a Homeboy test result, and a real run cannot produce
+# the cases that matter most here -- a compile failure that emits no events, a
+# retry that must not be double-counted, a child process leaking its own libtest
+# JSON into the captured stream.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="${HOMEBOY_TESTED_EXTENSION_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+RUNNER="${EXTENSION_DIR}/scripts/test-runner.sh"
+WORK_DIR="$(mktemp -d -t homeboy-nextest-unsharded.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+FAILURES=0
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    FAILURES=$((FAILURES + 1))
+}
+
+# ── Part 1: rust_nextest_unsharded_counts in isolation ──
+#
+# Sourcing the runner would execute it, so the two functions under test are
+# extracted with their own dependencies stubbed. EXTENSION_PATH is what the
+# heredoc uses to find nextest_events_lib.
+cat > "$WORK_DIR/counts-harness.sh" <<EOF
+set -euo pipefail
+EXTENSION_PATH="${EXTENSION_DIR}"
+EOF
+python3 - "$RUNNER" "$WORK_DIR/counts-harness.sh" <<'PY'
+import re
+import sys
+
+source = open(sys.argv[1], encoding="utf-8").read()
+match = re.search(r"^rust_nextest_unsharded_counts\(\) \{\n.*?^\}\n", source, re.S | re.M)
+assert match, "rust_nextest_unsharded_counts not found in test-runner.sh"
+with open(sys.argv[2], "a", encoding="utf-8") as handle:
+    handle.write(match.group(0))
+PY
+
+counts_case() {
+    local label="$1" stream="$2" expected_counts="$3" expected_failed="$4"
+    local names="$WORK_DIR/failed-names.txt" actual status=0
+    : > "$names"
+    actual="$(bash -c 'source "$1"; rust_nextest_unsharded_counts "$2" "$3"' _ \
+        "$WORK_DIR/counts-harness.sh" "$stream" "$names")" || status=$?
+
+    if [ "$expected_counts" = "UNMEASURED" ]; then
+        if [ "$status" -eq 0 ]; then
+            fail "${label}: expected unmeasured (non-zero exit), got exit 0 with '${actual}'"
+        fi
+        if [ -n "$actual" ]; then
+            fail "${label}: unmeasured runs must print nothing, got '${actual}'"
+        fi
+        return 0
+    fi
+
+    if [ "$status" -ne 0 ]; then
+        fail "${label}: expected measured counts, exited ${status}"
+        return 0
+    fi
+    if [ "$actual" != "$(printf '%b' "$expected_counts")" ]; then
+        fail "${label}: counts '${actual}' != expected '${expected_counts}'"
+    fi
+    local actual_failed
+    actual_failed="$(tr '\n' ' ' < "$names" | sed 's/ $//')"
+    if [ "$actual_failed" != "$expected_failed" ]; then
+        fail "${label}: failed names '${actual_failed}' != expected '${expected_failed}'"
+    fi
+}
+
+# All passing.
+cat > "$WORK_DIR/pass.jsonl" <<'EOF'
+{"type":"suite","event":"started","test_count":3}
+{"type":"test","event":"started","name":"alpha::alpha_lib$tests::one"}
+{"type":"test","event":"ok","name":"alpha::alpha_lib$tests::one"}
+{"type":"test","event":"ok","name":"alpha::alpha_lib$tests::two"}
+{"type":"test","event":"ok","name":"beta::beta_integration$covers_three"}
+{"type":"suite","event":"ok","passed":3}
+EOF
+counts_case "passing run" "$WORK_DIR/pass.jsonl" '3\t3\t0\t0' ""
+
+# Failures, and their identities must survive.
+cat > "$WORK_DIR/fail.jsonl" <<'EOF'
+{"type":"test","event":"ok","name":"alpha::alpha_lib$tests::one"}
+{"type":"test","event":"failed","name":"alpha::alpha_lib$tests::two","stdout":"assertion failed"}
+{"type":"test","event":"failed","name":"beta::beta_integration$covers_three"}
+{"type":"test","event":"ignored","name":"beta::beta_integration$covers_four"}
+EOF
+counts_case "run with failures" "$WORK_DIR/fail.jsonl" '4\t1\t2\t1' \
+    'alpha::alpha_lib$tests::two beta::beta_integration$covers_three'
+
+# All skipped is a measured outcome, not an absent one.
+cat > "$WORK_DIR/skipped.jsonl" <<'EOF'
+{"type":"test","event":"ignored","name":"alpha::alpha_lib$tests::one"}
+{"type":"test","event":"ignored","name":"alpha::alpha_lib$tests::two"}
+EOF
+counts_case "all-skipped run" "$WORK_DIR/skipped.jsonl" '2\t0\t0\t2' ""
+
+# No events at all — a compile failure never reaches the first test.
+cat > "$WORK_DIR/compile-failure.jsonl" <<'EOF'
+   Compiling alpha v0.1.0 (/project)
+error[E0425]: cannot find value `nope` in this scope
+ --> src/lib.rs:4:5
+error: could not compile `alpha` (lib test) due to 1 previous error
+EOF
+counts_case "compile failure" "$WORK_DIR/compile-failure.jsonl" UNMEASURED ""
+
+# Truly empty output — killed before it wrote anything.
+: > "$WORK_DIR/empty.jsonl"
+counts_case "empty output" "$WORK_DIR/empty.jsonl" UNMEASURED ""
+
+# Lifecycle events only: started but never finished. Nothing terminal, so
+# nothing measured — this must not read as a zero-failure pass.
+cat > "$WORK_DIR/lifecycle-only.jsonl" <<'EOF'
+{"type":"suite","event":"started","test_count":2}
+{"type":"test","event":"started","name":"alpha::alpha_lib$tests::one"}
+{"type":"test","event":"started","name":"alpha::alpha_lib$tests::two"}
+EOF
+counts_case "lifecycle events only" "$WORK_DIR/lifecycle-only.jsonl" UNMEASURED ""
+
+# A retry is one test with one outcome. Flaky-then-green counts once, passed.
+cat > "$WORK_DIR/retry.jsonl" <<'EOF'
+{"type":"test","event":"failed","name":"alpha::alpha_lib$tests::flaky"}
+{"type":"test","event":"ok","name":"alpha::alpha_lib$tests::flaky#2"}
+{"type":"test","event":"ok","name":"alpha::alpha_lib$tests::stable"}
+EOF
+counts_case "retry folds onto its base identity" "$WORK_DIR/retry.jsonl" '2\t2\t0\t0' ""
+
+# A retry that stays red is still one test, and still reports its base name.
+cat > "$WORK_DIR/retry-red.jsonl" <<'EOF'
+{"type":"test","event":"failed","name":"alpha::alpha_lib$tests::flaky"}
+{"type":"test","event":"failed","name":"alpha::alpha_lib$tests::flaky#2"}
+EOF
+counts_case "exhausted retry stays failed" "$WORK_DIR/retry-red.jsonl" '1\t0\t1\t0' \
+    'alpha::alpha_lib$tests::flaky'
+
+# Interleaved noise: nextest's human progress output shares the captured stream,
+# and a child process can emit its own libtest JSON with an unparseable name.
+cat > "$WORK_DIR/noisy.jsonl" <<'EOF'
+    Starting 2 tests across 1 binary
+{"type":"test","event":"ok","name":"alpha::alpha_lib$tests::one"}
+{"type":"test","event":"ok","name":"bare_name_without_separators"}
+{"type":"test","event":"ok","name":null}
+not json at all
+{"type":"test","event":"ok","name":"alpha::alpha_lib$tests::two"}
+        PASS [   0.011s] alpha::alpha_lib tests::two
+------------
+     Summary [   0.021s] 2 tests run: 2 passed, 0 skipped
+EOF
+counts_case "noise and unparseable identities are ignored" "$WORK_DIR/noisy.jsonl" '2\t2\t0\t0' ""
+
+# ── Part 2: the runner end to end, with a fake cargo ──
+
+PROJECT_DIR="$WORK_DIR/project"
+HELPER_DIR="$WORK_DIR/helpers"
+BIN_DIR="$WORK_DIR/bin"
+mkdir -p "$PROJECT_DIR/tests" "$HELPER_DIR" "$BIN_DIR"
+
+cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
+[package]
+name = "rust-nextest-unsharded-smoke"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat > "$PROJECT_DIR/tests/integration_scope.rs" <<'EOF'
+#[test]
+fn integration_scope_runs() {
+    assert_eq!(1, 1);
+}
+EOF
+
+cat > "$HELPER_DIR/runner-prelude.sh" <<'EOF'
+homeboy_runner_init() {
+    PROJECT_PATH="$HOMEBOY_COMPONENT_PATH"
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+}
+should_run_step() { return 0; }
+EOF
+
+cat > "$HELPER_DIR/command-capture.sh" <<'EOF'
+homeboy_run_step_capture() {
+    local output_var="$1" exit_var="$2"
+    shift 3
+    [ "${1:-}" != -- ] || shift
+    local output status=0
+    output="$(mktemp)"
+    "$@" >"$output" 2>&1 || status=$?
+    printf -v "$output_var" '%s' "$output"
+    printf -v "$exit_var" '%s' "$status"
+    return "$status"
+}
+homeboy_cleanup_step_capture() { rm -f "$1"; }
+EOF
+
+cat > "$HELPER_DIR/write-test-results.sh" <<'EOF'
+homeboy_write_test_results() {
+    python3 - "$HOMEBOY_TEST_RESULTS_FILE" "$@" <<'PY'
+import json
+import sys
+
+path, total, passed, failed, skipped, partial = sys.argv[1:]
+json.dump({"total": int(total), "passed": int(passed), "failed": int(failed), "skipped": int(skipped), "partial": partial}, open(path, "w"))
+PY
+}
+EOF
+
+# Fake cargo: replays whatever stream the case put in HOMEBOY_FAKE_NEXTEST_STREAM
+# and records the argv it was called with.
+cat > "$BIN_DIR/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "nextest" ] && [ "${2:-}" = "--version" ]; then
+    echo "cargo-nextest 0.9.140"
+    exit 0
+fi
+
+printf '%s\n' "$@" > "${HOMEBOY_FAKE_CARGO_ARGS}"
+printf '%s\n' "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON:-unset}" \
+    > "${HOMEBOY_FAKE_CARGO_ENV}"
+if [ -n "${HOMEBOY_FAKE_NEXTEST_STREAM:-}" ] && [ -f "${HOMEBOY_FAKE_NEXTEST_STREAM}" ]; then
+    cat "${HOMEBOY_FAKE_NEXTEST_STREAM}"
+fi
+exit "${HOMEBOY_FAKE_CARGO_EXIT:-0}"
+EOF
+chmod +x "$BIN_DIR/cargo"
+
+run_runner() {
+    local results_file="$1" stream="$2" cargo_exit="$3" measured="$4"
+    shift 4
+    PATH="$BIN_DIR:$PATH" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_RUST_TEST_RUNNER=nextest \
+    HOMEBOY_RUST_NEXTEST_MEASURED_COUNTS="$measured" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$HELPER_DIR/runner-prelude.sh" \
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$HELPER_DIR/command-capture.sh" \
+    HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$HELPER_DIR/write-test-results.sh" \
+    HOMEBOY_TEST_RESULTS_FILE="$results_file" \
+    HOMEBOY_FAKE_NEXTEST_STREAM="$stream" \
+    HOMEBOY_FAKE_CARGO_EXIT="$cargo_exit" \
+    HOMEBOY_FAKE_CARGO_ARGS="$WORK_DIR/cargo-args.txt" \
+    HOMEBOY_FAKE_CARGO_ENV="$WORK_DIR/cargo-env.txt" \
+    "$@" \
+    bash "$RUNNER" 2>&1 || true
+}
+
+# Measured green run writes the cargo-shaped result tuple.
+RESULTS="$WORK_DIR/results-pass.json"
+rm -f "$RESULTS"
+OUTPUT="$(run_runner "$RESULTS" "$WORK_DIR/pass.jsonl" 0 1)"
+
+if [[ "$OUTPUT" != *"Rust test runner: cargo nextest (measured counts from libtest-json-plus)"* ]]; then
+    fail "runner must announce the measured nextest selection. Output:
+$OUTPUT"
+fi
+if [[ "$OUTPUT" != *"Rust nextest result: total=3 passed=3 failed=0 skipped=0"* ]]; then
+    fail "runner must report measured counts. Output:
+$OUTPUT"
+fi
+if [[ "$OUTPUT" == *"ran 0 tests"* ]]; then
+    fail "a fully green measured run must not warn about zero tests. Output:
+$OUTPUT"
+fi
+if [ ! -f "$RESULTS" ]; then
+    fail "measured run must write a Homeboy test result"
+else
+    python3 - "$RESULTS" <<'PY' || exit 1
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+expected = {"total": 3, "passed": 3, "failed": 0, "skipped": 0, "partial": ""}
+if data != expected:
+    raise SystemExit(f"FAIL: measured result {data!r} != {expected!r}")
+PY
+fi
+
+# The invocation carries the flags the parser depends on.
+ACTUAL_ARGS="$(cat "$WORK_DIR/cargo-args.txt")"
+for required in "--no-fail-fast" "--no-tests" "warn" "libtest-json-plus" "--message-format-version" "0.1"; do
+    if ! printf '%s\n' "$ACTUAL_ARGS" | grep -qx -- "$required"; then
+        fail "measured nextest invocation missing '${required}'. Args:
+$ACTUAL_ARGS"
+    fi
+done
+if ! grep -qx 'NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1' "$WORK_DIR/cargo-env.txt"; then
+    fail "measured nextest run must export NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1"
+fi
+
+# Failures: counted, named, and red.
+RESULTS="$WORK_DIR/results-fail.json"
+rm -f "$RESULTS"
+OUTPUT="$(run_runner "$RESULTS" "$WORK_DIR/fail.jsonl" 100 1)"
+if [[ "$OUTPUT" != *"Rust nextest result: total=4 passed=1 failed=2 skipped=1"* ]]; then
+    fail "failing measured run must report its counts. Output:
+$OUTPUT"
+fi
+python3 - "$RESULTS" <<'PY' || exit 1
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+expected = {"total": 4, "passed": 1, "failed": 2, "skipped": 1, "partial": ""}
+if data != expected:
+    raise SystemExit(f"FAIL: failing measured result {data!r} != {expected!r}")
+PY
+
+# A measured failure with a zero exit code is still a failure.
+RESULTS="$WORK_DIR/results-liar.json"
+rm -f "$RESULTS"
+OUTPUT="$(run_runner "$RESULTS" "$WORK_DIR/fail.jsonl" 0 1)"
+if [[ "$OUTPUT" != *"treating the run as failed"* ]]; then
+    fail "measured failures must override a zero exit code. Output:
+$OUTPUT"
+fi
+if [[ "$OUTPUT" == *"Rust tests passed"* ]]; then
+    fail "a run with measured failures must not report success. Output:
+$OUTPUT"
+fi
+
+# All skipped: measured, written, and not mistaken for a broken run.
+RESULTS="$WORK_DIR/results-skipped.json"
+rm -f "$RESULTS"
+OUTPUT="$(run_runner "$RESULTS" "$WORK_DIR/skipped.jsonl" 0 1)"
+python3 - "$RESULTS" <<'PY' || exit 1
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+expected = {"total": 2, "passed": 0, "failed": 0, "skipped": 2, "partial": ""}
+if data != expected:
+    raise SystemExit(f"FAIL: all-skipped result {data!r} != {expected!r}")
+PY
+
+# No events: unmeasured. No result file is the signal, and it must be said out
+# loud rather than left to a silent green.
+RESULTS="$WORK_DIR/results-unmeasured.json"
+rm -f "$RESULTS"
+OUTPUT="$(run_runner "$RESULTS" "$WORK_DIR/compile-failure.jsonl" 101 1)"
+if [ -f "$RESULTS" ]; then
+    fail "a run with no test events must not write a test result: $(cat "$RESULTS")"
+fi
+if [[ "$OUTPUT" != *"no structured test counts"* ]]; then
+    fail "unmeasured run must say so. Output:
+$OUTPUT"
+fi
+if [[ "$OUTPUT" == *"Rust tests passed"* ]]; then
+    fail "unmeasured run must not report success. Output:
+$OUTPUT"
+fi
+
+# Same stream, but the runner exits 0. Still unmeasured, still no result.
+RESULTS="$WORK_DIR/results-unmeasured-green.json"
+rm -f "$RESULTS"
+OUTPUT="$(run_runner "$RESULTS" "$WORK_DIR/empty.jsonl" 0 1)"
+if [ -f "$RESULTS" ]; then
+    fail "an empty stream must not write a test result even on exit 0: $(cat "$RESULTS")"
+fi
+if [[ "$OUTPUT" != *"no structured test counts"* ]]; then
+    fail "empty stream must be reported as unmeasured. Output:
+$OUTPUT"
+fi
+
+# ── Part 3: the gate ──
+
+# Measurement off: legacy invocation shape, no JSON flags, no measured result.
+RESULTS="$WORK_DIR/results-off.json"
+rm -f "$RESULTS"
+OUTPUT="$(run_runner "$RESULTS" "$WORK_DIR/pass.jsonl" 0 0)"
+if [[ "$OUTPUT" != *"unmeasured; rust_nextest_measured_counts is off"* ]]; then
+    fail "disabled measurement must be visible in the output. Output:
+$OUTPUT"
+fi
+EXPECTED_LEGACY_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n--workspace'
+if [ "$(cat "$WORK_DIR/cargo-args.txt")" != "$EXPECTED_LEGACY_ARGS" ]; then
+    fail "measurement off must preserve the legacy nextest invocation. Args:
+$(cat "$WORK_DIR/cargo-args.txt")"
+fi
+
+# nextest absent: falls back to cargo exactly as before, and the fallback path
+# is not a measured nextest run.
+cat > "$BIN_DIR/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "nextest" ] && [ "${2:-}" = "--version" ]; then
+    exit 1
+fi
+
+printf '%s\n' "$@" > "${HOMEBOY_FAKE_CARGO_ARGS}"
+echo "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"
+EOF
+chmod +x "$BIN_DIR/cargo"
+
+RESULTS="$WORK_DIR/results-fallback.json"
+rm -f "$RESULTS"
+OUTPUT="$(run_runner "$RESULTS" "$WORK_DIR/pass.jsonl" 0 1)"
+if [[ "$OUTPUT" != *"falling back to cargo test"* ]]; then
+    fail "missing nextest must fall back to cargo test. Output:
+$OUTPUT"
+fi
+if [[ "$OUTPUT" != *"Rust test runner: cargo test"* ]]; then
+    fail "fallback must announce cargo. Output:
+$OUTPUT"
+fi
+if [ "$(head -1 "$WORK_DIR/cargo-args.txt")" != "test" ]; then
+    fail "fallback must invoke cargo test. Args:
+$(cat "$WORK_DIR/cargo-args.txt")"
+fi
+python3 - "$RESULTS" <<'PY' || exit 1
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+expected = {"total": 1, "passed": 1, "failed": 0, "skipped": 0, "partial": ""}
+if data != expected:
+    raise SystemExit(f"FAIL: cargo fallback result {data!r} != {expected!r}")
+PY
+
+if [ "$FAILURES" -ne 0 ]; then
+    printf '%s check(s) failed\n' "$FAILURES" >&2
+    exit 1
+fi
+
+printf 'rust nextest unsharded counts smoke ok\n'


### PR DESCRIPTION
## Summary

This unblocks removing `rust_cargo_test_threads = 1` from homeboy — the cause of hour-long local test runs.

## The chain

```
Aug 2   #11242  set threads=1          emergency lever for the getenv/setenv race
Aug 3   #11266  fixed the race         Mutex-guarded home-root override
Aug 3   #11271  REMOVED threads=1      "the serialization is pure cost"
Aug 4   #11474  PUT IT BACK            alongside CI sharding
```

#11271 measured it: **400–900s for `homeboy-agents` against roughly 302s before.**

`homeboy/docs/internals/test-tiers.md` says why it had to return:

> The Cargo cap is a fallback workaround, not the primary CI strategy. Sharded nextest replay sets `rust_nextest_shard_threads = 0`, selecting nextest's process-per-test parallelism...
>
> **...unsharded nextest output is not yet a measured Homeboy result, so local and release gates remain on serialized Cargo.**

Sharded PR CI is already parallel. Local and release are not. This closes the one gap keeping them serialized.

## What changed

The **event-reading half** of `rust_nextest_counts` moves into `rust/scripts/nextest_events_lib.py` — the `package::target$test` identity projection, the retry-suffix rules including the `"invalid"` sentinel, the status sets, and the JSON-lines filtering. **Manifest reconciliation stays in the runner**, because that is the part that had to become optional, not the parsing.

`rust_nextest_unsharded_counts` derives `total/passed/failed/skipped` from the same events with **no manifest**, written through `homeboy_write_test_results` in the identical 5-tuple shape `parse_cargo_test` produces (traced through `parse-test-results.sh` → `scripts/lib/test-result-adapters.sh` to confirm). Failed names keep the shard path's identity form, so `rust_nextest_merge_failure_evidence` consumes either unchanged.

<h2>The dangerous part was not the counting</h2>

`rust_run_executed_no_tests` and the trailing `TOTAL_PASSED` both scrape **`N passed` from raw output**. A `libtest-json` stream never contains that phrase.

Naively adding `--message-format` would have made every derived scope widen to the full suite — and with `HOMEBOY_CHANGED_TEST_FILES` set, **exited 1 on a fully green run**. Both now read the measured counts.

That is the kind of thing that would have shipped silently and been blamed on flakiness.

## `--no-tests` deliberately differs from the sharded path

Sharded replay preflights exact membership, so `fail` is correct there. Unsharded, the filter is derived from changed paths, and `fail` would exit non-zero — blocking the scope widening that requires exit 0, producing exactly the false failure #10477 documents. Uses `warn`. `--no-fail-fast` stays consistent.

## Signalling and safety

- **"No structured counts"** is signalled by *absence of the write* — the same mechanism the cargo path uses when `parse_cargo_test` returns False. A stream with no terminal test event writes no result and says so on stderr. Mutation-tested: "return zeros instead of exit 1" is caught.
- A **measured failure with a zero exit code is treated as a failure** — evidence over exit code.

## Gating: this switches nobody

Runner selection is **unchanged**; `rust_test_runner` still defaults to `cargo`. The new `rust_nextest_measured_counts` (default true) only decides whether a run that *already chose* nextest is measured — and unsharded nextest emits no `test result:` lines today, so it currently produces **no counts at all**. Purely additive.

**The follow-up is homeboy's own PR:** flip `rust_test_runner: nextest` and drop `rust_cargo_test_threads = 1`. Deliberately not done here.

Missing nextest still falls back to cargo exactly as before. Selection is now printed: `Rust test runner: cargo nextest (measured counts from libtest-json-plus)`.

## Known non-equivalence, documented not faked

Unsharded skip counts are not equivalent to cargo's. nextest omits never-run tests from its stream, so `#[ignore]` membership cannot be reconstructed without a manifest.

## Verification

This repo has **no PR CI** (push-to-main only), so local verification is the only verification.

- New `rust/tests/nextest-unsharded-counts-smoke.sh` — fixtures only, no nextest needed. Passing, failures + failed-name capture, all-skipped, compile-failure, empty, lifecycle-only, retry folding green and red, interleaved noise, plus end-to-end runner cases and cargo fallback. **Passes.**
- **Diff-fuzzed the refactor** against the original `rust_nextest_counts` extracted from `HEAD` — **1200 randomized manifest/stream pairs**, comparing exit code, stdout, stderr and the failed-names file. **Zero mismatches**, with every error branch exercised (duplicate planned identity, malformed retry suffix, membership mismatch, ambiguous identity, duplicate emitted identity).
- Mutation-tested five ways; every mutation caught.
- `rust-nextest-runner-smoke.sh`, `parse-test-results-smoke.sh`, `parse-test-failures-smoke.sh` all pass. `nextest-shard-real-smoke.sh` requires `cargo-nextest 0.9.140` installed and exits at its version check on line 11, before reaching changed code — environmental, not a regression.

### Orphaned tests found

Four rust smoke tests were referenced by nothing: `rust-nextest-runner-smoke.sh`, `parse-test-results-smoke.sh`, `parse-test-failures-smoke.sh`, `workspace-member-test-scope-smoke.sh`. `rust-nextest-runner-smoke.sh` pinned the old argument shape — **this change broke it and, with no PR CI, that would have gone unnoticed.** It is fixed and, with the new one, registered in `rust/homeboy.json` self-checks. The other two pass and are left for a separate call.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode general coding subagent, outside the Homeboy control plane
- **Used for:** Investigation, implementation, smoke tests, diff-fuzzing, and mutation testing. Review and verification by hand.