### PR TITLE
feat(rust): declare Cargo CI cache

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -68,6 +68,17 @@
   "env_provider": {
     "script": "scripts/env-provider.sh"
   },
+  "ci": {
+    "cache": {
+      "namespace": "cargo",
+      "key_files": ["Cargo.lock"],
+      "paths": [
+        { "root": "home", "path": ".cargo/registry" },
+        { "root": "home", "path": ".cargo/git" },
+        { "root": "component", "path": "target", "env": "CARGO_TARGET_DIR" }
+      ]
+    }
+  },
   "toolchain_readiness": [
     {
       "id": "cargo-lint-toolchain",

--- a/rust/scripts/env-provider.sh
+++ b/rust/scripts/env-provider.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./lib/toolchain-env.sh
 source "${SCRIPT_DIR}/lib/toolchain-env.sh"
 
-if [ -n "${CARGO_TARGET_DIR:-}" ] || [ ! -f "${project_path}/Cargo.toml" ]; then
+if [ ! -f "${project_path}/Cargo.toml" ]; then
     printf '{}\n'
     exit 0
 fi
@@ -45,7 +45,7 @@ fi
 
 hash="$(hash_identity "$identity")"
 data_dir="${HOMEBOY_DATA_DIR:-${XDG_DATA_HOME:-${HOME}/.local/share}/homeboy}"
-target_dir="${data_dir}/cargo-targets/${label}-${hash:0:12}"
+target_dir="${CARGO_TARGET_DIR:-${data_dir}/cargo-targets/${label}-${hash:0:12}}"
 toolchain_env_json="$(homeboy_rust_toolchain_env_json)"
 
 python3 - "$target_dir" "$toolchain_env_json" "${CARGO_HOME:-${HOME}/.cargo}" "${RUSTUP_HOME:-${HOME}/.rustup}" <<'PY'

--- a/rust/tests/env-provider-smoke.sh
+++ b/rust/tests/env-provider-smoke.sh
@@ -80,8 +80,10 @@ explicit_output="$(
     HOMEBOY_COMPONENT_PATH="$primary" \
     "$EXTENSION_DIR/scripts/env-provider.sh"
 )"
-if [ "$explicit_output" != '{}' ]; then
-    printf 'Expected explicit CARGO_TARGET_DIR to suppress provider output, got %s\n' "$explicit_output" >&2
+explicit_target="$(printf '%s' "$explicit_output" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("CARGO_TARGET_DIR", ""))')"
+explicit_homeboy_target="$(printf '%s' "$explicit_output" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("HOMEBOY_CARGO_TARGET_DIR", ""))')"
+if [ "$explicit_target" != "$explicit" ] || [ "$explicit_homeboy_target" != "$explicit" ]; then
+    printf 'Expected explicit CARGO_TARGET_DIR to remain the provider target, got %s\n' "$explicit_output" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- declare the Rust extension's Cargo registry, Git checkout, and target cache paths
- bind CI `CARGO_TARGET_DIR` to the declared component target so raw builds and extension commands share one path layout
- preserve the full Rust env-provider output when callers explicitly select a target directory

## Verification
- `bash rust/tests/env-provider-smoke.sh`
- `bash -n rust/scripts/env-provider.sh rust/tests/env-provider-smoke.sh`
- `git diff --check`

Depends on Extra-Chill/homeboy#13217. Tracks Extra-Chill/homeboy#11751 W1-5/W1-6.

## AI assistance
Implemented and verified with OpenAI gpt-5.6-sol using OpenCode; AI was used to trace the Rust target selection, declare the extension-owned cache policy, and verify local and explicit-target behavior.