### PR TITLE
feat(wordpress): attest release package provenance

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -352,6 +352,35 @@ defaults, or mandatory Homeboy safety exclusions. Use component-root rsync
 patterns such as `/playground-runtime/` to exclude a root directory. Exclude
 patterns are strings and cannot traverse outside the component.
 
+### Release provenance preparation
+
+Components that need release-specific preparation or provenance can set
+`release_provenance_command` in their WordPress extension settings. The command
+runs after `release.package` stages the ZIP. It writes a JSON object to the
+provided sidecar path; a nonzero exit or missing/invalid sidecar aborts release.
+
+```json
+{
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "release_provenance_command": "my-provenance-tool > \"$HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH\""
+      }
+    }
+  }
+}
+```
+
+The command receives `HOMEBOY_WORDPRESS_RELEASE_PACKAGE_ROOT`, source
+`VERSION`, `TAG`, and `COMMIT`, plus `ZIP_PATH`, `OUTPUT_PATH`, and
+`SIDECAR_PATH` (all prefixed with `HOMEBOY_WORDPRESS_RELEASE_`). The package
+root and output paths are resolved inside the component checkout. The extension
+seals the sidecar with schema version `1`, the release source coordinates, and
+the ZIP SHA-256. `release.publish` requires those exact values from its release
+payload, uploads the sidecar before the ZIP, verifies both remote asset names,
+rolls back either named asset after a failed transaction, and emits ZIP and
+sidecar digests in its receipt.
+
 ### Local workspace dependency overrides
 
 A component can depend on a sibling workspace package that is intentionally not

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -110,6 +110,7 @@
       "bash tests/phpstan-relative-include-path-smoke.sh",
       "bash tests/phpstan-relative-dependency-path-smoke.sh",
       "bash tests/release-scripts-smoke.sh",
+      "bash tests/release-provenance-contract-smoke.sh",
       "bash tests/validation-dependencies-smoke.sh",
       "node tests/wordpress-fuzz-runtime-capabilities-smoke.js",
       "bash tests/wp-cli-auto-flags-smoke.sh",

--- a/wordpress/scripts/release/package.sh
+++ b/wordpress/scripts/release/package.sh
@@ -28,6 +28,10 @@ set -euo pipefail
 #                          - explicit source checkout override for package builds.
 #   HOMEBOY_RELEASE_SOURCE_PATH
 #                          - generic release source checkout path from Homeboy.
+#   release_provenance_command
+#                          - component-configured command run after the ZIP is
+#                            staged. It writes the JSON sidecar named by
+#                            HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -54,6 +58,7 @@ if [[ -n "${PACKAGE_SOURCE_PATH}" ]]; then
   cd "${PACKAGE_SOURCE_PATH}"
 fi
 export HOMEBOY_COMPONENT_PATH="$(pwd)"
+PACKAGE_ROOT="$(pwd -P)"
 
 COMPONENT_SETTINGS_JSON="{}"
 if [[ -f homeboy.json ]]; then
@@ -70,6 +75,28 @@ SETTINGS_JSON="$(jq -cn \
     $component + object_or_empty($payload)
   ')"
 export HOMEBOY_SETTINGS_JSON="${SETTINGS_JSON}"
+
+release_provenance_command="$(printf '%s' "${SETTINGS_JSON}" | jq -r '.release_provenance_command // empty')"
+if [[ -n "${release_provenance_command}" ]] && [[ "$(printf '%s' "${SETTINGS_JSON}" | jq -r '.release_provenance_command | type')" != "string" ]]; then
+  echo "Error: release_provenance_command must be a string" >&2
+  exit 1
+fi
+
+assert_contained_regular_file() {
+  local path="$1"
+  local label="$2"
+  local resolved_path=""
+
+  if [[ -L "${path}" ]] || [[ ! -f "${path}" ]]; then
+    echo "Error: ${label} must be a regular non-symlink file: ${path}" >&2
+    exit 1
+  fi
+  resolved_path="$(cd -P "$(dirname "${path}")" && pwd)/$(basename "${path}")"
+  case "${resolved_path}" in
+    "${PACKAGE_ROOT}"/*) ;;
+    *) echo "Error: ${label} must remain within package root: ${path}" >&2; exit 1;;
+  esac
+}
 
 # Resolve the component slug the way build.sh does (so the ZIP path matches).
 COMPONENT_SLUG="${HOMEBOY_COMPONENT_ID:-}"
@@ -103,6 +130,7 @@ echo "Building release ZIP for ${COMPONENT_SLUG}..." >&2
 bash "${BUILD_SCRIPT}" >&2
 
 ARTIFACT_PATH="build/${COMPONENT_SLUG}.zip"
+SIDECAR_PATH="build/${COMPONENT_SLUG}.provenance.json"
 
 if [[ ! -f "${ARTIFACT_PATH}" ]]; then
   echo "Error: expected ZIP at ${ARTIFACT_PATH} but none was produced" >&2
@@ -139,5 +167,57 @@ else
   echo "Warning: could not determine expected version; skipping artifact version verification" >&2
 fi
 
-jq -cn --arg path "${ARTIFACT_PATH}" \
-  '[{path: $path, type: "wordpress-zip", platform: null}]'
+if [[ -n "${release_provenance_command}" ]]; then
+  SOURCE_VERSION="$(printf '%s' "${SETTINGS_JSON}" | jq -r '.release.version // empty')"
+  SOURCE_TAG="$(printf '%s' "${SETTINGS_JSON}" | jq -r '.release.tag // empty')"
+  SOURCE_COMMIT="$(printf '%s' "${SETTINGS_JSON}" | jq -r '.release.commit // .release.source_commit // .release.sha // empty')"
+  if [[ -z "${SOURCE_VERSION}" || -z "${SOURCE_TAG}" || -z "${SOURCE_COMMIT}" ]]; then
+    echo "Error: release_provenance_command requires release.version, release.tag, and release.commit" >&2
+    exit 1
+  fi
+
+  artifact_absolute_path="$(cd "$(dirname "${ARTIFACT_PATH}")" && pwd -P)/$(basename "${ARTIFACT_PATH}")"
+  sidecar_absolute_path="$(cd "$(dirname "${SIDECAR_PATH}")" && pwd -P)/$(basename "${SIDECAR_PATH}")"
+  assert_contained_regular_file "${artifact_absolute_path}" "release ZIP"
+  case "$(dirname "${sidecar_absolute_path}")" in "${PACKAGE_ROOT}"/*) ;; *) echo "Error: release provenance sidecar must remain within package root" >&2; exit 1;; esac
+
+  export HOMEBOY_WORDPRESS_RELEASE_PACKAGE_ROOT="${PACKAGE_ROOT}"
+  export HOMEBOY_WORDPRESS_RELEASE_SOURCE_VERSION="${SOURCE_VERSION}"
+  export HOMEBOY_WORDPRESS_RELEASE_SOURCE_TAG="${SOURCE_TAG}"
+  export HOMEBOY_WORDPRESS_RELEASE_SOURCE_COMMIT="${SOURCE_COMMIT}"
+  export HOMEBOY_WORDPRESS_RELEASE_ZIP_PATH="${artifact_absolute_path}"
+  export HOMEBOY_WORDPRESS_RELEASE_OUTPUT_PATH="$(dirname "${artifact_absolute_path}")"
+  export HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH="${sidecar_absolute_path}"
+
+  rm -f "${sidecar_absolute_path}"
+  if ! bash -c "${release_provenance_command}"; then
+    echo "Error: release_provenance_command failed" >&2
+    exit 1
+  fi
+  assert_contained_regular_file "${artifact_absolute_path}" "release ZIP"
+  assert_contained_regular_file "${sidecar_absolute_path}" "release provenance sidecar"
+  if ! jq -e 'type == "object"' "${sidecar_absolute_path}" >/dev/null; then
+    echo "Error: release_provenance_command must write a JSON object sidecar at ${SIDECAR_PATH}" >&2
+    exit 1
+  fi
+
+  ZIP_SHA256="$(shasum -a 256 "${artifact_absolute_path}")"
+  ZIP_SHA256="${ZIP_SHA256%% *}"
+  sidecar_tmp="${sidecar_absolute_path}.tmp"
+  jq \
+    --arg version "${SOURCE_VERSION}" \
+    --arg tag "${SOURCE_TAG}" \
+    --arg commit "${SOURCE_COMMIT}" \
+    --arg zip_path "${ARTIFACT_PATH}" \
+    --arg zip_sha256 "${ZIP_SHA256}" \
+    '. + {homeboy_wordpress_release_provenance: {version: 1, source: {version: $version, tag: $tag, commit: $commit}, zip: {path: $zip_path, sha256: $zip_sha256}}}' \
+    "${sidecar_absolute_path}" > "${sidecar_tmp}"
+  mv "${sidecar_tmp}" "${sidecar_absolute_path}"
+  echo "Prepared and sealed ${SIDECAR_PATH}" >&2
+
+  jq -cn --arg path "${ARTIFACT_PATH}" --arg sidecar "${SIDECAR_PATH}" \
+    '[{path: $path, type: "wordpress-zip", platform: null}, {path: $sidecar, type: "wordpress-provenance", platform: null}]'
+else
+  jq -cn --arg path "${ARTIFACT_PATH}" \
+    '[{path: $path, type: "wordpress-zip", platform: null}]'
+fi

--- a/wordpress/scripts/release/publish.sh
+++ b/wordpress/scripts/release/publish.sh
@@ -113,6 +113,31 @@ resolve_github_token() {
   fi
 }
 
+cleanup_provenance_assets() {
+  local zip_name="$1"
+  local sidecar_name="$2"
+  local cleanup_failed=0
+
+  for asset_name in "${zip_name}" "${sidecar_name}"; do
+    if ! gh release delete-asset "${TAG}" "${asset_name}" --yes --repo "${REPO_SLUG}" >&2; then
+      echo "Error: failed to remove partial release asset ${asset_name}" >&2
+      cleanup_failed=1
+    fi
+  done
+  return "${cleanup_failed}"
+}
+
+verify_provenance_assets() {
+  local zip_name="$1"
+  local sidecar_name="$2"
+  local assets=""
+
+  assets="$(gh release view "${TAG}" --repo "${REPO_SLUG}" --json assets)" || return 1
+  printf '%s' "${assets}" | jq -e --arg zip "${zip_name}" --arg sidecar "${sidecar_name}" '
+    [.assets[]?.name] | index($zip) != null and index($sidecar) != null
+  ' >/dev/null
+}
+
 if ! command -v gh >/dev/null 2>&1; then
   echo "Error: gh CLI is required to upload release assets" >&2
   exit 1
@@ -183,6 +208,67 @@ if [[ ! -f "${ARTIFACT_PATH}" ]]; then
   exit 1
 fi
 
+# A component that opted into package provenance must publish its sealed
+# sidecar alongside the ZIP. Resolve an explicitly recovered sidecar first;
+# otherwise use the deterministic package output name.
+RELEASE_PROVENANCE_COMMAND=""
+if [[ -f "homeboy.json" ]]; then
+  RELEASE_PROVENANCE_COMMAND="$(jq -r '.extensions.wordpress.settings.release_provenance_command // empty' homeboy.json)"
+fi
+PROVENANCE_SIDECARS="$(echo "${PAYLOAD}" | jq -c '[.release.artifacts // [] | .[]? | select(type == "object" and (.type == "wordpress-provenance" or .artifact_type == "wordpress-provenance"))]')"
+PROVENANCE_SIDECAR_COUNT="$(echo "${PROVENANCE_SIDECARS}" | jq 'length')"
+if [[ "${PROVENANCE_SIDECAR_COUNT}" -gt 1 ]]; then
+  echo "Error: release payload contains multiple WordPress provenance sidecars" >&2
+  exit 1
+fi
+if [[ "${PROVENANCE_SIDECAR_COUNT}" -eq 1 ]]; then
+  if ! echo "${PROVENANCE_SIDECARS}" | jq -e '.[0].path | type == "string" and length > 0' >/dev/null; then
+    echo "Error: WordPress provenance sidecar path must be a non-empty string" >&2
+    exit 1
+  fi
+  SIDECAR_PATH="$(echo "${PROVENANCE_SIDECARS}" | jq -r '.[0].path')"
+elif [[ -n "${RELEASE_PROVENANCE_COMMAND}" ]]; then
+  SIDECAR_PATH="${ARTIFACT_PATH%.zip}.provenance.json"
+else
+  SIDECAR_PATH=""
+fi
+
+ZIP_SHA256=""
+SIDECAR_SHA256=""
+if [[ -n "${SIDECAR_PATH}" ]]; then
+  if [[ ! -f "${SIDECAR_PATH}" ]]; then
+    echo "Error: expected release provenance sidecar at ${SIDECAR_PATH}" >&2
+    exit 1
+  fi
+  ZIP_SHA256="$(shasum -a 256 "${ARTIFACT_PATH}")"
+  ZIP_SHA256="${ZIP_SHA256%% *}"
+  SOURCE_VERSION="$(echo "${PAYLOAD}" | jq -r '.release.version // empty')"
+  SOURCE_TAG="$(echo "${PAYLOAD}" | jq -r '.release.tag // empty')"
+  SOURCE_COMMIT="$(echo "${PAYLOAD}" | jq -r '.release.commit // .release.source_commit // .release.sha // empty')"
+  if [[ -z "${SOURCE_VERSION}" || -z "${SOURCE_TAG}" || -z "${SOURCE_COMMIT}" ]]; then
+    echo "Error: provenance publish requires release.version, release.tag, and release.commit" >&2
+    exit 1
+  fi
+  if ! jq -e \
+    --arg version "${SOURCE_VERSION}" \
+    --arg tag "${SOURCE_TAG}" \
+    --arg commit "${SOURCE_COMMIT}" \
+    --arg zip_sha256 "${ZIP_SHA256}" \
+    '
+      .homeboy_wordpress_release_provenance as $provenance
+      | ($provenance | type == "object")
+      and ($provenance.version == 1)
+      and ($provenance.source | (type == "object") and (.version == $version) and (.tag == $tag) and (.commit == $commit))
+      and ($provenance.zip | (type == "object") and (.path | type == "string") and (.sha256 == $zip_sha256))
+    ' "${SIDECAR_PATH}" >/dev/null; then
+    echo "Error: release provenance sidecar schema, source, or ZIP digest does not match release payload" >&2
+    exit 1
+  fi
+  SIDECAR_SHA256="$(shasum -a 256 "${SIDECAR_PATH}")"
+  SIDECAR_SHA256="${SIDECAR_SHA256%% *}"
+  echo "Verified ${SIDECAR_PATH} binds ${ARTIFACT_PATH}" >&2
+fi
+
 # Resolve the GitHub repository slug. Prefer the env var set by GitHub Actions;
 # fall back to parsing the origin remote so local dry-runs also work.
 GITHUB_HOST="${GH_HOST:-github.com}"
@@ -221,11 +307,40 @@ EXPECTED_VERSION="${TAG##*v}"
 bash "${SCRIPT_DIR}/verify-artifact-version.sh" "${ARTIFACT_PATH}" "${EXPECTED_VERSION}" >/dev/null
 echo "Verified ${ARTIFACT_PATH} contains version ${EXPECTED_VERSION} (tag ${TAG})" >&2
 
-echo "Uploading ${ARTIFACT_PATH} to ${REPO_SLUG} release ${TAG}..." >&2
+echo "Uploading ${ARTIFACT_PATH}${SIDECAR_PATH:+ and ${SIDECAR_PATH}} to ${REPO_SLUG} release ${TAG}..." >&2
 
-gh release upload "${TAG}" "${ARTIFACT_PATH}" \
-  --clobber \
-  --repo "${REPO_SLUG}" >&2
+if [[ -n "${SIDECAR_PATH}" ]]; then
+  ZIP_ASSET_NAME="$(basename "${ARTIFACT_PATH}")"
+  SIDECAR_ASSET_NAME="$(basename "${SIDECAR_PATH}")"
+  # The ZIP is last so a sidecar upload failure can never create a new
+  # unprovenanced ZIP. Any failed or unverifiable transaction removes both.
+  if ! gh release upload "${TAG}" "${SIDECAR_PATH}" --clobber --repo "${REPO_SLUG}" >&2; then
+    if cleanup_provenance_assets "${ZIP_ASSET_NAME}" "${SIDECAR_ASSET_NAME}"; then
+      echo "Error: provenance sidecar upload failed; partial assets were removed" >&2
+    else
+      echo "Error: provenance sidecar upload failed and rollback was incomplete" >&2
+    fi
+    exit 1
+  fi
+  if ! gh release upload "${TAG}" "${ARTIFACT_PATH}" --clobber --repo "${REPO_SLUG}" >&2; then
+    if cleanup_provenance_assets "${ZIP_ASSET_NAME}" "${SIDECAR_ASSET_NAME}"; then
+      echo "Error: release ZIP upload failed; partial assets were removed" >&2
+    else
+      echo "Error: release ZIP upload failed and rollback was incomplete" >&2
+    fi
+    exit 1
+  fi
+  if ! verify_provenance_assets "${ZIP_ASSET_NAME}" "${SIDECAR_ASSET_NAME}"; then
+    if cleanup_provenance_assets "${ZIP_ASSET_NAME}" "${SIDECAR_ASSET_NAME}"; then
+      echo "Error: provenance release assets could not be verified; partial assets were removed" >&2
+    else
+      echo "Error: provenance release assets could not be verified and rollback was incomplete" >&2
+    fi
+    exit 1
+  fi
+else
+  gh release upload "${TAG}" "${ARTIFACT_PATH}" --clobber --repo "${REPO_SLUG}" >&2
+fi
 
 echo "Uploaded ${ARTIFACT_PATH} to ${REPO_SLUG} release ${TAG}" >&2
 
@@ -318,6 +433,9 @@ jq -cn \
   --arg host "${GITHUB_HOST}" \
   --arg repo "${REPO_SLUG}" \
   --arg path "${ARTIFACT_PATH}" \
+  --arg sidecar_path "${SIDECAR_PATH}" \
+  --arg zip_sha256 "${ZIP_SHA256}" \
+  --arg sidecar_sha256 "${SIDECAR_SHA256}" \
   --arg branch "${PUSHED_BRANCH}" \
   '{
     target: "github-release-asset",
@@ -325,6 +443,7 @@ jq -cn \
     github_host: $host,
     repository: $repo,
     artifact_path: $path,
+    provenance: (if $sidecar_path == "" then null else {sidecar_path: $sidecar_path, zip_sha256: $zip_sha256, sidecar_sha256: $sidecar_sha256} end),
     release_latest_branch: (if $branch == "" then null else $branch end),
     success: true
   }'

--- a/wordpress/tests/release-provenance-contract-smoke.sh
+++ b/wordpress/tests/release-provenance-contract-smoke.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_SH="${ROOT_DIR}/scripts/release/package.sh"
+PUBLISH_SH="${ROOT_DIR}/scripts/release/publish.sh"
+TMP_DIR="$(mktemp -d -t homeboy-wp-provenance.XXXXXX)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+PROJECT="${TMP_DIR}/project"
+RUNTIME="${TMP_DIR}/runtime"
+BIN_DIR="${TMP_DIR}/bin"
+mkdir -p "${PROJECT}/build" "${RUNTIME}/scripts/build" "${RUNTIME}/scripts/release" "${BIN_DIR}"
+cp "${PACKAGE_SH}" "${RUNTIME}/scripts/release/package.sh"
+cp "${PUBLISH_SH}" "${RUNTIME}/scripts/release/publish.sh"
+cp "${ROOT_DIR}/scripts/release/verify-artifact-version.sh" "${RUNTIME}/scripts/release/verify-artifact-version.sh"
+chmod +x "${RUNTIME}/scripts/release/package.sh" "${RUNTIME}/scripts/release/publish.sh"
+
+cat > "${RUNTIME}/scripts/build/build.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+test -f build/demo-plugin.zip
+SH
+chmod +x "${RUNTIME}/scripts/build/build.sh"
+
+python3 -c "
+import zipfile
+with zipfile.ZipFile('${PROJECT}/build/demo-plugin.zip', 'w') as z:
+    z.writestr('demo-plugin/demo-plugin.php', '<?php\n/**\n * Plugin Name: Demo Plugin\n * Version: 1.2.3\n */')
+"
+
+cat > "${PROJECT}/homeboy.json" <<'JSON'
+{
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "release_provenance_command": "jq -n --arg root \"$HOMEBOY_WORDPRESS_RELEASE_PACKAGE_ROOT\" --arg version \"$HOMEBOY_WORDPRESS_RELEASE_SOURCE_VERSION\" --arg tag \"$HOMEBOY_WORDPRESS_RELEASE_SOURCE_TAG\" --arg commit \"$HOMEBOY_WORDPRESS_RELEASE_SOURCE_COMMIT\" --arg zip \"$HOMEBOY_WORDPRESS_RELEASE_ZIP_PATH\" --arg output \"$HOMEBOY_WORDPRESS_RELEASE_OUTPUT_PATH\" --arg sidecar \"$HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH\" '{root:$root,version:$version,tag:$tag,commit:$commit,zip:$zip,output:$output,sidecar:$sidecar}' > \"$HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH\""
+      }
+    }
+  }
+}
+JSON
+
+PAYLOAD='{"release":{"version":"1.2.3","tag":"v1.2.3","commit":"abc123","component_id":"demo-plugin"}}'
+PACKAGE_OUTPUT="$(cd "${PROJECT}" && HOMEBOY_COMPONENT_ID=demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/package.sh")"
+SIDECAR="${PROJECT}/build/demo-plugin.provenance.json"
+PROJECT_REALPATH="$(cd "${PROJECT}" && pwd -P)"
+
+printf '%s' "${PACKAGE_OUTPUT}" | jq -e 'length == 2 and .[1].type == "wordpress-provenance"' >/dev/null
+jq -e --arg root "${PROJECT_REALPATH}" '
+  .root == $root and
+  .version == "1.2.3" and
+  .tag == "v1.2.3" and
+  .commit == "abc123" and
+  (.zip | startswith($root + "/")) and
+  (.output | startswith($root + "/")) and
+  (.sidecar | startswith($root + "/")) and
+  .homeboy_wordpress_release_provenance.zip.sha256 != ""
+' "${SIDECAR}" >/dev/null
+printf 'OK: provenance hook receives bounded root, source coordinates, and output paths\n'
+
+FAIL_PROJECT="${TMP_DIR}/failure"
+cp -R "${PROJECT}" "${FAIL_PROJECT}"
+jq '.extensions.wordpress.settings.release_provenance_command = "exit 17"' "${FAIL_PROJECT}/homeboy.json" > "${FAIL_PROJECT}/homeboy.json.tmp"
+mv "${FAIL_PROJECT}/homeboy.json.tmp" "${FAIL_PROJECT}/homeboy.json"
+if (cd "${FAIL_PROJECT}" && HOMEBOY_COMPONENT_ID=demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/package.sh" >/dev/null 2>&1); then
+  echo 'FAIL: failing provenance command did not abort package' >&2
+  exit 1
+fi
+printf 'OK: failing provenance hook aborts package\n'
+
+# The hook cannot escape the fixed sidecar destination through a symlink.
+EXTERNAL_DIR="${TMP_DIR}/external"
+mkdir -p "${EXTERNAL_DIR}"
+printf '{}' > "${EXTERNAL_DIR}/sidecar.json"
+SIDECAR_ESCAPE_PROJECT="${TMP_DIR}/sidecar-escape"
+cp -R "${PROJECT}" "${SIDECAR_ESCAPE_PROJECT}"
+jq --arg external "${EXTERNAL_DIR}/sidecar.json" '.extensions.wordpress.settings.release_provenance_command = "ln -s \($external) \"$HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH\""' "${SIDECAR_ESCAPE_PROJECT}/homeboy.json" > "${SIDECAR_ESCAPE_PROJECT}/homeboy.json.tmp"
+mv "${SIDECAR_ESCAPE_PROJECT}/homeboy.json.tmp" "${SIDECAR_ESCAPE_PROJECT}/homeboy.json"
+if (cd "${SIDECAR_ESCAPE_PROJECT}" && HOMEBOY_COMPONENT_ID=demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/package.sh" >/dev/null 2>&1); then
+  echo 'FAIL: symlink-escaped sidecar did not abort package' >&2
+  exit 1
+fi
+
+# The hook cannot replace the staged ZIP with a symlink to an external output.
+ZIP_ESCAPE_PROJECT="${TMP_DIR}/zip-escape"
+cp -R "${PROJECT}" "${ZIP_ESCAPE_PROJECT}"
+mkdir -p "${EXTERNAL_DIR}/zip"
+cp "${ZIP_ESCAPE_PROJECT}/build/demo-plugin.zip" "${EXTERNAL_DIR}/zip/demo-plugin.zip"
+jq --arg external "${EXTERNAL_DIR}/zip/demo-plugin.zip" '.extensions.wordpress.settings.release_provenance_command = "rm \"$HOMEBOY_WORDPRESS_RELEASE_ZIP_PATH\"; ln -s \($external) \"$HOMEBOY_WORDPRESS_RELEASE_ZIP_PATH\"; printf \"{}\" > \"$HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH\""' "${ZIP_ESCAPE_PROJECT}/homeboy.json" > "${ZIP_ESCAPE_PROJECT}/homeboy.json.tmp"
+mv "${ZIP_ESCAPE_PROJECT}/homeboy.json.tmp" "${ZIP_ESCAPE_PROJECT}/homeboy.json"
+if (cd "${ZIP_ESCAPE_PROJECT}" && HOMEBOY_COMPONENT_ID=demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/package.sh" >/dev/null 2>&1); then
+  echo 'FAIL: symlink-escaped ZIP did not abort package' >&2
+  exit 1
+fi
+
+# Replacing the post-hook output directory with an external symlink is also
+# rejected after command execution, rather than trusting its initial location.
+OUTPUT_ESCAPE_PROJECT="${TMP_DIR}/output-escape"
+cp -R "${PROJECT}" "${OUTPUT_ESCAPE_PROJECT}"
+mkdir -p "${EXTERNAL_DIR}/output"
+jq --arg external "${EXTERNAL_DIR}/output" '.extensions.wordpress.settings.release_provenance_command = "mv \"$HOMEBOY_WORDPRESS_RELEASE_ZIP_PATH\" \($external)/demo-plugin.zip; rmdir \"$HOMEBOY_WORDPRESS_RELEASE_OUTPUT_PATH\"; ln -s \($external) \"$HOMEBOY_WORDPRESS_RELEASE_OUTPUT_PATH\"; printf \"{}\" > \"$HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH\""' "${OUTPUT_ESCAPE_PROJECT}/homeboy.json" > "${OUTPUT_ESCAPE_PROJECT}/homeboy.json.tmp"
+mv "${OUTPUT_ESCAPE_PROJECT}/homeboy.json.tmp" "${OUTPUT_ESCAPE_PROJECT}/homeboy.json"
+if (cd "${OUTPUT_ESCAPE_PROJECT}" && HOMEBOY_COMPONENT_ID=demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/package.sh" >/dev/null 2>&1); then
+  echo 'FAIL: post-hook output directory escape did not abort package' >&2
+  exit 1
+fi
+printf 'OK: external, symlink, and post-hook output containment are enforced\n'
+
+cat > "${BIN_DIR}/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${HOMEBOY_GH_LOG}"
+if [[ "$1 $2" == "release upload" ]] && [[ -n "${HOMEBOY_GH_FAIL_ASSET:-}" ]] && [[ "$*" == *"${HOMEBOY_GH_FAIL_ASSET}"* ]]; then
+  exit 1
+fi
+if [[ "$1 $2" == "release view" ]]; then
+  if [[ -n "${HOMEBOY_GH_ASSETS_JSON:-}" ]]; then
+    printf '%s\n' "${HOMEBOY_GH_ASSETS_JSON}"
+  else
+    printf '%s\n' '{"assets":[]}'
+  fi
+fi
+SH
+chmod +x "${BIN_DIR}/gh"
+
+# Mutating the staged ZIP after the hook has sealed its digest must prevent
+# both the ZIP and sidecar from reaching the release upload command.
+printf 'mutation' >> "${PROJECT}/build/demo-plugin.zip"
+if (cd "${PROJECT}" && PATH="${BIN_DIR}:${PATH}" HOMEBOY_GH_LOG="${TMP_DIR}/mutation-gh.log" GITHUB_REPOSITORY=example/demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/publish.sh" >/dev/null 2>&1); then
+  echo 'FAIL: post-hook ZIP mutation did not abort publish' >&2
+  exit 1
+fi
+test ! -e "${TMP_DIR}/mutation-gh.log"
+printf 'OK: post-hook ZIP mutation invalidates provenance before upload\n'
+
+# The sidecar schema and immutable source coordinates must match the exact
+# release payload even when the ZIP digest remains valid.
+PACKAGE_OUTPUT="$(cd "${PROJECT}" && HOMEBOY_COMPONENT_ID=demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/package.sh")"
+jq '.homeboy_wordpress_release_provenance.source.commit = "wrong"' "${SIDECAR}" > "${SIDECAR}.tmp"
+mv "${SIDECAR}.tmp" "${SIDECAR}"
+if (cd "${PROJECT}" && PATH="${BIN_DIR}:${PATH}" HOMEBOY_GH_LOG="${TMP_DIR}/source-mismatch-gh.log" GITHUB_REPOSITORY=example/demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/publish.sh" >/dev/null 2>&1); then
+  echo 'FAIL: source-mismatched sidecar did not abort publish' >&2
+  exit 1
+fi
+test ! -e "${TMP_DIR}/source-mismatch-gh.log"
+PACKAGE_OUTPUT="$(cd "${PROJECT}" && HOMEBOY_COMPONENT_ID=demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/package.sh")"
+jq '.homeboy_wordpress_release_provenance.version = 2' "${SIDECAR}" > "${SIDECAR}.tmp"
+mv "${SIDECAR}.tmp" "${SIDECAR}"
+if (cd "${PROJECT}" && PATH="${BIN_DIR}:${PATH}" HOMEBOY_GH_LOG="${TMP_DIR}/schema-mismatch-gh.log" GITHUB_REPOSITORY=example/demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/publish.sh" >/dev/null 2>&1); then
+  echo 'FAIL: unsupported sidecar schema version did not abort publish' >&2
+  exit 1
+fi
+test ! -e "${TMP_DIR}/schema-mismatch-gh.log"
+printf 'OK: sidecar schema and source coordinates are verified\n'
+
+# Rebuild and reseal, then assert the publisher uploads both assets and its
+# receipt binds the independently computed ZIP and sidecar digests.
+python3 -c "
+import zipfile
+with zipfile.ZipFile('${PROJECT}/build/demo-plugin.zip', 'w') as z:
+    z.writestr('demo-plugin/demo-plugin.php', '<?php\n/**\n * Plugin Name: Demo Plugin\n * Version: 1.2.3\n */')
+"
+PACKAGE_OUTPUT="$(cd "${PROJECT}" && HOMEBOY_COMPONENT_ID=demo-plugin HOMEBOY_SETTINGS_JSON="${PAYLOAD}" "${RUNTIME}/scripts/release/package.sh")"
+PUBLISH_PAYLOAD="$(printf '%s' "${PAYLOAD}" | jq --arg zip "${PROJECT}/build/demo-plugin.zip" --arg sidecar "${SIDECAR}" '.release.artifacts = [{path:$zip,type:"wordpress-zip"},{path:$sidecar,type:"wordpress-provenance"}]')"
+PUBLISH_OUTPUT="$(cd "${PROJECT}" && PATH="${BIN_DIR}:${PATH}" HOMEBOY_GH_LOG="${TMP_DIR}/upload-gh.log" HOMEBOY_GH_ASSETS_JSON='{"assets":[{"name":"demo-plugin.zip"},{"name":"demo-plugin.provenance.json"}]}' GITHUB_REPOSITORY=example/demo-plugin HOMEBOY_SETTINGS_JSON="${PUBLISH_PAYLOAD}" "${RUNTIME}/scripts/release/publish.sh")"
+grep -F "release upload v1.2.3 ${SIDECAR} --clobber --repo example/demo-plugin" "${TMP_DIR}/upload-gh.log" >/dev/null
+grep -F "release upload v1.2.3 ${PROJECT}/build/demo-plugin.zip --clobber --repo example/demo-plugin" "${TMP_DIR}/upload-gh.log" >/dev/null
+ZIP_SHA256="$(shasum -a 256 "${PROJECT}/build/demo-plugin.zip")"
+ZIP_SHA256="${ZIP_SHA256%% *}"
+SIDECAR_SHA256="$(shasum -a 256 "${SIDECAR}")"
+SIDECAR_SHA256="${SIDECAR_SHA256%% *}"
+printf '%s' "${PUBLISH_OUTPUT}" | tail -1 | jq -e --arg zip "${ZIP_SHA256}" --arg sidecar "${SIDECAR_SHA256}" '
+  .success == true and .provenance.zip_sha256 == $zip and .provenance.sidecar_sha256 == $sidecar
+' >/dev/null
+
+# A sidecar upload failure never uploads the ZIP and rolls back both names so
+# a stale sidecar or unprovenanced ZIP cannot remain from this attempt.
+if (cd "${PROJECT}" && PATH="${BIN_DIR}:${PATH}" HOMEBOY_GH_LOG="${TMP_DIR}/sidecar-failure-gh.log" HOMEBOY_GH_FAIL_ASSET="demo-plugin.provenance.json" GITHUB_REPOSITORY=example/demo-plugin HOMEBOY_SETTINGS_JSON="${PUBLISH_PAYLOAD}" "${RUNTIME}/scripts/release/publish.sh" >/dev/null 2>&1); then
+  echo 'FAIL: sidecar upload failure did not abort publish' >&2
+  exit 1
+fi
+grep -F "release upload v1.2.3 ${SIDECAR}" "${TMP_DIR}/sidecar-failure-gh.log" >/dev/null
+if grep -F "release upload v1.2.3 ${PROJECT}/build/demo-plugin.zip" "${TMP_DIR}/sidecar-failure-gh.log" >/dev/null; then
+  echo 'FAIL: ZIP uploaded after sidecar failure' >&2
+  exit 1
+fi
+grep -F 'release delete-asset v1.2.3 demo-plugin.zip --yes --repo example/demo-plugin' "${TMP_DIR}/sidecar-failure-gh.log" >/dev/null
+grep -F 'release delete-asset v1.2.3 demo-plugin.provenance.json --yes --repo example/demo-plugin' "${TMP_DIR}/sidecar-failure-gh.log" >/dev/null
+
+# If the second-leg ZIP upload fails after sidecar success, both names are
+# removed, preventing a stale sidecar from representing a failed release.
+if (cd "${PROJECT}" && PATH="${BIN_DIR}:${PATH}" HOMEBOY_GH_LOG="${TMP_DIR}/zip-failure-gh.log" HOMEBOY_GH_FAIL_ASSET="demo-plugin.zip" GITHUB_REPOSITORY=example/demo-plugin HOMEBOY_SETTINGS_JSON="${PUBLISH_PAYLOAD}" "${RUNTIME}/scripts/release/publish.sh" >/dev/null 2>&1); then
+  echo 'FAIL: ZIP upload failure did not abort publish' >&2
+  exit 1
+fi
+grep -F "release upload v1.2.3 ${SIDECAR}" "${TMP_DIR}/zip-failure-gh.log" >/dev/null
+grep -F "release upload v1.2.3 ${PROJECT}/build/demo-plugin.zip" "${TMP_DIR}/zip-failure-gh.log" >/dev/null
+grep -F 'release delete-asset v1.2.3 demo-plugin.zip --yes --repo example/demo-plugin' "${TMP_DIR}/zip-failure-gh.log" >/dev/null
+grep -F 'release delete-asset v1.2.3 demo-plugin.provenance.json --yes --repo example/demo-plugin' "${TMP_DIR}/zip-failure-gh.log" >/dev/null
+printf 'OK: failed provenance publication is rolled back\n'
+printf 'PASS: release provenance contract smoke\n'

--- a/wordpress/tests/release-publish-github-host-proxy-smoke.sh
+++ b/wordpress/tests/release-publish-github-host-proxy-smoke.sh
@@ -23,7 +23,11 @@ set -euo pipefail
 SH
 chmod +x "${BIN_DIR}/gh"
 
-printf 'zip fixture\n' > "${WORK_DIR}/build/demo-plugin.zip"
+python3 -c "
+import zipfile
+with zipfile.ZipFile('${WORK_DIR}/build/demo-plugin.zip', 'w') as z:
+    z.writestr('demo-plugin/demo-plugin.php', '<?php\n/**\n * Plugin Name: Demo Plugin\n * Version: 1.2.3\n */')
+"
 
 git -C "${WORK_DIR}" init -q
 git -C "${WORK_DIR}" remote add origin git@github.enterprise.test:owner/demo-plugin.git

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.36.1",
+  "version": "3.37.0",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
@@ -1484,6 +1484,13 @@
       "type": "array",
       "default": [],
       "description": "Declared local (unpublished) workspace package dependencies to build from source, pack, and install into the consumer as a self-contained built tarball before the consumer build runs. Installing a built tarball (not a file: symlink) lets peer dependencies such as React dedupe to the consumer's single copy. Each entry is an object: name (required package name), path (required source path relative to the component, may reference sibling repos), and optional package_dir (monorepo subpackage to pack), build (explicit build command run in path; defaults to install + run build script), and package_manager (npm|pnpm|yarn, auto-detected by default)."
+    },
+    {
+      "id": "release_provenance_command",
+      "label": "WordPress release provenance command",
+      "type": "string",
+      "default": "",
+      "description": "Optional component command run after the release ZIP is staged and before it is published. The command writes a JSON object to HOMEBOY_WORDPRESS_RELEASE_SIDECAR_PATH. It receives the bounded package root, source version/tag/commit, ZIP path, and output path through HOMEBOY_WORDPRESS_RELEASE_PACKAGE_ROOT, HOMEBOY_WORDPRESS_RELEASE_SOURCE_VERSION, HOMEBOY_WORDPRESS_RELEASE_SOURCE_TAG, HOMEBOY_WORDPRESS_RELEASE_SOURCE_COMMIT, HOMEBOY_WORDPRESS_RELEASE_ZIP_PATH, and HOMEBOY_WORDPRESS_RELEASE_OUTPUT_PATH. A failing command or missing sidecar aborts release; publish verifies and uploads the resulting sidecar with the ZIP."
     }
   ],
   "release_preflights": [


### PR DESCRIPTION
## Summary

- add an opt-in bounded WordPress post-stage provenance command
- validate sidecar schema/source/digest and reject path escapes or post-hook mutation
- publish ZIP and provenance sidecar with verified evidence and rollback on partial failure

Closes #2671.

## Verification

- release provenance contract smoke
- WordPress release package cwd smoke
- GitHub host/proxy publication smoke
- shell syntax, JSON validation, and `git diff --check`

## AI assistance

GPT-5.6-sol via OpenCode coordinated direct coding and review subagents, implemented the generic package hook, corrected trust/rollback findings, and ran verification. Chris Huber remains responsible for every line.