### PR TITLE
fix(wordpress): preserve explicit smoke test scope

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -124,22 +124,23 @@ Available factories from the WordPress test framework: `user`, `post`,
 ### Real-WordPress host smokes
 
 Standalone smoke files matching `tests/**/*-smoke.php` are diagnostic/operator
-targets, not default release gates. A component can declare each file's required
-environment in a root `homeboy-test-manifest.json`:
+targets, not default release gates. A component can declare a default and exact
+per-file environment overrides in a root `homeboy-test-manifest.json`:
 
 ```json
 {
   "schema": "homeboy/test-manifest/v1",
+  "default_environment": "standalone-php",
   "tests": {
-    "tests/contract-smoke.php": { "environment": "standalone-php" },
     "tests/runtime-smoke.php": { "environment": "wordpress" }
   }
 }
 ```
 
 `standalone-php` files run directly with PHP, while `wordpress` files are
-mounted with the component and executed via `wordpress.run-php`. Undeclared
-PHP smokes default to `wordpress`, preserving the existing runtime behavior.
+mounted with the component and executed via `wordpress.run-php`. An exact
+`tests` entry overrides `default_environment`. Omitting `default_environment`
+keeps the existing `wordpress` default.
 
 To rerun one existing smoke on demand before pushing:
 

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -68,19 +68,22 @@ rejected with a clear error.
 ## Real-WordPress host smokes
 
 Standalone PHP smoke files can live under `tests/**/*-smoke.php`. They are
-diagnostic/operator targets, not default release gates. Declare each smoke's
-environment in a root `homeboy-test-manifest.json` using schema
-`homeboy/test-manifest/v1`. Its `tests` object maps exact test paths to an
-`environment` of `standalone-php` or `wordpress`. Undeclared PHP smokes default
-to `wordpress`. `standalone-php` scripts run directly with PHP; `wordpress`
-scripts use the selected runtime backend with component mounts, dependency
-mounts, drop-in handling, WordPress version selection, and `wordpress.run-php`:
+diagnostic/operator targets, not default release gates. Declare smoke
+environments in a root `homeboy-test-manifest.json` using schema
+`homeboy/test-manifest/v1`. `default_environment` applies to undeclared files,
+and the `tests` object maps exact test paths to overrides. Both accept
+`standalone-php` or `wordpress`; omitting `default_environment` preserves the
+`wordpress` default. `standalone-php` scripts run directly with PHP;
+`wordpress` scripts use the selected runtime backend with component mounts,
+dependency mounts, drop-in handling, WordPress version selection, and
+`wordpress.run-php`:
 
 ```json
 {
   "schema": "homeboy/test-manifest/v1",
+  "default_environment": "standalone-php",
   "tests": {
-    "tests/contract-smoke.php": { "environment": "standalone-php" }
+    "tests/runtime-smoke.php": { "environment": "wordpress" }
   }
 }
 ```

--- a/wordpress/scripts/test/test-inventory-smoke.sh
+++ b/wordpress/scripts/test/test-inventory-smoke.sh
@@ -14,9 +14,9 @@ set -euo pipefail
 #     `json.dumps(record_without_that_key, sort_keys=True, separators=(",",":"))`,
 #     which is the byte layout core reproduces by hand.
 #
-# Enumeration must also match what the runner would actually execute. A file the
-# runner cannot route must not appear, or a shard would claim a test that never
-# runs and the aggregate totals would not reconcile.
+# Enumeration must also match the runner's default release gates. Explicit
+# diagnostic smoke targets must not become required checks merely because the
+# suite is sharded.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -44,7 +44,7 @@ homeboy_runner_init() {
 }
 SH
 
-# Routable by the runner: host PHP smoke, JS smoke, shell smoke, node test, PHPUnit.
+# Explicit diagnostic smokes remain routable, but are not release-gate inventory.
 printf '<?php\n' > "${plugin}/tests/alpha-smoke.php"
 printf '<?php\n' > "${plugin}/tests/nested/beta-smoke.php"
 printf '// js\n'  > "${plugin}/tests/gamma-smoke.js"
@@ -93,10 +93,6 @@ ids = [t["id"] for t in doc["tests"]]
 assert len(ids) == len(set(ids)), "test ids must be unique"
 
 expected = {
-    "tests/alpha-smoke.php": ("smoke", "host-php-smoke"),
-    "tests/nested/beta-smoke.php": ("smoke", "host-php-smoke"),
-    "tests/gamma-smoke.js": ("smoke", "host-js-smoke"),
-    "tests/delta-smoke.sh": ("smoke", "host-shell-smoke"),
     "tests/epsilon.test.js": ("test", "node-test"),
     "tests/ZetaTest.php": ("test", "phpunit"),
     "tests/test-eta.php": ("test", "phpunit"),

--- a/wordpress/scripts/test/test-inventory-smoke.sh
+++ b/wordpress/scripts/test/test-inventory-smoke.sh
@@ -56,6 +56,7 @@ printf '<?php\n'  > "${plugin}/tests/test-eta.php"
 # Not routable, and must not be enumerated: a fixture, a support file, and
 # anything inside a skipped directory.
 printf '<?php\n' > "${plugin}/tests/fixture-data.php"
+printf '<?php\n' > "${plugin}/tests/nested/test-helper.php"
 printf '<?php\n' > "${plugin}/vendor/pkg/tests/vendor-smoke.php"
 printf '// dep\n' > "${plugin}/node_modules/x/dep-smoke.js"
 

--- a/wordpress/scripts/test/test-inventory.py
+++ b/wordpress/scripts/test/test-inventory.py
@@ -154,7 +154,10 @@ def classify(relative):
     for suffix in (".test.js", ".test.cjs", ".test.mjs", ".test.jsx", ".test.ts", ".test.tsx"):
         if name.endswith(suffix):
             return "test", "node-test"
-    if name.endswith("Test.php") or name.startswith("test-") and name.endswith(".php"):
+    root_test_prefix = relative.startswith("tests/test-") or relative.startswith(
+        "wordpress/tests/test-"
+    )
+    if name.endswith("Test.php") or (root_test_prefix and name.endswith(".php")):
         return "test", "phpunit"
     return None
 

--- a/wordpress/scripts/test/test-inventory.py
+++ b/wordpress/scripts/test/test-inventory.py
@@ -147,12 +147,10 @@ def classify(relative):
     name = relative.rsplit("/", 1)[-1]
     in_tests = within_tests_tree(relative)
 
-    if in_tests and name.endswith("-smoke.php"):
-        return "smoke", "host-php-smoke"
-    if in_tests and name.endswith("-smoke.js"):
-        return "smoke", "host-js-smoke"
-    if in_tests and name.endswith("-smoke.sh"):
-        return "smoke", "host-shell-smoke"
+    # Smoke scripts are explicit diagnostic/operator targets, not default
+    # release gates. Changed-scope and --file routing still execute them.
+    if in_tests and name.endswith(("-smoke.php", "-smoke.js", "-smoke.sh")):
+        return None
     for suffix in (".test.js", ".test.cjs", ".test.mjs", ".test.jsx", ".test.ts", ".test.tsx"):
         if name.endswith(suffix):
             return "test", "node-test"

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -310,10 +310,8 @@ assert_not_contains "${TMPDIR}/smoke-file.out" "WP_CODEBOX_STUB"
 cat > "${component}/homeboy-test-manifest.json" <<'JSON'
 {
   "schema": "homeboy/test-manifest/v1",
+  "default_environment": "standalone-php",
   "tests": {
-    "tests/import-agent-ability-smoke.php": {
-      "environment": "standalone-php"
-    },
     "tests/queue-routing-smoke.php": {
       "environment": "wordpress"
     }

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -110,7 +110,8 @@ homeboy_wordpress_test_environment() {
         elif (.tests | type) != "object" then
             error("expected tests object")
         else
-            (.tests[$testFile].environment // "wordpress") as $environment
+            (.default_environment // "wordpress") as $defaultEnvironment
+            | (.tests[$testFile].environment // $defaultEnvironment) as $environment
             | if $environment == "wordpress" or $environment == "standalone-php" then
                 $environment
             else

--- a/wordpress/scripts/test/test-shard-replay-smoke.sh
+++ b/wordpress/scripts/test/test-shard-replay-smoke.sh
@@ -34,21 +34,7 @@ jq -e '
 
 printf '<?php\nclass AlphaTest extends PHPUnit\\Framework\\TestCase {}\n' > "${component}/tests/Unit/AlphaTest.php"
 printf '<?php\nclass BetaTest extends PHPUnit\\Framework\\TestCase {}\n' > "${component}/tests/Unit/BetaTest.php"
-printf '<?php\necho "standalone smoke ran\\n";\n' > "${component}/tests/standalone-smoke.php"
-printf '<?php\necho "wordpress smoke ran\\n";\n' > "${component}/tests/wordpress-smoke.php"
-printf 'console.log("js smoke ran");\n' > "${component}/tests/browser-smoke.js"
 printf 'import test from "node:test";\ntest("node shard", () => console.log("node test ran"));\n' > "${component}/tests/worker.test.mjs"
-printf '#!/usr/bin/env bash\necho "shell smoke ran"\n' > "${component}/tests/contract-smoke.sh"
-chmod +x "${component}/tests/contract-smoke.sh"
-cat > "${component}/homeboy-test-manifest.json" <<'JSON'
-{
-  "schema": "homeboy/test-manifest/v1",
-  "tests": {
-    "tests/standalone-smoke.php": { "environment": "standalone-php" },
-    "tests/wordpress-smoke.php": { "environment": "wordpress" }
-  }
-}
-JSON
 
 runner_prelude="${WORKDIR}/runner-prelude.sh"
 cat > "$runner_prelude" <<'SH'
@@ -124,20 +110,16 @@ run_manifest() {
 
 first="${WORKDIR}/shard-1.json"
 second="${WORKDIR}/shard-2.json"
-write_manifest "$first" shard-1 tests/Unit/AlphaTest.php tests/standalone-smoke.php tests/wordpress-smoke.php tests/browser-smoke.js tests/worker.test.mjs tests/contract-smoke.sh
+write_manifest "$first" shard-1 tests/Unit/AlphaTest.php tests/worker.test.mjs
 write_manifest "$second" shard-2 tests/Unit/BetaTest.php
 
 run_manifest "$first" "${WORKDIR}/first.out"
-assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_MANIFEST:id=shard-1 selected=6'
-assert_contains "${WORKDIR}/first.out" 'PHP_SMOKE_OK:tests/standalone-smoke.php'
-assert_contains "${WORKDIR}/first.out" 'HOST_SMOKE_OK:tests/wordpress-smoke.php'
-assert_contains "${WORKDIR}/first.out" 'js smoke ran'
+assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_MANIFEST:id=shard-1 selected=2'
 assert_contains "${WORKDIR}/first.out" 'node test ran'
-assert_contains "${WORKDIR}/first.out" 'shell smoke ran'
 assert_contains "${WORKDIR}/first.out" 'PHPUNIT_CHANGED=tests/Unit/AlphaTest.php'
 assert_contains "${WORKDIR}/first.out" 'PHPUNIT_EXECUTED:tests/Unit/AlphaTest.php'
-assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_SUMMARY:id=shard-1 selected=6 routed=6 status=passed'
-if [ "$(jq -r '.total' "${WORKDIR}/first.out.results.json")" -ne 6 ]; then
+assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_SUMMARY:id=shard-1 selected=2 routed=2 status=passed'
+if [ "$(jq -r '.total' "${WORKDIR}/first.out.results.json")" -ne 2 ]; then
     fail 'shard result sidecar does not match first manifest membership'
 fi
 assert_not_contains "${WORKDIR}/first.out" 'BetaTest.php'
@@ -157,7 +139,7 @@ HOMEBOY_TEST_SHARD_MANIFEST="$first" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${WORKDIR}/write-test-results.sh" \
 HOMEBOY_TEST_RESULTS_FILE="${WORKDIR}/parsed-results.json" \
     bash "${EXTENSION_PATH}/scripts/test/parse-test-results.sh" "${WORKDIR}/first.out"
-if [ "$(jq -r '.total' "${WORKDIR}/parsed-results.json")" -ne 6 ]; then
+if [ "$(jq -r '.total' "${WORKDIR}/parsed-results.json")" -ne 2 ]; then
     fail 'result parser does not recover validated shard membership'
 fi
 
@@ -219,11 +201,11 @@ if HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
     HOMEBOY_TEST_SHARD_MANIFEST="$first" \
     HOMEBOY_TEST_SCOPE_KIND="exclusive_env" \
     HOMEBOY_TEST_SCOPE_ENV_NAME="HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" \
-    HOMEBOY_TEST_SCOPE_ENV_VALUE="tests/standalone-smoke.php" \
+    HOMEBOY_TEST_SCOPE_ENV_VALUE="tests/diagnostic-smoke.php" \
         bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${WORKDIR}/exclusive.out" 2>&1; then
     fail 'exclusive scope bypassed the shard manifest'
 fi
 assert_contains "${WORKDIR}/exclusive.out" 'is mutually exclusive with HOMEBOY_TEST_SCOPE_KIND=exclusive_env'
-assert_not_contains "${WORKDIR}/exclusive.out" 'standalone smoke ran'
+assert_not_contains "${WORKDIR}/exclusive.out" 'PHP_SMOKE_BEGIN:'
 
 printf 'All WordPress test shard replay checks passed.\n'


### PR DESCRIPTION
## Summary

- keep explicit `*-smoke.php`, `*-smoke.js`, and `*-smoke.sh` diagnostics out of the default sharded release-gate inventory
- preserve their existing changed-scope and `--file` execution paths
- allow `homeboy-test-manifest.json` to declare a component-level `default_environment` for explicit PHP smoke runs while retaining exact overrides and the existing `wordpress` fallback

## Root cause

WordPress shard replay correctly began honoring immutable manifests in #2646, but the inventory included diagnostic smoke targets even though the extension contract documents them as operator targets rather than default release gates. This silently promoted 345 Data Machine PHP diagnostics into required CI. The result was environment-dependent failures in both directions: 44 known host-bootstrap artifacts under standalone PHP and widespread redeclaration failures when booted inside WordPress.

The shard inventory now represents the default gate population. Explicit smoke routing is unchanged and remains independently covered.

Consumer tracker: https://github.com/Extra-Chill/data-machine/issues/2850
Downstream evidence: https://github.com/Extra-Chill/data-machine/actions/runs/31963440109
Runtime repair: https://github.com/Automattic/wp-codebox/pull/2270

## Verification

- `bash scripts/test/test-inventory-smoke.sh`
- `bash scripts/test/test-shard-replay-smoke.sh`
- `bash scripts/test/test-runner-file-routing-smoke.sh`
- `bash scripts/test/changed-scope-test-routing-smoke.sh`
- `bash -n scripts/test/test-runner.sh scripts/test/test-inventory-smoke.sh scripts/test/test-shard-replay-smoke.sh`
- `python3 -m py_compile scripts/test/test-inventory.py`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to analyze the downstream shard artifacts, identify the inventory/replay contract mismatch, implement the generic fix, update documentation, and run the listed verification. Chris Huber reviewed and remains responsible for the change.