### PR TITLE
Floor the nextest version check instead of pinning it exactly

### DIFF
--- a/rust/tests/nextest-shard-real-smoke.sh
+++ b/rust/tests/nextest-shard-real-smoke.sh
@@ -8,8 +8,36 @@ WORK_DIR="$(mktemp -d -t homeboy-nextest-real.XXXXXX)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 cd "$FIXTURE_DIR"
 
-if ! cargo nextest --version | grep -q '^cargo-nextest 0\.9\.140'; then
-    printf 'Expected cargo-nextest exactly 0.9.140; install with cargo install cargo-nextest --version 0.9.140 --locked\n' >&2
+# Minimum, not equality. This test drives the real shard-replay path, which
+# needs `--message-format libtest-json-plus --message-format-version 0.1` under
+# `NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1`. The floor is the oldest release this
+# repository has validated that projection against, not a version the code
+# requires exactly.
+#
+# Raise it only when a newer nextest feature is actually depended on. An
+# equality check here made every newer toolchain fail on the *version guard*
+# rather than on anything this test measures — and in a repository with no PR
+# CI, a stale guard and a real shard-replay regression produce the same output.
+NEXTEST_MIN_VERSION='0.9.140'
+
+NEXTEST_VERSION_LINE="$(cargo nextest --version 2>/dev/null || true)"
+if [ -z "$NEXTEST_VERSION_LINE" ]; then
+    printf 'cargo-nextest is not installed. Install at least %s with: cargo install cargo-nextest --version %s --locked\n' \
+        "$NEXTEST_MIN_VERSION" "$NEXTEST_MIN_VERSION" >&2
+    exit 1
+fi
+
+NEXTEST_VERSION="$(printf '%s\n' "$NEXTEST_VERSION_LINE" | sed -n 's/^cargo-nextest \([0-9][0-9.]*\).*$/\1/p')"
+if [ -z "$NEXTEST_VERSION" ]; then
+    printf 'Could not parse a cargo-nextest version from: %s\n' "$NEXTEST_VERSION_LINE" >&2
+    exit 1
+fi
+
+# `sort -V` orders version strings; the minimum sorts first unless it is the
+# only value, so an equal version passes and an older one is rejected.
+if [ "$(printf '%s\n%s\n' "$NEXTEST_MIN_VERSION" "$NEXTEST_VERSION" | sort -V | head -1)" != "$NEXTEST_MIN_VERSION" ]; then
+    printf 'cargo-nextest %s is older than the %s minimum this shard-replay test validates against. Install with: cargo install cargo-nextest --version %s --locked\n' \
+        "$NEXTEST_VERSION" "$NEXTEST_MIN_VERSION" "$NEXTEST_MIN_VERSION" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to #2639. `rust/tests/nextest-shard-real-smoke.sh` required cargo-nextest to be **exactly** `0.9.140`:

```bash
if ! cargo nextest --version | grep -q '^cargo-nextest 0\.9\.140'; then
    printf 'Expected cargo-nextest exactly 0.9.140; ...'
```

## Why this was a staleness trap

**Nothing else in either repository references that version** — not `rust.json`, not any workflow, not the homeboy repo. A grep literal in one test file was the sole authority, so any newer toolchain fails on the **version guard** rather than on anything the test measures.

That matters more here than it would elsewhere: this repository has **no PR CI**, so local runs are the only verification. An equality guard makes a stale pin and a real shard-replay regression produce the same output.

<callout accent="#f59e0b">
It already did. Yesterday I ran this test on a host where nextest simply was not installed, and it printed:

```
error: no such command: `nextest`
Expected cargo-nextest exactly 0.9.140
```

I classified that as environmental rather than a regression — correctly, but **only because I read line 11.** The output itself could not tell me.
</callout>

## What changed

The check is now a **minimum**, compared with `sort -V`, and the two failure modes are distinguished:

| condition | message |
|---|---|
| not installed | `cargo-nextest is not installed. Install at least 0.9.140 with: …` |
| too old | `cargo-nextest 0.9.139 is older than the 0.9.140 minimum this shard-replay test validates against…` |
| unparseable output | names the line it could not parse |

Both actionable messages carry the install command.

## The floor stays at 0.9.140, deliberately

It is the oldest release this repository has **validated** the `libtest-json-plus` projection against — not a version the code requires exactly. **No lower bound is documented anywhere**, so I did not invent one. The comment says to raise it only when a newer nextest feature is actually depended on.

## Audit of both repos

I checked for the same shape everywhere:

- **homeboy** — zero exact-version tool checks in `.github`, `docs`, `crates`, `tests`
- **homeboy-extensions** — this was the only real one. The other `version = "0.1.0"` hits are fixture `Cargo.toml` contents that smoke tests generate, and `wordpress/tests/release-scripts-smoke.sh`'s `"1.4.0"` assertions are about a fixture package the test itself creates. Both correct as-is.

Also confirmed the things that **should** float already do: `Extra-Chill/homeboy-action@v2` is a floating major tag across all seven workflow references, and homeboy's `homeboy.json` pins no extension version, resolving to the latest published release.

## Verification

```
0.9.139  → reject
0.9.140  → accept
0.9.141  → accept
0.10.0   → accept
```

Plus `bash -n` clean, the absent-nextest path verified on this host to name the real cause, and `nextest-unsharded-counts-smoke.sh` and `rust-nextest-runner-smoke.sh` both still pass.

The shard-replay body itself still cannot run here (no nextest installed), which is exactly the condition this change makes legible.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude via OpenCode
- **Used for:** Auditing both repositories for exact-version checks, the fix, and verification.