### PR TITLE
fix(wordpress): replay assigned test shard manifests

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -28,6 +28,7 @@
       "bash tests/wordpress-install-command-smoke.sh",
       "bash tests/wordpress-release-artifact-version-smoke.sh",
       "bash tests/wordpress-runtime-helper-resolver-smoke.sh",
+      "bash wordpress/scripts/test/test-shard-replay-smoke.sh",
       "bash wordpress/tests/node-test-result-parser-smoke.sh",
       "node tests/wp-codebox-adapter-contract-smoke.mjs",
       "node tests/wp-codebox-callback-data-smoke.mjs",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -127,6 +127,7 @@
     "test:wp-codebox-database-service": "node tests/wp-codebox-database-service-smoke.mjs",
     "test:wp-codebox-native-database-canary": "node tests/wp-codebox-native-database-canary.mjs",
     "test:wp-codebox-doctor": "bash scripts/test/wp-codebox-doctor-smoke.sh",
+    "test:test-shard-replay": "bash scripts/test/test-shard-replay-smoke.sh",
     "test:extension-composer-vendor-integrity": "bash tests/extension-composer-vendor-integrity-smoke.sh",
     "test:wordpress-multisite-e2e-rig": "node rigs/wordpress-multisite-e2e/tests/contract.test.mjs",
     "test:wordpress-multisite-e2e-rig-integration": "node tests/wp-codebox-multisite-network-rig-integration.mjs",

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -72,6 +72,41 @@ homeboy_wordpress_parse_with_adapters() {
     shift || true
     local generic_adapters=()
 
+    if type homeboy_write_test_results >/dev/null 2>&1 \
+        && [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ] \
+        && [ -f "$HOMEBOY_TEST_SHARD_MANIFEST" ] \
+        && [ ! -L "$HOMEBOY_TEST_SHARD_MANIFEST" ]; then
+        local shard_summary
+        shard_summary="$(python3 - "$output_file" "$HOMEBOY_TEST_SHARD_MANIFEST" <<'PY'
+import json
+import re
+import sys
+
+try:
+    text = open(sys.argv[1], encoding="utf-8").read()
+    manifest = json.load(open(sys.argv[2], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    sys.exit(0)
+
+matches = re.findall(
+    r"^TEST_SHARD_SUMMARY:id=(shard-[1-9][0-9]*) selected=(\d+) routed=(\d+) status=passed$",
+    text,
+    flags=re.MULTILINE,
+)
+if matches:
+    shard_id, selected_raw, routed_raw = matches[-1]
+    selected, routed = int(selected_raw), int(routed_raw)
+    expected = len(manifest.get("tests", [])) if isinstance(manifest.get("tests"), list) else 0
+    if manifest.get("schema") == "homeboy/test-shard-manifest/v1" and manifest.get("id") == shard_id and selected > 0 and selected == routed == expected:
+        print(selected)
+PY
+)"
+        if [ -n "$shard_summary" ]; then
+            homeboy_write_test_results "$shard_summary" "$shard_summary" 0 0 "shard-membership"
+            return 0
+        fi
+    fi
+
     for adapter in "$@"; do
         if [ "$adapter" = "wp-codebox-json" ]; then
             if type homeboy_parse_wp_codebox_test_results >/dev/null 2>&1 && homeboy_parse_wp_codebox_test_results "$output_file"; then

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -260,6 +260,10 @@ if [ -z "$COMPONENT_SHAPE" ]; then
 fi
 
 if [ "$COMPONENT_SHAPE" = "core-dev" ]; then
+    if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ]; then
+        echo "ERROR: WordPress core-dev shard replay is unsupported; refusing to ignore HOMEBOY_TEST_SHARD_MANIFEST." >&2
+        exit 2
+    fi
     CORE_WORDPRESS_RUNTIME_RUNNER="$(homeboy_wordpress_core_runtime_runner)" || exit $?
     if [ -n "$TARGET_FILE" ]; then
         HOMEBOY_WORDPRESS_CORE_PHPUNIT_TEST_FILE="$TARGET_FILE" exec bash "$CORE_WORDPRESS_RUNTIME_RUNNER" "${PASSTHROUGH_ARGS[@]}"
@@ -797,6 +801,10 @@ if [ -n "$TARGET_HOST_SMOKE_FILE" ]; then
 fi
 
 if [ -z "$TARGET_FILE" ] && [ "${HOMEBOY_TEST_SCOPE_KIND:-}" = "exclusive_env" ]; then
+    if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ]; then
+        echo "ERROR: HOMEBOY_TEST_SHARD_MANIFEST is mutually exclusive with HOMEBOY_TEST_SCOPE_KIND=exclusive_env." >&2
+        exit 2
+    fi
     if [ "${HOMEBOY_TEST_SCOPE_ENV_NAME:-}" = "HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" ] && [ -n "${HOMEBOY_TEST_SCOPE_ENV_VALUE:-}" ]; then
         standalone_php_smoke_files=""
         wordpress_smoke_files=""
@@ -851,6 +859,125 @@ homeboy_wordpress_is_php_smoke_file() {
     esac
 }
 
+homeboy_wordpress_load_test_shard_manifest() {
+    local manifest_path="${HOMEBOY_TEST_SHARD_MANIFEST:-}"
+    local shard_id shard_tests test_file test_rel selected_count
+    local current_inventory current_runner current_workspace shard_canonical shard_fingerprint
+
+    [ -n "$manifest_path" ] || return 0
+
+    if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ] || [ -n "$TARGET_FILE" ] || [ -n "$TARGET_HOST_SMOKE_FILE" ] || [ "${#PASSTHROUGH_ARGS[@]}" -gt 0 ]; then
+        echo "ERROR: HOMEBOY_TEST_SHARD_MANIFEST is mutually exclusive with other test selectors and passthrough arguments." >&2
+        return 2
+    fi
+    if [ ! -f "$manifest_path" ] || [ -L "$manifest_path" ]; then
+        echo "ERROR: WordPress test shard manifest must be a readable non-symlink file: ${manifest_path}" >&2
+        return 2
+    fi
+
+    shard_id="$(jq -er '
+        def hex_digest: type == "string" and test("^[0-9a-f]{64}$");
+        def valid_test_path:
+            type == "string"
+            and length > 0
+            and (startswith("/") | not)
+            and (contains("\\") | not)
+            and (split("/") | index("..") | not)
+            and (test("[[:cntrl:]]") | not);
+        if type != "object" then error("manifest must be an object")
+        elif .schema != "homeboy/test-shard-manifest/v1" then error("unsupported schema")
+        elif (.id | type) != "string" or (.id | test("^shard-[1-9][0-9]*$") | not) then error("invalid shard id")
+        elif .runner != "wordpress" then error("runner must be wordpress")
+        elif (.runner_fingerprint | hex_digest | not) then error("invalid runner fingerprint")
+        elif (.workspace_fingerprint | hex_digest | not) then error("invalid workspace fingerprint")
+        elif (.inventory_fingerprint | hex_digest | not) then error("invalid inventory fingerprint")
+        elif (.tests | type) != "array" or (.tests | length) == 0 then error("tests must be a non-empty array")
+        elif (.tests | all(valid_test_path) | not) then error("tests contain an invalid path")
+        elif (.tests | unique | length) != (.tests | length) then error("tests contain duplicate paths")
+        else .id end
+    ' "$manifest_path")" || {
+        echo "ERROR: invalid WordPress test shard manifest: ${manifest_path}" >&2
+        return 2
+    }
+    shard_tests="$(jq -er '.tests[]' "$manifest_path")" || {
+        echo "ERROR: could not read assigned tests from WordPress shard ${shard_id}." >&2
+        return 2
+    }
+
+    current_inventory="$(mktemp)" || return 1
+    if ! python3 "${SCRIPT_DIR}/test-inventory.py" \
+        --project "$PLUGIN_PATH" \
+        --extension-path "$EXTENSION_PATH" \
+        --runner wordpress \
+        --package "${HOMEBOY_COMPONENT_ID:-wordpress}" \
+        --output "$current_inventory" >/dev/null; then
+        rm -f "$current_inventory"
+        echo "ERROR: could not regenerate the current WordPress test inventory for shard validation." >&2
+        return 2
+    fi
+
+    current_runner="$(jq -r '.runner_fingerprint' "$current_inventory")"
+    current_workspace="$(jq -r '.workspace_fingerprint' "$current_inventory")"
+    if [ "$current_runner" != "$(jq -r '.runner_fingerprint' "$manifest_path")" ] \
+        || [ "$current_workspace" != "$(jq -r '.workspace_fingerprint' "$manifest_path")" ]; then
+        rm -f "$current_inventory"
+        echo "ERROR: WordPress shard ${shard_id} is stale for the current runner or workspace." >&2
+        return 2
+    fi
+    if ! jq -e --slurpfile manifest "$manifest_path" '
+        (.tests | map(.id)) as $inventory_ids
+        | all($manifest[0].tests[]; . as $id | $inventory_ids | index($id) != null)
+    ' "$current_inventory" >/dev/null; then
+        rm -f "$current_inventory"
+        echo "ERROR: WordPress shard ${shard_id} contains a test outside the current inventory." >&2
+        return 2
+    fi
+    shard_canonical="$(jq -cS --slurpfile manifest "$manifest_path" '
+        ($manifest[0].tests | reduce .[] as $test_id ({}; .[$test_id] = true)) as $selected
+        | {schema,runner,runner_fingerprint,workspace_fingerprint,tests:(.tests | map(select($selected[.id])) | sort_by(.id))}
+    ' "$current_inventory")"
+    rm -f "$current_inventory"
+    if command -v sha256sum >/dev/null 2>&1; then
+        shard_fingerprint="$(printf '%s' "$shard_canonical" | sha256sum | cut -d ' ' -f 1)"
+    elif command -v shasum >/dev/null 2>&1; then
+        shard_fingerprint="$(printf '%s' "$shard_canonical" | shasum -a 256 | cut -d ' ' -f 1)"
+    else
+        echo "ERROR: WordPress shard validation requires sha256sum or shasum." >&2
+        return 2
+    fi
+    if [ "$shard_fingerprint" != "$(jq -r '.inventory_fingerprint' "$manifest_path")" ]; then
+        echo "ERROR: WordPress shard ${shard_id} inventory fingerprint does not match its assigned tests." >&2
+        return 2
+    fi
+
+    selected_count=0
+    while IFS= read -r test_file; do
+        [ -n "$test_file" ] || continue
+        selected_count=$((selected_count + 1))
+        if ! test_rel="$(homeboy_wordpress_rel_test_file "$test_file")"; then
+            echo "ERROR: WordPress shard ${shard_id} assigned a missing or out-of-component test: ${test_file}" >&2
+            return 2
+        fi
+        if ! homeboy_wordpress_is_js_smoke_file "$test_rel" \
+            && ! homeboy_wordpress_is_shell_smoke_file "$test_rel" \
+            && ! homeboy_wordpress_is_node_test_file "$test_rel" \
+            && ! homeboy_wordpress_is_php_smoke_file "$test_rel" \
+            && ! homeboy_wordpress_is_phpunit_test_file "$test_rel"; then
+            echo "ERROR: WordPress shard ${shard_id} assigned an unroutable test: ${test_rel}" >&2
+            return 2
+        fi
+    done <<< "$shard_tests"
+
+    [ "$selected_count" -gt 0 ] || {
+        echo "ERROR: WordPress shard ${shard_id} selected no tests." >&2
+        return 2
+    }
+
+    export HOMEBOY_WORDPRESS_SHARD_TEST_FILES="$shard_tests"
+    export HOMEBOY_WORDPRESS_SHARD_ID="$shard_id"
+    echo "TEST_SHARD_MANIFEST:id=${shard_id} selected=${selected_count}"
+}
+
 # Dispatch host PHP smokes exactly the way the exclusive_env scope above does:
 # the manifest decides which need a booted WordPress and which are standalone.
 homeboy_wordpress_run_php_smoke_files() {
@@ -878,6 +1005,75 @@ homeboy_wordpress_run_php_smoke_files() {
     fi
     return "$status"
 }
+
+homeboy_wordpress_replay_test_shard() {
+    local test_file test_rel
+    local js_smoke_files=""
+    local shell_smoke_files=""
+    local node_test_files=""
+    local php_smoke_files=""
+    local phpunit_files=""
+    local selected=0
+    local routed=0
+
+    while IFS= read -r test_file; do
+        [ -n "$test_file" ] || continue
+        selected=$((selected + 1))
+        test_rel="$(homeboy_wordpress_rel_test_file "$test_file")" || return 2
+        if homeboy_wordpress_is_js_smoke_file "$test_rel"; then
+            js_smoke_files+="${js_smoke_files:+$'\n'}${test_rel}"
+            echo "TEST_SHARD_ROUTE:${test_rel}:runner=host-js-smoke"
+        elif homeboy_wordpress_is_shell_smoke_file "$test_rel"; then
+            shell_smoke_files+="${shell_smoke_files:+$'\n'}${test_rel}"
+            echo "TEST_SHARD_ROUTE:${test_rel}:runner=host-shell-smoke"
+        elif homeboy_wordpress_is_node_test_file "$test_rel"; then
+            node_test_files+="${node_test_files:+$'\n'}${test_rel}"
+            echo "TEST_SHARD_ROUTE:${test_rel}:runner=node-test"
+        elif homeboy_wordpress_is_php_smoke_file "$test_rel"; then
+            php_smoke_files+="${php_smoke_files:+$'\n'}${test_rel}"
+            echo "TEST_SHARD_ROUTE:${test_rel}:runner=host-php-smoke"
+        elif homeboy_wordpress_is_phpunit_test_file "$test_rel"; then
+            phpunit_files+="${phpunit_files:+$'\n'}${test_rel}"
+            echo "TEST_SHARD_ROUTE:${test_rel}:runner=phpunit"
+        else
+            echo "ERROR: WordPress shard ${HOMEBOY_WORDPRESS_SHARD_ID} could not route ${test_rel}." >&2
+            return 2
+        fi
+        routed=$((routed + 1))
+    done <<< "$HOMEBOY_WORDPRESS_SHARD_TEST_FILES"
+
+    [ -z "$js_smoke_files" ] || homeboy_wordpress_run_js_smoke_files "$js_smoke_files" || return $?
+    [ -z "$shell_smoke_files" ] || homeboy_wordpress_run_shell_smoke_files "$shell_smoke_files" || return $?
+    [ -z "$node_test_files" ] || homeboy_wordpress_run_js_unit_test_files "$node_test_files" || return $?
+    [ -z "$php_smoke_files" ] || homeboy_wordpress_run_php_smoke_files "$php_smoke_files" || return $?
+    if [ -n "$phpunit_files" ]; then
+        export HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES="$phpunit_files"
+        WORDPRESS_RUNTIME_RUNNER="$(homeboy_wordpress_runtime_runner)" || return $?
+        bash "$WORDPRESS_RUNTIME_RUNNER" "${PASSTHROUGH_ARGS[@]}" || return $?
+    fi
+
+    [ "$selected" -eq "$routed" ] || {
+        echo "ERROR: WordPress shard ${HOMEBOY_WORDPRESS_SHARD_ID} routed ${routed} of ${selected} assigned tests." >&2
+        return 2
+    }
+    echo "TEST_SHARD_SUMMARY:id=${HOMEBOY_WORDPRESS_SHARD_ID} selected=${selected} routed=${routed} status=passed"
+    if ! type homeboy_write_test_results >/dev/null 2>&1 && [ -n "${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}" ] && [ -f "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS" ]; then
+        # shellcheck source=/dev/null
+        source "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS"
+    fi
+    if type homeboy_write_test_results >/dev/null 2>&1; then
+        homeboy_write_test_results "$selected" "$selected" 0 0 "shard-membership"
+    elif [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+        echo "ERROR: WordPress shard result normalization cannot write HOMEBOY_TEST_RESULTS_FILE." >&2
+        return 2
+    fi
+}
+
+if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ]; then
+    homeboy_wordpress_load_test_shard_manifest || exit $?
+    homeboy_wordpress_replay_test_shard || exit $?
+    exit 0
+fi
 
 if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     changed_js_smoke_files=""

--- a/wordpress/scripts/test/test-shard-replay-smoke.sh
+++ b/wordpress/scripts/test/test-shard-replay-smoke.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression: homeboy-extensions#2644. WordPress inventories were split into
+# immutable manifests, but replay ignored the manifest and ran the full suite.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+assert_contains() {
+    grep -Fq -- "$2" "$1" || fail "expected $1 to contain: $2"
+}
+
+assert_not_contains() {
+    if grep -Fq -- "$2" "$1"; then
+        fail "expected $1 not to contain: $2"
+    fi
+}
+
+component="${WORKDIR}/component"
+mkdir -p "${component}/tests/Unit" "${WORKDIR}/stubs"
+
+jq -e '
+    .test.portable_env.keys as $keys
+    | all(["HOMEBOY_TEST_INVENTORY_ONLY", "HOMEBOY_TEST_INVENTORY_FILE", "HOMEBOY_TEST_SHARD_MANIFEST"][]; . as $key | $keys | index($key) != null)
+' "${EXTENSION_PATH}/wordpress.json" >/dev/null || fail 'wordpress.json does not preserve the shard selection environment'
+
+printf '<?php\nclass AlphaTest extends PHPUnit\\Framework\\TestCase {}\n' > "${component}/tests/Unit/AlphaTest.php"
+printf '<?php\nclass BetaTest extends PHPUnit\\Framework\\TestCase {}\n' > "${component}/tests/Unit/BetaTest.php"
+printf '<?php\necho "standalone smoke ran\\n";\n' > "${component}/tests/standalone-smoke.php"
+printf '<?php\necho "wordpress smoke ran\\n";\n' > "${component}/tests/wordpress-smoke.php"
+printf 'console.log("js smoke ran");\n' > "${component}/tests/browser-smoke.js"
+printf 'import test from "node:test";\ntest("node shard", () => console.log("node test ran"));\n' > "${component}/tests/worker.test.mjs"
+printf '#!/usr/bin/env bash\necho "shell smoke ran"\n' > "${component}/tests/contract-smoke.sh"
+chmod +x "${component}/tests/contract-smoke.sh"
+cat > "${component}/homeboy-test-manifest.json" <<'JSON'
+{
+  "schema": "homeboy/test-manifest/v1",
+  "tests": {
+    "tests/standalone-smoke.php": { "environment": "standalone-php" },
+    "tests/wordpress-smoke.php": { "environment": "wordpress" }
+  }
+}
+JSON
+
+runner_prelude="${WORKDIR}/runner-prelude.sh"
+cat > "$runner_prelude" <<'SH'
+homeboy_runner_init() {
+    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:?HOMEBOY_COMPONENT_PATH is required}"
+    PLUGIN_PATH="$COMPONENT_PATH"
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:?HOMEBOY_EXTENSION_PATH is required}"
+}
+SH
+
+cat > "${WORKDIR}/stubs/wp-codebox.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'PHPUNIT_CHANGED=%s\n' "${HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES:-}"
+while IFS= read -r test_file; do
+    [ -z "$test_file" ] || printf 'PHPUNIT_EXECUTED:%s\n' "$test_file"
+done <<< "${HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES:-}"
+SH
+chmod +x "${WORKDIR}/stubs/wp-codebox.sh"
+
+cat > "${WORKDIR}/stubs/host-smoke-wp.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r test_file; do
+    [ -z "$test_file" ] || printf 'HOST_SMOKE_OK:%s\n' "$test_file"
+done <<< "${HOMEBOY_WORDPRESS_HOST_SMOKE_FILES:-}"
+SH
+chmod +x "${WORKDIR}/stubs/host-smoke-wp.sh"
+
+cat > "${WORKDIR}/write-test-results.sh" <<'SH'
+homeboy_write_test_results() {
+    jq -n --argjson total "$1" --argjson passed "$2" --argjson failed "$3" --argjson skipped "$4" --arg partial "${5:-}" \
+        '{total:$total,passed:$passed,failed:$failed,skipped:$skipped,partial:$partial}' > "$HOMEBOY_TEST_RESULTS_FILE"
+}
+SH
+
+inventory="${WORKDIR}/inventory.json"
+python3 "${EXTENSION_PATH}/scripts/test/test-inventory.py" \
+    --project "$component" \
+    --extension-path "$EXTENSION_PATH" \
+    --runner wordpress \
+    --package component \
+    --output "$inventory" >/dev/null
+
+write_manifest() {
+    local target="$1" id="$2" tests_json canonical fingerprint
+    shift 2
+    tests_json="$(printf '%s\n' "$@" | jq -R . | jq -s .)"
+    canonical="$(jq -cS --argjson tests "$tests_json" '
+        ($tests | reduce .[] as $test_id ({}; .[$test_id] = true)) as $selected
+        | {schema,runner,runner_fingerprint,workspace_fingerprint,tests:(.tests | map(select($selected[.id])) | sort_by(.id))}
+    ' "$inventory")"
+    fingerprint="$(printf '%s' "$canonical" | sha256sum | cut -d ' ' -f 1)"
+    jq -cn --arg id "$id" --argjson tests "$tests_json" --arg fingerprint "$fingerprint" --slurpfile inventory "$inventory" \
+        '{schema:"homeboy/test-shard-manifest/v1",id:$id,runner:$inventory[0].runner,runner_fingerprint:$inventory[0].runner_fingerprint,workspace_fingerprint:$inventory[0].workspace_fingerprint,inventory_fingerprint:$fingerprint,tests:$tests}' > "$target"
+}
+
+run_manifest() {
+    local manifest="$1"
+    local output="$2"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+    HOMEBOY_COMPONENT_ID="component" \
+    HOMEBOY_COMPONENT_PATH="$component" \
+    HOMEBOY_COMPONENT_SHAPE="plugin" \
+    HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE_WP="${WORKDIR}/stubs/host-smoke-wp.sh" \
+    HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${WORKDIR}/stubs/wp-codebox.sh" \
+    HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${WORKDIR}/write-test-results.sh" \
+    HOMEBOY_TEST_RESULTS_FILE="${output}.results.json" \
+    HOMEBOY_TEST_SHARD_MANIFEST="$manifest" \
+        bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "$output" 2>&1
+}
+
+first="${WORKDIR}/shard-1.json"
+second="${WORKDIR}/shard-2.json"
+write_manifest "$first" shard-1 tests/Unit/AlphaTest.php tests/standalone-smoke.php tests/wordpress-smoke.php tests/browser-smoke.js tests/worker.test.mjs tests/contract-smoke.sh
+write_manifest "$second" shard-2 tests/Unit/BetaTest.php
+
+run_manifest "$first" "${WORKDIR}/first.out"
+assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_MANIFEST:id=shard-1 selected=6'
+assert_contains "${WORKDIR}/first.out" 'PHP_SMOKE_OK:tests/standalone-smoke.php'
+assert_contains "${WORKDIR}/first.out" 'HOST_SMOKE_OK:tests/wordpress-smoke.php'
+assert_contains "${WORKDIR}/first.out" 'js smoke ran'
+assert_contains "${WORKDIR}/first.out" 'node test ran'
+assert_contains "${WORKDIR}/first.out" 'shell smoke ran'
+assert_contains "${WORKDIR}/first.out" 'PHPUNIT_CHANGED=tests/Unit/AlphaTest.php'
+assert_contains "${WORKDIR}/first.out" 'PHPUNIT_EXECUTED:tests/Unit/AlphaTest.php'
+assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_SUMMARY:id=shard-1 selected=6 routed=6 status=passed'
+if [ "$(jq -r '.total' "${WORKDIR}/first.out.results.json")" -ne 6 ]; then
+    fail 'shard result sidecar does not match first manifest membership'
+fi
+assert_not_contains "${WORKDIR}/first.out" 'BetaTest.php'
+
+run_manifest "$second" "${WORKDIR}/second.out"
+assert_contains "${WORKDIR}/second.out" 'TEST_SHARD_MANIFEST:id=shard-2 selected=1'
+assert_contains "${WORKDIR}/second.out" 'PHPUNIT_CHANGED=tests/Unit/BetaTest.php'
+assert_contains "${WORKDIR}/second.out" 'PHPUNIT_EXECUTED:tests/Unit/BetaTest.php'
+assert_contains "${WORKDIR}/second.out" 'TEST_SHARD_SUMMARY:id=shard-2 selected=1 routed=1 status=passed'
+if [ "$(jq -r '.total' "${WORKDIR}/second.out.results.json")" -ne 1 ]; then
+    fail 'shard result sidecar does not match second manifest membership'
+fi
+assert_not_contains "${WORKDIR}/second.out" 'AlphaTest.php'
+assert_not_contains "${WORKDIR}/second.out" 'standalone smoke ran'
+
+HOMEBOY_TEST_SHARD_MANIFEST="$first" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${WORKDIR}/write-test-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="${WORKDIR}/parsed-results.json" \
+    bash "${EXTENSION_PATH}/scripts/test/parse-test-results.sh" "${WORKDIR}/first.out"
+if [ "$(jq -r '.total' "${WORKDIR}/parsed-results.json")" -ne 6 ]; then
+    fail 'result parser does not recover validated shard membership'
+fi
+
+malformed="${WORKDIR}/malformed.json"
+printf '{"schema":"wrong","tests":["tests/Unit/AlphaTest.php"]}\n' > "$malformed"
+if run_manifest "$malformed" "${WORKDIR}/malformed.out"; then
+    fail 'malformed shard manifest was accepted'
+fi
+assert_contains "${WORKDIR}/malformed.out" 'ERROR: invalid WordPress test shard manifest'
+assert_not_contains "${WORKDIR}/malformed.out" 'PHPUNIT_CHANGED='
+
+stale="${WORKDIR}/stale.json"
+jq '.workspace_fingerprint = ("d" * 64)' "$first" > "$stale"
+if run_manifest "$stale" "${WORKDIR}/stale.out"; then
+    fail 'stale shard manifest was accepted'
+fi
+assert_contains "${WORKDIR}/stale.out" 'is stale for the current runner or workspace'
+assert_not_contains "${WORKDIR}/stale.out" 'PHPUNIT_EXECUTED:'
+
+missing="${WORKDIR}/missing.json"
+write_manifest "$missing" shard-3 tests/Unit/MissingTest.php
+if run_manifest "$missing" "${WORKDIR}/missing.out"; then
+    fail 'missing shard assignment was accepted'
+fi
+assert_contains "${WORKDIR}/missing.out" 'contains a test outside the current inventory'
+assert_not_contains "${WORKDIR}/missing.out" 'PHPUNIT_CHANGED='
+
+if HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+    HOMEBOY_COMPONENT_ID="component" \
+    HOMEBOY_COMPONENT_PATH="$component" \
+    HOMEBOY_COMPONENT_SHAPE="plugin" \
+    HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${WORKDIR}/stubs/wp-codebox.sh" \
+    HOMEBOY_TEST_SHARD_MANIFEST="$first" \
+    HOMEBOY_CHANGED_TEST_FILES="tests/Unit/BetaTest.php" \
+        bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${WORKDIR}/collision.out" 2>&1; then
+    fail 'shard and changed-test selectors were accepted together'
+fi
+assert_contains "${WORKDIR}/collision.out" 'is mutually exclusive with other test selectors and passthrough arguments'
+
+if HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+    HOMEBOY_COMPONENT_ID="component" \
+    HOMEBOY_COMPONENT_PATH="$component" \
+    HOMEBOY_COMPONENT_SHAPE="plugin" \
+    HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${WORKDIR}/stubs/wp-codebox.sh" \
+    HOMEBOY_TEST_SHARD_MANIFEST="$first" \
+        bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --filter Alpha > "${WORKDIR}/passthrough.out" 2>&1; then
+    fail 'passthrough filter altered immutable shard replay'
+fi
+assert_contains "${WORKDIR}/passthrough.out" 'is mutually exclusive with other test selectors and passthrough arguments'
+
+if HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+    HOMEBOY_COMPONENT_ID="component" \
+    HOMEBOY_COMPONENT_PATH="$component" \
+    HOMEBOY_COMPONENT_SHAPE="plugin" \
+    HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${WORKDIR}/stubs/wp-codebox.sh" \
+    HOMEBOY_TEST_SHARD_MANIFEST="$first" \
+    HOMEBOY_TEST_SCOPE_KIND="exclusive_env" \
+    HOMEBOY_TEST_SCOPE_ENV_NAME="HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" \
+    HOMEBOY_TEST_SCOPE_ENV_VALUE="tests/standalone-smoke.php" \
+        bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${WORKDIR}/exclusive.out" 2>&1; then
+    fail 'exclusive scope bypassed the shard manifest'
+fi
+assert_contains "${WORKDIR}/exclusive.out" 'is mutually exclusive with HOMEBOY_TEST_SCOPE_KIND=exclusive_env'
+assert_not_contains "${WORKDIR}/exclusive.out" 'standalone smoke ran'
+
+printf 'All WordPress test shard replay checks passed.\n'

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1047,6 +1047,13 @@
     ]
   },
   "test": {
+    "portable_env": {
+      "keys": [
+        "HOMEBOY_TEST_INVENTORY_ONLY",
+        "HOMEBOY_TEST_INVENTORY_FILE",
+        "HOMEBOY_TEST_SHARD_MANIFEST"
+      ]
+    },
     "result_parse": {
       "extension_script": "scripts/test/parse-test-results.sh",
       "adapters": ["wp-codebox-json", "node-test"]


### PR DESCRIPTION
## Summary

- Preserve the immutable shard manifest environment through the WordPress extension boundary.
- Validate manifests against the current runner, workspace, and exact inventory subset before execution.
- Replay every assigned PHP smoke, WordPress smoke, JS, shell, Node, and PHPUnit path exactly once through its existing runner.
- Normalize successful structured results to validated manifest membership so Homeboy Action can reconcile complete shard coverage.
- Fail closed on stale, forged, malformed, missing, duplicate, conflicting, core-dev, or passthrough-filtered shard requests.

Closes #2644.

Consumer blocker: Extra-Chill/data-machine#2850.

## Verification

- `npm run test:test-shard-replay`
- `bash wordpress/scripts/test/changed-scope-test-routing-smoke.sh`
- `bash wordpress/scripts/test/test-inventory-smoke.sh`
- `node tests/extension-shape-lint.mjs`
- `node tests/extension-shape-lint-toolchain-probes.test.mjs`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/parse-test-results.sh wordpress/scripts/test/test-shard-replay-smoke.sh`
- `jq empty homeboy.json wordpress/wordpress.json wordpress/package.json`
- `git diff --check`

Repository-wide `npm run lint:js` remains red on 53 pre-existing errors in untouched JavaScript files. No changed JavaScript files are included here.

## AI assistance

- **Model:** GPT-5.6 Sol
- **Tools:** OpenCode and Homeboy
- **Used for:** Root-cause analysis, implementation, review, and verification. Chris Huber remains responsible for every line.