### PR TITLE
fix(wordpress): resolve shared agent runtimes from the installed layout

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -702,6 +702,18 @@ shorthand; Homeboy core only sees generic durable agent-task plans.
 and runtime-path dispatch; it forwards to the WordPress payload so both monorepo
 and installed extension layouts use the same implementation.
 
+Reach that tree through `scripts/lib/agent-runtime-paths.cjs`, never through a
+fixed relative path. `agent-runtimes` is a shared asset declared in
+`homeboy-extension-root.json`, and Homeboy installs it at `<homeboy>/agent-runtimes`
+— a sibling of `<homeboy>/extensions`, one level further from this extension than
+a monorepo checkout puts it. A linked dev install hides the difference because
+Node resolves a symlinked script back to the checkout, so a hardcoded
+`../../../agent-runtimes/...` passes locally and fails on every copied install.
+The resolver probes both layouts and reports the probed paths plus a reinstall
+remediation when the shared tree is absent, and `scripts/build/setup.sh` verifies
+the runtime files this extension's entrypoints need so an incomplete payload
+fails at setup rather than at shard bootstrap.
+
 The generic provider boundary is documented in
 [`../docs/agent-runtime-package-contract.md`](../docs/agent-runtime-package-contract.md).
 Discovery exposes the required request fields, outcome status vocabulary,

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -21,8 +21,8 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh scripts/test/changed-scope-test-routing-smoke.sh scripts/test/test-runner-file-routing-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/installed-build-helper-resolution-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
-      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/lib/wp-codebox-timeout-diagnostics.mjs scripts/lib/wp-codebox-phpunit-timeout.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs"
+      "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh scripts/test/changed-scope-test-routing-smoke.sh scripts/test/test-runner-file-routing-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/installed-build-helper-resolution-smoke.sh tests/installed-agent-runtime-resolution-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
+      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/lib/agent-runtime-paths.cjs scripts/agent/homeboy-opencode-agent-task-executor.cjs scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/lib/wp-codebox-timeout-diagnostics.mjs scripts/lib/wp-codebox-phpunit-timeout.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs"
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
@@ -32,6 +32,8 @@
       "bash scripts/test/wp-codebox-cli-resolution-smoke.sh",
       "bash tests/installed-build-helper-resolution-smoke.sh",
       "bash tests/installed-test-helper-resolution-smoke.sh",
+      "node tests/agent-runtime-paths-smoke.js",
+      "bash tests/installed-agent-runtime-resolution-smoke.sh",
       "bash tests/extension-composer-vendor-integrity-smoke.sh",
       "node tests/wp-codebox-phpunit-multisite-smoke.mjs",
       "node tests/wp-codebox-phpunit-aggregate-smoke.mjs",

--- a/wordpress/scripts/agent/homeboy-opencode-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-opencode-agent-task-executor.cjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
 'use strict';
 
-require('../../../agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs');
+/**
+ * Internal dependencies
+ */
+// Shared agent runtimes install beside the extensions directory, so a fixed
+// relative require only resolves from a checkout (#12585).
+const { requireAgentRuntimeModule } = require('../lib/agent-runtime-paths.cjs');
+
+requireAgentRuntimeModule('opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs');

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -430,7 +430,43 @@ if [ -f "package.json" ]; then
     fi
 fi
 
+# Verify the shared agent-runtime files this extension's installed entrypoints
+# require. They live in a separate shared-asset tree that the extension payload
+# does not carry, so an install can succeed while leaving them absent — the
+# failure then surfaces only when a test shard boots and dies on
+# MODULE_NOT_FOUND, with zero tests executed (#12585). Fail here instead, before
+# anything is planned or fanned out.
+verify_shared_agent_runtime_assets() {
+    local resolver="${EXTENSION_PATH}/scripts/lib/agent-runtime-paths.cjs"
+    local missing=0
+    local dependency
+
+    if [ ! -f "${resolver}" ]; then
+        echo "Error: agent runtime resolver missing at ${resolver}; the WordPress extension payload is incomplete." >&2
+        return 1
+    fi
+
+    for dependency in \
+        "wp-codebox/lib/wp-codebox-runtime-selection.js" \
+        "wp-codebox/scripts/lib/test-result-adapters.sh" \
+        "wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs" \
+        "opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs"; do
+        if ! node "${resolver}" "${dependency}" >/dev/null; then
+            missing=1
+        fi
+    done
+
+    if [ "${missing}" -ne 0 ]; then
+        echo "Error: shared agent runtime assets are missing from this installation; WordPress test shards cannot bootstrap." >&2
+        return 1
+    fi
+
+    echo "Shared agent runtime assets verified."
+}
+
 install_wp_codebox
+
+verify_shared_agent_runtime_assets
 
 echo "WordPress extension setup complete."
 echo "Default test backend: WP Codebox (WordPress Playground runtime)"

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -437,9 +437,16 @@ fi
 # MODULE_NOT_FOUND, with zero tests executed (#12585). Fail here instead, before
 # anything is planned or fanned out.
 verify_shared_agent_runtime_assets() {
-    local resolver="${EXTENSION_PATH}/scripts/lib/agent-runtime-paths.cjs"
+    # Resolve from this script's own location, not the working directory: the
+    # resolver ships beside setup.sh in the extension payload, and that is the
+    # payload whose completeness is in question.
+    local script_dir
+    local resolver
     local missing=0
     local dependency
+
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    resolver="${script_dir}/../lib/agent-runtime-paths.cjs"
 
     if [ ! -f "${resolver}" ]; then
         echo "Error: agent runtime resolver missing at ${resolver}; the WordPress extension payload is incomplete." >&2

--- a/wordpress/scripts/lib/agent-runtime-paths.cjs
+++ b/wordpress/scripts/lib/agent-runtime-paths.cjs
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * Resolve files inside a shared agent-runtime package from a WordPress
+ * extension script.
+ *
+ * `agent-runtimes` is declared in `homeboy-extension-root.json` as a shared
+ * asset, and Homeboy installs shared runtimes BESIDE the extensions directory
+ * rather than inside it:
+ *
+ *   monorepo checkout   <repo>/wordpress                 -> <repo>/agent-runtimes
+ *   installed layout    <homeboy>/extensions/wordpress   -> <homeboy>/agent-runtimes
+ *
+ * The two layouts differ by exactly one directory level, so a relative require
+ * that is correct in a checkout resolves to a nonexistent
+ * `<homeboy>/extensions/agent-runtimes` once the extension is installed. A
+ * linked (symlinked) dev install hides this, because Node resolves a symlinked
+ * module's `__dirname` back to the source checkout; only a copied install — a
+ * fresh CI runner — takes the broken branch. That is what produced four
+ * identical `MODULE_NOT_FOUND` shard bootstrap failures in #12585.
+ *
+ * Probing both layouts is what lets one script load the same runtime module
+ * from either. When neither resolves, the caller gets the probed paths and a
+ * remediation instead of a bare `MODULE_NOT_FOUND` stack.
+ */
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const EXTENSION_ROOT = path.resolve(__dirname, '..', '..');
+
+/**
+ * Candidate `agent-runtimes` roots, most-specific first.
+ *
+ * @param {{ env?: NodeJS.ProcessEnv, extensionRoot?: string }} [options]
+ * @return {string[]} Absolute `agent-runtimes` roots to probe, in order.
+ */
+function agentRuntimeRoots(options = {}) {
+	const env = options.env || process.env;
+	const extensionRoots = [];
+
+	if (options.extensionRoot) {
+		extensionRoots.push(path.resolve(options.extensionRoot));
+	} else {
+		if (env.HOMEBOY_EXTENSION_PATH) {
+			extensionRoots.push(path.resolve(env.HOMEBOY_EXTENSION_PATH));
+		}
+		extensionRoots.push(EXTENSION_ROOT);
+	}
+
+	const roots = [];
+	for (const extensionRoot of extensionRoots) {
+		// Installed: <homeboy>/extensions/<extension> -> <homeboy>/agent-runtimes
+		roots.push(path.resolve(extensionRoot, '..', '..', 'agent-runtimes'));
+		// Checkout: <repo>/<extension> -> <repo>/agent-runtimes
+		roots.push(path.resolve(extensionRoot, '..', 'agent-runtimes'));
+	}
+
+	return roots.filter((root, index) => roots.indexOf(root) === index);
+}
+
+/**
+ * Absolute path to a file inside a shared agent runtime.
+ *
+ * @param {string}                                              relativePath Path relative to the `agent-runtimes` root,
+ *                                                                           e.g. `wp-codebox/lib/wp-codebox-runtime-selection.js`.
+ * @param {{ env?: NodeJS.ProcessEnv, extensionRoot?: string }} [options]
+ * @return {string} Absolute path to the resolved runtime file.
+ * @throws {Error} When the file is absent from every probed layout.
+ */
+function resolveAgentRuntimeFile(relativePath, options = {}) {
+	const probed = agentRuntimeRoots(options).map((root) => path.join(root, relativePath));
+	const resolved = probed.find((candidate) => fs.existsSync(candidate));
+	if (resolved) {
+		return resolved;
+	}
+
+	const error = new Error(
+		[
+			`Homeboy WordPress extension could not resolve shared agent runtime file '${relativePath}'.`,
+			'Probed:',
+			...probed.map((candidate) => `  - ${candidate}`),
+			"Shared agent runtimes are declared in homeboy-extension-root.json and install beside the extensions directory (<homeboy>/agent-runtimes), not inside it. The installed extension payload is incomplete.",
+			'Remediation: reinstall the extension so its shared runtime assets are materialized (`homeboy extension install wordpress`).',
+		].join('\n')
+	);
+	error.code = 'HOMEBOY_AGENT_RUNTIME_FILE_MISSING';
+	error.probed = probed;
+	throw error;
+}
+
+/**
+ * Require a module from a shared agent runtime.
+ *
+ * @param {string}                                              relativePath Path relative to the `agent-runtimes` root.
+ * @param {{ env?: NodeJS.ProcessEnv, extensionRoot?: string }} [options]
+ * @return {unknown} The runtime module exports.
+ */
+function requireAgentRuntimeModule(relativePath, options = {}) {
+	return require(resolveAgentRuntimeFile(relativePath, options));
+}
+
+module.exports = { agentRuntimeRoots, resolveAgentRuntimeFile, requireAgentRuntimeModule };
+
+// CLI mode: print the resolved path, or exit non-zero with the diagnostic.
+// Setup uses this to fail an incomplete install before any shard is planned.
+if (require.main === module) {
+	const relativePath = process.argv[2];
+	if (!relativePath) {
+		process.stderr.write('Usage: agent-runtime-paths.cjs <path-relative-to-agent-runtimes>\n');
+		process.exit(2);
+	}
+	try {
+		process.stdout.write(`${resolveAgentRuntimeFile(relativePath)}\n`);
+	} catch (error) {
+		process.stderr.write(`${error.message}\n`);
+		process.exit(1);
+	}
+}

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -673,6 +673,27 @@ def default_sibling_path(component_root, sibling_name):
     return os.path.join(os.path.dirname(os.path.abspath(component_root)), sibling_name)
 
 
+def agent_runtime_file(script_dir, relative_path):
+    """Resolve a file inside a shared agent runtime across both layouts.
+
+    `agent-runtimes` is a shared asset: Homeboy installs it beside the
+    extensions directory (<homeboy>/agent-runtimes), one level above where a
+    monorepo checkout puts it relative to the extension (<repo>/agent-runtimes).
+    Probing a single layout resolves to a nonexistent path on a copied install
+    (#12585). Falls back to the installed candidate so the caller reports a
+    missing runner path rather than an empty argument.
+    """
+    extension_root = os.path.dirname(os.path.abspath(script_dir))
+    candidates = [
+        os.path.join(os.path.dirname(os.path.dirname(extension_root)), 'agent-runtimes', relative_path),
+        os.path.join(os.path.dirname(extension_root), 'agent-runtimes', relative_path),
+    ]
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return candidates[0]
+
+
 def wp_codebox_workspace_slug_from_path(source):
     return re.sub(r'[^a-zA-Z0-9_-]', '-', os.path.basename(str(source or '')).split('@')[0])
 
@@ -1002,10 +1023,8 @@ def wp_codebox_task_runner_args(data, settings, script_dir):
     component_root = data.get('root') or data.get('component_path') or os.getcwd()
     homeboy_path = settings.get('wp_codebox_homeboy_path') or os.environ.get('HOMEBOY_WP_CODEBOX_HOMEBOY_PATH') or default_sibling_path(component_root, 'homeboy')
     homeboy_extensions_path = settings.get('wp_codebox_homeboy_extensions_path') or os.environ.get('HOMEBOY_WP_CODEBOX_HOMEBOY_EXTENSIONS_PATH') or default_sibling_path(component_root, 'homeboy-extensions')
-    extension_root = os.path.dirname(os.path.dirname(script_dir))
-
     args = [
-        os.path.join(extension_root, 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+        agent_runtime_file(script_dir, os.path.join('wp-codebox', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs')),
     ]
     if os.path.isdir(homeboy_path):
         args.extend(['--homeboy', homeboy_path])

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -46,8 +46,23 @@ fi
 ADAPTERS_HELPER="${HOMEBOY_RUNTIME_TEST_RESULT_ADAPTERS:-${SHARED_LIB_DIR}/test-result-adapters.sh}"
 # shellcheck source=../../../scripts/lib/test-result-adapters.sh
 source "$ADAPTERS_HELPER"
-WP_CODEBOX_ADAPTERS_HELPER="${HOMEBOY_WP_CODEBOX_TEST_RESULT_ADAPTERS:-${SCRIPT_DIR}/../../../agent-runtimes/wp-codebox/scripts/lib/test-result-adapters.sh}"
-if [ -f "$WP_CODEBOX_ADAPTERS_HELPER" ]; then
+# Shared agent runtimes install beside the extensions directory
+# (<homeboy>/agent-runtimes), one level above where a monorepo checkout puts
+# them relative to this script. Probe both so an installed extension still
+# finds the WP Codebox result adapters instead of silently parsing without
+# them (#12585).
+WP_CODEBOX_ADAPTERS_HELPER="${HOMEBOY_WP_CODEBOX_TEST_RESULT_ADAPTERS:-}"
+if [ -z "$WP_CODEBOX_ADAPTERS_HELPER" ]; then
+    for candidate in \
+        "${SCRIPT_DIR}/../../../../agent-runtimes/wp-codebox/scripts/lib/test-result-adapters.sh" \
+        "${SCRIPT_DIR}/../../../agent-runtimes/wp-codebox/scripts/lib/test-result-adapters.sh"; do
+        if [ -f "$candidate" ]; then
+            WP_CODEBOX_ADAPTERS_HELPER="$candidate"
+            break
+        fi
+    done
+fi
+if [ -n "$WP_CODEBOX_ADAPTERS_HELPER" ] && [ -f "$WP_CODEBOX_ADAPTERS_HELPER" ]; then
     # shellcheck source=/dev/null
     source "$WP_CODEBOX_ADAPTERS_HELPER"
 fi

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -10,11 +10,19 @@ import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
+/**
+ * Internal dependencies
+ */
 import { createTimeoutLineRedactor, recipeRunProjection, readBoundedText, wpCodeboxTimeoutDiagnostics } from '../lib/wp-codebox-timeout-diagnostics.mjs';
 import { configuredWpCodeboxPhpunitTimeoutSeconds } from '../lib/wp-codebox-phpunit-timeout.mjs';
 
 const require = createRequire(import.meta.url);
-const { preflightWpCodeboxCommand } = require('../../../agent-runtimes/wp-codebox/lib/wp-codebox-runtime-selection.js');
+// Shared agent runtimes install beside the extensions directory, so their path
+// relative to this script differs between a checkout and an install. Resolving
+// through the helper keeps both layouts loadable and turns an incomplete
+// install into a diagnostic instead of a MODULE_NOT_FOUND stack (#12585).
+const { requireAgentRuntimeModule } = require('../lib/agent-runtime-paths.cjs');
+const { preflightWpCodeboxCommand } = requireAgentRuntimeModule('wp-codebox/lib/wp-codebox-runtime-selection.js');
 
 const settings = parseSettings(process.env.HOMEBOY_SETTINGS_JSON);
 const phpunitTimeoutSeconds = configuredWpCodeboxPhpunitTimeoutSeconds(process.env, settings);

--- a/wordpress/tests/agent-runtime-paths-smoke.js
+++ b/wordpress/tests/agent-runtime-paths-smoke.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	agentRuntimeRoots,
+	resolveAgentRuntimeFile,
+	requireAgentRuntimeModule,
+} = require('../scripts/lib/agent-runtime-paths.cjs');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-agent-runtime-paths-'));
+
+// Installed layout: <homeboy>/extensions/wordpress alongside <homeboy>/agent-runtimes.
+const homeboyRoot = path.join(root, 'config', 'homeboy');
+const installedExtension = path.join(homeboyRoot, 'extensions', 'wordpress');
+const installedRuntimeFile = path.join(homeboyRoot, 'agent-runtimes', 'wp-codebox', 'lib', 'selection.js');
+fs.mkdirSync(installedExtension, { recursive: true });
+fs.mkdirSync(path.dirname(installedRuntimeFile), { recursive: true });
+fs.writeFileSync(installedRuntimeFile, 'module.exports = { layout: "installed" };\n');
+
+assert.equal(
+	resolveAgentRuntimeFile('wp-codebox/lib/selection.js', { extensionRoot: installedExtension }),
+	installedRuntimeFile
+);
+assert.equal(
+	requireAgentRuntimeModule('wp-codebox/lib/selection.js', { extensionRoot: installedExtension }).layout,
+	'installed'
+);
+
+// A monorepo checkout keeps the shared tree one level closer to the extension.
+const checkoutRoot = path.join(root, 'homeboy-extensions');
+const checkoutExtension = path.join(checkoutRoot, 'wordpress');
+const checkoutRuntimeFile = path.join(checkoutRoot, 'agent-runtimes', 'wp-codebox', 'lib', 'selection.js');
+fs.mkdirSync(checkoutExtension, { recursive: true });
+fs.mkdirSync(path.dirname(checkoutRuntimeFile), { recursive: true });
+fs.writeFileSync(checkoutRuntimeFile, 'module.exports = { layout: "checkout" };\n');
+
+assert.equal(
+	resolveAgentRuntimeFile('wp-codebox/lib/selection.js', { extensionRoot: checkoutExtension }),
+	checkoutRuntimeFile
+);
+
+// HOMEBOY_EXTENSION_PATH is honored ahead of this script's own location.
+assert.equal(
+	resolveAgentRuntimeFile('wp-codebox/lib/selection.js', {
+		env: { HOMEBOY_EXTENSION_PATH: installedExtension },
+	}),
+	installedRuntimeFile
+);
+
+// Both layouts are probed for every candidate extension root, installed first.
+assert.deepEqual(agentRuntimeRoots({ extensionRoot: installedExtension }), [
+	path.join(homeboyRoot, 'agent-runtimes'),
+	path.join(homeboyRoot, 'extensions', 'agent-runtimes'),
+]);
+
+// The reported #12585 failure resolved to <homeboy>/extensions/agent-runtimes and
+// produced a bare MODULE_NOT_FOUND. An absent runtime must instead name every
+// probed path and how to repair the install.
+const emptyExtension = path.join(root, 'empty', 'extensions', 'wordpress');
+fs.mkdirSync(emptyExtension, { recursive: true });
+assert.throws(
+	() => resolveAgentRuntimeFile('wp-codebox/lib/wp-codebox-runtime-selection.js', { extensionRoot: emptyExtension }),
+	(error) => {
+		assert.equal(error.code, 'HOMEBOY_AGENT_RUNTIME_FILE_MISSING');
+		assert.match(error.message, /wp-codebox\/lib\/wp-codebox-runtime-selection\.js/);
+		assert.match(error.message, /homeboy extension install wordpress/);
+		for (const probed of agentRuntimeRoots({ extensionRoot: emptyExtension })) {
+			assert.ok(
+				error.message.includes(probed),
+				`expected diagnostic to name probed root ${probed}`
+			);
+		}
+		return true;
+	}
+);
+
+// The real checkout resolves the module the PHPUnit adapter needs.
+const selection = requireAgentRuntimeModule('wp-codebox/lib/wp-codebox-runtime-selection.js');
+assert.equal(typeof selection.preflightWpCodeboxCommand, 'function');
+
+fs.rmSync(root, { recursive: true, force: true });
+
+console.log('agent runtime paths smoke passed');

--- a/wordpress/tests/installed-agent-runtime-resolution-smoke.sh
+++ b/wordpress/tests/installed-agent-runtime-resolution-smoke.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Prove the installed extension layout can load shared agent-runtime files.
+#
+# `agent-runtimes` is a shared asset: Homeboy installs it at
+# <homeboy>/agent-runtimes, a sibling of <homeboy>/extensions, while a monorepo
+# checkout keeps it one level closer to the extension. A linked dev install
+# hides the difference because Node and `pwd -P` resolve a symlinked extension
+# back to the checkout, so this fixture COPIES the extension scripts — that is
+# the shape a fresh CI runner has, and the shape that produced four identical
+# MODULE_NOT_FOUND shard bootstrap failures in #12585.
+set -euo pipefail
+
+WORDPRESS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPOSITORY_ROOT="$(cd "${WORDPRESS_ROOT}/.." && pwd)"
+FIXTURE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+HOMEBOY_ROOT="${FIXTURE_ROOT}/config/homeboy"
+EXTENSION_DIR="${HOMEBOY_ROOT}/extensions/wordpress"
+mkdir -p "${EXTENSION_DIR}" "${HOMEBOY_ROOT}/extensions/scripts"
+cp -R "${WORDPRESS_ROOT}/scripts" "${EXTENSION_DIR}/scripts"
+ln -s "${REPOSITORY_ROOT}/agent-runtimes" "${HOMEBOY_ROOT}/agent-runtimes"
+ln -s "${REPOSITORY_ROOT}/scripts/lib" "${HOMEBOY_ROOT}/extensions/scripts/lib"
+
+# The WordPress wrapper must reach the shared opencode runtime executor.
+executor_output="$(node "${EXTENSION_DIR}/scripts/agent/homeboy-opencode-agent-task-executor.cjs" </dev/null 2>&1)"
+case "$executor_output" in
+    *'"provider": "opencode.agent-task-executor"'*) ;;
+    *)
+        echo "Expected installed opencode executor wrapper to load the shared runtime, got: ${executor_output}" >&2
+        exit 1
+        ;;
+esac
+
+# The PHPUnit adapter resolves its runtime-selection module before it validates
+# its own environment, so reaching the HOMEBOY_COMPONENT_PATH error is proof the
+# require succeeded.
+set +e
+adapter_output="$(HOMEBOY_SETTINGS_JSON='{}' node "${EXTENSION_DIR}/scripts/test/wp-codebox-phpunit-adapter.mjs" 2>&1)"
+set -e
+case "$adapter_output" in
+    *"Cannot find module"*)
+        echo "Installed PHPUnit adapter failed to resolve a module: ${adapter_output}" >&2
+        exit 1
+        ;;
+esac
+case "$adapter_output" in
+    *HOMEBOY_COMPONENT_PATH*) ;;
+    *)
+        echo "Expected installed PHPUnit adapter to reach its environment validation, got: ${adapter_output}" >&2
+        exit 1
+        ;;
+esac
+
+# The result parser sources the WP Codebox adapters from the shared tree; when
+# it cannot, wp-codebox-json silently degrades and a shard reports no counts.
+mkdir -p "${FIXTURE_ROOT}/artifacts/files"
+cat > "${FIXTURE_ROOT}/artifacts/files/test-results.json" <<'JSON'
+{"schema":"wp-codebox/test-results/v1","summary":{"total":3,"passed":2,"failed":1,"skipped":0}}
+JSON
+cat > "${FIXTURE_ROOT}/write-test-results.sh" <<'EOF'
+homeboy_write_test_results() {
+    printf 'total=%s passed=%s failed=%s skipped=%s\n' "$1" "$2" "$3" "$4"
+}
+EOF
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${FIXTURE_ROOT}/write-test-results.sh" \
+HOMEBOY_EXTENSION_PATH="${EXTENSION_DIR}" \
+    bash "${EXTENSION_DIR}/scripts/test/parse-test-results.sh" \
+        "${FIXTURE_ROOT}/artifacts" wp-codebox-json >"${FIXTURE_ROOT}/parse-output.txt" 2>&1
+if ! grep -q 'total=3 passed=2 failed=1 skipped=0' "${FIXTURE_ROOT}/parse-output.txt"; then
+    echo "Expected installed result parser to report WP Codebox counts, got: $(cat "${FIXTURE_ROOT}/parse-output.txt")" >&2
+    exit 1
+fi
+
+# An incomplete install must name what is missing instead of emitting a bare
+# MODULE_NOT_FOUND stack that says nothing about shared-asset packaging.
+rm "${HOMEBOY_ROOT}/agent-runtimes"
+set +e
+missing_output="$(HOMEBOY_SETTINGS_JSON='{}' node "${EXTENSION_DIR}/scripts/test/wp-codebox-phpunit-adapter.mjs" 2>&1)"
+missing_status=$?
+set -e
+[ "$missing_status" -ne 0 ] || { echo "Expected missing shared runtime to fail the adapter" >&2; exit 1; }
+case "$missing_output" in
+    *"could not resolve shared agent runtime file"*"${HOMEBOY_ROOT}/agent-runtimes"*"homeboy extension install wordpress"*) ;;
+    *)
+        echo "Expected an actionable missing-runtime diagnostic, got: ${missing_output}" >&2
+        exit 1
+        ;;
+esac
+
+printf '%s\n' 'installed agent runtime resolution smoke passed'

--- a/wordpress/tests/installed-agent-runtime-resolution-smoke.sh
+++ b/wordpress/tests/installed-agent-runtime-resolution-smoke.sh
@@ -22,34 +22,56 @@ cp -R "${WORDPRESS_ROOT}/scripts" "${EXTENSION_DIR}/scripts"
 ln -s "${REPOSITORY_ROOT}/agent-runtimes" "${HOMEBOY_ROOT}/agent-runtimes"
 ln -s "${REPOSITORY_ROOT}/scripts/lib" "${HOMEBOY_ROOT}/extensions/scripts/lib"
 
-# The WordPress wrapper must reach the shared opencode runtime executor.
-executor_output="$(node "${EXTENSION_DIR}/scripts/agent/homeboy-opencode-agent-task-executor.cjs" </dev/null 2>&1)"
+# Every step below asserts its own outcome, including exit status. Leaving
+# errexit on would abort on a probe that is *expected* to fail and discard the
+# captured output with it, reporting the failure as a silent exit 1.
+set +e
+
+fail() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+# HOMEBOY_EXTENSION_PATH is an accepted resolver input, so an ambient value
+# would let these probes resolve against the caller's extension instead of the
+# fixture. Unset it wherever the point is what a script's own location finds.
+fixture_node() {
+    env -u HOMEBOY_EXTENSION_PATH node "$@"
+}
+
+# Resolution is the invariant under test, so assert the resolved paths directly
+# instead of inferring them from a runtime's exit code. The shared runtimes
+# themselves depend on ambient tooling (the opencode executor spawns `homeboy`
+# for contract constants), which is not what an installed-layout packaging test
+# should be gated on.
+for target in \
+    "wp-codebox/lib/wp-codebox-runtime-selection.js" \
+    "opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs"; do
+    resolved="$(fixture_node "${EXTENSION_DIR}/scripts/lib/agent-runtime-paths.cjs" "${target}" 2>&1)"
+    expected="${HOMEBOY_ROOT}/agent-runtimes/${target}"
+    [ "$resolved" = "$expected" ] || fail "Expected installed resolution of ${target} to ${expected}, got: ${resolved}"
+done
+
+# The opencode wrapper's only job is to resolve and require the shared runtime,
+# so assert that it gets past resolution. What the runtime then does with an
+# empty request is out of scope here.
+executor_output="$(fixture_node "${EXTENSION_DIR}/scripts/agent/homeboy-opencode-agent-task-executor.cjs" </dev/null 2>&1)"
 case "$executor_output" in
-    *'"provider": "opencode.agent-task-executor"'*) ;;
-    *)
-        echo "Expected installed opencode executor wrapper to load the shared runtime, got: ${executor_output}" >&2
-        exit 1
+    *"Cannot find module"*|*"could not resolve shared agent runtime file"*)
+        fail "Installed opencode executor wrapper failed to load the shared runtime: ${executor_output}"
         ;;
 esac
 
 # The PHPUnit adapter resolves its runtime-selection module before it validates
 # its own environment, so reaching the HOMEBOY_COMPONENT_PATH error is proof the
 # require succeeded.
-set +e
-adapter_output="$(HOMEBOY_SETTINGS_JSON='{}' node "${EXTENSION_DIR}/scripts/test/wp-codebox-phpunit-adapter.mjs" 2>&1)"
-set -e
+adapter_output="$(HOMEBOY_SETTINGS_JSON='{}' fixture_node "${EXTENSION_DIR}/scripts/test/wp-codebox-phpunit-adapter.mjs" 2>&1)"
 case "$adapter_output" in
-    *"Cannot find module"*)
-        echo "Installed PHPUnit adapter failed to resolve a module: ${adapter_output}" >&2
-        exit 1
-        ;;
+    *"Cannot find module"*) fail "Installed PHPUnit adapter failed to resolve a module: ${adapter_output}" ;;
 esac
 case "$adapter_output" in
     *HOMEBOY_COMPONENT_PATH*) ;;
-    *)
-        echo "Expected installed PHPUnit adapter to reach its environment validation, got: ${adapter_output}" >&2
-        exit 1
-        ;;
+    *) fail "Expected installed PHPUnit adapter to reach its environment validation, got: ${adapter_output}" ;;
 esac
 
 # The result parser sources the WP Codebox adapters from the shared tree; when
@@ -63,29 +85,24 @@ homeboy_write_test_results() {
     printf 'total=%s passed=%s failed=%s skipped=%s\n' "$1" "$2" "$3" "$4"
 }
 EOF
-HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${FIXTURE_ROOT}/write-test-results.sh" \
-HOMEBOY_EXTENSION_PATH="${EXTENSION_DIR}" \
+parse_output="$(HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${FIXTURE_ROOT}/write-test-results.sh" \
+    HOMEBOY_EXTENSION_PATH="${EXTENSION_DIR}" \
     bash "${EXTENSION_DIR}/scripts/test/parse-test-results.sh" \
-        "${FIXTURE_ROOT}/artifacts" wp-codebox-json >"${FIXTURE_ROOT}/parse-output.txt" 2>&1
-if ! grep -q 'total=3 passed=2 failed=1 skipped=0' "${FIXTURE_ROOT}/parse-output.txt"; then
-    echo "Expected installed result parser to report WP Codebox counts, got: $(cat "${FIXTURE_ROOT}/parse-output.txt")" >&2
-    exit 1
-fi
+        "${FIXTURE_ROOT}/artifacts" wp-codebox-json 2>&1)"
+case "$parse_output" in
+    *"total=3 passed=2 failed=1 skipped=0"*) ;;
+    *) fail "Expected installed result parser to report WP Codebox counts, got: ${parse_output}" ;;
+esac
 
 # An incomplete install must name what is missing instead of emitting a bare
 # MODULE_NOT_FOUND stack that says nothing about shared-asset packaging.
 rm "${HOMEBOY_ROOT}/agent-runtimes"
-set +e
-missing_output="$(HOMEBOY_SETTINGS_JSON='{}' node "${EXTENSION_DIR}/scripts/test/wp-codebox-phpunit-adapter.mjs" 2>&1)"
+missing_output="$(HOMEBOY_SETTINGS_JSON='{}' fixture_node "${EXTENSION_DIR}/scripts/test/wp-codebox-phpunit-adapter.mjs" 2>&1)"
 missing_status=$?
-set -e
-[ "$missing_status" -ne 0 ] || { echo "Expected missing shared runtime to fail the adapter" >&2; exit 1; }
+[ "$missing_status" -ne 0 ] || fail "Expected missing shared runtime to fail the adapter"
 case "$missing_output" in
     *"could not resolve shared agent runtime file"*"${HOMEBOY_ROOT}/agent-runtimes"*"homeboy extension install wordpress"*) ;;
-    *)
-        echo "Expected an actionable missing-runtime diagnostic, got: ${missing_output}" >&2
-        exit 1
-        ;;
+    *) fail "Expected an actionable missing-runtime diagnostic, got: ${missing_output}" ;;
 esac
 
 printf '%s\n' 'installed agent runtime resolution smoke passed'


### PR DESCRIPTION
Fixes Extra-Chill/homeboy#12585.

## Root cause

`agent-runtimes` is a **shared asset** (declared in `homeboy-extension-root.json`). Homeboy installs shared runtimes *beside* the extensions directory, not inside it:

```
checkout    <repo>/wordpress                 ->  <repo>/agent-runtimes            (../)
installed   <homeboy>/extensions/wordpress   ->  <homeboy>/agent-runtimes         (../../)
```

Four WordPress entrypoints hardcoded the checkout distance, so on a copied install they resolved to a nonexistent `<homeboy>/extensions/agent-runtimes`.

A **linked (symlinked) dev install hides this** — Node and `pwd -P` resolve a symlinked script back to the source checkout, so the broken branch is only ever taken on a copied install. That is exactly why the same code passes locally and dies on a fresh GitHub runner.

Reproduced against `origin/main` in a copied installed layout:

```
Error: Cannot find module '../../../agent-runtimes/wp-codebox/lib/wp-codebox-runtime-selection.js'
Require stack:
- .../config/homeboy/extensions/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
```

Identical to https://github.com/Extra-Chill/data-machine/actions/runs/31915807136, where all four shards failed in ~1.2s with zero tests executed.

## Change

- **New** `wordpress/scripts/lib/agent-runtime-paths.cjs` — probes both layouts (honoring `HOMEBOY_EXTENSION_PATH`) and, when neither resolves, throws with the probed paths and a reinstall remediation instead of a bare `MODULE_NOT_FOUND` stack. Also usable as a CLI.
- `scripts/test/wp-codebox-phpunit-adapter.mjs` — the reported break; routes through the resolver.
- `scripts/agent/homeboy-opencode-agent-task-executor.cjs` — same shape, same fix.
- `scripts/test/parse-test-results.sh` — same shape, but it failed *silently* (`if [ -f ]`), dropping the `wp-codebox-json` adapter so an installed shard lost its test counts. Now probes both layouts.
- `scripts/refactor.py` — same shape in `wp_codebox_task_runner_args`.
- `scripts/build/setup.sh` — verifies the four shared runtime files this extension's entrypoints need, so an incomplete payload fails at **candidate setup**, before planning or fanout.

`scripts/fuzz/fuzz-runner.cjs` already did two-layout resolution and is unchanged; this brings the rest of the extension to that contract.

## Tests

- `wordpress/tests/agent-runtime-paths-smoke.js` — resolver unit coverage: installed layout, checkout layout, `HOMEBOY_EXTENSION_PATH` precedence, probe ordering, and the actionable missing-runtime diagnostic.
- `wordpress/tests/installed-agent-runtime-resolution-smoke.sh` — materializes a **copied** installed layout (the shape that reproduces the bug; the existing `installed-test-helper-resolution-smoke.sh` symlinks, which is why this class went unobserved) and asserts the opencode wrapper loads the shared runtime, the PHPUnit adapter gets past module resolution to its own env validation, the result parser reports WP Codebox counts, and removing the shared tree yields the precise diagnostic rather than `MODULE_NOT_FOUND`.

Both registered in `wordpress/homeboy.json` self-checks (lint + test).

## Acceptance

| Acceptance criterion | Status |
|---|---|
| Shards can load `wp-codebox-phpunit-adapter.mjs` on a fresh runner | verified in copied-install fixture; pre-fix reproduces the exact CI stack |
| Missing transitive runtime files fail with a precise diagnostic | `setup.sh` fails candidate setup; resolver names every probed path + remediation |
| Consumer rerun executes assigned tests | needs a Data Machine rerun after this releases |

## Verification

```
node wordpress/tests/agent-runtime-paths-smoke.js                    passed
bash wordpress/tests/installed-agent-runtime-resolution-smoke.sh     passed
bash wordpress/tests/installed-test-helper-resolution-smoke.sh       passed
node wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js     passed
node tests/extension-shape-lint.mjs                                  passed (8 extensions)
node tests/wp-codebox-adapter-contract-smoke.mjs                     passed
node tests/wp-codebox-runner-readiness-smoke.mjs                     passed
bash tests/wordpress-runtime-helper-resolver-smoke.sh                passed
wordpress/homeboy.json self_checks.lint (all 3)                      passed
6 wp-codebox-phpunit-* smokes                                        passed
eslint on all changed JS                                             clean
```

`wordpress/tests/refactor-source-wp-codebox-smoke.js` fails identically before and after this change (verified via `git stash`); it is not registered in self-checks and is out of scope here.