### PR TITLE
fix(wordpress): route declared standalone PHP tests

### DIFF
--- a/wordpress/scripts/test/changed-scope-test-routing-smoke.sh
+++ b/wordpress/scripts/test/changed-scope-test-routing-smoke.sh
@@ -55,9 +55,22 @@ homeboy_runner_init() {
 }
 SH
 
+results_writer="${WORKDIR}/write-test-results.sh"
+cat > "$results_writer" <<'SH'
+homeboy_write_test_results() {
+    jq -n --argjson total "$1" --argjson passed "$2" --argjson failed "$3" --argjson skipped "$4" --arg source "$5" \
+        '{total: $total, passed: $passed, failed: $failed, skipped: $skipped, source: $source}' > "$HOMEBOY_TEST_RESULTS_FILE"
+}
+SH
+
 cat > "${component}/tests/standalone-smoke.php" <<'PHP'
 <?php
 echo "standalone smoke ran\n";
+PHP
+
+cat > "${component}/tests/worktree-command-help-snapshots.php" <<'PHP'
+<?php
+echo "standalone declared test ran\n";
 PHP
 
 cat > "${component}/tests/wordpress-smoke.php" <<'PHP'
@@ -137,7 +150,10 @@ run_changed_scope() {
     HOMEBOY_COMPONENT_SHAPE="plugin" \
     HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE_WP="${WORKDIR}/stubs/host-smoke-wp.sh" \
     HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${WORKDIR}/stubs/wp-codebox.sh" \
+    HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$results_writer" \
+    HOMEBOY_TEST_RESULTS_FILE="${outfile}.results.json" \
     HOMEBOY_CHANGED_TEST_FILES="$changed" \
+    HOMEBOY_SETTINGS_JSON='{"standalone_php_test_paths":["tests/*-command-help-snapshots.php"]}' \
         bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "$outfile" 2>&1
     status=$?
     set -e
@@ -148,17 +164,20 @@ run_changed_scope() {
 # A changed scope containing a PHPUnit class plus standalone smoke scripts, plus
 # a non-test helper. Every path must be accounted for.
 mixed="${WORKDIR}/mixed.out"
-run_changed_scope "$mixed" $'tests/Unit/OwnershipTest.php\ntests/standalone-smoke.php\ntests/wordpress-smoke.php\ntests/Unit/Support/TestDoubles.php'
+run_changed_scope "$mixed" $'tests/Unit/OwnershipTest.php\ntests/standalone-smoke.php\ntests/worktree-command-help-snapshots.php\ntests/wordpress-smoke.php\ntests/Unit/Support/TestDoubles.php'
 
 assert_contains "$mixed" "CHANGED_SCOPE_ROUTE:tests/Unit/OwnershipTest.php:runner=phpunit"
 assert_contains "$mixed" "CHANGED_SCOPE_ROUTE:tests/standalone-smoke.php:runner=host-php-smoke"
+assert_contains "$mixed" "CHANGED_SCOPE_ROUTE:tests/worktree-command-help-snapshots.php:runner=host-php-smoke"
 assert_contains "$mixed" "CHANGED_SCOPE_ROUTE:tests/wordpress-smoke.php:runner=host-php-smoke"
 assert_contains "$mixed" "CHANGED_SCOPE_EXCLUDED:tests/Unit/Support/TestDoubles.php:reason=unsupported_test_shape"
-assert_contains "$mixed" "CHANGED_SCOPE_SUMMARY:selected=4 routed=3 excluded=1"
+assert_contains "$mixed" "CHANGED_SCOPE_SUMMARY:selected=5 routed=4 excluded=1"
 
 # The standalone smoke actually executed...
 assert_contains "$mixed" "PHP_SMOKE_BEGIN:tests/standalone-smoke.php"
 assert_contains "$mixed" "PHP_SMOKE_OK:tests/standalone-smoke.php"
+assert_contains "$mixed" "PHP_SMOKE_BEGIN:tests/worktree-command-help-snapshots.php"
+assert_contains "$mixed" "PHP_SMOKE_OK:tests/worktree-command-help-snapshots.php"
 # ...the manifest-declared WordPress smoke went to the booted-WordPress runner...
 assert_contains "$mixed" "HOST_SMOKE_BEGIN:tests/wordpress-smoke.php"
 # ...and the PHPUnit class still reached the backend as an explicit scope rather
@@ -177,7 +196,14 @@ assert_contains "$only_smokes" "HOST_SMOKE_BEGIN:tests/wordpress-smoke.php"
 assert_contains "$only_smokes" "CHANGED_SCOPE_SUMMARY:selected=2 routed=2 excluded=0"
 assert_not_contains "$only_smokes" "WP_CODEBOX_STUB"
 
-# --- Scenario 3: a failing smoke fails the scope ----------------------------
+# --- Scenario 3: declared standalone-only scope writes exact results --------
+declared_only="${WORKDIR}/declared-only.out"
+run_changed_scope "$declared_only" 'tests/worktree-command-help-snapshots.php'
+assert_contains "$declared_only" "CHANGED_SCOPE_SUMMARY:selected=1 routed=1 excluded=0"
+assert_contains "$declared_only" "PHP_SMOKE_OK:tests/worktree-command-help-snapshots.php"
+jq -e '.total == 1 and .passed == 1 and .failed == 0 and .skipped == 0 and .source == "changed-scope-host-php"' "${declared_only}.results.json" >/dev/null
+
+# --- Scenario 4: a failing smoke fails the scope ----------------------------
 # The runner execs the PHPUnit backend, which would replace the process and
 # report only the backend's status. A passing backend must not erase a failing
 # host smoke.
@@ -193,7 +219,17 @@ if [ "$failing_status" -eq 0 ]; then
     exit 1
 fi
 
-# --- Scenario 4: --file on a standalone smoke stops there -------------------
+# A standalone-only failure publishes the same exact result shape as a pass.
+failing_only="${WORKDIR}/failing-only.out"
+failing_only_status=0
+run_changed_scope "$failing_only" 'tests/failing-smoke.php' || failing_only_status=$?
+if [ "$failing_only_status" -eq 0 ]; then
+    echo "Expected a failing standalone-only scope to fail" >&2
+    exit 1
+fi
+jq -e '.total == 1 and .passed == 0 and .failed == 1 and .skipped == 0 and .source == "changed-scope-host-php"' "${failing_only}.results.json" >/dev/null
+
+# --- Scenario 5: --file on a standalone smoke stops there -------------------
 # The WordPress-environment branch execs and therefore terminates; the
 # standalone branch returns, and without an explicit exit a request for one file
 # fell through into the full-suite PHPUnit run below it.

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -183,6 +183,8 @@ homeboy_wordpress_run_standalone_php_smoke_files() {
     done <<< "$smoke_files_raw"
 
     echo "PHP_SMOKE_SUMMARY:passed=${passed} failed=${failed}"
+    WORDPRESS_STANDALONE_PHP_SMOKE_PASSED="$passed"
+    WORDPRESS_STANDALONE_PHP_SMOKE_FAILED="$failed"
     [ "$failed" -eq 0 ] || return "$last_failure_exit"
 }
 
@@ -887,6 +889,42 @@ homeboy_wordpress_is_php_smoke_file() {
     esac
 }
 
+# Components that use executable PHP scripts without the shared `*-smoke.php`
+# convention declare their component-relative paths or shell-glob patterns in
+# standalone_php_test_paths. The declaration classifies already-selected files;
+# it never broadens a changed scope or turns support files into tests by default.
+homeboy_wordpress_is_declared_standalone_php_test_file() {
+    local test_file="$1"
+    local declared_path
+    local declared_paths
+
+    case "$test_file" in
+        *.php)
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    declared_paths="$(homeboy_setting standalone_php_test_paths '.standalone_php_test_paths // [] | if type == "array" and all(.[]; type == "string") then .[] else error("expected an array of strings") end')" || {
+        echo "ERROR: standalone_php_test_paths must be an array of strings." >&2
+        return 2
+    }
+    while IFS= read -r declared_path; do
+        [ -n "$declared_path" ] || continue
+        case "$declared_path" in
+            /*|..|../*|*/../*)
+                echo "ERROR: standalone_php_test_paths contains an invalid component-relative selector: ${declared_path}" >&2
+                return 2
+                ;;
+        esac
+        if [[ "$test_file" == $declared_path ]]; then
+            return 0
+        fi
+    done <<< "$declared_paths"
+    return 1
+}
+
 homeboy_wordpress_load_test_shard_manifest() {
     local manifest_path="${HOMEBOY_TEST_SHARD_MANIFEST:-}"
     local shard_id shard_tests test_file test_rel selected_count
@@ -1013,14 +1051,25 @@ homeboy_wordpress_load_test_shard_manifest() {
 # the manifest decides which need a booted WordPress and which are standalone.
 homeboy_wordpress_run_php_smoke_files() {
     local smoke_files_raw="$1"
-    local smoke_rel smoke_environment
+    local smoke_rel smoke_environment declared_status
     local standalone_php_smoke_files=""
     local wordpress_smoke_files=""
     local status=0
 
+    WORDPRESS_CHANGED_SCOPE_HOST_PHP_FILES=0
+
     while IFS= read -r smoke_rel; do
         [ -n "$smoke_rel" ] || continue
-        smoke_environment="$(homeboy_wordpress_test_environment "$smoke_rel")" || return $?
+        # A component declaration is the explicit standalone contract. Existing
+        # smoke files without that declaration retain their manifest-selected
+        # WordPress or standalone environment.
+        if homeboy_wordpress_is_declared_standalone_php_test_file "$smoke_rel"; then
+            smoke_environment="standalone-php"
+        else
+            declared_status=$?
+            [ "$declared_status" -eq 1 ] || return "$declared_status"
+            smoke_environment="$(homeboy_wordpress_test_environment "$smoke_rel")" || return $?
+        fi
         if [ "$smoke_environment" = "standalone-php" ]; then
             standalone_php_smoke_files+="${standalone_php_smoke_files:+$'\n'}${smoke_rel}"
         else
@@ -1032,9 +1081,30 @@ homeboy_wordpress_run_php_smoke_files() {
         homeboy_wordpress_run_standalone_php_smoke_files "$standalone_php_smoke_files" || status=$?
     fi
     if [ -n "$wordpress_smoke_files" ]; then
+        while IFS= read -r smoke_rel; do
+            [ -n "$smoke_rel" ] || continue
+            WORDPRESS_CHANGED_SCOPE_HOST_PHP_FILES=$((WORDPRESS_CHANGED_SCOPE_HOST_PHP_FILES + 1))
+        done <<< "$wordpress_smoke_files"
         HOMEBOY_WORDPRESS_HOST_SMOKE_FILES="$wordpress_smoke_files" bash "$SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}" || status=$?
     fi
     return "$status"
+}
+
+homeboy_wordpress_write_changed_scope_results() {
+    local total="$1"
+    local passed="$2"
+    local failed="$3"
+
+    if ! type homeboy_write_test_results >/dev/null 2>&1 && [ -n "${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}" ] && [ -f "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS" ]; then
+        # shellcheck source=/dev/null
+        source "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS"
+    fi
+    if type homeboy_write_test_results >/dev/null 2>&1; then
+        homeboy_write_test_results "$total" "$passed" "$failed" 0 "changed-scope-host-php"
+    elif [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+        echo "ERROR: WordPress changed-scope result normalization cannot write HOMEBOY_TEST_RESULTS_FILE." >&2
+        return 2
+    fi
 }
 
 homeboy_wordpress_replay_test_shard() {
@@ -1131,6 +1201,13 @@ if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
             changed_php_smoke_files+="$changed_test_rel"
             echo "CHANGED_SCOPE_ROUTE:${changed_test_rel}:runner=host-php-smoke"
             changed_routed_count=$((changed_routed_count + 1))
+        elif homeboy_wordpress_is_declared_standalone_php_test_file "$changed_test_rel"; then
+            if [ -n "$changed_php_smoke_files" ]; then
+                changed_php_smoke_files+=$'\n'
+            fi
+            changed_php_smoke_files+="$changed_test_rel"
+            echo "CHANGED_SCOPE_ROUTE:${changed_test_rel}:runner=host-php-smoke"
+            changed_routed_count=$((changed_routed_count + 1))
         elif homeboy_wordpress_is_phpunit_test_file "$changed_test_rel"; then
             if [ -n "$changed_phpunit_files" ]; then
                 changed_phpunit_files+=$'\n'
@@ -1192,6 +1269,15 @@ if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     # changed-test list, which it reads as "run everything" — silently widening
     # a changed-file review to the full suite.
     if [ -n "$changed_php_smoke_files" ] && [ -z "$changed_js_smoke_files" ] && [ -z "$changed_shell_smoke_files" ] && [ -z "$changed_node_test_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
+        # A standalone-only scope has exact host-PHP counts. Publish them here
+        # instead of falling through to PHPUnit, whose empty changed scope means
+        # a full-suite run and whose results would not describe these scripts.
+        if [ "${WORDPRESS_CHANGED_SCOPE_HOST_PHP_FILES:-0}" -eq 0 ]; then
+            homeboy_wordpress_write_changed_scope_results \
+                "$changed_routed_count" \
+                "${WORDPRESS_STANDALONE_PHP_SMOKE_PASSED:-0}" \
+                "${WORDPRESS_STANDALONE_PHP_SMOKE_FAILED:-0}" || changed_scope_status=$?
+        fi
         exit "$changed_scope_status"
     fi
 fi

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -15,7 +15,7 @@ assert.ok(
 	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
 );
 
-for (const settingId of ['package_artifacts', 'package_excludes', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wp_codebox_multisite', 'wp_codebox_database_service', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version', 'wordpress_runtime_workload_plugin_slug']) {
+for (const settingId of ['package_artifacts', 'package_excludes', 'standalone_php_test_paths', 'wp_codebox_extra_themes', 'wp_codebox_dependency_overlays', 'wp_codebox_multisite', 'wp_codebox_database_service', 'wordpress_multisite_synthetic_fixture', 'wordpress_runtime_php_version', 'wordpress_runtime_workload_plugin_slug']) {
 	assert.ok(settingIds.has(settingId), `wordpress manifest declares ${settingId}`);
 }
 

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1206,6 +1206,13 @@
   },
   "settings": [
     {
+      "id": "standalone_php_test_paths",
+      "label": "Standalone PHP test paths",
+      "type": "array",
+      "default": [],
+      "description": "Component-relative PHP paths or shell-glob patterns that identify executable standalone PHP tests in changed-file scopes. Matching files run through the bounded host-PHP runner; PHPUnit and *-smoke.php conventions remain available without this declaration."
+    },
+    {
       "id": "validation_dependencies",
       "label": "Validation Dependencies",
       "type": "array",


### PR DESCRIPTION
## Summary
- add the component-owned `standalone_php_test_paths` path/glob declaration
- route matching changed PHP files through the bounded standalone host-PHP runner
- preserve PHPUnit and `*-smoke.php` routing, explicit support-file exclusions, and publish exact standalone-only structured results

## Verification
- `bash wordpress/scripts/test/changed-scope-test-routing-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `node wordpress/tests/wordpress-manifest-settings-smoke.js`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/changed-scope-test-routing-smoke.sh`
- `jq empty wordpress/wordpress.json`

Closes #2674

## AI Assistance
GPT-5.6 Sol via OpenCode analyzed the existing routing contract, implemented the manifest and runner changes, and added deterministic coverage. Chris Huber reviewed and remains responsible for this change.