### PR TITLE
fix(opencode): capture executed model provenance

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -71,6 +71,7 @@ const OPENCODE_GIT_CAPTURE_OPTIONS = {
 };
 const MAX_STRUCTURED_OUTPUT_BYTES = 64 * 1024;
 const MAX_STRUCTURED_ANSWER_BYTES = MAX_STRUCTURED_OUTPUT_BYTES + 16 * 1024;
+const OPENCODE_SESSION_EXPORT_TIMEOUT_MS = 2_000;
 
 const OPENCODE_CAPABILITIES = [
 	'cli_runtime',
@@ -522,6 +523,7 @@ function findArtifact(artifacts, declaration) {
 function opencodeSuccessOutcome(context) {
 	const structured = structuredOpenCodeOutputs(context);
 	const evidence = collectOpenCodeArtifacts(context, structured);
+	const session = sessionMetadata(context);
 	const emptyPatch = evidence.artifacts?.some((artifact) => artifact.name === 'patch' && artifact.bytes === 0);
 	const missingRequiredOutputs = structured.missingRequiredOutputs || [];
 	const intentionalNoChange = structured.outputs && missingRequiredOutputs.length === 0 && emptyPatch && context.initialRevision?.revision
@@ -548,7 +550,8 @@ function opencodeSuccessOutcome(context) {
 		],
 		metadata: {
 			exit_code: 0,
-			opencode_session: sessionMetadata(context),
+			opencode_session: session,
+			...(session.model ? { model: session.model } : {}),
 			opencode_progress: progressMetadata(context),
 		},
 		...(structured.outputs || intentionalNoChange ? {
@@ -1050,8 +1053,76 @@ function mergeEvidence(primary = {}, secondary = {}) {
 }
 
 function sessionMetadata(context = {}) {
-	const explicit = context.spawnResult?.opencode_session || context.spawnResult?.opencodeSession;
-	return explicit && typeof explicit === 'object' && !Array.isArray(explicit) ? explicit : OPENCODE_SESSION_METADATA_ABSENT;
+	if (context.sessionMetadata) {
+		return context.sessionMetadata;
+	}
+	const sessionId = openCodeSessionId(context.spawnResult?.stdout);
+	if (!sessionId || !isOpenCodeCommand(context.commandSpec)) {
+		context.sessionMetadata = OPENCODE_SESSION_METADATA_ABSENT;
+		return context.sessionMetadata;
+	}
+	const result = spawnSync(context.commandSpec.command, [
+		...arrayValue(context.commandSpec.args),
+		'export',
+		sessionId,
+		'--sanitize',
+	], {
+		cwd: context.cwd,
+		env: context.spawnExtra?.env,
+		encoding: 'utf8',
+		maxBuffer: 1024 * 1024,
+		// Session provenance is supplementary to a completed provider run. Bound
+		// its follow-up process so a wedged export cannot hold Cook indefinitely.
+		timeout: OPENCODE_SESSION_EXPORT_TIMEOUT_MS,
+		killSignal: 'SIGKILL',
+	});
+	if (result.status !== 0 || result.error) {
+		context.sessionMetadata = {
+			status: 'unavailable',
+			session_id: sessionId,
+			reason: 'OpenCode did not return a readable completed-session export.',
+		};
+		return context.sessionMetadata;
+	}
+	const exported = parseOpenCodeExport(result.stdout);
+	const provider = stringValue(exported?.info?.model?.providerID);
+	const model = stringValue(exported?.info?.model?.id);
+	if (!provider || !model) {
+		context.sessionMetadata = {
+			status: 'unavailable',
+			session_id: sessionId,
+			reason: 'OpenCode session export did not contain a concrete provider and model.',
+		};
+		return context.sessionMetadata;
+	}
+	context.sessionMetadata = {
+		status: 'captured',
+		session_id: sessionId,
+		model: `${provider}/${model}`,
+	};
+	return context.sessionMetadata;
+}
+
+function openCodeSessionId(stdout = '') {
+	for (const event of parseJsonObjectsFromText(stdout)) {
+		const sessionId = stringValue(event.sessionID || event.session_id || event.part?.sessionID);
+		if (sessionId) {
+			return sessionId;
+		}
+	}
+	return '';
+}
+
+function parseOpenCodeExport(output = '') {
+	const start = String(output).indexOf('{');
+	if (start < 0) {
+		return null;
+	}
+	try {
+		return JSON.parse(String(output).slice(start));
+	} catch {
+		return null;
+	}
 }
 
 function progressMetadata(context = {}) {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -662,6 +662,68 @@ process.exit(0);
 	assert.equal(preflightReadWrite.status, 'succeeded', JSON.stringify(preflightReadWrite.diagnostics));
 	assert.equal(fs.readFileSync(preflightRunMarker, 'utf8'), 'run\nrun\n');
 
+	const provenanceOpenCode = path.join(root, 'opencode');
+	fs.writeFileSync(provenanceOpenCode, `#!/usr/bin/env node
+const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
+if (process.argv[2] === 'debug') {
+  const permission = Object.entries(config.agent.build.permission)
+    .flatMap(([name, rules]) => Object.entries(rules).map(([pattern, action]) => ({ permission: name, pattern, action })));
+  process.stdout.write(JSON.stringify({ permission }));
+  process.exit(0);
+}
+if (process.argv[2] === 'export') {
+  if (process.env.HOMEBOY_TEST_HANG_EXPORT === '1') {
+    setInterval(() => {}, 1_000);
+  } else {
+    process.stdout.write('Exporting session\\n' + JSON.stringify({ info: { model: { providerID: 'openai', id: 'gpt-5.6-sol' } } }));
+    process.exit(0);
+  }
+} else {
+  process.stdout.write(JSON.stringify({ type: 'step_start', sessionID: 'ses_default_model', part: { sessionID: 'ses_default_model' } }) + '\\n');
+  process.exit(0);
+}
+`);
+	fs.chmodSync(provenanceOpenCode, 0o755);
+	const defaultModelResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-default-model-provenance',
+		workspace_path: preflightWorkspace,
+		artifacts_path: path.join(root, 'default-model-artifacts'),
+		executor: {
+			...request.executor,
+			config: { ...request.executor.config, runtime_bin: provenanceOpenCode, command_args: [] },
+		},
+	}, { env: fixtureEnv });
+	assert.equal(defaultModelResult.status, 'succeeded', JSON.stringify(defaultModelResult.diagnostics));
+	assert.equal(defaultModelResult.metadata.model, 'openai/gpt-5.6-sol');
+	assert.deepEqual(defaultModelResult.metadata.opencode_session, {
+		status: 'captured', session_id: 'ses_default_model', model: 'openai/gpt-5.6-sol',
+	});
+	const exportStarted = Date.now();
+	const unavailableModelResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-unavailable-session-model',
+		workspace_path: preflightWorkspace,
+		artifacts_path: path.join(root, 'unavailable-model-artifacts'),
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				runtime_bin: provenanceOpenCode,
+				command_args: [],
+				runtime_env: { HOMEBOY_TEST_HANG_EXPORT: '1' },
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.ok(Date.now() - exportStarted < 4_000, 'session export must not block provider completion');
+	assert.equal(unavailableModelResult.status, 'succeeded', JSON.stringify(unavailableModelResult.diagnostics));
+	assert.deepEqual(unavailableModelResult.metadata.opencode_session, {
+		status: 'unavailable',
+		session_id: 'ses_default_model',
+		reason: 'OpenCode did not return a readable completed-session export.',
+	});
+	assert.equal(unavailableModelResult.metadata.model, undefined);
+
 	const scratchAttempts = [
 		{ id: 'run-2250-attempt-1', status: 0 },
 		{ id: 'run-2250-attempt-2', status: 17 },


### PR DESCRIPTION
## Summary
- capture the OpenCode session ID from the completed JSON event stream
- export the completed session with sanitization and record its concrete provider/model as actual execution evidence
- bound provenance export to two seconds and remain fail-closed when export is unavailable

## Root cause
The OpenCode adapter discarded the provider-owned session ID and always reported session metadata as undiscovered. Homeboy therefore received a successful outcome with `provider_model: null`, blocking normal finalization after green gates. Homeboy Extensions owns this runtime adapter behavior; Homeboy core already projects provider-reported `metadata.model` into durable provenance.

## Verification
- `npm run test:opencode-agent-task-executor-boundary`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `npm run check:runtime-manifest`
- `git diff --check origin/main...HEAD`

Fixes Extra-Chill/homeboy#13045

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode general coding subagent
- **Used for:** adapter tracing, session-export implementation, bounded timeout tests, and compatibility review

Chris Huber reviewed the diff and remains responsible for every line.