### PR TITLE
fix(opencode): version runtime behavior changes

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
+++ b/agent-runtimes/opencode/lib/opencode-runtime-manifest.js
@@ -9,7 +9,7 @@ function runtimeManifest() {
 		schema: 'homeboy/agent-runtime-manifest/v1',
 		id: 'opencode',
 		name: 'OpenCode',
-		version: '1.3.1',
+		version: '1.3.2',
 		description: 'OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.',
 		requires: {
 			homeboy: '>=0.345.0',

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "opencode",
   "name": "OpenCode",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "requires": {
     "homeboy": ">=0.345.0"

--- a/agent-runtimes/opencode/package.json
+++ b/agent-runtimes/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeboy-agent-runtime-opencode",
-  "version": "1.0.0",
+  "version": "1.3.2",
   "private": true,
   "main": "index.js",
   "exports": {

--- a/agent-runtimes/opencode/scripts/agent/homeboy-opencode-runtime-manifest.cjs
+++ b/agent-runtimes/opencode/scripts/agent/homeboy-opencode-runtime-manifest.cjs
@@ -10,6 +10,7 @@ const {
 } = require('../../lib/opencode-runtime-manifest');
 
 const manifestPath = path.join(__dirname, '..', '..', 'opencode.json');
+const packagePath = path.join(__dirname, '..', '..', 'package.json');
 const manifestJson = `${JSON.stringify(runtimeManifest(), null, 2)}\n`;
 const command = process.argv[2] || '--print';
 
@@ -17,6 +18,11 @@ if (command === '--write') {
 	fs.writeFileSync(manifestPath, manifestJson);
 } else if (command === '--check') {
 	try {
+		assert.equal(
+			JSON.parse(fs.readFileSync(packagePath, 'utf8')).version,
+			runtimeManifest().version,
+			'OpenCode package and manifest versions must match so runtime installs refresh executable changes.'
+		);
 		assert.deepEqual(JSON.parse(fs.readFileSync(manifestPath, 'utf8')), runtimeManifest());
 	} catch {
 		process.stderr.write('agent-runtimes/opencode/opencode.json is out of date. Run `node scripts/agent/homeboy-opencode-runtime-manifest.cjs --write`.\n');

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -165,6 +165,7 @@ assert.deepEqual(
 assert.equal('Unexpected server error. Check server logs for details. err_not-hex'.match(errorRefPattern), null);
 const packageJson = JSON.parse(fs.readFileSync(path.join(runtimeRoot, 'package.json'), 'utf8'));
 assert.equal(packageJson.name, 'homeboy-agent-runtime-opencode');
+assert.equal(packageJson.version, manifest.version);
 assert.equal(packageJson.homeboy.agent_runtime_manifest, 'opencode.json');
 assert.equal(JSON.stringify({ manifest, packageJson }).includes('wp-codebox'), false);
 assert.equal(JSON.stringify({ manifest, packageJson }).includes('WP Codebox'), false);
@@ -684,16 +685,22 @@ if (process.argv[2] === 'export') {
 }
 `);
 	fs.chmodSync(provenanceOpenCode, 0o755);
-	const defaultModelResult = await executeOpenCodeAgentTask({
-		...request,
-		task_id: 'opencode-default-model-provenance',
-		workspace_path: preflightWorkspace,
-		artifacts_path: path.join(root, 'default-model-artifacts'),
-		executor: {
-			...request.executor,
-			config: { ...request.executor.config, runtime_bin: provenanceOpenCode, command_args: [] },
-		},
-	}, { env: fixtureEnv });
+	const defaultModelRun = spawnSync(process.execPath, [scriptPath], {
+		encoding: 'utf8',
+		env: fixtureEnv,
+		input: JSON.stringify({
+			...request,
+			task_id: 'opencode-default-model-provenance',
+			workspace_path: preflightWorkspace,
+			artifacts_path: path.join(root, 'default-model-artifacts'),
+			executor: {
+				...request.executor,
+				config: { ...request.executor.config, runtime_bin: provenanceOpenCode, command_args: [] },
+			},
+		}),
+	});
+	assert.equal(defaultModelRun.status, 0, defaultModelRun.stderr);
+	const defaultModelResult = JSON.parse(defaultModelRun.stdout);
 	assert.equal(defaultModelResult.status, 'succeeded', JSON.stringify(defaultModelResult.diagnostics));
 	assert.equal(defaultModelResult.metadata.model, 'openai/gpt-5.6-sol');
 	assert.deepEqual(defaultModelResult.metadata.opencode_session, {


### PR DESCRIPTION
## Summary
- advance the OpenCode runtime contract/install identity to `1.3.2` after the session-export provenance behavior change
- require package and generated manifest versions to agree
- execute the materialized runtime entrypoint in the default-model provenance boundary test

Closes #2669
Related: Extra-Chill/homeboy#13045

## Verification
- `npm run check:runtime-manifest`
- `npm run test:opencode-agent-task-executor-boundary`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `git diff --check`

## Evidence boundary
This proves the runtime package has a new discoverable identity, manifest/package drift fails validation, and the packaged entrypoint captures a concrete model from completed-session export. External installer cache replacement remains owned by its installer.

## AI assistance
OpenAI GPT-5.6-sol via OpenCode traced the stale installed adapter identity, implemented the version/freshness contract and boundary coverage, and ran verification. Chris Huber reviewed the diff and remains responsible for every line.