### PR TITLE
fix(wordpress): expose host smoke runtime roots

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -88,6 +88,20 @@ dependency mounts, drop-in handling, WordPress version selection, and
 }
 ```
 
+The booted runtime sets `WP_PATH=/wordpress` in each WordPress smoke child.
+Declared validation dependencies are exposed as a JSON object in
+`HOMEBOY_WORDPRESS_DEPENDENCY_ROOTS_JSON`, mapping each plugin slug to its
+mounted `/wordpress/wp-content/plugins/<slug>` root. These are sandbox paths,
+not host checkout paths, so a smoke can require a dependency without embedding
+machine-specific locations. Each slug also receives its deterministic uppercase
+namespaced path mapping. Every character is encoded with its type so separators
+and case do not collide: `example-plugin` becomes
+`HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_E_LOWER_X_LOWER_A_LOWER_M_LOWER_P_LOWER_L_LOWER_E_HYPHEN_LOWER_P_LOWER_L_LOWER_U_LOWER_G_LOWER_I_LOWER_N_ROOT=/wordpress/wp-content/plugins/example-plugin`.
+The legacy `EXAMPLE_PLUGIN_PATH` form remains available only when it is unique
+among the declared dependencies and does not conflict with a reserved runtime
+variable. This preserves established callers such as `DATA_MACHINE_PATH` while
+the JSON map remains the canonical multi-dependency interface.
+
 ```bash
 homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -127,6 +127,7 @@
     "test:wp-codebox-database-service": "node tests/wp-codebox-database-service-smoke.mjs",
     "test:wp-codebox-native-database-canary": "node tests/wp-codebox-native-database-canary.mjs",
     "test:wp-codebox-doctor": "bash scripts/test/wp-codebox-doctor-smoke.sh",
+    "test:host-smoke-wp-runtime": "bash scripts/test/host-smoke-wp-runtime-e2e.sh",
     "test:test-shard-replay": "bash scripts/test/test-shard-replay-smoke.sh",
     "test:extension-composer-vendor-integrity": "bash tests/extension-composer-vendor-integrity-smoke.sh",
     "test:wordpress-multisite-e2e-rig": "node rigs/wordpress-multisite-e2e/tests/contract.test.mjs",

--- a/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
@@ -8,8 +8,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/crates/homeboy-extension/src/runtime/resolve-context.sh}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve-context helper: ${RESOLVE_CONTEXT_HELPER}" >&2
+    exit 1
+fi
+export HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER"
 
 assert_contains() {
     local file="$1" expected="$2"
@@ -101,6 +109,92 @@ assert_contains "$captured_recipe" "workspace-recipe/v1"
 assert_contains "${CAPTURE_DIR}/wrapper.php" "\$homeboy_smoke_stderr = defined(\"STDERR\") ? STDERR : fopen(\"php://stderr\", \"w\");"
 assert_contains "${CAPTURE_DIR}/wrapper.php" "fwrite(\$homeboy_smoke_stderr"
 assert_not_contains "${CAPTURE_DIR}/wrapper.php" "fwrite(STDERR"
+
+# --- Child environment contract: runtime and dependency roots are sandbox
+# paths, even when their host checkout paths need shell quoting/translation.
+component_with_spaces="${TMPDIR}/component with spaces"
+dependency_with_spaces="${TMPDIR}/dependency roots/dependency-plugin"
+make_component "$component_with_spaces"
+mkdir -p "$dependency_with_spaces"
+cat > "${dependency_with_spaces}/dependency-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Dependency Plugin
+ */
+PHP
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component_with_spaces" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="tests/alpha-smoke.php" \
+HOMEBOY_SETTINGS_JSON="$(jq -nc --arg path "$dependency_with_spaces" '{validation_dependencies: [{path: $path, plugin_slug: "dependency-plugin"}]}')" \
+FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/environment.out"
+
+captured_environment_recipe="$(ls -t "${CAPTURE_DIR}"/recipe-*.json | head -1)"
+assert_contains "$captured_environment_recipe" "${component_with_spaces}"
+assert_contains "$captured_environment_recipe" "${dependency_with_spaces}"
+assert_contains "$captured_environment_recipe" "/wordpress/wp-content/plugins/dependency-plugin"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'WP_PATH' => '/wordpress'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_ROOTS_JSON' => '{\"dependency-plugin\":\"/wordpress/wp-content/plugins/dependency-plugin\"}'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_D_LOWER_E_LOWER_P_LOWER_E_LOWER_N_LOWER_D_LOWER_E_LOWER_N_LOWER_C_LOWER_Y_HYPHEN_LOWER_P_LOWER_L_LOWER_U_LOWER_G_LOWER_I_LOWER_N_ROOT' => '/wordpress/wp-content/plugins/dependency-plugin'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'DEPENDENCY_PLUGIN_PATH' => '/wordpress/wp-content/plugins/dependency-plugin'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "putenv(\$name . \"=\" . \$value)"
+
+# --- Normalized legacy aliases cannot overwrite one another or WP_PATH. The
+# canonical JSON map and injective namespaced variables retain every root.
+collision_component="${TMPDIR}/collision-component"
+mkdir -p "${collision_component}/tests"
+cp "${component}/tests/alpha-smoke.php" "${collision_component}/tests/alpha-smoke.php"
+collision_dependencies=()
+for slug in foo-bar foo.bar foo_bar foo FOO wp data-machine; do
+    dependency="${TMPDIR}/collision-dependencies/${slug}"
+    mkdir -p "$dependency"
+    cat > "${dependency}/${slug}.php" <<PHP
+<?php
+/**
+ * Plugin Name: ${slug}
+ */
+PHP
+    collision_dependencies+=("$dependency")
+done
+
+collision_settings="$(jq -nc \
+    --arg fooHyphen "${collision_dependencies[0]}" \
+    --arg fooDot "${collision_dependencies[1]}" \
+    --arg fooUnderscore "${collision_dependencies[2]}" \
+    --arg fooLower "${collision_dependencies[3]}" \
+    --arg fooUpper "${collision_dependencies[4]}" \
+    --arg wp "${collision_dependencies[5]}" \
+    --arg dataMachine "${collision_dependencies[6]}" \
+    '{validation_dependencies: [$fooHyphen, $fooDot, $fooUnderscore, $fooLower, $fooUpper, $wp, $dataMachine]}')"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="collision-component" \
+HOMEBOY_COMPONENT_PATH="$collision_component" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="tests/alpha-smoke.php" \
+HOMEBOY_SETTINGS_JSON="$collision_settings" \
+FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/collision.out"
+
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'WP_PATH' => '/wordpress'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_F_LOWER_O_LOWER_O_HYPHEN_LOWER_B_LOWER_A_LOWER_R_ROOT' => '/wordpress/wp-content/plugins/foo-bar'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_F_LOWER_O_LOWER_O_DOT_LOWER_B_LOWER_A_LOWER_R_ROOT' => '/wordpress/wp-content/plugins/foo.bar'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_F_LOWER_O_LOWER_O_UNDERSCORE_LOWER_B_LOWER_A_LOWER_R_ROOT' => '/wordpress/wp-content/plugins/foo_bar'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_F_LOWER_O_LOWER_O_ROOT' => '/wordpress/wp-content/plugins/foo'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_UPPER_F_UPPER_O_UPPER_O_ROOT' => '/wordpress/wp-content/plugins/FOO'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_W_LOWER_P_ROOT' => '/wordpress/wp-content/plugins/wp'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_D_LOWER_A_LOWER_T_LOWER_A_HYPHEN_LOWER_M_LOWER_A_LOWER_C_LOWER_H_LOWER_I_LOWER_N_LOWER_E_ROOT' => '/wordpress/wp-content/plugins/data-machine'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "'DATA_MACHINE_PATH' => '/wordpress/wp-content/plugins/data-machine'"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "\"foo-bar\":\"/wordpress/wp-content/plugins/foo-bar\""
+assert_contains "${CAPTURE_DIR}/wrapper.php" "\"foo.bar\":\"/wordpress/wp-content/plugins/foo.bar\""
+assert_contains "${CAPTURE_DIR}/wrapper.php" "\"foo_bar\":\"/wordpress/wp-content/plugins/foo_bar\""
+assert_contains "${CAPTURE_DIR}/wrapper.php" "\"foo\":\"/wordpress/wp-content/plugins/foo\""
+assert_contains "${CAPTURE_DIR}/wrapper.php" "\"FOO\":\"/wordpress/wp-content/plugins/FOO\""
+assert_not_contains "${CAPTURE_DIR}/wrapper.php" "'FOO_BAR_PATH'"
+assert_not_contains "${CAPTURE_DIR}/wrapper.php" "'FOO_PATH'"
+assert_not_contains "${CAPTURE_DIR}/wrapper.php" "'WP_PATH' => '/wordpress/wp-content/plugins/wp'"
 
 # --- Failure propagation: a fake codebox returning success=false fails the run.
 FAKE_CODEBOX_FAIL="${TMPDIR}/fake-wp-codebox-fail.cjs"

--- a/wordpress/scripts/test/host-smoke-wp-runtime-e2e.sh
+++ b/wordpress/scripts/test/host-smoke-wp-runtime-e2e.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Execute the host-smoke contract through the installed WP Codebox runtime. The
+# smoke reads the injected roots and requires a file from the mounted dependency.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${HOMEBOY_CORE_DIR}/crates/homeboy-extension/src/runtime/resolve-context.sh}"
+WP_CODEBOX_BIN="${HOMEBOY_WP_CODEBOX_BIN:-wp-codebox}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if [ ! -f "$RESOLVE_CONTEXT_HELPER" ]; then
+    echo "Missing resolve-context helper: ${RESOLVE_CONTEXT_HELPER}" >&2
+    exit 1
+fi
+if ! command -v "$WP_CODEBOX_BIN" >/dev/null 2>&1; then
+    echo "Missing WP Codebox executable: ${WP_CODEBOX_BIN}" >&2
+    exit 1
+fi
+
+component="${WORKDIR}/component"
+dependency="${WORKDIR}/dependency roots/runtime-dependency"
+mkdir -p "${component}/tests" "$dependency"
+cat > "${component}/tests/runtime-contract-smoke.php" <<'PHP'
+<?php
+
+$wp_path = getenv( 'WP_PATH' );
+$roots   = json_decode( getenv( 'HOMEBOY_WORDPRESS_DEPENDENCY_ROOTS_JSON' ), true );
+
+if ( '/wordpress' !== $wp_path || ! is_dir( $wp_path ) || ! function_exists( 'wp_json_encode' ) ) {
+
+	fwrite( STDERR, "Booted WordPress root is unavailable.\n" );
+	exit( 1 );
+}
+if ( ! is_array( $roots ) || '/wordpress/wp-content/plugins/runtime-dependency' !== ( $roots['runtime-dependency'] ?? null ) ) {
+
+	fwrite( STDERR, "Dependency root mapping is unavailable.\n" );
+	exit( 1 );
+}
+if ( '/wordpress/wp-content/plugins/runtime-dependency' !== getenv( 'HOMEBOY_WORDPRESS_DEPENDENCY_LOWER_R_LOWER_U_LOWER_N_LOWER_T_LOWER_I_LOWER_M_LOWER_E_HYPHEN_LOWER_D_LOWER_E_LOWER_P_LOWER_E_LOWER_N_LOWER_D_LOWER_E_LOWER_N_LOWER_C_LOWER_Y_ROOT' ) ) {
+
+	fwrite( STDERR, "Namespaced dependency root is unavailable.\n" );
+	exit( 1 );
+}
+
+require $roots['runtime-dependency'] . '/runtime-dependency.php';
+if ( ! defined( 'HOMEBOY_RUNTIME_DEPENDENCY_LOADED' ) ) {
+
+	fwrite( STDERR, "Mounted dependency file was not loaded.\n" );
+	exit( 1 );
+}
+
+echo "runtime host smoke passed\n";
+PHP
+cat > "${dependency}/runtime-dependency.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Runtime Dependency
+ */
+
+define( 'HOMEBOY_RUNTIME_DEPENDENCY_LOADED', true );
+PHP
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_WP_CODEBOX_BIN="$WP_CODEBOX_BIN" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="tests/runtime-contract-smoke.php" \
+HOMEBOY_SETTINGS_JSON="$(jq -nc --arg path "$dependency" '{validation_dependencies: [{path: $path, plugin_slug: "runtime-dependency"}]}')" \
+    bash "${SCRIPT_DIR}/test-runner-host-smoke-wp.sh" > "${WORKDIR}/run.out"
+
+if ! grep -Fq "runtime host smoke passed" "${WORKDIR}/run.out"; then
+    echo "Expected the WordPress host smoke to read and use runtime mappings." >&2
+    sed 's/^/  /' "${WORKDIR}/run.out" >&2
+    exit 1
+fi
+
+echo "Real WordPress host-smoke runtime contract passed"

--- a/wordpress/scripts/test/test-runner-host-smoke-wp.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke-wp.sh
@@ -43,6 +43,13 @@ HOST_SMOKE_TIMEOUT_SECONDS="${HOMEBOY_WORDPRESS_HOST_SMOKE_TIMEOUT_SECONDS:-120}
 HOST_SMOKE_EXCERPT_BYTES="${HOMEBOY_WORDPRESS_HOST_SMOKE_EXCERPT_BYTES:-65536}"
 WP_CODEBOX_TIMEOUT_DIAGNOSTICS="${SCRIPT_DIR}/../lib/wp-codebox-timeout-diagnostics.mjs"
 
+case "$PLUGIN_SLUG" in
+    ''|*[!A-Za-z0-9._-]*)
+        echo "ERROR: component has an unsafe WordPress plugin slug: ${PLUGIN_SLUG}" >&2
+        exit 2
+        ;;
+esac
+
 homeboy_wordpress_host_smoke_abs() {
     local raw_path="$1"
     local abs_path
@@ -95,11 +102,11 @@ homeboy_wordpress_smoke_wp_version() {
     printf '%s\n' "$version"
 }
 
-# Build the JSON array of recipe mounts: the plugin, its validation
-# dependencies, and the db.php drop-in if present. WordPress loads all mounted
-# plugins so the smoke's `require` paths resolve and WP core functions exist.
-homeboy_wordpress_smoke_recipe_mounts() {
+# Build the recipe mounts and child environment mapping together so every
+# dependency root exposed to a smoke is the translated path that was mounted.
+homeboy_wordpress_smoke_recipe_inputs() {
     local mounts_json='[]'
+    local dependency_roots_json='{}'
     local plugin_source
     plugin_source="$(homeboy_wp_codebox_resolve_mount_path "$PLUGIN_PATH")"
     mounts_json=$(jq -nc --argjson mounts "$mounts_json" --arg source "$plugin_source" --arg target "/wordpress/wp-content/plugins/${PLUGIN_SLUG}" '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
@@ -108,7 +115,7 @@ homeboy_wordpress_smoke_recipe_mounts() {
         homeboy_export_validation_dependency_paths "$PLUGIN_PATH" >/dev/null 2>&1 || true
     fi
     if [ -n "${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}" ]; then
-        local dep_path dep_slug dep_source
+        local dep_path dep_slug dep_source dep_target
         while IFS= read -r dep_path; do
             [ -n "$dep_path" ] || continue
             [ -d "$dep_path" ] || continue
@@ -117,8 +124,16 @@ homeboy_wordpress_smoke_recipe_mounts() {
             else
                 dep_slug="$(basename "$dep_path")"
             fi
+            case "$dep_slug" in
+                ''|*[!A-Za-z0-9._-]*)
+                    echo "ERROR: validation dependency has an unsafe WordPress plugin slug: ${dep_slug}" >&2
+                    return 1
+                    ;;
+            esac
             dep_source="$(homeboy_wp_codebox_resolve_mount_path "$dep_path")"
-            mounts_json=$(jq -nc --argjson mounts "$mounts_json" --arg source "$dep_source" --arg target "/wordpress/wp-content/plugins/${dep_slug}" '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
+            dep_target="/wordpress/wp-content/plugins/${dep_slug}"
+            mounts_json=$(jq -nc --argjson mounts "$mounts_json" --arg source "$dep_source" --arg target "$dep_target" '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
+            dependency_roots_json=$(jq -nc --argjson roots "$dependency_roots_json" --arg slug "$dep_slug" --arg root "$dep_target" '$roots + {($slug): $root}')
         done <<< "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS"
     fi
 
@@ -128,7 +143,7 @@ homeboy_wordpress_smoke_recipe_mounts() {
         mounts_json=$(jq -nc --argjson mounts "$mounts_json" --arg source "$db_source" --arg target "/wordpress/wp-content/db.php" '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
     fi
 
-    printf '%s\n' "$mounts_json"
+    jq -nc --argjson mounts "$mounts_json" --argjson dependencyRoots "$dependency_roots_json" '{mounts: $mounts, dependency_roots: $dependencyRoots}'
 }
 
 # Emit (to stdout) a PHP wrapper that, when executed inside the booted-WP
@@ -137,16 +152,20 @@ homeboy_wordpress_smoke_recipe_mounts() {
 # This prints the wrapper source; it does not run the smoke on the host.
 homeboy_wordpress_smoke_wrapper() {
     local sandbox_smoke_path="$1"
+    local environment_json="$2"
     php -r '
         $smoke = $argv[1];
+        $environment = json_decode($argv[2], true, 512, JSON_THROW_ON_ERROR);
         echo "<?php\n";
         echo "\$smoke = " . var_export($smoke, true) . ";\n";
+        echo "\$homeboy_smoke_environment = " . var_export($environment, true) . ";\n";
+        echo "foreach (\$homeboy_smoke_environment as \$name => \$value) { putenv(\$name . \"=\" . \$value); \$_ENV[\$name] = \$value; }\n";
         echo "\$homeboy_smoke_stderr = defined(\"STDERR\") ? STDERR : fopen(\"php://stderr\", \"w\");\n";
         echo "if (!is_resource(\$homeboy_smoke_stderr)) { \$homeboy_smoke_stderr = fopen(\"php://output\", \"w\"); }\n";
         echo "if (!file_exists(\$smoke)) { fwrite(\$homeboy_smoke_stderr, \"smoke file missing in sandbox: \" . \$smoke . \"\\n\"); exit(3); }\n";
         echo "register_shutdown_function(function () { \$e = error_get_last(); if (\$e && in_array(\$e[\"type\"], array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR), true)) { exit(1); } });\n";
         echo "try { require \$smoke; } catch (\\Throwable \$e) { fwrite(\$homeboy_smoke_stderr, \"smoke threw: \" . \$e->getMessage() . \"\\n\"); exit(1); }\n";
-    ' "$sandbox_smoke_path"
+    ' "$sandbox_smoke_path" "$environment_json"
 }
 
 run_one_smoke() {
@@ -162,7 +181,7 @@ run_one_smoke() {
     stderr_file="${artifacts_dir}/wp-codebox.stderr"
     termination_file="${artifacts_dir}/termination.json"
 
-    homeboy_wordpress_smoke_wrapper "$sandbox_smoke_path" > "$wrapper_file"
+    homeboy_wordpress_smoke_wrapper "$sandbox_smoke_path" "$RECIPE_ENVIRONMENT" > "$wrapper_file"
     echo "HOST_SMOKE_PROGRESS:${rel_path}:phase=wrapper-created artifacts=${artifacts_dir}"
 
     jq -n \
@@ -345,7 +364,44 @@ case "$WP_CODEBOX_BIN" in
         ;;
 esac
 WP_VERSION="$(homeboy_wordpress_smoke_wp_version)"
-RECIPE_MOUNTS="$(homeboy_wordpress_smoke_recipe_mounts)"
+RECIPE_INPUTS="$(homeboy_wordpress_smoke_recipe_inputs)" || exit 1
+RECIPE_MOUNTS="$(jq -c '.mounts' <<< "$RECIPE_INPUTS")"
+RECIPE_DEPENDENCY_ROOTS="$(jq -c '.dependency_roots' <<< "$RECIPE_INPUTS")"
+RECIPE_ENVIRONMENT="$(jq -c '
+    def namespaced_dependency_name:
+        split("")
+        | map(
+            if test("^[a-z]$") then "LOWER_" + ascii_upcase
+            elif test("^[A-Z]$") then "UPPER_" + .
+            elif test("^[0-9]$") then "DIGIT_" + .
+            elif . == "-" then "HYPHEN"
+            elif . == "." then "DOT"
+            elif . == "_" then "UNDERSCORE"
+            else error("unsupported WordPress plugin slug character")
+            end
+        )
+        | "HOMEBOY_WORDPRESS_DEPENDENCY_" + join("_") + "_ROOT";
+    def legacy_dependency_name:
+        ascii_upcase | gsub("[^A-Z0-9_]"; "_") + "_PATH";
+    .dependency_roots as $roots
+    | ["WP_PATH", "HOMEBOY_WORDPRESS_DEPENDENCY_ROOTS_JSON", "PATH", "HOME", "PWD", "TMPDIR", "SHELL", "USER", "LOGNAME"] as $reserved
+    | [$roots | keys[] | legacy_dependency_name]
+    | group_by(.)
+    | map(select(length == 1) | .[0]) as $unique_legacy_names
+    | {
+        WP_PATH: "/wordpress",
+        HOMEBOY_WORDPRESS_DEPENDENCY_ROOTS_JSON: ($roots | tojson)
+    }
+    + reduce ($roots | to_entries[]) as $dependency (
+        {};
+        ($dependency.key | namespaced_dependency_name) as $namespaced_name
+        | ($dependency.key | legacy_dependency_name) as $legacy_name
+        | . + {($namespaced_name): $dependency.value}
+        | if (($unique_legacy_names | index($legacy_name)) != null and ($reserved | index($legacy_name)) == null)
+          then . + {($legacy_name): $dependency.value}
+          else .
+          end
+    )' <<< "$RECIPE_INPUTS")"
 
 echo "  Files: ${#smoke_files[@]}"
 echo "  WordPress: ${WP_VERSION:-default}"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.35.10",
+  "version": "3.35.11",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
## Summary

- expose the booted WordPress root to WordPress host-smoke children
- expose declared validation dependencies through a canonical JSON map and collision-safe namespaced environment variables
- retain safe legacy plugin-path aliases only when unique and non-reserved
- add a real WP Codebox runtime test that loads a mounted dependency file

Closes #2652.

## Verification

- `bash wordpress/scripts/test/host-smoke-wp-runner-smoke.sh`
- `npm run test:host-smoke-wp-runtime`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `node tests/wordpress-manifest-settings-smoke.js`
- real Data Machine Business WordPress schema smoke through WP Codebox
- shell/JSON validation and `git diff --check`

Repository-wide JS lint retains 52 pre-existing unrelated findings.

## AI assistance disclosure

OpenAI GPT-5.6-sol via OpenCode traced the release test environment failure, implemented and iteratively reviewed the generic runtime/dependency mapping contract, and added real WP Codebox execution coverage. Chris Huber directed and reviewed the work.