### PR TITLE
fix(opencode): harden default model provenance

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -1056,11 +1056,19 @@ function sessionMetadata(context = {}) {
 	if (context.sessionMetadata) {
 		return context.sessionMetadata;
 	}
-	const sessionId = openCodeSessionId(context.spawnResult?.stdout);
-	if (!sessionId || !isOpenCodeCommand(context.commandSpec)) {
+	const sessionIds = openCodeSessionIds(context.spawnResult?.stdout);
+	if (!isOpenCodeCommand(context.commandSpec) || sessionIds.length === 0) {
 		context.sessionMetadata = OPENCODE_SESSION_METADATA_ABSENT;
 		return context.sessionMetadata;
 	}
+	if (sessionIds.length !== 1) {
+		context.sessionMetadata = {
+			status: 'unavailable',
+			reason: 'OpenCode completion output contained conflicting session identifiers.',
+		};
+		return context.sessionMetadata;
+	}
+	const [sessionId] = sessionIds;
 	const result = spawnSync(context.commandSpec.command, [
 		...arrayValue(context.commandSpec.args),
 		'export',
@@ -1103,14 +1111,11 @@ function sessionMetadata(context = {}) {
 	return context.sessionMetadata;
 }
 
-function openCodeSessionId(stdout = '') {
-	for (const event of parseJsonObjectsFromText(stdout)) {
-		const sessionId = stringValue(event.sessionID || event.session_id || event.part?.sessionID);
-		if (sessionId) {
-			return sessionId;
-		}
-	}
-	return '';
+function openCodeSessionIds(stdout = '') {
+	return [...new Set(parseJsonObjectsFromText(stdout)
+		.flatMap((event) => [event.sessionID, event.session_id, event.part?.sessionID])
+		.map(stringValue)
+		.filter(Boolean))];
 }
 
 function parseOpenCodeExport(output = '') {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -681,6 +681,9 @@ if (process.argv[2] === 'export') {
   }
 } else {
   process.stdout.write(JSON.stringify({ type: 'step_start', sessionID: 'ses_default_model', part: { sessionID: 'ses_default_model' } }) + '\\n');
+  if (process.env.HOMEBOY_TEST_CONFLICT_SESSION === '1') {
+    process.stdout.write(JSON.stringify({ type: 'step_end', sessionID: 'ses_conflicting_model' }) + '\\n');
+  }
   process.exit(0);
 }
 `);
@@ -730,6 +733,27 @@ if (process.argv[2] === 'export') {
 		reason: 'OpenCode did not return a readable completed-session export.',
 	});
 	assert.equal(unavailableModelResult.metadata.model, undefined);
+	const conflictingSessionResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-conflicting-session-provenance',
+		workspace_path: preflightWorkspace,
+		artifacts_path: path.join(root, 'conflicting-session-artifacts'),
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				runtime_bin: provenanceOpenCode,
+				command_args: [],
+				runtime_env: { HOMEBOY_TEST_CONFLICT_SESSION: '1' },
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(conflictingSessionResult.status, 'succeeded', JSON.stringify(conflictingSessionResult.diagnostics));
+	assert.deepEqual(conflictingSessionResult.metadata.opencode_session, {
+		status: 'unavailable',
+		reason: 'OpenCode completion output contained conflicting session identifiers.',
+	});
+	assert.equal(conflictingSessionResult.metadata.model, undefined);
 
 	const scratchAttempts = [
 		{ id: 'run-2250-attempt-1', status: 0 },

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -704,6 +704,8 @@ if (process.argv[2] === 'export') {
 	});
 	assert.equal(defaultModelRun.status, 0, defaultModelRun.stderr);
 	const defaultModelResult = JSON.parse(defaultModelRun.stdout);
+	assert.equal(defaultModelResult.schema, 'homeboy/agent-task-outcome/v1');
+	assert.equal(defaultModelResult.task_id, 'opencode-default-model-provenance');
 	assert.equal(defaultModelResult.status, 'succeeded', JSON.stringify(defaultModelResult.diagnostics));
 	assert.equal(defaultModelResult.metadata.model, 'openai/gpt-5.6-sol');
 	assert.deepEqual(defaultModelResult.metadata.opencode_session, {


### PR DESCRIPTION
## Summary

- require one unambiguous OpenCode session before exporting model provenance
- preserve fail-closed behavior when completion output contains conflicting session identifiers
- prove the production stdin/stdout executor boundary emits default-model `metadata.model`

## Verification

- `npm run test:opencode-agent-task-executor-boundary`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `npm run check:runtime-manifest`
- `git diff --check origin/main...HEAD`

Relates to Extra-Chill/homeboy#13045

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding and independent review agents rebased, hardened, tested, and reviewed the default-model provenance path. Chris Huber remains responsible for every line.