### PR TITLE
Fix WP Codebox PHPUnit recipe evidence

### DIFF
--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -1536,14 +1536,14 @@ function buildRecipeRunStepsLedger(recipeRun) {
       phpunit: recipeRun.phpunitIndexes.includes(index),
     });
   });
-  return clean({
+  return {
     schema: 'homeboy/wordpress-recipe-run-steps/v1',
     parse_status: recipeRun.parse_status,
     phpunit_executed: recipeRun.phpunitIndexes.length > 0,
     phpunit_step_indexes: recipeRun.phpunitIndexes,
     executions,
-    parse_diagnostics: recipeRun.parse_diagnostics,
-  });
+    ...(recipeRun.parse_diagnostics ? { parse_diagnostics: recipeRun.parse_diagnostics } : {}),
+  };
 }
 function recipeStepName(step) {
   return step?.command || `step ${step?.index ?? '?'}`;

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -1060,7 +1060,7 @@ async function preservePhpunitOutput(artifactDirectory, execution, managedRuntim
   // reaches the PHPUnit step still names the stage that stopped it.
   const recipeRun = execution.timedOut
     ? { ...recipeRunProjection(stdout), payload: null, phpunitIndexes: [], parse_status: 'bounded_timeout_projection' }
-    : parseRecipeRunPayload(stdout);
+    : parseRecipeRunPayload(stdout, stderr);
   const recipeRunSteps = buildRecipeRunStepsLedger(recipeRun);
   await writeFile(recipeRunStepsPath, `${JSON.stringify(recipeRunSteps, null, 2)}\n`);
   const timeoutEvidence = execution.timedOut ? wpCodeboxTimeoutDiagnostics({
@@ -1430,10 +1430,16 @@ function normalizedTestStatus(results, aggregate, executionStatus, validResults)
   }
   return results.status;
 }
-function parseRecipeRunPayload(stdout) {
-  const payload = json(stdout.trim(), null);
+function parseRecipeRunPayload(stdout, stderr = '') {
+  const payload = json(stdout.trim(), null) || extractRecipeRunJson(stdout);
   if (payload === null) {
-    return { payload: null, executions: [], phpunitIndexes: [], parse_status: 'unparseable' };
+    return {
+      payload: null,
+      executions: [],
+      phpunitIndexes: [],
+      parse_status: 'unparseable',
+      parse_diagnostics: recipeRunParseDiagnostics(stdout, stderr),
+    };
   }
   const executions = isObject(payload) && Array.isArray(payload.executions) ? payload.executions : [];
   const phpunitIndexes = [];
@@ -1443,6 +1449,58 @@ function parseRecipeRunPayload(stdout) {
     executions,
     phpunitIndexes,
     parse_status: executions.length > 0 ? 'executions' : 'no_executions',
+  };
+}
+function extractRecipeRunJson(stdout) {
+  const candidates = [];
+  for (let start = 0; start < stdout.length; start += 1) {
+    if (stdout[start] !== '{') {
+      continue;
+    }
+    let depth = 0;
+    let quoted = false;
+    let escaped = false;
+    for (let end = start; end < stdout.length; end += 1) {
+      const character = stdout[end];
+      if (quoted) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === '\\') {
+          escaped = true;
+        } else if (character === '"') {
+          quoted = false;
+        }
+        continue;
+      }
+      if (character === '"') {
+        quoted = true;
+      } else if (character === '{') {
+        depth += 1;
+      } else if (character === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          const candidate = json(stdout.slice(start, end + 1), null);
+          if (isObject(candidate)) {
+            candidates.push(candidate);
+          }
+          break;
+        }
+      }
+    }
+  }
+  return candidates.findLast((candidate) => Array.isArray(candidate.executions)) || candidates.at(-1) || null;
+}
+function recipeRunParseDiagnostics(stdout, stderr) {
+  const diagnostic = (value) => {
+    const redacted = redactSecrets(typeof value === 'string' ? value : '');
+    const bytes = Buffer.byteLength(redacted);
+    const excerpt = Buffer.from(redacted).subarray(0, 4096).toString('utf8');
+    return { bytes, truncated: bytes > 4096, excerpt };
+  };
+  return {
+    reason: 'recipe-run stdout did not contain a complete JSON object payload',
+    stdout: diagnostic(stdout),
+    stderr: diagnostic(stderr),
   };
 }
 // A PHPUnit invocation is identified by its recipe command name when the
@@ -1478,13 +1536,14 @@ function buildRecipeRunStepsLedger(recipeRun) {
       phpunit: recipeRun.phpunitIndexes.includes(index),
     });
   });
-  return {
+  return clean({
     schema: 'homeboy/wordpress-recipe-run-steps/v1',
     parse_status: recipeRun.parse_status,
     phpunit_executed: recipeRun.phpunitIndexes.length > 0,
     phpunit_step_indexes: recipeRun.phpunitIndexes,
     executions,
-  };
+    parse_diagnostics: recipeRun.parse_diagnostics,
+  });
 }
 function recipeStepName(step) {
   return step?.command || `step ${step?.index ?? '?'}`;

--- a/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs
@@ -56,7 +56,11 @@ if (typeof fixture.commandsLog === 'string') {
   fs.mkdirSync(path.join(runtime, 'logs'), { recursive: true });
   fs.writeFileSync(path.join(runtime, 'logs', 'commands.log'), fixture.commandsLog);
 }
-process.stdout.write(JSON.stringify({ success: false, executions: fixture.executions || [] }) + '\\n');
+const payload = JSON.stringify({ success: false, executions: fixture.executions || [] });
+const output = typeof fixture.rawStdout === 'string'
+  ? fixture.rawStdout
+  : (fixture.stdoutPrefix || '') + payload + (fixture.stdoutSuffix || '') + '\\n';
+process.stdout.write(output);
 process.exitCode = fixture.exitCode === undefined ? 1 : fixture.exitCode;
 `);
 await chmod(cli, 0o755);
@@ -104,6 +108,42 @@ try {
       },
     ],
   };
+
+  // The real CLI can print its progress/banner on stdout around the JSON
+  // summary. Recover the complete payload, but do not treat an incomplete
+  // object as evidence.
+  const mixedPayload = await runScenario('mixed-payload', {
+    executions: [
+      { command: 'wordpress.phpunit', status: 'completed', exitCode: 0, stdout: 'OK (2 tests, 2 assertions)\\n', stderr: '' },
+    ],
+    stdoutPrefix: 'Preparing recipe...\\n[wp-codebox] recipe-run\\n',
+    stdoutSuffix: '\\nrecipe-run complete\\n',
+    exitCode: 0,
+    testResults: {
+      schema: 'wp-codebox/test-results/v1',
+      status: 'passed',
+      summary: { total: 2, passed: 2, failed: 0, skipped: 0, unknown: 0 },
+      suites: [],
+    },
+  });
+  assert.equal(mixedPayload.run.status, 0, mixedPayload.run.stderr);
+  const mixedLedger = JSON.parse(await readFile(path.join(mixedPayload.publishedFiles, 'recipe-run-steps.json'), 'utf8'));
+  assert.equal(mixedLedger.parse_status, 'executions');
+  assert.deepEqual(mixedLedger.phpunit_step_indexes, [0]);
+  assert.equal(mixedLedger.parse_diagnostics, undefined);
+
+  const malformedPayload = await runScenario('malformed-payload', {
+    rawStdout: 'noise secret=fixture-ledger-secret {"success":false,"executions":[ truncated\\n',
+    secretValue: 'fixture-ledger-secret',
+  });
+  assert.equal(malformedPayload.run.status, 1, malformedPayload.run.stderr);
+  const malformedLedger = JSON.parse(await readFile(path.join(malformedPayload.publishedFiles, 'recipe-run-steps.json'), 'utf8'));
+  assert.equal(malformedLedger.parse_status, 'unparseable');
+  assert.equal(malformedLedger.phpunit_executed, false);
+  assert.equal(malformedLedger.parse_diagnostics.stdout.bytes > 0, true);
+  assert.equal(malformedLedger.parse_diagnostics.stdout.truncated, false);
+  assert.match(malformedLedger.parse_diagnostics.stdout.excerpt, /secret=\[REDACTED\]/);
+  assert.match(JSON.parse(await readFile(path.join(malformedPayload.publishedFiles, 'phpunit-execution-diagnosis.json'), 'utf8')).cause, /recipe_run_payload_unparseable/);
 
   const setupOnly = await runScenario('setup-only', setupOnlyFixture);
   assert.equal(setupOnly.run.status, 1, setupOnly.run.stderr);


### PR DESCRIPTION
## Summary
- recover valid recipe-run JSON when WP Codebox writes progress around the structured payload
- preserve bounded, secret-redacted stdout and stderr diagnostics when parsing still fails
- cover mixed and malformed real-world output shapes without weakening zero-test failures

## Verification
- `node --check wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs`
- `node wordpress/tests/wp-codebox-phpunit-recipe-run-ledger-smoke.mjs`
- `node wordpress/tests/wp-codebox-phpunit-evidence-smoke.mjs`

Closes #2650