### PR TITLE
fix(wordpress): order Git URL delimiter correctly

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -249,6 +249,27 @@ git -C "${REQUESTED_WORKTREE}" commit --quiet -m 'requested source fixture'
 REQUESTED_SHA="$(git -C "${REQUESTED_WORKTREE}" rev-parse HEAD)"
 git -C "${REQUESTED_WORKTREE}" push --quiet origin HEAD:main
 
+# `--` after the remote name is parsed as the replacement URL, not an option
+# terminator. Keep this fixture dash-prefixed so the old ordering must fail.
+if git -C "${STALE_ORIGIN_REPO_DIR}" remote set-url origin -- "${REQUESTED_SOURCE}"; then
+    echo "Expected the previous git remote set-url delimiter ordering to fail" >&2
+    exit 1
+fi
+
+if [ "$(git -C "${STALE_ORIGIN_REPO_DIR}" remote get-url origin)" != "${DIFFERENT_SOURCE}" ]; then
+    echo "Expected failed delimiter ordering to leave the stale origin unchanged" >&2
+    exit 1
+fi
+
+git -C "${STALE_ORIGIN_REPO_DIR}" remote set-url -- origin "${REQUESTED_SOURCE}"
+if [ "$(git -C "${STALE_ORIGIN_REPO_DIR}" remote get-url origin)" != "${REQUESTED_SOURCE}" ]; then
+    echo "Expected corrected git remote set-url delimiter ordering to replace the stale origin" >&2
+    exit 1
+fi
+
+# Restore the stale cache so setup itself must perform the same repair.
+git -C "${STALE_ORIGIN_REPO_DIR}" remote set-url -- origin "${DIFFERENT_SOURCE}"
+
 (
     cd "${EXTENSION_DIR}"
     HOME="${TMPDIR}/stale-origin-home" \

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -384,7 +384,7 @@ EOF
     else
         # This is a Homeboy-owned cache, so converge a stale or dead origin to
         # the caller's requested source before fetching its requested ref.
-        git -C "${repo_dir}" remote set-url origin -- "${source}"
+        git -C "${repo_dir}" remote set-url -- origin "${source}"
     fi
 
     git -C "${repo_dir}" fetch --quiet origin "${ref}"


### PR DESCRIPTION
## Summary

- place the Git option terminator before the remote name when converging managed WP Codebox cache origins
- add a real Git regression proving the prior ordering fails and the corrected ordering updates a dash-prefixed relative URL

Closes #2653.

## Verification

- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash wordpress/scripts/build/update-wp-codebox-cache-smoke.sh`
- focused shell syntax checks
- `git diff --check`

## AI assistance disclosure

OpenAI GPT-5.6-sol via OpenCode traced the released setup failure to incorrect Git option-terminator ordering, implemented the correction, and added a real regression distinguishing both forms. Chris Huber directed and reviewed the work.