### PR TITLE
fix(wordpress): compose repository ESLint configs

### DIFF
--- a/tests/wordpress-eslint-scope-smoke.sh
+++ b/tests/wordpress-eslint-scope-smoke.sh
@@ -75,6 +75,10 @@ cat > "$FAKE_EXTENSION/eslint.config.mjs" <<'JS'
 export default [];
 JS
 
+cat > "$FAKE_EXTENSION/eslint.runner.config.mjs" <<'JS'
+export default [];
+JS
+
 cat > "$SIDECAR_WRITER" <<'SH'
 homeboy_sidecar_merge_json_array() {
     local target="$1"
@@ -167,7 +171,7 @@ HOMEBOY_LINT_FILE='assets/admin.js' \
 assert_contains "$TMP_DIR/js-success.out" "Linting single file: assets/admin.js"
 assert_contains "$TMP_DIR/js-success.out" "ESLint linting passed"
 assert_contains "$ESLINT_ARGS_FILE" "--config"
-assert_contains "$ESLINT_ARGS_FILE" "$FAKE_EXTENSION/eslint.config.mjs"
+assert_contains "$ESLINT_ARGS_FILE" "$FAKE_EXTENSION/eslint.runner.config.mjs"
 assert_contains "$ESLINT_ARGS_FILE" "assets/admin.js"
 
 set +e

--- a/wordpress/eslint.config.mjs
+++ b/wordpress/eslint.config.mjs
@@ -18,6 +18,9 @@ export default [
       'tests/',
     ],
   },
+  {
+    files: [ '**/*.{js,jsx,ts,tsx}' ],
+  },
   ...wordpress.configs.recommended,
   {
     languageOptions: {

--- a/wordpress/eslint.runner.config.mjs
+++ b/wordpress/eslint.runner.config.mjs
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createJiti } from 'jiti';
+
+/**
+ * Internal dependencies
+ */
+import defaults from './eslint.config.mjs';
+
+const componentPath = process.env.HOMEBOY_ESLINT_COMPONENT_PATH;
+const configNames = [
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'eslint.config.cjs',
+  'eslint.config.ts',
+  'eslint.config.mts',
+  'eslint.config.cts',
+];
+
+let localConfig = [];
+
+if ( componentPath ) {
+  const localConfigPath = configNames
+    .map( ( configName ) => resolve( componentPath, configName ) )
+    .find( ( configPath ) => existsSync( configPath ) );
+
+  if ( localConfigPath ) {
+    const jiti = createJiti( import.meta.url );
+    const exportedConfig = await jiti.import( localConfigPath, {
+      default: true,
+    } );
+    localConfig = Array.isArray( exportedConfig )
+      ? exportedConfig
+      : [ exportedConfig ];
+  }
+}
+
+export default [ ...defaults, ...localConfig ];

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -82,6 +82,7 @@
       "bash scripts/bench/bench-results-artifacts-smoke.sh",
       "bash scripts/bench/bench-runner-runtime-backend-smoke.sh",
       "bash scripts/lint/eslint-no-files-smoke.sh",
+      "bash tests/eslint-provider-config-smoke.sh",
       "bash scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh",
       "bash tests/php-fixer-safety-smoke.sh",
       "bash scripts/lint/phpcs-config-selection-smoke.sh",

--- a/wordpress/package-lock.json
+++ b/wordpress/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "devDependencies": {
         "@wordpress/eslint-plugin": "^25.3.0",
-        "eslint": "^9.39.4"
+        "eslint": "^9.39.4",
+        "jiti": "^2.7.0"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -5847,6 +5848,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -83,6 +83,7 @@
     "lint:js": "eslint",
     "test:eslint-build-ignore": "bash scripts/lint/eslint-build-ignore-smoke.sh",
     "test:eslint-dependency-tree-scope": "bash scripts/lint/eslint-dependency-tree-scope-smoke.sh",
+    "test:eslint-provider-config": "bash tests/eslint-provider-config-smoke.sh",
     "test:admin-page-scenarios": "node tests/admin-page-scenarios-smoke.js",
     "test:admin-page-fuzz-surfaces": "node tests/admin-page-fuzz-surfaces-smoke.js",
     "test:wordpress-admin-form-action-surfaces": "node tests/wordpress-admin-form-action-surfaces-smoke.js",
@@ -207,7 +208,8 @@
   },
   "devDependencies": {
     "@wordpress/eslint-plugin": "^25.3.0",
-    "eslint": "^9.39.4"
+    "eslint": "^9.39.4",
+    "jiti": "^2.7.0"
   },
   "overrides": {
     "minimatch@>=9.0.0 <9.0.6": "^10.0.1"

--- a/wordpress/scripts/lint/eslint-build-ignore-smoke.sh
+++ b/wordpress/scripts/lint/eslint-build-ignore-smoke.sh
@@ -21,14 +21,7 @@ for index in $(seq 1 1500); do
     printf 'const = generated%s;\n' "$index" > "${component_dir}/nested/build/generated-${index}.js"
 done
 
-cat > "${component_dir}/eslint.config.mjs" <<JS
-/**
- * External dependencies
- */
-import config from '${EXTENSION_PATH}/eslint.config.mjs';
-
-export default config;
-JS
+printf '%s\n' 'export default [];' > "${component_dir}/eslint.config.mjs"
 
 run_eslint() {
     HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
@@ -41,7 +34,8 @@ run_eslint() {
 run_package_eslint() {
     (
         cd "$component_dir"
-        "${EXTENSION_PATH}/node_modules/.bin/eslint" .
+        "${EXTENSION_PATH}/node_modules/.bin/eslint" \
+            --config "${EXTENSION_PATH}/eslint.config.mjs" .
     )
 }
 

--- a/wordpress/scripts/lint/eslint-dependency-tree-scope-smoke.sh
+++ b/wordpress/scripts/lint/eslint-dependency-tree-scope-smoke.sh
@@ -17,7 +17,7 @@ component_dir="${TMPDIR}/component"
 eslint_log="${TMPDIR}/eslint-args.txt"
 
 mkdir -p "${EXTENSION_PATH}/node_modules/.bin"
-touch "${EXTENSION_PATH}/eslint.config.mjs"
+touch "${EXTENSION_PATH}/eslint.runner.config.mjs"
 
 cat > "${EXTENSION_PATH}/node_modules/.bin/eslint" <<'SH'
 #!/usr/bin/env bash

--- a/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
+++ b/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
@@ -39,7 +39,7 @@ assert_not_contains() {
 component_dir="${TMPDIR}/component"
 findings_file="${TMPDIR}/eslint-findings.json"
 mkdir -p "${component_dir}/inc" "${component_dir}/assets" "${EXTENSION_PATH}/node_modules/.bin"
-touch "${EXTENSION_PATH}/eslint.config.mjs"
+touch "${EXTENSION_PATH}/eslint.runner.config.mjs"
 printf '%s\n' '<?php' > "${component_dir}/inc/Thing.php"
 printf '%s\n' 'const answer = 42;' > "${component_dir}/assets/app.js"
 

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -156,7 +156,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
 fi
 
 ESLINT_BIN="${EXTENSION_PATH}/node_modules/.bin/eslint"
-ESLINT_CONFIG="${EXTENSION_PATH}/eslint.config.mjs"
+ESLINT_CONFIG="${EXTENSION_PATH}/eslint.runner.config.mjs"
 
 # Validate tools exist
 if [ ! -f "$ESLINT_BIN" ]; then
@@ -165,7 +165,7 @@ if [ ! -f "$ESLINT_BIN" ]; then
 fi
 
 if [ ! -f "$ESLINT_CONFIG" ]; then
-    echo "Warning: eslint.config.mjs not found at $ESLINT_CONFIG, skipping JavaScript linting"
+    echo "Warning: ESLint runner config not found at $ESLINT_CONFIG, skipping JavaScript linting"
     exit 0
 fi
 
@@ -180,8 +180,9 @@ if [ -n "$TEXT_DOMAIN" ] && [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Detected text domain: $TEXT_DOMAIN"
 fi
 
-# Build base ESLint arguments. Keep config anchored to this extension so
-# worktree targets do not also load a primary-checkout config.
+# Build base ESLint arguments. The provider config composes a standard flat
+# config only from this resolved component path, never from a primary checkout.
+export HOMEBOY_ESLINT_COMPONENT_PATH="$PLUGIN_PATH"
 eslint_base_args=(--config "$ESLINT_CONFIG")
 
 if [ -n "$TEXT_DOMAIN" ]; then

--- a/wordpress/tests/eslint-provider-config-smoke.sh
+++ b/wordpress/tests/eslint-provider-config-smoke.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTENSION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ESLINT_BIN="${EXTENSION_DIR}/node_modules/.bin/eslint"
+ESLINT_CONFIG="${EXTENSION_DIR}/eslint.runner.config.mjs"
+ESLINT_RUNNER="${EXTENSION_DIR}/scripts/lint/eslint-runner.sh"
+FIXTURES_DIR="${EXTENSION_DIR}/tests/fixtures/eslint-provider"
+
+if [ ! -x "$ESLINT_BIN" ]; then
+    echo "Skipping: $ESLINT_BIN not found (run \`npm ci\` in $EXTENSION_DIR)" >&2
+    exit 0
+fi
+
+print_config() {
+    local component_path="$1"
+    local output_file="$2"
+    local source_file="${3:-src/admin.jsx}"
+
+    (
+        cd "$component_path"
+        HOMEBOY_ESLINT_COMPONENT_PATH="$component_path" \
+            "$ESLINT_BIN" --config "$ESLINT_CONFIG" \
+            --print-config "$source_file" > "$output_file"
+    )
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+print_config "${FIXTURES_DIR}/repository@feature" "${TMP_DIR}/worktree.json"
+print_config "${FIXTURES_DIR}/repository" "${TMP_DIR}/primary.json"
+print_config "${FIXTURES_DIR}/default-only" "${TMP_DIR}/default.json"
+print_config "${FIXTURES_DIR}/precedence" "${TMP_DIR}/precedence.json" "src/admin.js"
+for config_extension in js mjs cjs ts mts cts; do
+    print_config \
+        "${FIXTURES_DIR}/standard-${config_extension}" \
+        "${TMP_DIR}/standard-${config_extension}.json" \
+        "src/admin.js"
+done
+for extension in js ts tsx; do
+    print_config \
+        "${FIXTURES_DIR}/default-only" \
+        "${TMP_DIR}/default-${extension}.json" \
+        "src/admin.${extension}"
+done
+
+node - \
+    "${TMP_DIR}/worktree.json" \
+    "${TMP_DIR}/primary.json" \
+    "${TMP_DIR}/default.json" \
+    "${TMP_DIR}/precedence.json" \
+    "${TMP_DIR}/standard-js.json" \
+    "${TMP_DIR}/standard-mjs.json" \
+    "${TMP_DIR}/standard-cjs.json" \
+    "${TMP_DIR}/standard-ts.json" \
+    "${TMP_DIR}/standard-mts.json" \
+    "${TMP_DIR}/standard-cts.json" <<'JS'
+const fs = require( 'fs' );
+
+const readConfig = ( file ) => JSON.parse( fs.readFileSync( file, 'utf8' ) );
+const worktree = readConfig( process.argv[ 2 ] );
+const primary = readConfig( process.argv[ 3 ] );
+const defaults = readConfig( process.argv[ 4 ] );
+const precedence = readConfig( process.argv[ 5 ] );
+
+if ( worktree.rules[ 'no-console' ][ 0 ] !== 0 ) {
+  throw new Error( 'Expected the worktree JSX override to disable no-console' );
+}
+if ( primary.rules[ 'no-console' ][ 0 ] !== 2 ) {
+  throw new Error( 'Expected the sibling primary fixture to enable no-console' );
+}
+if ( defaults.rules[ 'no-console' ][ 0 ] !== 1 ) {
+  throw new Error( 'Expected default-only JSX to retain provider no-console' );
+}
+if ( defaults.rules[ 'no-undef' ][ 0 ] !== 2 ) {
+  throw new Error( 'Expected default-only JSX to retain WordPress rules' );
+}
+if ( defaults.languageOptions.parserOptions.ecmaFeatures.jsx !== true ) {
+  throw new Error( 'Expected provider defaults to parse discovered JSX' );
+}
+if ( precedence.rules[ 'no-console' ][ 0 ] !== 0 ) {
+  throw new Error( 'Expected eslint.config.js to take precedence over eslint.config.ts' );
+}
+
+const standardExtensions = [ 'js', 'mjs', 'cjs', 'ts', 'mts', 'cts' ];
+standardExtensions.forEach( ( extension, index ) => {
+  const config = readConfig( process.argv[ 6 + index ] );
+  if ( config.settings.homeboyFixture !== extension ) {
+    throw new Error( `Expected eslint.config.${ extension } to execute` );
+  }
+  if ( config.rules.eqeqeq[ 0 ] !== 2 ) {
+    throw new Error( `Expected eslint.config.${ extension } to compose provider defaults` );
+  }
+} );
+JS
+
+for extension in js ts tsx; do
+    node -e '
+      const config = require( process.argv[ 1 ] );
+      if ( config.rules.eqeqeq[ 0 ] !== 2 ) {
+        throw new Error( `Expected ${ process.argv[ 2 ] } to receive WordPress defaults` );
+      }
+    ' "${TMP_DIR}/default-${extension}.json" "$extension"
+done
+
+run_provider() {
+    local component_path="$1"
+    local output_file="$2"
+
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$component_path" \
+    HOMEBOY_COMPONENT_ID="eslint-provider-fixture" \
+    HOMEBOY_COMPONENT_TEXT_DOMAIN="eslint-provider-fixture" \
+        bash "$ESLINT_RUNNER" > "$output_file" 2>&1
+}
+
+run_provider \
+    "${FIXTURES_DIR}/repository@feature" \
+    "${TMP_DIR}/worktree-runner.out"
+run_provider \
+    "${FIXTURES_DIR}/default-only" \
+    "${TMP_DIR}/default-runner.out"
+
+for output_file in \
+    "${TMP_DIR}/worktree-runner.out" \
+    "${TMP_DIR}/default-runner.out"; do
+    if ! grep -Fq "ESLint linting passed" "$output_file"; then
+        echo "Expected provider runner to lint JSX successfully" >&2
+        cat "$output_file" >&2
+        exit 1
+    fi
+    if grep -Fq "File ignored because no matching configuration was supplied" "$output_file"; then
+        echo "Expected discovered JSX to receive matching configuration" >&2
+        cat "$output_file" >&2
+        exit 1
+    fi
+done
+
+echo "WordPress ESLint provider config smoke passed"

--- a/wordpress/tests/fixtures/eslint-provider/default-only/src/admin.js
+++ b/wordpress/tests/fixtures/eslint-provider/default-only/src/admin.js
@@ -1,0 +1,1 @@
+export default true;

--- a/wordpress/tests/fixtures/eslint-provider/default-only/src/admin.jsx
+++ b/wordpress/tests/fixtures/eslint-provider/default-only/src/admin.jsx
@@ -1,0 +1,2 @@
+console.log( 'provider defaults' );
+export default <div />;

--- a/wordpress/tests/fixtures/eslint-provider/default-only/src/admin.ts
+++ b/wordpress/tests/fixtures/eslint-provider/default-only/src/admin.ts
@@ -1,0 +1,1 @@
+export default true;

--- a/wordpress/tests/fixtures/eslint-provider/default-only/src/admin.tsx
+++ b/wordpress/tests/fixtures/eslint-provider/default-only/src/admin.tsx
@@ -1,0 +1,1 @@
+export default <div />;

--- a/wordpress/tests/fixtures/eslint-provider/precedence/eslint.config.js
+++ b/wordpress/tests/fixtures/eslint-provider/precedence/eslint.config.js
@@ -1,0 +1,8 @@
+module.exports = [
+  {
+    files: [ '**/*.js' ],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+];

--- a/wordpress/tests/fixtures/eslint-provider/precedence/eslint.config.ts
+++ b/wordpress/tests/fixtures/eslint-provider/precedence/eslint.config.ts
@@ -1,0 +1,8 @@
+export default [
+  {
+    files: [ '**/*.js' ],
+    rules: {
+      'no-console': 'error',
+    },
+  },
+];

--- a/wordpress/tests/fixtures/eslint-provider/precedence/src/admin.js
+++ b/wordpress/tests/fixtures/eslint-provider/precedence/src/admin.js
@@ -1,0 +1,3 @@
+const ready = true;
+
+export default ready;

--- a/wordpress/tests/fixtures/eslint-provider/repository/eslint.config.mjs
+++ b/wordpress/tests/fixtures/eslint-provider/repository/eslint.config.mjs
@@ -1,0 +1,8 @@
+export default [
+  {
+    files: [ '**/*.jsx' ],
+    rules: {
+      'no-console': 'error',
+    },
+  },
+];

--- a/wordpress/tests/fixtures/eslint-provider/repository/src/admin.jsx
+++ b/wordpress/tests/fixtures/eslint-provider/repository/src/admin.jsx
@@ -1,0 +1,1 @@
+export default <div />;

--- a/wordpress/tests/fixtures/eslint-provider/repository@feature/eslint.config.ts
+++ b/wordpress/tests/fixtures/eslint-provider/repository@feature/eslint.config.ts
@@ -1,0 +1,10 @@
+const config: object[] = [
+  {
+    files: [ '**/*.jsx' ],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+];
+
+export default config;

--- a/wordpress/tests/fixtures/eslint-provider/repository@feature/src/admin.jsx
+++ b/wordpress/tests/fixtures/eslint-provider/repository@feature/src/admin.jsx
@@ -1,0 +1,2 @@
+console.log( 'worktree config' );
+export default <div />;

--- a/wordpress/tests/fixtures/eslint-provider/standard-cjs/eslint.config.cjs
+++ b/wordpress/tests/fixtures/eslint-provider/standard-cjs/eslint.config.cjs
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+    settings: {
+      homeboyFixture: 'cjs',
+    },
+  },
+];

--- a/wordpress/tests/fixtures/eslint-provider/standard-cjs/src/admin.js
+++ b/wordpress/tests/fixtures/eslint-provider/standard-cjs/src/admin.js
@@ -1,0 +1,1 @@
+export default true;

--- a/wordpress/tests/fixtures/eslint-provider/standard-cts/eslint.config.cts
+++ b/wordpress/tests/fixtures/eslint-provider/standard-cts/eslint.config.cts
@@ -1,0 +1,9 @@
+const config: object[] = [
+  {
+    settings: {
+      homeboyFixture: 'cts',
+    },
+  },
+];
+
+export default config;

--- a/wordpress/tests/fixtures/eslint-provider/standard-cts/src/admin.js
+++ b/wordpress/tests/fixtures/eslint-provider/standard-cts/src/admin.js
@@ -1,0 +1,1 @@
+export default true;

--- a/wordpress/tests/fixtures/eslint-provider/standard-js/eslint.config.js
+++ b/wordpress/tests/fixtures/eslint-provider/standard-js/eslint.config.js
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+    settings: {
+      homeboyFixture: 'js',
+    },
+  },
+];

--- a/wordpress/tests/fixtures/eslint-provider/standard-js/src/admin.js
+++ b/wordpress/tests/fixtures/eslint-provider/standard-js/src/admin.js
@@ -1,0 +1,1 @@
+export default true;

--- a/wordpress/tests/fixtures/eslint-provider/standard-mjs/eslint.config.mjs
+++ b/wordpress/tests/fixtures/eslint-provider/standard-mjs/eslint.config.mjs
@@ -1,0 +1,7 @@
+export default [
+  {
+    settings: {
+      homeboyFixture: 'mjs',
+    },
+  },
+];

--- a/wordpress/tests/fixtures/eslint-provider/standard-mjs/src/admin.js
+++ b/wordpress/tests/fixtures/eslint-provider/standard-mjs/src/admin.js
@@ -1,0 +1,1 @@
+export default true;

--- a/wordpress/tests/fixtures/eslint-provider/standard-mts/eslint.config.mts
+++ b/wordpress/tests/fixtures/eslint-provider/standard-mts/eslint.config.mts
@@ -1,0 +1,9 @@
+const config: object[] = [
+  {
+    settings: {
+      homeboyFixture: 'mts',
+    },
+  },
+];
+
+export default config;

--- a/wordpress/tests/fixtures/eslint-provider/standard-mts/src/admin.js
+++ b/wordpress/tests/fixtures/eslint-provider/standard-mts/src/admin.js
@@ -1,0 +1,1 @@
+export default true;

--- a/wordpress/tests/fixtures/eslint-provider/standard-ts/eslint.config.ts
+++ b/wordpress/tests/fixtures/eslint-provider/standard-ts/eslint.config.ts
@@ -1,0 +1,9 @@
+const config: object[] = [
+  {
+    settings: {
+      homeboyFixture: 'ts',
+    },
+  },
+];
+
+export default config;

--- a/wordpress/tests/fixtures/eslint-provider/standard-ts/src/admin.js
+++ b/wordpress/tests/fixtures/eslint-provider/standard-ts/src/admin.js
@@ -1,0 +1,1 @@
+export default true;


### PR DESCRIPTION
## Summary
- compose component-local flat ESLint configs after WordPress provider defaults
- anchor standard config discovery to the target worktree and support js, mjs, cjs, ts, mts, and cts configs
- retain provider ignores/default rules for components without local configuration
- add registered CI smoke coverage for JSX/TypeScript matching, precedence, and primary/worktree isolation

## Verification
- registered provider config and all six filename fixture smokes pass
- runner scope, dependency-tree, glob-filter, and build-ignore smokes pass
- shell/Node/JSON checks and `git diff --check` pass

Closes #2659