### PR TITLE
fix(wordpress): terminate WP Codebox runs on an unclaimed fatal runtime crash

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -166,6 +166,36 @@ HOMEBOY_WORDPRESS_TEST_RUNTIME_BACKEND=wp-codebox homeboy test <component-id>
 The `test-runner-wp-codebox.sh` script name and existing WP Codebox settings are
 preserved for compatibility with the current implementation.
 
+### Fatal runtime crashes
+
+A PHP-WASM trap (`RuntimeError: null function or function signature mismatch`
+and friends) leaves the interpreter unusable, but the WP Codebox CLI logs the
+rejection instead of exiting — so the recipe-run promise never settles and the
+run sits until its budget expires. On #12617 that turned a crash which happened
+in the first seconds into a 24-minute shard, reported only as a timeout.
+
+The adapter watches recipe-run output for an *unclaimed* fatal error — an
+unhandled rejection or uncaught exception carrying a WebAssembly `RuntimeError`
+— and arms a short deadline instead of waiting out the budget. A stack frame
+mentioning `php.wasm` on its own does not qualify; traces get logged for
+non-fatal reasons.
+
+The grace window is what makes acting on the signature safe: a run that somehow
+recovers and finishes inside it is untouched, while a wedged one costs about a
+minute instead of the full budget.
+
+```bash
+# default 60s; 0 disables early termination
+HOMEBOY_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS=60 homeboy test <component-id>
+```
+
+The same value can be set as `wp_codebox_runtime_crash_grace_seconds` in
+extension settings. When a crash is detected the run reports
+`PHPUNIT_ZERO_TESTS cause=runtime_crashed`, and
+`files/wp-codebox-timeout-diagnostics.json` carries
+`termination.result = "runtime_crash"` plus a `runtime_crash` object naming the
+signature — so the failure names the crash rather than the elapsed budget.
+
 ### Runtime dependencies
 
 If a plugin depends on other local plugins at runtime, declare them via

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -22,7 +22,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/build/install-composer-dependencies.sh scripts/build/setup.sh scripts/build/setup-wp-codebox-smoke.sh scripts/build/update-wp-codebox-cache.sh scripts/build/update-wp-codebox-cache-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/wp-codebox-cli-resolution-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/doctor/wp-codebox-doctor.sh scripts/test/wp-codebox-doctor-smoke.sh scripts/test/changed-scope-test-routing-smoke.sh scripts/test/test-runner-file-routing-smoke.sh tests/extension-composer-vendor-integrity-smoke.sh tests/installed-build-helper-resolution-smoke.sh tests/installed-agent-runtime-resolution-smoke.sh tests/js-test-framework-routing-smoke.sh scripts/lint/eslint-dependency-tree-scope-smoke.sh",
-      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/lib/agent-runtime-paths.cjs scripts/agent/homeboy-opencode-agent-task-executor.cjs scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/lib/wp-codebox-timeout-diagnostics.mjs scripts/lib/wp-codebox-phpunit-timeout.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs"
+      "node --check index.js lib/codebox-client.js lib/wp-codebox-resolver.js lib/wp-codebox-fuzz-run.js scripts/lib/agent-runtime-paths.cjs scripts/agent/homeboy-opencode-agent-task-executor.cjs scripts/fuzz/fuzz-runner.cjs scripts/bench/wp-codebox-bench-adapter.mjs scripts/lib/wp-codebox-timeout-diagnostics.mjs scripts/lib/wp-codebox-phpunit-timeout.mjs scripts/lib/wp-codebox-runtime-crash.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs"
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
@@ -43,6 +43,8 @@
       "node tests/wp-codebox-phpunit-timeout-options-smoke.mjs",
       "node tests/wp-codebox-phpunit-target-activation-smoke.mjs",
       "node tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs",
+      "node tests/wp-codebox-runtime-crash-detector-smoke.mjs",
+      "node tests/wp-codebox-phpunit-runtime-crash-smoke.mjs",
       "node tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs",
       "bash scripts/test/changed-scope-test-routing-smoke.sh",
       "bash scripts/test/test-runner-file-routing-smoke.sh",

--- a/wordpress/scripts/lib/wp-codebox-runtime-crash.mjs
+++ b/wordpress/scripts/lib/wp-codebox-runtime-crash.mjs
@@ -1,0 +1,131 @@
+/**
+ * Detect fatal WP Codebox runtime crashes in streamed recipe-run output.
+ *
+ * A PHP-WASM trap — `RuntimeError: null function or function signature
+ * mismatch` and friends — leaves the interpreter in an undefined state. The WP
+ * Codebox CLI logs the rejection instead of exiting, so the recipe-run promise
+ * never settles and the runner sits until its budget expires. On #12617 that
+ * turned a crash which happened in the first seconds into a 24-minute wall
+ * clock, four shards deep, reported only as `test phase timed out ... before
+ * reporting test counts`.
+ *
+ * The signature is an unhandled rejection or uncaught exception carrying a
+ * WebAssembly `RuntimeError`. That pairing is what makes it safe to act on: a
+ * wasm trap is not recoverable, and an *unhandled* one means nothing in the
+ * runtime claimed it. A stack frame mentioning `php.wasm` on its own is not
+ * enough — traces get logged for non-fatal reasons — so it only corroborates.
+ */
+
+export const WP_CODEBOX_RUNTIME_CRASH_SCHEMA = 'homeboy/wp-codebox-runtime-crash/v1';
+export const DEFAULT_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS = 60;
+
+// Retained across chunk boundaries so a signature split by the stream still
+// matches. Two lines of slack is enough for every pattern below.
+const CARRY_BYTES = 4096;
+const MESSAGE_BYTES = 512;
+
+const SIGNATURES = [
+  {
+    id: 'php_wasm_unhandled_rejection',
+    pattern: /Unhandled rejection:\s*(RuntimeError:[^\n]*)/,
+  },
+  {
+    id: 'php_wasm_uncaught_exception',
+    pattern: /Uncaught\s+(RuntimeError:[^\n]*)/,
+  },
+  {
+    id: 'php_wasm_trap',
+    pattern: /(RuntimeError: (?:null function or function signature mismatch|memory access out of bounds|unreachable|integer divide by zero|table index is out of bounds)[^\n]*)/,
+  },
+];
+
+const WASM_FRAME = /\bat [\w.]*\.?wasm[\w.$-]*\.|wasm:\/\/wasm\//;
+
+/**
+ * Inspect a complete text buffer for a fatal runtime crash.
+ *
+ * @param {string} text
+ * @return {{ id: string, message: string, wasm_frame: boolean } | null} The
+ *   first matching crash, or null when the text carries no fatal signature.
+ */
+export function detectWpCodeboxRuntimeCrash(text) {
+  const haystack = typeof text === 'string' ? text : '';
+  if (!haystack) {
+    return null;
+  }
+  for (const signature of SIGNATURES) {
+    const match = signature.pattern.exec(haystack);
+    if (!match) {
+      continue;
+    }
+    return {
+      id: signature.id,
+      message: boundedMessage(match[1] || match[0]),
+      wasm_frame: WASM_FRAME.test(haystack),
+    };
+  }
+  return null;
+}
+
+/**
+ * Stateful detector for chunked output.
+ *
+ * Reports the first crash only: a wasm trap usually cascades, and the first
+ * signature is the one that explains the run.
+ *
+ * @return {{ write: (chunk: Buffer | string) => Object | null, crash: () => Object | null }} A
+ *   detector holding the first crash it sees.
+ */
+export function createWpCodeboxRuntimeCrashDetector() {
+  let carry = '';
+  let crash = null;
+
+  return {
+    write(chunk) {
+      if (crash) {
+        return null;
+      }
+      const text = `${carry}${Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk ?? '')}`;
+      const detected = detectWpCodeboxRuntimeCrash(text);
+      if (detected) {
+        crash = detected;
+        carry = '';
+        return crash;
+      }
+      carry = text.length > CARRY_BYTES ? text.slice(-CARRY_BYTES) : text;
+      return null;
+    },
+    crash() {
+      return crash;
+    },
+  };
+}
+
+/**
+ * Seconds to wait after a crash signature before terminating the runtime.
+ *
+ * A grace window is what makes acting on the signature safe: a run that somehow
+ * recovers and finishes inside the window is untouched, while a wedged one is
+ * cut from the full budget to about a minute. `0` disables early termination.
+ *
+ * @param {NodeJS.ProcessEnv} [environment]
+ * @param {Object}            [settings]
+ * @return {number} Grace period in seconds.
+ */
+export function configuredWpCodeboxRuntimeCrashGraceSeconds(environment = process.env, settings = {}) {
+  const raw = environment.HOMEBOY_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS
+    ?? settings.wp_codebox_runtime_crash_grace_seconds
+    ?? DEFAULT_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS;
+  const seconds = Number(raw);
+  if (!Number.isSafeInteger(seconds) || seconds < 0) {
+    throw new Error('WP Codebox runtime crash grace must be a non-negative integer number of seconds.');
+  }
+  return seconds;
+}
+
+function boundedMessage(value) {
+  const text = String(value ?? '').trim().replace(/\s+/g, ' ');
+  return Buffer.byteLength(text) > MESSAGE_BYTES
+    ? Buffer.from(text).subarray(0, MESSAGE_BYTES).toString('utf8')
+    : text;
+}

--- a/wordpress/scripts/lib/wp-codebox-timeout-diagnostics.mjs
+++ b/wordpress/scripts/lib/wp-codebox-timeout-diagnostics.mjs
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+/**
+ * External dependencies
+ */
+
 import { open, readFile } from 'node:fs/promises';
 import { StringDecoder } from 'node:string_decoder';
 
@@ -20,6 +24,7 @@ export function wpCodeboxTimeoutDiagnostics({
   artifacts = [],
   payload,
   stderr = '',
+  runtimeCrash = null,
   secretValues = secretValuesFromEnvironment(process.env),
 } = {}) {
   const recipeRun = asObject(payload);
@@ -47,6 +52,14 @@ export function wpCodeboxTimeoutDiagnostics({
       code: Number.isInteger(termination.code) ? termination.code : undefined,
     },
     artifact_refs: artifacts.slice(0, 20).map((artifact) => boundedText(artifact, FIELD_BYTES, secretValues)).filter(Boolean),
+    // A fatal runtime crash is the cause; the elapsed budget is only how long
+    // it took to notice. Project it as its own field so a consumer does not
+    // have to grep the excerpts to find out which one it was reading.
+    runtime_crash: asObject(runtimeCrash) ? withoutUndefined({
+      id: boundedText(runtimeCrash.id, FIELD_BYTES, secretValues) || undefined,
+      message: boundedText(runtimeCrash.message, FIELD_BYTES, secretValues) || undefined,
+      wasm_frame: runtimeCrash.wasm_frame === true ? true : undefined,
+    }) : undefined,
     excerpts: boundedText(stderr, TEXT_EXCERPT_BYTES, secretValues) || undefined,
   };
   removeUndefined(diagnostic.termination);

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -15,6 +15,7 @@ import { createRequire } from 'node:module';
  */
 import { createTimeoutLineRedactor, recipeRunProjection, readBoundedText, wpCodeboxTimeoutDiagnostics } from '../lib/wp-codebox-timeout-diagnostics.mjs';
 import { configuredWpCodeboxPhpunitTimeoutSeconds } from '../lib/wp-codebox-phpunit-timeout.mjs';
+import { configuredWpCodeboxRuntimeCrashGraceSeconds, createWpCodeboxRuntimeCrashDetector } from '../lib/wp-codebox-runtime-crash.mjs';
 
 const require = createRequire(import.meta.url);
 // Shared agent runtimes install beside the extensions directory, so their path
@@ -26,6 +27,7 @@ const { preflightWpCodeboxCommand } = requireAgentRuntimeModule('wp-codebox/lib/
 
 const settings = parseSettings(process.env.HOMEBOY_SETTINGS_JSON);
 const phpunitTimeoutSeconds = configuredWpCodeboxPhpunitTimeoutSeconds(process.env, settings);
+const runtimeCrashGraceSeconds = configuredWpCodeboxRuntimeCrashGraceSeconds(process.env, settings);
 const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMPONENT_PATH');
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const extensionRoot = path.resolve(scriptDirectory, '../..');
@@ -151,32 +153,56 @@ async function runCaptured(args, timeoutSeconds) {
     const stderrFile = createWriteStream(stderrPath);
     const stdoutRedactor = createTimeoutLineRedactor(secretValues);
     const stderrRedactor = createTimeoutLineRedactor(secretValues);
+    const crashDetector = createWpCodeboxRuntimeCrashDetector();
     let childError;
     let timedOut = false;
+    let crashTimer;
     const startedAt = Date.now();
     let stdoutPreview = Buffer.alloc(0);
-    const timer = setTimeout(() => {
-      timedOut = true;
+    const terminate = () => {
       killChildGroup(child, 'SIGTERM');
       // Do not clear or unref this timer when the leader exits: a descendant
       // can ignore SIGTERM after the CLI has been reaped.
       setTimeout(() => killChildGroup(child, 'SIGKILL'), 5000);
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminate();
     }, timeoutSeconds * 1000);
+
+    // A wasm trap the runtime never claimed will not resolve on its own, so
+    // stop paying the full budget for it. The grace window is what keeps this
+    // safe: a run that recovers and finishes inside it is left alone.
+    const armCrashDeadline = (chunk) => {
+      if (crashTimer || runtimeCrashGraceSeconds === 0 || !crashDetector.write(chunk)) {
+        return;
+      }
+      const crash = crashDetector.crash();
+      process.stdout.write(`WP Codebox runtime crash detected (${crash.id}): ${crash.message}\n`);
+      process.stdout.write(`Terminating the recipe-run in ${runtimeCrashGraceSeconds}s unless it completes first.\n`);
+      crashTimer = setTimeout(() => {
+        timedOut = true;
+        terminate();
+      }, runtimeCrashGraceSeconds * 1000);
+    };
 
     child.stdout.on('data', (chunk) => {
       if (stdoutPreview.byteLength < 128 * 1024) {
         stdoutPreview = Buffer.concat([stdoutPreview, chunk.subarray(0, (128 * 1024) - stdoutPreview.byteLength)]);
       }
+      armCrashDeadline(chunk);
       chunk = stdoutRedactor.write(chunk);
       stdoutFile.write(chunk);
     });
     child.stderr.on('data', (chunk) => {
+      armCrashDeadline(chunk);
       chunk = stderrRedactor.write(chunk);
       stderrFile.write(chunk);
     });
     child.on('error', (error) => { childError = error; });
     child.on('close', (status, signal) => {
       clearTimeout(timer);
+      clearTimeout(crashTimer);
       const stdoutTail = stdoutRedactor.end();
       const stderrTail = stderrRedactor.end();
       stdoutFile.write(stdoutTail);
@@ -191,18 +217,28 @@ async function runCaptured(args, timeoutSeconds) {
           reject(childError);
           return;
         }
+        const runtimeCrash = crashDetector.crash();
         resolve({
           status: status ?? 1,
           stdoutPath,
           stderrPath,
           stdoutPreview: stdoutPreview.toString('utf8'),
           timedOut,
+          runtimeCrash,
           elapsedSeconds: Math.ceil((Date.now() - startedAt) / 1000),
-          termination: { result: timedOut ? 'timeout' : 'exited', signal, code: status },
+          // A crash that we terminated on is reported as such: naming the
+          // budget would describe the symptom and hide the cause.
+          termination: { result: terminationResult(runtimeCrash, timedOut), signal, code: status },
         });
       }, reject);
     });
   });
+}
+function terminationResult(runtimeCrash, timedOut) {
+  if (runtimeCrash) {
+    return 'runtime_crash';
+  }
+  return timedOut ? 'timeout' : 'exited';
 }
 function killChildGroup(child, signal) {
   if (!child || typeof child.pid !== 'number') {
@@ -999,6 +1035,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
     ],
     payload: recipeRun,
     stderr,
+    runtimeCrash: execution.runtimeCrash,
     secretValues: configuredSecretValues(),
   }) : null;
   if (timeoutEvidence) {
@@ -1137,6 +1174,19 @@ async function phpunitExecutionDiagnosis(artifactDirectory, results, execution, 
     }
     if (executed > 0) {
       return { cause: 'tests_executed', detail: `PHPUnit executed ${executed} test(s).`, remediation: 'No execution diagnosis is required.' };
+    }
+    // Ranked under the stage markers, which name the failing seam directly, and
+    // over every ledger-derived cause: with a trapped runtime the ledger is a
+    // description of the wreckage, not of what stopped the run.
+    if (execution?.runtimeCrash) {
+      const crash = execution.runtimeCrash;
+      return {
+        cause: 'runtime_crashed',
+        detail: `The WP Codebox runtime raised an unclaimed fatal error before PHPUnit executed (${crash.id}): ${crash.message}`,
+        remediation: crash.wasm_frame
+          ? 'A PHP-WASM trap leaves the interpreter unusable, so the recipe-run cannot recover. Read logs/recipe-run.stderr.log for the faulting stack and identify the PHP call that trapped; an unsupported extension call (for example async mysqli polling) is the usual cause.'
+          : 'Read logs/recipe-run.stderr.log for the faulting stack; the runtime terminated before PHPUnit could be invoked.',
+      };
     }
     if (recipeRunSteps?.parse_status === 'unparseable') {
       return {

--- a/wordpress/tests/wp-codebox-phpunit-runtime-crash-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-runtime-crash-smoke.mjs
@@ -1,0 +1,152 @@
+/**
+ * Regression: Extra-Chill/homeboy#12617. A PHP-WASM trap leaves the interpreter
+ * in an undefined state, but the WP Codebox CLI logs the rejection instead of
+ * exiting, so the recipe-run promise never settles. Before this, a crash that
+ * happened in the first seconds cost the full test budget — 24 minutes per
+ * shard, four shards deep — and surfaced only as "test phase timed out ...
+ * before reporting test counts", naming the symptom and hiding the cause.
+ *
+ * The run must now terminate on the crash signature, and report the crash as
+ * its failure cause. A run without the signature must be left alone.
+ *
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const extension = path.resolve(import.meta.dirname, '..');
+const runner = path.join(extension, 'scripts/test/test-runner-wp-codebox.sh');
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-runtime-crash-'));
+const component = path.join(root, 'sample-plugin');
+const cli = path.join(root, 'wp-codebox');
+await mkdir(component, { recursive: true });
+await writeFile(path.join(component, 'sample-plugin.php'), '<?php\n/* Plugin Name: Sample Plugin */\n');
+
+// The budget is what the fix must avoid paying; the grace is what it should pay
+// instead. Keeping them far apart is what makes the assertion meaningful while
+// the test still runs in seconds.
+const BUDGET_SECONDS = 90;
+const GRACE_SECONDS = 2;
+
+// Stands in for WP Codebox wedged by a wasm trap: it emits the crash the way
+// the runtime does — an unhandled rejection with a php.wasm stack — completes
+// its setup step, and then never returns.
+await writeFile(cli, `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+const args = process.argv.slice(2);
+if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args[0] === 'recipe' && args[1] === 'build') {
+  fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
+  process.exit(0);
+}
+const artifactRoot = args[args.indexOf('--artifacts') + 1];
+const runtime = path.join(artifactRoot, 'runtime-fixture');
+fs.mkdirSync(path.join(runtime, 'files'), { recursive: true });
+fs.writeFileSync(path.join(artifactRoot, 'latest-runtime.json'), JSON.stringify({ paths: { runtimeDirectory: 'runtime-fixture' } }));
+fs.writeFileSync(path.join(runtime, 'files', 'test-results.json'), JSON.stringify({
+  schema: 'wp-codebox/test-results/v1',
+  status: 'skipped',
+  summary: { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 },
+  suites: [],
+}));
+process.stdout.write('Running the wordpress.run-php setup step...\\n');
+if (process.env.FIXTURE_EMIT_CRASH === '1') {
+  process.stderr.write([
+    'Unhandled rejection: RuntimeError: null function or function signature mismatch',
+    '    at php.wasm._php_stream_write_filtered (wasm://wasm/php.wasm-05996276:wasm-function[3039]:0x26c31e)',
+    '    at php.wasm.zif_mysqli_poll (wasm://wasm/php.wasm-05996276:wasm-function[12986]:0x9949a8)',
+    '',
+  ].join('\\n'));
+}
+if (process.env.FIXTURE_HANG === '1') {
+  // The wedged shape: the promise never settles and nothing more is written.
+  setInterval(() => {}, 1000);
+} else {
+  process.stdout.write(JSON.stringify({ success: false, executions: [
+    { command: 'wordpress.run-php', status: 'completed', exitCode: 0, stdout: '', stderr: '' },
+  ] }) + '\\n');
+  process.exit(1);
+}
+`);
+await chmod(cli, 0o755);
+
+async function runScenario(name, fixtureEnv) {
+  const artifacts = path.join(root, `${name}-artifacts`);
+  const invocationArtifacts = path.join(root, `${name}-invocation`);
+  await mkdir(invocationArtifacts, { recursive: true });
+  await writeFile(path.join(invocationArtifacts, 'homeboy-artifact-manifest.json'), '{"schema":"homeboy/artifact-manifest/v1"}\n');
+  const startedAt = Date.now();
+  const run = spawnSync(runner, [], {
+    env: {
+      ...process.env,
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'sample-plugin',
+      HOMEBOY_WP_CODEBOX_BIN: cli,
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: artifacts,
+      HOMEBOY_INVOCATION_ARTIFACT_DIR: invocationArtifacts,
+      HOMEBOY_SETTINGS_JSON: '{}',
+      HOMEBOY_WORDPRESS_PHPUNIT_TIMEOUT_SECONDS: String(BUDGET_SECONDS),
+      HOMEBOY_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS: String(GRACE_SECONDS),
+      ...fixtureEnv,
+    },
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return {
+    run,
+    elapsedSeconds: (Date.now() - startedAt) / 1000,
+    publishedFiles: path.join(invocationArtifacts, 'wp-codebox-phpunit', 'files'),
+  };
+}
+
+try {
+  const crashed = await runScenario('runtime-crash', { FIXTURE_EMIT_CRASH: '1', FIXTURE_HANG: '1' });
+
+  // The point of the fix: a wedged runtime costs the grace, not the budget.
+  assert.ok(
+    crashed.elapsedSeconds < BUDGET_SECONDS / 2,
+    `expected the crash to terminate near the ${GRACE_SECONDS}s grace, took ${crashed.elapsedSeconds}s of a ${BUDGET_SECONDS}s budget`
+  );
+  assert.match(crashed.run.stdout, /WP Codebox runtime crash detected \(php_wasm_unhandled_rejection\)/);
+  assert.match(crashed.run.stdout, /PHPUNIT_ZERO_TESTS cause=runtime_crashed/);
+
+  const diagnosis = JSON.parse(await readFile(path.join(crashed.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.equal(diagnosis.executed_tests, 0);
+  assert.equal(diagnosis.cause, 'runtime_crashed', `unexpected zero-test cause: ${diagnosis.cause}`);
+  assert.match(diagnosis.detail, /null function or function signature mismatch/);
+  assert.match(diagnosis.remediation, /PHP-WASM trap/);
+  // The ledger cause must lose: with a trapped runtime it describes the
+  // wreckage, not what stopped the run.
+  assert.notEqual(diagnosis.cause, 'phpunit_step_not_executed');
+
+  const timeoutDiagnostics = JSON.parse(await readFile(path.join(crashed.publishedFiles, 'wp-codebox-timeout-diagnostics.json'), 'utf8'));
+  assert.equal(timeoutDiagnostics.termination.result, 'runtime_crash', 'termination must name the crash, not the budget');
+  assert.equal(timeoutDiagnostics.runtime_crash.id, 'php_wasm_unhandled_rejection');
+  assert.equal(timeoutDiagnostics.runtime_crash.wasm_frame, true);
+  assert.match(timeoutDiagnostics.runtime_crash.message, /RuntimeError: null function or function signature mismatch/);
+
+  // Control: no crash signature, so nothing is terminated early and the run
+  // keeps its own ledger-derived cause.
+  const clean = await runScenario('no-crash', { FIXTURE_EMIT_CRASH: '0', FIXTURE_HANG: '0' });
+  assert.doesNotMatch(clean.run.stdout, /WP Codebox runtime crash detected/);
+  assert.doesNotMatch(clean.run.stdout, /PHPUNIT_ZERO_TESTS cause=runtime_crashed/);
+  const cleanDiagnosis = JSON.parse(await readFile(path.join(clean.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8'));
+  assert.notEqual(cleanDiagnosis.cause, 'runtime_crashed');
+
+  // A crash signature on a run that still finishes on its own must not be
+  // pre-empted: the grace window is the whole safety argument.
+  const recovered = await runScenario('crash-then-exit', { FIXTURE_EMIT_CRASH: '1', FIXTURE_HANG: '0' });
+  assert.match(recovered.run.stdout, /WP Codebox runtime crash detected/);
+  assert.ok(
+    recovered.elapsedSeconds < BUDGET_SECONDS / 2,
+    `expected a self-terminating run to exit promptly, took ${recovered.elapsedSeconds}s`
+  );
+
+  console.log('wp-codebox phpunit runtime crash smoke passed');
+} finally {
+  await rm(root, { recursive: true, force: true });
+}

--- a/wordpress/tests/wp-codebox-runtime-crash-detector-smoke.mjs
+++ b/wordpress/tests/wp-codebox-runtime-crash-detector-smoke.mjs
@@ -1,0 +1,75 @@
+/**
+ * Unit coverage for the WP Codebox fatal-runtime-crash detector (#12617).
+ *
+ * Acting on a signature only pays off if it is precise: a false positive kills
+ * a healthy run, and a false negative costs the full test budget. These pin
+ * both edges.
+ *
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+
+/**
+ * Internal dependencies
+ */
+import {
+  DEFAULT_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS,
+  configuredWpCodeboxRuntimeCrashGraceSeconds,
+  createWpCodeboxRuntimeCrashDetector,
+  detectWpCodeboxRuntimeCrash,
+} from '../scripts/lib/wp-codebox-runtime-crash.mjs';
+
+// The signature observed on Extra-Chill/homeboy#12617.
+const observed = [
+  'Unhandled rejection: RuntimeError: null function or function signature mismatch',
+  '    at php.wasm._php_stream_write_filtered (wasm://wasm/php.wasm-05996276:wasm-function[3039]:0x26c31e)',
+  '    at php.wasm.mysqlnd_stream_array_from_fd_set (wasm://wasm/php.wasm-05996276:wasm-function[8606]:0x69ad75)',
+  '    at php.wasm.zif_mysqli_poll (wasm://wasm/php.wasm-05996276:wasm-function[12986]:0x9949a8)',
+].join('\n');
+
+const crash = detectWpCodeboxRuntimeCrash(observed);
+assert.equal(crash.id, 'php_wasm_unhandled_rejection');
+assert.equal(crash.message, 'RuntimeError: null function or function signature mismatch');
+assert.equal(crash.wasm_frame, true);
+
+assert.equal(detectWpCodeboxRuntimeCrash('Uncaught RuntimeError: unreachable').id, 'php_wasm_uncaught_exception');
+assert.equal(detectWpCodeboxRuntimeCrash('RuntimeError: memory access out of bounds').id, 'php_wasm_trap');
+assert.equal(detectWpCodeboxRuntimeCrash('RuntimeError: table index is out of bounds').id, 'php_wasm_trap');
+
+// Not fatal, and must not be treated as such. A logged stack, a PHP-level
+// exception, or the word "RuntimeError" inside ordinary test output all reach
+// this detector during a healthy run.
+for (const benign of [
+  'Running PHPUnit tests via WP Codebox...\nOK (481 tests, 1234 assertions)',
+  'PHP Fatal error: Uncaught Error: Call to undefined function foo()',
+  '    at php.wasm.execute_ex (wasm://wasm/php.wasm-05996276:wasm-function[17805]:0xb880c4)',
+  'There was 1 failure:\n1) RuntimeErrorTest::testHandlesRuntimeError',
+  '',
+  undefined,
+]) {
+  assert.equal(detectWpCodeboxRuntimeCrash(benign), null, `expected no crash for: ${String(benign).slice(0, 60)}`);
+}
+
+// Streamed output splits wherever the pipe decides to, including mid-signature.
+const detector = createWpCodeboxRuntimeCrashDetector();
+assert.equal(detector.write('Running the wordpress.run-php setup step...\n'), null);
+assert.equal(detector.write('Unhandled reje'), null);
+assert.equal(detector.crash(), null);
+const streamed = detector.write(Buffer.from('ction: RuntimeError: null function or function signature mismatch\n'));
+assert.equal(streamed.id, 'php_wasm_unhandled_rejection');
+assert.equal(detector.crash().id, 'php_wasm_unhandled_rejection');
+
+// Only the first crash is reported: a wasm trap cascades, and the first
+// signature is the one that explains the run.
+assert.equal(detector.write('Unhandled rejection: RuntimeError: unreachable'), null);
+assert.equal(detector.crash().message, 'RuntimeError: null function or function signature mismatch');
+
+assert.equal(configuredWpCodeboxRuntimeCrashGraceSeconds({}, {}), DEFAULT_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS);
+assert.equal(configuredWpCodeboxRuntimeCrashGraceSeconds({ HOMEBOY_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS: '5' }, {}), 5);
+assert.equal(configuredWpCodeboxRuntimeCrashGraceSeconds({}, { wp_codebox_runtime_crash_grace_seconds: 30 }), 30);
+// Zero is the documented opt-out, not an invalid value.
+assert.equal(configuredWpCodeboxRuntimeCrashGraceSeconds({ HOMEBOY_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS: '0' }, {}), 0);
+assert.throws(() => configuredWpCodeboxRuntimeCrashGraceSeconds({ HOMEBOY_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS: '-1' }, {}));
+assert.throws(() => configuredWpCodeboxRuntimeCrashGraceSeconds({ HOMEBOY_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS: 'soon' }, {}));
+
+console.log('wp-codebox runtime crash detector smoke passed');


### PR DESCRIPTION
Refs Extra-Chill/homeboy#12617.

## Root cause

A PHP-WASM trap leaves the interpreter in an undefined state. The WP Codebox CLI **logs the rejection instead of exiting**, so the recipe-run promise never settles. The adapter had no signal for that and simply waited out its budget.

Observed on [data-machine run 31972638967](https://github.com/Extra-Chill/data-machine/actions/runs/31972638967), all four shards:

```
"execution":{"count":1,"count_complete":false,
  "last":{"command":"wordpress.run-php","status":"ok","exit_code":0,
          "stdout":{"bytes":0},"stderr":{"bytes":0}}},
"termination":{"result":"timeout","signal":"SIGTERM"}
```

```
Unhandled rejection: RuntimeError: null function or function signature mismatch
    at php.wasm._php_stream_write_filtered
    at php.wasm.mysqlnd_stream_array_from_fd_set
    at php.wasm.zif_mysqli_poll
```

A crash that happened in the first seconds cost **1447s per shard, four shards deep**, and surfaced only as `test phase timed out ... before reporting test counts` — the symptom, not the cause.

## Change

**Detect** an *unclaimed* fatal error in the streamed recipe-run output: an unhandled rejection or uncaught exception carrying a WebAssembly `RuntimeError`. The pairing is what makes the signature safe to act on — a wasm trap is unrecoverable, and an *unhandled* one means nothing in the runtime claimed it. A `php.wasm` stack frame on its own does **not** qualify; traces get logged for non-fatal reasons.

**Terminate on a deadline, not immediately.** That is the rest of the safety argument: a run that somehow recovers and finishes inside the grace is untouched, while a wedged one costs about a minute instead of the full budget.

```bash
# default 60s; 0 restores the previous behavior
HOMEBOY_WP_CODEBOX_RUNTIME_CRASH_GRACE_SECONDS=60
# or wp_codebox_runtime_crash_grace_seconds in extension settings
```

**Report the crash as the cause:**
- `termination.result` becomes `runtime_crash` instead of `timeout`
- the timeout diagnostic gains a `runtime_crash` object (`id`, `message`, `wasm_frame`)
- the zero-tests diagnosis gains a `runtime_crashed` cause, ranked **under** the stage markers (which name the failing seam directly) and **over** every ledger-derived cause — with a trapped runtime the ledger describes the wreckage, not what stopped the run
- stdout carries `WP Codebox runtime crash detected (<id>): <message>` and `PHPUNIT_ZERO_TESTS cause=runtime_crashed`

## Scope

This does not make `mysqli_poll` work — that is upstream in wp-codebox / php.wasm. It implements the issue's stated fallback (*"fails closed with a named diagnostic"*) and both of the other two expectations: prompt termination, and a failure that names the crash.

## Tests

- `wordpress/tests/wp-codebox-runtime-crash-detector-smoke.mjs` — signature precision. Covers the exact #12617 text, the other wasm trap kinds, chunk-boundary splits, first-crash-wins, grace config parsing including the `0` opt-out. Pins six benign inputs that must **not** trip it, including a bare `php.wasm` frame and a PHP-level `Uncaught Error`.
- `wordpress/tests/wp-codebox-phpunit-runtime-crash-smoke.mjs` — end-to-end through `test-runner-wp-codebox.sh` with a CLI stub that emits the crash and then wedges. Asserts termination near the grace rather than the budget, the `runtime_crashed` diagnosis, `termination.result = "runtime_crash"`, and the projected `runtime_crash` object. Two controls: a clean run is not terminated early and keeps its own cause; a run that emits the signature but exits on its own is not pre-empted.

Verified red before the fix — with the adapter changes stashed, the end-to-end smoke fails on the elapsed-time assertion.

## Verification

```
node tests/wp-codebox-runtime-crash-detector-smoke.mjs      passed
node tests/wp-codebox-phpunit-runtime-crash-smoke.mjs       passed
node tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs   passed
node tests/wp-codebox-timeout-diagnostics-smoke.mjs         passed
node tests/wp-codebox-phpunit-timeout-diagnostics-smoke.mjs passed
node ../tests/extension-shape-lint.mjs                      passed (8 extensions)
wordpress/homeboy.json self_checks.lint (all 3)             passed
wordpress/homeboy.json self_checks.test                     passed except 6 pre-existing
eslint on all changed files                                 clean
```

The 6 exceptions are the `scripts/lint/*-smoke.sh` set, which fail locally with `HOMEBOY_RUNTIME_RUNNER_PRELUDE is required` — an environment dependency CI supplies. Same baseline as #2642, unrelated to this change.