### PR TITLE
fix(wordpress): inventory canonical PHPUnit suite

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -3,7 +3,7 @@
   "id": "wp-codebox",
   "name": "WP Codebox",
   "version": "1.5.3",
-  "minimum_version": "0.20.0",
+  "minimum_version": "0.21.0",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
   "contract_producers": [
     {

--- a/tests/wp-codebox-callback-data-smoke.mjs
+++ b/tests/wp-codebox-callback-data-smoke.mjs
@@ -30,7 +30,7 @@ const artifactRoot = path.join(tempRoot, 'artifacts');
 
 fs.writeFileSync(fakeBin, `#!/usr/bin/env node
 if (process.argv.includes('--version')) {
-  process.stdout.write('0.20.0');
+  process.stdout.write('0.21.0');
   process.exit(0);
 }
 const fs = require('node:fs');

--- a/tests/wp-codebox-runner-readiness-smoke.mjs
+++ b/tests/wp-codebox-runner-readiness-smoke.mjs
@@ -24,7 +24,7 @@ try {
   const declaration = manifest.agent_task_executors[0].runner_readiness[0];
   assert.deepEqual(declaration.invocation.argv, ['node', '{{runtime_path}}/scripts/agent/homeboy-wp-codebox-runner-readiness.cjs']);
   assert.equal(declaration.remediation, 'homeboy extension setup wordpress');
-  assert.equal(manifest.minimum_version, '0.20.0');
+  assert.equal(manifest.minimum_version, '0.21.0');
   assert.equal(manifest.version, '1.5.3');
   const stalePath = path.join(temp, 'stale-path');
   const stale = path.join(stalePath, 'wp-codebox');
@@ -56,38 +56,38 @@ try {
 
   const cachedCurrent = path.join(temp, 'cached-current');
   const cachedCli = path.join(cachedCurrent, 'source/packages/cli/dist/index.js');
-  executable(cachedCli, '0.20.0');
+  executable(cachedCli, '0.21.0');
   const cached = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: cachedCurrent, PATH: `${stalePath}:${process.env.PATH}` });
   assert.equal(cached.ready, true);
   assert.equal(cached.identity.executable, cachedCli);
   assert.equal(cached.identity.source, 'managed');
-  assert.equal(cached.identity.version, '0.20.0');
+  assert.equal(cached.identity.version, '0.21.0');
 
   const override = path.join(temp, 'override');
-  executable(override, '0.20.0');
+  executable(override, '0.21.0');
   const explicit = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: incomplete, HOMEBOY_WP_CODEBOX_BIN: override, PATH: `${stalePath}:${process.env.PATH}` });
   assert.equal(explicit.ready, true);
   assert.equal(explicit.identity.executable, override);
   assert.equal(explicit.identity.source, 'configured');
-  assert.equal(explicit.identity.version, '0.20.0');
-  assert.equal(explicit.required_version, '0.20.0');
+  assert.equal(explicit.identity.version, '0.21.0');
+  assert.equal(explicit.required_version, '0.21.0');
 
   const settingsBin = path.join(temp, 'settings-bin');
-  executable(settingsBin, '0.20.0');
+  executable(settingsBin, '0.21.0');
   const settingsOnly = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: incomplete, HOMEBOY_SETTINGS_WP_CODEBOX_BIN: settingsBin, PATH: `${stalePath}:${process.env.PATH}` });
   assert.equal(settingsOnly.ready, true);
   assert.equal(settingsOnly.identity.executable, settingsBin);
   assert.equal(settingsOnly.identity.source, 'configured');
 
   const jsonSettingsBin = path.join(temp, 'json-settings-bin');
-  executable(jsonSettingsBin, '0.20.0');
+  executable(jsonSettingsBin, '0.21.0');
   const jsonSettingsOnly = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: incomplete, HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: jsonSettingsBin }), PATH: `${stalePath}:${process.env.PATH}` });
   assert.equal(jsonSettingsOnly.ready, true);
   assert.equal(jsonSettingsOnly.identity.executable, jsonSettingsBin);
   assert.equal(jsonSettingsOnly.identity.source, 'configured');
 
   const currentManaged = path.join(temp, 'current-managed');
-  executable(path.join(currentManaged, 'source/packages/cli/dist/index.js'), '0.20.0');
+  executable(path.join(currentManaged, 'source/packages/cli/dist/index.js'), '0.21.0');
   const oldOverride = path.join(temp, 'old-override');
   executable(oldOverride, '0.19.0');
   const configuredWins = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: currentManaged, HOMEBOY_WP_CODEBOX_BIN: oldOverride, PATH: `${stalePath}:${process.env.PATH}` });
@@ -96,11 +96,11 @@ try {
   assert.equal(configuredWins.identity.source, 'configured');
 
   const prerelease = path.join(temp, 'prerelease');
-  executable(prerelease, '0.20.0-rc.1');
+  executable(prerelease, '0.21.0-rc.1');
   const prereleaseResult = run({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: incomplete, HOMEBOY_WP_CODEBOX_BIN: prerelease, PATH: `${stalePath}:${process.env.PATH}` });
   assert.equal(prereleaseResult.ready, false);
   assert.equal(prereleaseResult.classification, 'wp_codebox_version_too_old');
-  assert.equal(prereleaseResult.identity.version, '0.20.0-rc.1');
+  assert.equal(prereleaseResult.identity.version, '0.21.0-rc.1');
 } finally {
   fs.rmSync(temp, { recursive: true, force: true });
 }

--- a/tests/wp-codebox-runtime-readiness-smoke.mjs
+++ b/tests/wp-codebox-runtime-readiness-smoke.mjs
@@ -187,7 +187,7 @@ try {
   fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
 const fs = require('node:fs');
 if (process.argv.includes('--version')) {
-  process.stdout.write('0.20.0');
+  process.stdout.write('0.21.0');
   process.exit(0);
 }
 const inputFile = process.argv.find((arg) => arg.startsWith('--input-file=')).slice('--input-file='.length);

--- a/wordpress/scripts/test/test-inventory-smoke.sh
+++ b/wordpress/scripts/test/test-inventory-smoke.sh
@@ -31,8 +31,9 @@ fail() {
 }
 
 plugin="${WORKDIR}/plugin"
-mkdir -p "${plugin}/tests/nested" "${plugin}/inc" "${plugin}/vendor/pkg/tests" "${plugin}/node_modules/x"
+mkdir -p "${plugin}/tests/nested" "${plugin}/custom-suite" "${plugin}/inc" "${plugin}/vendor/pkg/tests" "${plugin}/node_modules/x"
 printf '{}\n' > "${plugin}/composer.json"
+printf '<phpunit/>\n' > "${plugin}/phpunit.xml.dist"
 printf '<?php\n' > "${plugin}/inc/Runtime.php"
 
 runner_prelude="${WORKDIR}/runner-prelude.sh"
@@ -44,7 +45,23 @@ homeboy_runner_init() {
 }
 SH
 
-# Routable by the runner: host PHP smoke, JS smoke, shell smoke, node test, PHPUnit.
+default_discovery="${WORKDIR}/default-discovery.json"
+custom_discovery="${WORKDIR}/custom-discovery.json"
+jq -cn '{schema:"wp-codebox/phpunit-discovery/v1",plugin_slug:"fixture-plugin",phpunit_xml:"/wordpress/wp-content/plugins/fixture-plugin/phpunit.xml.dist",test_root:"/wordpress/wp-content/plugins/fixture-plugin/tests",selected_testsuites:[],files:["/wordpress/wp-content/plugins/fixture-plugin/tests/ZetaTest.php","/wordpress/wp-content/plugins/fixture-plugin/tests/test-eta.php"]}' > "$default_discovery"
+jq -cn '{schema:"wp-codebox/phpunit-discovery/v1",plugin_slug:"fixture-plugin",phpunit_xml:"/wordpress/wp-content/plugins/fixture-plugin/tests/custom/phpunit.xml.dist",test_root:"/wordpress/wp-content/plugins/fixture-plugin/tests/custom",selected_testsuites:[],files:["/wordpress/wp-content/plugins/fixture-plugin/tests/custom/behavior-spec.php"]}' > "$custom_discovery"
+discovery_stub="${WORKDIR}/wp-codebox-discovery.sh"
+cat > "$discovery_stub" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${HOMEBOY_SETTINGS_JSON:-}" == *'wp_codebox_phpunit_test_root'* ]]; then
+    cat "$custom_discovery"
+else
+    cat "$default_discovery"
+fi
+SH
+chmod +x "$discovery_stub"
+
+# Explicitly routable diagnostics are not members of the canonical full suite.
 printf '<?php\n' > "${plugin}/tests/alpha-smoke.php"
 printf '<?php\n' > "${plugin}/tests/nested/beta-smoke.php"
 printf '// js\n'  > "${plugin}/tests/gamma-smoke.js"
@@ -52,9 +69,9 @@ printf '# sh\n'   > "${plugin}/tests/delta-smoke.sh"
 printf '// node\n' > "${plugin}/tests/epsilon.test.js"
 printf '<?php\n'  > "${plugin}/tests/ZetaTest.php"
 printf '<?php\n'  > "${plugin}/tests/test-eta.php"
+printf '<?php\n'  > "${plugin}/custom-suite/behavior-spec.php"
 
-# Not routable, and must not be enumerated: a fixture, a support file, and
-# anything inside a skipped directory.
+# Fixtures, support files, and skipped dependencies are not members either.
 printf '<?php\n' > "${plugin}/tests/fixture-data.php"
 printf '<?php\n' > "${plugin}/vendor/pkg/tests/vendor-smoke.php"
 printf '// dep\n' > "${plugin}/node_modules/x/dep-smoke.js"
@@ -64,6 +81,7 @@ run_producer() {
     HOMEBOY_COMPONENT_PATH="$plugin" \
     HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
     HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+    HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="$discovery_stub" \
     HOMEBOY_TEST_INVENTORY_FILE="$1" \
     HOMEBOY_TEST_INVENTORY_ONLY=1 \
         bash "$RUNNER"
@@ -93,11 +111,6 @@ ids = [t["id"] for t in doc["tests"]]
 assert len(ids) == len(set(ids)), "test ids must be unique"
 
 expected = {
-    "tests/alpha-smoke.php": ("smoke", "host-php-smoke"),
-    "tests/nested/beta-smoke.php": ("smoke", "host-php-smoke"),
-    "tests/gamma-smoke.js": ("smoke", "host-js-smoke"),
-    "tests/delta-smoke.sh": ("smoke", "host-shell-smoke"),
-    "tests/epsilon.test.js": ("test", "node-test"),
     "tests/ZetaTest.php": ("test", "phpunit"),
     "tests/test-eta.php": ("test", "phpunit"),
 }
@@ -118,7 +131,17 @@ canonical = json.dumps(record, sort_keys=True, separators=(",", ":"))
 assert hashlib.sha256(canonical.encode()).hexdigest() == doc["inventory_fingerprint"], \
     "inventory_fingerprint is not the canonical digest core will recompute"
 
-print(f"PASS: enumerated {len(ids)} routable tests, fingerprints are canonical")
+print(f"PASS: enumerated {len(ids)} canonical full-suite tests, fingerprints are canonical")
+PY
+
+custom_settings="$(jq -cn --arg source "${plugin}/custom-suite" \
+    '{wp_codebox_phpunit_test_root:"/wordpress/wp-content/plugins/fixture-plugin/tests/custom",wp_codebox_phpunit_mounts:[{source:$source,target:"/wordpress/wp-content/plugins/fixture-plugin/tests/custom"}]}')"
+HOMEBOY_SETTINGS_JSON="$custom_settings" run_producer "${WORKDIR}/custom.json" > /dev/null || fail "configured test-root inventory failed"
+python3 - "${WORKDIR}/custom.json" <<'PY' || fail "configured test-root assertions failed"
+import json, sys
+doc = json.load(open(sys.argv[1]))
+assert [test["id"] for test in doc["tests"]] == ["custom-suite/behavior-spec.php"], doc["tests"]
+print("PASS: configured PHPUnit root defines canonical inventory membership")
 PY
 
 # Determinism: identical input must produce an identical document, or a shard
@@ -151,20 +174,28 @@ after_php="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["wo
 [ "$before_ws" != "$after_php" ] || fail "a declared PHP source edit did not move the workspace fingerprint"
 printf 'PASS: declared source edits move the workspace fingerprint\n'
 
+# PHPUnit configuration defines canonical membership and must invalidate stale
+# shard manifests even when all previously assigned files still exist.
+printf '<phpunit cacheResult="false"/>\n' > "${plugin}/phpunit.xml.dist"
+run_producer "${WORKDIR}/phpunit-config.json" > /dev/null || fail "producer failed after PHPUnit config edit"
+after_phpunit_config="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["workspace_fingerprint"])' "${WORKDIR}/phpunit-config.json")"
+[ "$after_php" != "$after_phpunit_config" ] || fail "a PHPUnit config edit did not move the workspace fingerprint"
+printf 'PASS: PHPUnit config edits move the workspace fingerprint\n'
+
 # An empty enumeration is refused: it cannot be told apart from a broken
 # producer, and sharding nothing would report a green suite that ran no tests.
 empty="${WORKDIR}/empty"
 mkdir -p "${empty}"
 printf '{}\n' > "${empty}/composer.json"
 if python3 "$PRODUCER" --project "$empty" --extension-path "$EXTENSION_PATH" \
-    --runner wordpress --output "${WORKDIR}/empty.json" >/dev/null 2>&1; then
+    --runner wordpress --discovery-file "$default_discovery" --output "${WORKDIR}/empty.json" >/dev/null 2>&1; then
     fail "producer accepted a component with no tests"
 fi
 printf 'PASS: an empty enumeration is refused\n'
 
 # An undeclared runner has no version command and therefore no identity.
 if python3 "$PRODUCER" --project "$plugin" --extension-path "$EXTENSION_PATH" \
-    --runner not-declared --output "${WORKDIR}/bad-runner.json" >/dev/null 2>&1; then
+    --runner not-declared --discovery-file "$default_discovery" --output "${WORKDIR}/bad-runner.json" >/dev/null 2>&1; then
     fail "producer accepted an undeclared runner"
 fi
 printf 'PASS: an undeclared runner is refused\n'
@@ -176,6 +207,7 @@ if HOMEBOY_COMPONENT_ID=fixture-plugin \
     HOMEBOY_COMPONENT_PATH="$plugin" \
     HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
     HOMEBOY_RUNTIME_RUNNER_PRELUDE="$runner_prelude" \
+    HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="$discovery_stub" \
     HOMEBOY_TEST_INVENTORY_FILE="${WORKDIR}/failed.json" \
     HOMEBOY_TEST_INVENTORY_ONLY=1 \
     HOMEBOY_WORDPRESS_INVENTORY_RUNNER=not-declared \

--- a/wordpress/scripts/test/test-inventory.py
+++ b/wordpress/scripts/test/test-inventory.py
@@ -127,62 +127,72 @@ def runner_fingerprint(root, config, runner):
     return digest(f"{runner}\0{result.stdout.strip()}")
 
 
-def within_tests_tree(relative):
-    """Match the runner's own `tests/` and `wordpress/tests/` prefixes."""
-    parts = relative.split("/")
-    if parts[0] == "tests":
-        return True
-    return len(parts) > 1 and parts[0] == "wordpress" and parts[1] == "tests"
+def settings():
+    raw_settings = os.environ.get("HOMEBOY_SETTINGS_JSON") or "{}"
+    try:
+        value = json.loads(raw_settings)
+    except json.JSONDecodeError:
+        value = {}
+    return value if isinstance(value, dict) else {}
 
 
-def classify(relative):
-    """Return (target_kind, target) or None, mirroring the runner's matchers.
+def host_test_path(project, plugin_slug, sandbox_path):
+    mounts = settings().get("wp_codebox_phpunit_mounts") or []
+    for mount in sorted(mounts, key=lambda item: len(item.get("target", "")) if isinstance(item, dict) else 0, reverse=True):
+        if not isinstance(mount, dict):
+            continue
+        source = mount.get("source")
+        target = mount.get("target")
+        if not isinstance(source, str) or not isinstance(target, str):
+            continue
+        target = target.rstrip("/")
+        if sandbox_path != target and not sandbox_path.startswith(f"{target}/"):
+            continue
+        return Path(source).joinpath(sandbox_path[len(target):].lstrip("/"))
 
-    These predicates are the ones `test-runner.sh` uses to route a changed-scope
-    selection, so the inventory enumerates exactly the population the runner
-    would execute. A file the runner cannot route must not appear here: a shard
-    would then claim a test that never runs, and the aggregate totals would not
-    reconcile.
-    """
-    name = relative.rsplit("/", 1)[-1]
-    in_tests = within_tests_tree(relative)
+    plugin_root = f"/wordpress/wp-content/plugins/{plugin_slug}/"
+    if sandbox_path.startswith(plugin_root):
+        return project / sandbox_path[len(plugin_root):]
 
-    if in_tests and name.endswith("-smoke.php"):
-        return "smoke", "host-php-smoke"
-    if in_tests and name.endswith("-smoke.js"):
-        return "smoke", "host-js-smoke"
-    if in_tests and name.endswith("-smoke.sh"):
-        return "smoke", "host-shell-smoke"
-    for suffix in (".test.js", ".test.cjs", ".test.mjs", ".test.jsx", ".test.ts", ".test.tsx"):
-        if name.endswith(suffix):
-            return "test", "node-test"
-    if name.endswith("Test.php") or name.startswith("test-") and name.endswith(".php"):
-        return "test", "phpunit"
-    return None
+    fail(f"discovered PHPUnit file has no declared host mount: {sandbox_path}")
 
 
-def enumerate_tests(root, package, config):
-    skip = set(config.get("fingerprint_skip_dirs") or [])
+def enumerate_tests(project, package, discovery_file):
+    try:
+        discovery = json.loads(Path(discovery_file).read_text())
+    except OSError as error:
+        fail(f"could not read WP Codebox discovery result: {error}")
+    except json.JSONDecodeError as error:
+        fail(f"WP Codebox discovery result is not valid JSON: {error}")
+    if not isinstance(discovery, dict) or discovery.get("schema") != "wp-codebox/phpunit-discovery/v1":
+        fail("WP Codebox discovery result has an unsupported schema")
+    plugin_slug = discovery.get("plugin_slug")
+    files = discovery.get("files")
+    if not isinstance(plugin_slug, str) or not plugin_slug or not isinstance(files, list) or not files:
+        fail("WP Codebox discovery result has no plugin identity or files")
+    if any(not isinstance(path, str) or not path.startswith("/") for path in files):
+        fail("WP Codebox discovery files must be unique sandbox-absolute paths")
+    if len(files) != len(set(files)):
+        fail("WP Codebox discovery files must be unique sandbox-absolute paths")
+
     tests = {}
-    for directory, subdirectories, files in os.walk(root):
-        subdirectories[:] = [name for name in subdirectories if name not in skip]
-        for name in files:
-            relative = str((Path(directory) / name).relative_to(root))
-            classified = classify(relative)
-            if not classified:
-                continue
-            target_kind, target = classified
-            # The path is the id: it is what HOMEBOY_CHANGED_TEST_FILES already
-            # carries, so a shard manifest slice can be replayed through the
-            # existing changed-scope routing without a second selector format.
-            tests[relative] = {
-                "id": relative,
-                "package": package,
-                "target": target,
-                "target_kind": target_kind,
-                "name": name,
-                "expected_outcome": "executed",
-            }
+    project = project.resolve()
+    for sandbox_path in files:
+        path = host_test_path(project, plugin_slug, sandbox_path).resolve()
+        try:
+            relative = str(path.relative_to(project))
+        except ValueError:
+            fail(f"configured PHPUnit test file escapes the component: {path}")
+        if not path.is_file():
+            fail(f"discovered PHPUnit test file is missing on the host: {path}")
+        tests[relative] = {
+            "id": relative,
+            "package": package,
+            "target": "phpunit",
+            "target_kind": "test",
+            "name": path.name,
+            "expected_outcome": "executed",
+        }
     return [tests[key] for key in sorted(tests)]
 
 
@@ -209,6 +219,7 @@ def main():
     parser.add_argument("--extension-path", required=True, help="extension root holding wordpress.json")
     parser.add_argument("--runner", default="wordpress", help="declared runner identity")
     parser.add_argument("--package", default="", help="package label recorded on each test")
+    parser.add_argument("--discovery-file", required=True, help="WP Codebox canonical discovery result")
     parser.add_argument("--output", required=True, help="file to write the inventory to")
     args = parser.parse_args()
 
@@ -216,7 +227,7 @@ def main():
     root = workspace_root(args.project, config)
     package = args.package or Path(args.project).resolve().name
 
-    tests = enumerate_tests(root, package, config)
+    tests = enumerate_tests(Path(args.project).resolve(), package, args.discovery_file)
     if not tests:
         # Core refuses an empty inventory, and it is right to: an empty
         # enumeration cannot be distinguished from a broken producer, and

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -120,7 +120,7 @@ cat > "${TMPDIR}/stubs/wp-codebox.sh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "--version" ]; then
-    printf '0.20.0\n'
+    printf '0.21.0\n'
     exit 0
 fi
 echo "WP_CODEBOX_STUB"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -48,6 +48,23 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Component path: ${COMPONENT_PATH:-$(pwd)}"
 fi
 
+homeboy_wordpress_discover_phpunit_files() {
+    local output_file="$1"
+    local discovery_tmp
+    discovery_tmp="$(mktemp)" || return 1
+    if ! HOMEBOY_WORDPRESS_PHPUNIT_DISCOVERY_ONLY=1 bash "$WP_CODEBOX_RUNNER" > "$discovery_tmp"; then
+        rm -f "$discovery_tmp"
+        echo "ERROR: WP Codebox canonical PHPUnit discovery failed." >&2
+        return 1
+    fi
+    if ! jq -e '.schema == "wp-codebox/phpunit-discovery/v1" and (.files | type == "array" and length > 0)' "$discovery_tmp" >/dev/null 2>&1; then
+        rm -f "$discovery_tmp"
+        echo "ERROR: WP Codebox returned an invalid canonical PHPUnit discovery result." >&2
+        return 1
+    fi
+    mv "$discovery_tmp" "$output_file"
+}
+
 # Inventory-only mode enumerates the suite without running any of it, so that
 # Homeboy can plan bounded shards. It must return before any runner is selected:
 # a producer that executed tests would defeat the point, and core deliberately
@@ -72,21 +89,31 @@ if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = "1" ]; then
         echo "Error: could not create temporary WordPress test inventory." >&2
         exit 1
     }
+    discovery_data="$(mktemp)" || {
+        rm -f "$inventory_data"
+        echo "Error: could not create temporary WordPress PHPUnit discovery result." >&2
+        exit 1
+    }
+    if ! homeboy_wordpress_discover_phpunit_files "$discovery_data"; then
+        rm -f "$inventory_data" "$discovery_data"
+        exit 1
+    fi
     if ! python3 "$INVENTORY_TOOL" \
         --project "$PLUGIN_PATH" \
         --extension-path "$EXTENSION_PATH" \
         --runner "${HOMEBOY_WORDPRESS_INVENTORY_RUNNER:-wordpress}" \
         --package "${HOMEBOY_COMPONENT_ID:-wordpress}" \
+        --discovery-file "$discovery_data" \
         --output "$inventory_data"; then
-        rm -f "$inventory_data"
+        rm -f "$inventory_data" "$discovery_data"
         exit 1
     fi
     if ! cp "$inventory_data" "$HOMEBOY_TEST_INVENTORY_FILE"; then
-        rm -f "$inventory_data"
+        rm -f "$inventory_data" "$discovery_data"
         exit 1
     fi
     cat "$inventory_data"
-    rm -f "$inventory_data"
+    rm -f "$inventory_data" "$discovery_data"
     exit 0
 fi
 
@@ -905,16 +932,27 @@ homeboy_wordpress_load_test_shard_manifest() {
     }
 
     current_inventory="$(mktemp)" || return 1
+    local current_discovery
+    current_discovery="$(mktemp)" || {
+        rm -f "$current_inventory"
+        return 1
+    }
+    if ! homeboy_wordpress_discover_phpunit_files "$current_discovery"; then
+        rm -f "$current_inventory" "$current_discovery"
+        return 2
+    fi
     if ! python3 "${SCRIPT_DIR}/test-inventory.py" \
         --project "$PLUGIN_PATH" \
         --extension-path "$EXTENSION_PATH" \
         --runner wordpress \
         --package "${HOMEBOY_COMPONENT_ID:-wordpress}" \
+        --discovery-file "$current_discovery" \
         --output "$current_inventory" >/dev/null; then
-        rm -f "$current_inventory"
+        rm -f "$current_inventory" "$current_discovery"
         echo "ERROR: could not regenerate the current WordPress test inventory for shard validation." >&2
         return 2
     fi
+    rm -f "$current_discovery"
 
     current_runner="$(jq -r '.runner_fingerprint' "$current_inventory")"
     current_workspace="$(jq -r '.workspace_fingerprint' "$current_inventory")"
@@ -956,14 +994,6 @@ homeboy_wordpress_load_test_shard_manifest() {
         selected_count=$((selected_count + 1))
         if ! test_rel="$(homeboy_wordpress_rel_test_file "$test_file")"; then
             echo "ERROR: WordPress shard ${shard_id} assigned a missing or out-of-component test: ${test_file}" >&2
-            return 2
-        fi
-        if ! homeboy_wordpress_is_js_smoke_file "$test_rel" \
-            && ! homeboy_wordpress_is_shell_smoke_file "$test_rel" \
-            && ! homeboy_wordpress_is_node_test_file "$test_rel" \
-            && ! homeboy_wordpress_is_php_smoke_file "$test_rel" \
-            && ! homeboy_wordpress_is_phpunit_test_file "$test_rel"; then
-            echo "ERROR: WordPress shard ${shard_id} assigned an unroutable test: ${test_rel}" >&2
             return 2
         fi
     done <<< "$shard_tests"
@@ -1008,10 +1038,6 @@ homeboy_wordpress_run_php_smoke_files() {
 
 homeboy_wordpress_replay_test_shard() {
     local test_file test_rel
-    local js_smoke_files=""
-    local shell_smoke_files=""
-    local node_test_files=""
-    local php_smoke_files=""
     local phpunit_files=""
     local selected=0
     local routed=0
@@ -1020,32 +1046,11 @@ homeboy_wordpress_replay_test_shard() {
         [ -n "$test_file" ] || continue
         selected=$((selected + 1))
         test_rel="$(homeboy_wordpress_rel_test_file "$test_file")" || return 2
-        if homeboy_wordpress_is_js_smoke_file "$test_rel"; then
-            js_smoke_files+="${js_smoke_files:+$'\n'}${test_rel}"
-            echo "TEST_SHARD_ROUTE:${test_rel}:runner=host-js-smoke"
-        elif homeboy_wordpress_is_shell_smoke_file "$test_rel"; then
-            shell_smoke_files+="${shell_smoke_files:+$'\n'}${test_rel}"
-            echo "TEST_SHARD_ROUTE:${test_rel}:runner=host-shell-smoke"
-        elif homeboy_wordpress_is_node_test_file "$test_rel"; then
-            node_test_files+="${node_test_files:+$'\n'}${test_rel}"
-            echo "TEST_SHARD_ROUTE:${test_rel}:runner=node-test"
-        elif homeboy_wordpress_is_php_smoke_file "$test_rel"; then
-            php_smoke_files+="${php_smoke_files:+$'\n'}${test_rel}"
-            echo "TEST_SHARD_ROUTE:${test_rel}:runner=host-php-smoke"
-        elif homeboy_wordpress_is_phpunit_test_file "$test_rel"; then
-            phpunit_files+="${phpunit_files:+$'\n'}${test_rel}"
-            echo "TEST_SHARD_ROUTE:${test_rel}:runner=phpunit"
-        else
-            echo "ERROR: WordPress shard ${HOMEBOY_WORDPRESS_SHARD_ID} could not route ${test_rel}." >&2
-            return 2
-        fi
+        phpunit_files+="${phpunit_files:+$'\n'}${test_rel}"
+        echo "TEST_SHARD_ROUTE:${test_rel}:runner=phpunit"
         routed=$((routed + 1))
     done <<< "$HOMEBOY_WORDPRESS_SHARD_TEST_FILES"
 
-    [ -z "$js_smoke_files" ] || homeboy_wordpress_run_js_smoke_files "$js_smoke_files" || return $?
-    [ -z "$shell_smoke_files" ] || homeboy_wordpress_run_shell_smoke_files "$shell_smoke_files" || return $?
-    [ -z "$node_test_files" ] || homeboy_wordpress_run_js_unit_test_files "$node_test_files" || return $?
-    [ -z "$php_smoke_files" ] || homeboy_wordpress_run_php_smoke_files "$php_smoke_files" || return $?
     if [ -n "$phpunit_files" ]; then
         export HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES="$phpunit_files"
         WORDPRESS_RUNTIME_RUNNER="$(homeboy_wordpress_runtime_runner)" || return $?

--- a/wordpress/scripts/test/test-shard-replay-smoke.sh
+++ b/wordpress/scripts/test/test-shard-replay-smoke.sh
@@ -34,6 +34,7 @@ jq -e '
 
 printf '<?php\nclass AlphaTest extends PHPUnit\\Framework\\TestCase {}\n' > "${component}/tests/Unit/AlphaTest.php"
 printf '<?php\nclass BetaTest extends PHPUnit\\Framework\\TestCase {}\n' > "${component}/tests/Unit/BetaTest.php"
+printf '<?php\nclass BehaviorSpec extends PHPUnit\\Framework\\TestCase {}\n' > "${component}/tests/Unit/behavior-spec.php"
 printf '<?php\necho "standalone smoke ran\\n";\n' > "${component}/tests/standalone-smoke.php"
 printf '<?php\necho "wordpress smoke ran\\n";\n' > "${component}/tests/wordpress-smoke.php"
 printf 'console.log("js smoke ran");\n' > "${component}/tests/browser-smoke.js"
@@ -62,6 +63,10 @@ SH
 cat > "${WORKDIR}/stubs/wp-codebox.sh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${HOMEBOY_WORDPRESS_PHPUNIT_DISCOVERY_ONLY:-}" = "1" ]; then
+    jq -cn '{schema:"wp-codebox/phpunit-discovery/v1",plugin_slug:"component",phpunit_xml:"/wordpress/wp-content/plugins/component/phpunit.xml.dist",test_root:"/wordpress/wp-content/plugins/component/tests",selected_testsuites:[],files:["/wordpress/wp-content/plugins/component/tests/Unit/AlphaTest.php","/wordpress/wp-content/plugins/component/tests/Unit/BetaTest.php","/wordpress/wp-content/plugins/component/tests/Unit/behavior-spec.php"]}'
+    exit 0
+fi
 printf 'PHPUNIT_CHANGED=%s\n' "${HOMEBOY_WORDPRESS_PHPUNIT_CHANGED_TEST_FILES:-}"
 while IFS= read -r test_file; do
     [ -z "$test_file" ] || printf 'PHPUNIT_EXECUTED:%s\n' "$test_file"
@@ -86,11 +91,14 @@ homeboy_write_test_results() {
 SH
 
 inventory="${WORKDIR}/inventory.json"
+discovery="${WORKDIR}/discovery.json"
+HOMEBOY_WORDPRESS_PHPUNIT_DISCOVERY_ONLY=1 "${WORKDIR}/stubs/wp-codebox.sh" > "$discovery"
 python3 "${EXTENSION_PATH}/scripts/test/test-inventory.py" \
     --project "$component" \
     --extension-path "$EXTENSION_PATH" \
     --runner wordpress \
     --package component \
+    --discovery-file "$discovery" \
     --output "$inventory" >/dev/null
 
 write_manifest() {
@@ -124,20 +132,15 @@ run_manifest() {
 
 first="${WORKDIR}/shard-1.json"
 second="${WORKDIR}/shard-2.json"
-write_manifest "$first" shard-1 tests/Unit/AlphaTest.php tests/standalone-smoke.php tests/wordpress-smoke.php tests/browser-smoke.js tests/worker.test.mjs tests/contract-smoke.sh
+write_manifest "$first" shard-1 tests/Unit/behavior-spec.php
 write_manifest "$second" shard-2 tests/Unit/BetaTest.php
 
 run_manifest "$first" "${WORKDIR}/first.out"
-assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_MANIFEST:id=shard-1 selected=6'
-assert_contains "${WORKDIR}/first.out" 'PHP_SMOKE_OK:tests/standalone-smoke.php'
-assert_contains "${WORKDIR}/first.out" 'HOST_SMOKE_OK:tests/wordpress-smoke.php'
-assert_contains "${WORKDIR}/first.out" 'js smoke ran'
-assert_contains "${WORKDIR}/first.out" 'node test ran'
-assert_contains "${WORKDIR}/first.out" 'shell smoke ran'
-assert_contains "${WORKDIR}/first.out" 'PHPUNIT_CHANGED=tests/Unit/AlphaTest.php'
-assert_contains "${WORKDIR}/first.out" 'PHPUNIT_EXECUTED:tests/Unit/AlphaTest.php'
-assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_SUMMARY:id=shard-1 selected=6 routed=6 status=passed'
-if [ "$(jq -r '.total' "${WORKDIR}/first.out.results.json")" -ne 6 ]; then
+assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_MANIFEST:id=shard-1 selected=1'
+assert_contains "${WORKDIR}/first.out" 'PHPUNIT_CHANGED=tests/Unit/behavior-spec.php'
+assert_contains "${WORKDIR}/first.out" 'PHPUNIT_EXECUTED:tests/Unit/behavior-spec.php'
+assert_contains "${WORKDIR}/first.out" 'TEST_SHARD_SUMMARY:id=shard-1 selected=1 routed=1 status=passed'
+if [ "$(jq -r '.total' "${WORKDIR}/first.out.results.json")" -ne 1 ]; then
     fail 'shard result sidecar does not match first manifest membership'
 fi
 assert_not_contains "${WORKDIR}/first.out" 'BetaTest.php'
@@ -157,7 +160,7 @@ HOMEBOY_TEST_SHARD_MANIFEST="$first" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${WORKDIR}/write-test-results.sh" \
 HOMEBOY_TEST_RESULTS_FILE="${WORKDIR}/parsed-results.json" \
     bash "${EXTENSION_PATH}/scripts/test/parse-test-results.sh" "${WORKDIR}/first.out"
-if [ "$(jq -r '.total' "${WORKDIR}/parsed-results.json")" -ne 6 ]; then
+if [ "$(jq -r '.total' "${WORKDIR}/parsed-results.json")" -ne 1 ]; then
     fail 'result parser does not recover validated shard membership'
 fi
 

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -72,7 +72,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 
 const args = process.argv.slice(2)
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0) }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0) }
 fs.writeFileSync(process.env.FAKE_WP_CODEBOX_ARGS_FILE, `${args.join('\n')}\n`)
 
 if (args[0] === 'recipe' && args[1] === 'build' && args[2] === 'phpunit') {

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -25,6 +25,7 @@ const { requireAgentRuntimeModule } = require('../lib/agent-runtime-paths.cjs');
 const { preflightWpCodeboxCommand } = requireAgentRuntimeModule('wp-codebox/lib/wp-codebox-runtime-selection.js');
 
 const settings = parseSettings(process.env.HOMEBOY_SETTINGS_JSON);
+const discoveryOnly = process.env.HOMEBOY_WORDPRESS_PHPUNIT_DISCOVERY_ONLY === '1';
 const phpunitTimeoutSeconds = configuredWpCodeboxPhpunitTimeoutSeconds(process.env, settings);
 const componentPath = required(process.env.HOMEBOY_COMPONENT_PATH, 'HOMEBOY_COMPONENT_PATH');
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -45,8 +46,10 @@ const phpunitProfile = await resolvePhpunitProfile(settings, pluginSourceDirecto
 const phpunitBootstrap = resolvePhpunitBootstrap(settings, phpunitProfile);
 const topology = await resolveWordPressTopology(settings, pluginSourceDirectory);
 const databaseService = resolveDatabaseService(settings, process.env);
-requireDatabaseServiceCapability(databaseService);
-runPrepareSteps(settings.wp_codebox_prepare_steps, pluginSourceDirectory);
+if (!discoveryOnly) {
+  requireDatabaseServiceCapability(databaseService);
+  runPrepareSteps(settings.wp_codebox_prepare_steps, pluginSourceDirectory);
+}
 const directory = await mkdtemp(path.join(tmpdir(), 'homeboy-wp-codebox-phpunit-'));
 const optionsPath = path.join(directory, 'options.json');
 const recipePath = path.join(directory, 'recipe.json');
@@ -61,7 +64,7 @@ const runArtifacts = path.join(artifacts, `wp-codebox-phpunit.${process.pid}`);
 // The component under review is deliberately absent from this: its vendor/ is
 // produced by the declared dependency-materialization phase before the runner
 // is ever invoked.
-const dependencies = (await dependencyPaths(settings, [componentPath, pluginSourceDirectory])).map((source) => {
+const dependencies = (discoveryOnly ? [] : await dependencyPaths(settings, [componentPath, pluginSourceDirectory])).map((source) => {
   const dependencySlug = path.basename(source).replace(/@[^/]+$/, '');
   return { source, slug: dependencySlug, sandboxDirectory: sandboxPluginDirectory(dependencySlug), composer: 'install' };
 });
@@ -80,29 +83,32 @@ const activationPlan = [
   ...dependencies.map(({ source, slug: dependencySlug, composer }) => ({ role: 'validation-dependency', source, slug: dependencySlug, composer })),
   { role: 'target', source: root, sourceSubpath: subpath, slug },
 ];
-await requireHarness(harnessSource);
+if (!discoveryOnly) {
+  await requireHarness(harnessSource);
+}
 const options = clean({
   wordpressVersion: settings.wordpress_runtime_version,
   phpVersion: settings.wordpress_runtime_php_version,
-  databaseType: settings.database_type,
-  services: databaseService ? [databaseService.service] : undefined,
+  databaseType: discoveryOnly ? 'sqlite' : settings.database_type,
+  services: !discoveryOnly && databaseService ? [databaseService.service] : undefined,
   pluginSlug: slug,
   extra_plugins: activationPlan.map(({ role, ...plugin }) => clean({ ...plugin, activate: true })),
   dependencyMounts: [...new Set([sandboxPluginDirectory(slug), ...dependencies.map(({ sandboxDirectory }) => sandboxDirectory)])],
-  selectedTestFile,
-  changedTestFiles: changedTestFileScope.sandbox,
+  selectedTestFile: discoveryOnly ? '' : selectedTestFile,
+  changedTestFiles: discoveryOnly ? [] : changedTestFileScope.sandbox,
+  discoveryOnly,
   testRoot: phpunitProfile.testRoot,
   phpunitXml: phpunitProfile.config,
   cwd: phpunitProfile.cwd,
-  phpunitArgs: process.argv.slice(2),
+  phpunitArgs: discoveryOnly ? [] : process.argv.slice(2),
   env: settings.bench_env,
   wpConfigDefines: settings.wp_config_defines,
   autoloadFile: '/wp-codebox-vendor/autoload.php',
   bootstrapMode: phpunitBootstrap.mode,
   projectBootstrap: phpunitBootstrap.projectBootstrap,
-  multisite: topology.multisite,
+  multisite: discoveryOnly ? false : topology.multisite,
   preloadFiles: settings.wp_codebox_phpunit_preload_files,
-  mounts: [...canonicalMounts(settings.wp_codebox_phpunit_mounts), { source: harnessSource, target: '/wp-codebox-vendor', mode: 'readonly' }],
+  mounts: [...canonicalMounts(settings.wp_codebox_phpunit_mounts), ...(!discoveryOnly ? [{ source: harnessSource, target: '/wp-codebox-vendor', mode: 'readonly' }] : [])],
 });
 
 try {
@@ -115,27 +121,62 @@ try {
   // replaced this runner's shell implementation with the Node adapter and the
   // banner went with it, leaving the PHPUnit path as the only one whose run
   // logs do not say what executed them.
-  process.stdout.write('Running PHPUnit tests via WP Codebox...\n');
-  process.stdout.write(`  Plugin: ${slug} (${pluginSourceDirectory})\n`);
-  process.stdout.write('  Backend: wp-codebox\n');
+  if (!discoveryOnly) {
+    process.stdout.write('Running PHPUnit tests via WP Codebox...\n');
+    process.stdout.write(`  Plugin: ${slug} (${pluginSourceDirectory})\n`);
+    process.stdout.write('  Backend: wp-codebox\n');
+  }
   await writeFile(optionsPath, `${JSON.stringify(options)}\n`);
   run(['recipe', 'build', 'phpunit', '--options', optionsPath, '--output', recipePath]);
-  await applyDatabaseServiceAuthorization(recipePath);
+  if (!discoveryOnly) {
+    await applyDatabaseServiceAuthorization(recipePath);
+  }
   await mkdir(runArtifacts, { recursive: true });
-  await persistRecipeEvidence(runArtifacts, options, recipePath, phpunitProfile, dependencies);
+  if (!discoveryOnly) {
+    await persistRecipeEvidence(runArtifacts, options, recipePath, phpunitProfile, dependencies);
+  }
   const executionArgs = ['recipe-run', '--recipe', recipePath, '--artifacts', runArtifacts, '--json'];
-  if (databaseService?.boundary) {
+  if (!discoveryOnly && databaseService?.boundary) {
     executionArgs.push('--approve-external-service-writes', '--policy', JSON.stringify(databaseService.policy));
   }
   const execution = await runCaptured(executionArgs, phpunitTimeoutSeconds);
-  const artifactStatus = await handoffArtifacts(runArtifacts, execution);
-  if (execution.status !== 0 || !['passed', 'skipped'].includes(artifactStatus)) {
-    process.exitCode = execution.timedOut ? 124 : (execution.status || 1);
+  if (discoveryOnly) {
+    try {
+      if (execution.status !== 0) {
+        const stdout = (await readBoundedText(execution.stdoutPath, 8 * 1024)).trim();
+        const stderr = (await readBoundedText(execution.stderrPath, 8 * 1024)).trim();
+        const diagnostic = [stdout, stderr].filter(Boolean).join('\n');
+        throw new Error(`WP Codebox PHPUnit discovery failed with exit ${execution.status}${diagnostic ? `: ${diagnostic}` : '.'}`);
+      }
+      process.stdout.write(`${JSON.stringify(await readDiscoveryResult(execution.stdoutPath))}\n`);
+    } finally {
+      await rm(runArtifacts, { recursive: true, force: true });
+    }
   } else {
-    process.stdout.write('WP Codebox test run complete.\n');
+    const artifactStatus = await handoffArtifacts(runArtifacts, execution);
+    if (execution.status !== 0 || !['passed', 'skipped'].includes(artifactStatus)) {
+    process.exitCode = execution.timedOut ? 124 : (execution.status || 1);
+    } else {
+      process.stdout.write('WP Codebox test run complete.\n');
+    }
   }
 } finally {
   await rm(directory, { recursive: true, force: true });
+}
+async function readDiscoveryResult(stdoutPath) {
+  const payload = JSON.parse(await readFile(stdoutPath, 'utf8'));
+  const execution = Array.isArray(payload?.executions)
+    ? payload.executions.find((entry) => entry?.command === 'wordpress.phpunit')
+    : undefined;
+  const result = JSON.parse(execution?.stdout || 'null');
+  if (result?.schema !== 'wp-codebox/phpunit-discovery/v1'
+    || result.plugin_slug !== slug
+    || !Array.isArray(result.files)
+    || result.files.length === 0
+    || result.files.some((file) => typeof file !== 'string' || !file.startsWith('/'))) {
+    throw new Error('WP Codebox returned an invalid PHPUnit discovery result.');
+  }
+  return result;
 }
 async function runCaptured(args, timeoutSeconds) {
   const logsDirectory = path.join(runArtifacts, 'logs');

--- a/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
+++ b/wordpress/tests/wp-codebox-canonical-cli-adapters-smoke.mjs
@@ -22,7 +22,7 @@ await writeFile(writeResults, `homeboy_write_test_results() { printf '{"total":%
 await writeFile(cli, `#!/usr/bin/env node
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0); }
 await appendFile(process.env.OBSERVED, JSON.stringify(args) + '\\n');
 if (args[0] === 'recipe' && args[1] === 'build') {
   const options = JSON.parse(await readFile(args[args.indexOf('--options') + 1], 'utf8'));

--- a/wordpress/tests/wp-codebox-database-service-smoke.mjs
+++ b/wordpress/tests/wp-codebox-database-service-smoke.mjs
@@ -20,7 +20,7 @@ await writeFile(path.join(dependency, 'composer.json'), '{}\n');
 await writeFile(cli, `#!/usr/bin/env node
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0); }
 if (args[0] === 'runtime' && args[1] === 'descriptor') {
   const capabilities = process.env.OMIT_NATIVE_DATABASE_CAPABILITY === '1' ? [] : ['runtime-service:mysql:native:mariadb'];
   process.stdout.write(JSON.stringify({

--- a/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-aggregate-smoke.mjs
@@ -56,7 +56,7 @@ await writeFile(cli, `#!/usr/bin/env node
 import fs from 'node:fs';
 const args = process.argv.slice(2);
 const value = (name) => args[args.indexOf(name) + 1];
-if (args.includes('--version')) { process.stdout.write(process.env.WP_CODEBOX_FIXTURE_VERSION || '0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write(process.env.WP_CODEBOX_FIXTURE_VERSION || '0.21.0'); process.exit(0); }
 if (process.env.DISPATCHED) { fs.appendFileSync(process.env.DISPATCHED, JSON.stringify(args) + '\\n'); }
 if (args[0] === 'recipe') { fs.writeFileSync(value('--output'), JSON.stringify({ schema: 'wp-codebox/workspace-recipe/v1' })); process.exit(0); }
 const artifacts = value('--artifacts');
@@ -172,7 +172,7 @@ try {
   assert.equal(fs.existsSync(staleDispatch), false, 'an old runtime must not begin a recipe');
 
   const prereleaseDispatch = path.join(root, 'prerelease-dispatched.jsonl');
-  const prerelease = spawnSync(runner, [], { env: { ...process.env, DISPATCHED: prereleaseDispatch, WP_CODEBOX_FIXTURE_VERSION: '0.20.0-rc.1', HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'prerelease-artifacts'), HOMEBOY_SETTINGS_JSON: '{}' }, encoding: 'utf8' });
+  const prerelease = spawnSync(runner, [], { env: { ...process.env, DISPATCHED: prereleaseDispatch, WP_CODEBOX_FIXTURE_VERSION: '0.21.0-rc.1', HOMEBOY_COMPONENT_PATH: component, COMPONENT_ID: 'component', HOMEBOY_WP_CODEBOX_BIN: cli, HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: path.join(root, 'prerelease-artifacts'), HOMEBOY_SETTINGS_JSON: '{}' }, encoding: 'utf8' });
   assert.notEqual(prerelease.status, 0);
   assert.match(prerelease.stderr, /wp_codebox_version_too_old/);
   assert.equal(fs.existsSync(prereleaseDispatch), false, 'a prerelease runtime must not begin a recipe');

--- a/wordpress/tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-changed-scope-path-smoke.mjs
@@ -33,7 +33,7 @@ const cli = path.join(root, 'wp-codebox');
 await writeFile(cli, `#!/usr/bin/env node
 import fs from 'node:fs';
 const args = process.argv.slice(2);
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0); }
 if (args[0] === 'recipe' && args[1] === 'build') {
   const optionsPath = args[args.indexOf('--options') + 1];
   fs.copyFileSync(optionsPath, process.env.CAPTURED_OPTIONS);

--- a/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs
@@ -28,7 +28,7 @@ await writeFile(cli, `#!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
 const args = process.argv.slice(2);
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0); }
 if (args[0] === 'recipe' && args[1] === 'build') {
   fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
   process.exit(0);

--- a/wordpress/tests/wp-codebox-phpunit-failure-artifacts-smoke.sh
+++ b/wordpress/tests/wp-codebox-phpunit-failure-artifacts-smoke.sh
@@ -36,7 +36,7 @@ cat > "$FAKE_BIN" <<'SH'
 set -euo pipefail
 
 if [ "${1:-}" = "--version" ]; then
-	printf '0.20.0\n'
+	printf '0.21.0\n'
 	exit 0
 fi
 

--- a/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-multisite-smoke.mjs
@@ -20,7 +20,7 @@ const cli = path.join(root, 'wp-codebox');
 await writeFile(cli, `#!/usr/bin/env node
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 const args = process.argv.slice(2);
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0); }
 if (args[0] === 'recipe' && args[1] === 'build') {
   const options = JSON.parse(await readFile(args[args.indexOf('--options') + 1], 'utf8'));
   await appendFile(process.env.OBSERVED, JSON.stringify({ options }) + '\\n');

--- a/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
@@ -29,7 +29,7 @@ await writeFile(cli, `#!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
 const args = process.argv.slice(2);
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0); }
 if (args[0] === 'recipe' && args[1] === 'build') {
   fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
   process.exit(0);

--- a/wordpress/tests/wp-codebox-phpunit-target-activation-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-target-activation-smoke.mjs
@@ -48,7 +48,7 @@ await writeFile(cli, `#!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
 const args = process.argv.slice(2);
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0); }
 if (args[0] === 'recipe' && args[1] === 'build') {
   fs.copyFileSync(args[args.indexOf('--options') + 1], ${JSON.stringify(recipeOptionsCapture)});
   fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');

--- a/wordpress/tests/wp-codebox-phpunit-timeout-diagnostics-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-timeout-diagnostics-smoke.mjs
@@ -33,7 +33,7 @@ await writeFile(cli, `#!/usr/bin/env node
 import fs from 'node:fs';
 import { spawn } from 'node:child_process';
 const args = process.argv.slice(2);
-if (args.includes('--version')) { process.stdout.write('0.20.0'); process.exit(0); }
+if (args.includes('--version')) { process.stdout.write('0.21.0'); process.exit(0); }
 if (args[0] === 'recipe' && args[1] === 'build') {
   fs.writeFileSync(args[args.indexOf('--output') + 1], '{"schema":"wp-codebox/workspace-recipe/v1"}');
   process.exit(0);

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -29,7 +29,7 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
-function createFixtureWpCodebox(root, version = '0.20.0') {
+function createFixtureWpCodebox(root, version = '0.21.0') {
   fs.mkdirSync(root, { recursive: true });
   const binPath = path.join(root, 'fixture-wp-codebox.js');
   fs.writeFileSync(binPath, `#!/usr/bin/env node
@@ -128,7 +128,7 @@ try {
   const stalePayload = JSON.parse(stale.stdout);
   assert.equal(stalePayload.diagnostics[0].class, 'codebox.preflight.wp_codebox_version_too_old', stale.stdout);
   assert.equal(stalePayload.diagnostics[0].data.selected.version, '0.19.0');
-  assert.equal(stalePayload.diagnostics[0].data.required_version, '0.20.0');
+  assert.equal(stalePayload.diagnostics[0].data.required_version, '0.21.0');
   assert.equal(fs.existsSync(staleCapturePath), false, 'a rejected runtime must not start a recipe');
 
   const environmentalPrecedence = runTaskRunner(request, [

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1073,7 +1073,7 @@
     },
     "inventory": {
       "root_markers": ["composer.json", "readme.txt", "style.css"],
-      "fingerprint_names": ["composer.json", "composer.lock", "package.json", "package-lock.json"],
+      "fingerprint_names": ["composer.json", "composer.lock", "package.json", "package-lock.json", "phpunit.xml", "phpunit.xml.dist"],
       "fingerprint_extensions": ["php", "js", "jsx", "ts", "tsx", "sh"],
       "fingerprint_skip_dirs": [".git", "vendor", "node_modules", "build", "dist", "target", ".homeboy-action"],
       "runners": [{ "id": "wordpress", "version_command": ["php", "--version"] }]


### PR DESCRIPTION
## Summary

- Build WordPress shard inventories from WP Codebox's canonical `wp-codebox/phpunit-discovery/v1` result instead of changed-file smoke matchers.
- Preserve arbitrary PHPUnit XML suffixes, explicit files, exclusions, and longest-prefix mounted test roots as component-relative immutable IDs.
- Replay every canonical member as PHPUnit regardless filename while keeping explicit smoke/changed-file routing unchanged.
- Include PHPUnit configuration in workspace identity, revalidate discovery before replay, and clean bounded discovery artifacts.
- Require WP Codebox `0.21.0`, the first release containing discovery-only support.

Closes #2647.

Upstream primitive: Automattic/wp-codebox#2273.
Consumer blocker: Extra-Chill/data-machine#2850.

## Verification

- Real Data Machine discovery: 138 canonical PHPUnit files, all `target=phpunit`, zero retained discovery artifacts.
- `bash wordpress/scripts/test/test-inventory-smoke.sh`
- `npm --prefix wordpress run test:test-shard-replay`
- `bash wordpress/scripts/test/changed-scope-test-routing-smoke.sh`
- WP Codebox readiness, aggregate, canonical CLI adapter, and database service smoke contracts.
- `node tests/extension-shape-lint.mjs`
- Python/shell syntax, focused ESLint, JSON, and `git diff --check`.

## Dependency

This PR intentionally fails preflight against WP Codebox `0.20.x`. Automattic/wp-codebox#2273 is merged, but WP Codebox `0.21.0` must be released before this extension can be published or consumed by Data Machine CI.

## AI assistance

- **Model:** GPT-5.6 Sol
- **Tools:** OpenCode, Homeboy, and WP Codebox
- **Used for:** Cross-repository root-cause analysis, implementation, adversarial review, and verification. Chris Huber remains responsible for every line.