### PR TITLE
fix(wordpress): normalize bounded PHPUnit output reads

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -27,6 +27,7 @@
     ],
     "test": [
       "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
+      "node tests/wp-codebox-phpunit-bounded-output-smoke.mjs",
       "bash scripts/build/setup-wp-codebox-smoke.sh",
       "bash scripts/build/update-wp-codebox-cache-smoke.sh",
       "bash scripts/test/wp-codebox-doctor-smoke.sh",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -123,6 +123,7 @@
     "test:wp-codebox-recipe-helper": "node tests/wp-codebox-recipe-helper-smoke.js",
     "test:wp-codebox-fuzz-plan-recipe-builder": "node tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js",
     "test:wp-codebox-canonical-cli-adapters": "node tests/wp-codebox-canonical-cli-adapters-smoke.mjs",
+    "test:wp-codebox-phpunit-bounded-output": "node tests/wp-codebox-phpunit-bounded-output-smoke.mjs",
     "test:wp-codebox-phpunit-evidence": "node tests/wp-codebox-phpunit-evidence-smoke.mjs",
     "test:wp-codebox-phpunit-aggregate": "node tests/wp-codebox-phpunit-aggregate-smoke.mjs",
     "test:wp-codebox-database-service": "node tests/wp-codebox-database-service-smoke.mjs",

--- a/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
+++ b/wordpress/scripts/test/wp-codebox-phpunit-adapter.mjs
@@ -145,8 +145,8 @@ try {
   if (discoveryOnly) {
     try {
       if (execution.status !== 0) {
-        const stdout = (await readBoundedText(execution.stdoutPath, 8 * 1024)).trim();
-        const stderr = (await readBoundedText(execution.stderrPath, 8 * 1024)).trim();
+        const stdout = (await readBoundedText(execution.stdoutPath, 8 * 1024)).text.trim();
+        const stderr = (await readBoundedText(execution.stderrPath, 8 * 1024)).text.trim();
         const diagnostic = [stdout, stderr].filter(Boolean).join('\n');
         throw new Error(`WP Codebox PHPUnit discovery failed with exit ${execution.status}${diagnostic ? `: ${diagnostic}` : '.'}`);
       }

--- a/wordpress/tests/wp-codebox-phpunit-bounded-output-smoke.mjs
+++ b/wordpress/tests/wp-codebox-phpunit-bounded-output-smoke.mjs
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { strict as assert } from 'node:assert';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+/**
+ * Internal dependencies
+ */
+import { readBoundedText } from '../scripts/lib/wp-codebox-timeout-diagnostics.mjs';
+
+const root = await mkdtemp(path.join(os.tmpdir(), 'wp-codebox-phpunit-bounded-output-'));
+const extension = path.resolve(import.meta.dirname, '..');
+const adapter = path.join(extension, 'scripts/test/wp-codebox-phpunit-adapter.mjs');
+const component = path.join(root, 'sample-plugin');
+const cli = path.join(root, 'wp-codebox.mjs');
+const belowLimit = path.join(root, 'below-limit.log');
+const aboveLimit = path.join(root, 'above-limit.log');
+const empty = path.join(root, 'empty.log');
+const missing = path.join(root, 'missing.log');
+const unreadable = path.join(root, 'directory');
+
+await mkdir(path.join(component, 'tests'), { recursive: true });
+await mkdir(unreadable);
+await writeFile(path.join(component, 'sample-plugin.php'), '<?php\n/* Plugin Name: Sample Plugin */\n');
+await writeFile(belowLimit, 'under limit');
+await writeFile(aboveLimit, '123456789');
+await writeFile(empty, '');
+await writeFile(cli, `
+import { readFile, writeFile } from 'node:fs/promises';
+const args = process.argv.slice(2);
+if (args.includes('--version')) {
+  process.stdout.write('0.21.0');
+  process.exit(0);
+}
+if (args[0] === 'recipe' && args[1] === 'build') {
+  const options = await readFile(args[args.indexOf('--options') + 1], 'utf8');
+  await writeFile(args[args.indexOf('--output') + 1], options);
+  process.exit(0);
+}
+const options = JSON.parse(await readFile(args[args.indexOf('--recipe') + 1], 'utf8'));
+if (process.env.BOUNDED_OUTPUT_FIXTURE === 'failure') {
+  process.stdout.write('bounded discovery stdout ' + 'x'.repeat(9 * 1024) + ' END_UNBOUNDED');
+  process.stderr.write('bounded discovery stderr');
+  process.exit(7);
+}
+const discovery = {
+  schema: 'wp-codebox/phpunit-discovery/v1',
+  plugin_slug: options.pluginSlug,
+  files: ['/wordpress/wp-content/plugins/sample-plugin/tests/SampleTest.php'],
+};
+process.stdout.write(JSON.stringify({
+  executions: [{ command: 'wordpress.phpunit', stdout: JSON.stringify(discovery) }],
+}));
+`);
+
+function runAdapter(fixture) {
+  return spawnSync(process.execPath, [adapter], {
+    env: {
+      ...process.env,
+      HOMEBOY_COMPONENT_PATH: component,
+      COMPONENT_ID: 'sample-plugin',
+      HOMEBOY_SETTINGS_JSON: '{}',
+      HOMEBOY_WORDPRESS_PHPUNIT_DISCOVERY_ONLY: '1',
+      HOMEBOY_WP_CODEBOX_COMMAND_JSON: JSON.stringify([process.execPath, cli]),
+      BOUNDED_OUTPUT_FIXTURE: fixture,
+    },
+    encoding: 'utf8',
+  });
+}
+
+try {
+  assert.deepEqual(await readBoundedText(belowLimit, 16), { text: 'under limit', truncated: false });
+  assert.deepEqual(await readBoundedText(aboveLimit, 5), { text: '12345', truncated: true });
+  assert.deepEqual(await readBoundedText(empty, 16), { text: '', truncated: false });
+  assert.deepEqual(await readBoundedText(missing, 16), { text: '', truncated: false });
+  assert.deepEqual(await readBoundedText(unreadable, 16), { text: '', truncated: false });
+
+  const success = runAdapter('success');
+  assert.equal(success.status, 0, success.stderr);
+  assert.deepEqual(JSON.parse(success.stdout), {
+    schema: 'wp-codebox/phpunit-discovery/v1',
+    plugin_slug: 'sample-plugin',
+    files: ['/wordpress/wp-content/plugins/sample-plugin/tests/SampleTest.php'],
+  });
+
+  const failure = runAdapter('failure');
+  assert.equal(failure.status, 1, failure.stderr);
+  assert.match(failure.stderr, /WP Codebox PHPUnit discovery failed with exit 7: bounded discovery stdout/);
+  assert.match(failure.stderr, /bounded discovery stderr/);
+  assert.doesNotMatch(failure.stderr, /END_UNBOUNDED/);
+  assert.doesNotMatch(failure.stderr, /TypeError|\.trim is not a function|\[object Object\]/);
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+process.stdout.write('WP Codebox PHPUnit bounded output smoke passed.\n');


### PR DESCRIPTION
## Summary
- extract the canonical `text` field from bounded stdout and stderr results before trimming PHPUnit discovery diagnostics
- preserve the helper's `{ text, truncated }` contract and existing 8 KiB diagnostic bounds without object stringification
- add a focused helper and adapter regression covering successful inventory output and bounded command failures

## Root Cause
`readBoundedText()` returns `{ text, truncated }`, but the canonical PHPUnit discovery failure path still treated both returned objects as bare strings and called `.trim()` directly. That raised a JavaScript `TypeError` before Homeboy could emit useful discovery failure evidence or create candidate test shards.

Every repository caller was checked. Structured timeout and artifact consumers already read `.text` or intentionally pass the full bounded object. The only stale callers were discovery stdout and stderr in `wp-codebox-phpunit-adapter.mjs`; both now extract `.text` consistently.

## Regression Coverage
The new smoke covers:
- output below the byte limit
- output above the limit with `truncated: true`
- empty output
- missing output
- a read error from a directory path
- canonical WP Codebox PHPUnit discovery inventory output
- nonzero discovery execution with bounded stdout, retained stderr, and no `TypeError` or `[object Object]`

## Verification
- `npm run test:wp-codebox-phpunit-bounded-output` - passed
- `node tests/wp-codebox-timeout-diagnostics-smoke.mjs` - passed
- `node tests/wp-codebox-phpunit-timeout-diagnostics-smoke.mjs` - passed
- `npm run test:wp-codebox-canonical-cli-adapters` - passed
- `node ../tests/wp-codebox-adapter-contract-smoke.mjs` - passed
- `npm run test:build-package-artifacts` - passed
- `npx eslint --no-ignore scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-bounded-output-smoke.mjs` - passed
- `node --check scripts/lib/wp-codebox-timeout-diagnostics.mjs scripts/test/wp-codebox-phpunit-adapter.mjs tests/wp-codebox-phpunit-bounded-output-smoke.mjs` - passed
- `jq empty package.json homeboy.json wordpress.json` - passed
- `git diff --check` - passed
- `npm run lint:js` - existing repository-wide failure: 52 unrelated errors and 6 warnings outside this patch; changed files pass the focused lint command above

## CI Reproduction
The original crash reproduced twice in Extra-Chill/data-machine PR #3333 before inventory generation. Homeboy Test run 32615858582, job 97136545248 failed with `(await readBoundedText(...)).trim is not a function`, followed by `test_inventory_rejection: child_file_missing`; no candidate shards started.

https://github.com/Extra-Chill/data-machine/actions/runs/32615858582/job/97136545248

Fixes #2667