### PR TITLE
fix(wp-codebox): resolve installed runtime selection shim

### DIFF
--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-selection.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-selection.js
@@ -1,6 +1,21 @@
 'use strict';
 
-const runtimeSelection = require('../../../wordpress/lib/wp-codebox-runtime-selection');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const runtimeSelectionCandidates = [
+	path.resolve(__dirname, '../../../extensions/wordpress/lib/wp-codebox-runtime-selection.js'),
+	path.resolve(__dirname, '../../../wordpress/lib/wp-codebox-runtime-selection.js'),
+];
+const runtimeSelectionPath = runtimeSelectionCandidates.find((candidate) => fs.existsSync(candidate));
+
+if (!runtimeSelectionPath) {
+	throw new Error(
+		`WP Codebox runtime selection requires the installed WordPress extension. Probed:\n${runtimeSelectionCandidates.map((candidate) => `  - ${candidate}`).join('\n')}\nRun homeboy extension install wordpress.`
+	);
+}
+
+const runtimeSelection = require(runtimeSelectionPath);
 const { minimum_version: REQUIRED_WP_CODEBOX_VERSION } = require('../wp-codebox.json');
 
 const withRequiredVersion = (options = {}) => ({

--- a/tests/shared-assets-runtime-materialization-contract.mjs
+++ b/tests/shared-assets-runtime-materialization-contract.mjs
@@ -42,6 +42,11 @@ assert.ok(
 	'homeboy-extension-root.json must declare a shared_assets array'
 );
 const declaredSharedAssets = new Set(rootManifest.shared_assets);
+const installedExtensions = new Set(
+	fs.readdirSync(repoRoot, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory() && fs.existsSync(path.join(repoRoot, entry.name, 'homeboy.json')))
+		.map((entry) => entry.name)
+);
 
 // The runtime packages whose require graphs must resolve on an install. These
 // are themselves declared shared assets that Homeboy core materializes.
@@ -91,9 +96,9 @@ function requireSpecifiers(file) {
 	return specifiers;
 }
 
-// Walk every runtime shared-asset package and record which OTHER top-level
-// repo directories it reaches into via relative requires. Any such directory
-// must itself be a declared shared asset so core co-materializes it.
+// Walk every runtime shared-asset package and record which OTHER top-level repo
+// directories it reaches into via relative requires. Each dependency must be a
+// shared asset or an extension that Homeboy installs under extensions/<id>.
 const referencedSharedAssets = new Set();
 for (const asset of runtimeSharedAssets) {
 	const assetDir = path.join(repoRoot, asset);
@@ -116,16 +121,15 @@ for (const asset of runtimeSharedAssets) {
 	}
 }
 
-// Every top-level directory a runtime shared asset requires must be declared as
-// a shared asset itself. This is the invariant that broke in #7736:
-// agent-runtimes and runtime-agent-ci both require agent-task-contracts, so
-// agent-task-contracts must be a declared shared asset.
+// Every top-level dependency must have an installed materialization contract.
+// Shared packages are copied beside agent-runtimes; extension dependencies are
+// copied beneath extensions and must resolve that distinct installed layout.
 for (const referenced of [...referencedSharedAssets].sort()) {
 	assert.ok(
-		declaredSharedAssets.has(referenced),
+		declaredSharedAssets.has(referenced) || installedExtensions.has(referenced),
 		`runtime shared assets require top-level "${referenced}", so it must be declared in ` +
-			'homeboy-extension-root.json shared_assets for Homeboy core to co-materialize it. ' +
-			'Dropping it recreates Extra-Chill/homeboy#7736 (MODULE_NOT_FOUND before the agent runs).'
+			'homeboy-extension-root.json shared_assets or be an installable extension with homeboy.json. ' +
+			'Otherwise the dependency is absent after extension materialization.'
 	);
 }
 

--- a/wordpress/tests/installed-agent-runtime-resolution-smoke.sh
+++ b/wordpress/tests/installed-agent-runtime-resolution-smoke.sh
@@ -4,10 +4,9 @@
 # `agent-runtimes` is a shared asset: Homeboy installs it at
 # <homeboy>/agent-runtimes, a sibling of <homeboy>/extensions, while a monorepo
 # checkout keeps it one level closer to the extension. A linked dev install
-# hides the difference because Node and `pwd -P` resolve a symlinked extension
-# back to the checkout, so this fixture COPIES the extension scripts — that is
-# the shape a fresh CI runner has, and the shape that produced four identical
-# MODULE_NOT_FOUND shard bootstrap failures in #12585.
+# hides the difference because Node resolves symlinked modules back to the
+# checkout, so this fixture COPIES both the extension and shared runtimes. That
+# is the shape a fresh CI runner has, including the shim failure from #2690.
 set -euo pipefail
 
 WORDPRESS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -21,7 +20,10 @@ mkdir -p "${EXTENSION_DIR}" "${HOMEBOY_ROOT}/extensions/scripts"
 cp -R "${WORDPRESS_ROOT}/scripts" "${EXTENSION_DIR}/scripts"
 cp -R "${WORDPRESS_ROOT}/lib" "${EXTENSION_DIR}/lib"
 cp "${WORDPRESS_ROOT}/wordpress.json" "${EXTENSION_DIR}/wordpress.json"
-ln -s "${REPOSITORY_ROOT}/agent-runtimes" "${HOMEBOY_ROOT}/agent-runtimes"
+cp -R "${REPOSITORY_ROOT}/agent-runtimes" "${HOMEBOY_ROOT}/agent-runtimes"
+cp -R "${REPOSITORY_ROOT}/agent-task-contracts" "${HOMEBOY_ROOT}/agent-task-contracts"
+cp -R "${REPOSITORY_ROOT}/dependency-adapters" "${HOMEBOY_ROOT}/dependency-adapters"
+cp -R "${REPOSITORY_ROOT}/runtime-agent-ci" "${HOMEBOY_ROOT}/runtime-agent-ci"
 ln -s "${REPOSITORY_ROOT}/scripts/lib" "${HOMEBOY_ROOT}/extensions/scripts/lib"
 
 # Every step below asserts its own outcome, including exit status. Leaving
@@ -53,6 +55,19 @@ for target in \
     expected="$(cd "$(dirname "${HOMEBOY_ROOT}")" && pwd -P)/$(basename "${HOMEBOY_ROOT}")/agent-runtimes/${target}"
     [ "$resolved" = "$expected" ] || fail "Expected installed resolution of ${target} to ${expected}, got: ${resolved}"
 done
+
+# Resolving a shim filename is insufficient: execute the copied runtime shim so
+# its dependency on the copied WordPress extension is proven in the installed
+# sibling layout that failed before test inventory started in #2690.
+selection_module="$(fixture_node "${EXTENSION_DIR}/scripts/lib/agent-runtime-paths.cjs" "wp-codebox/lib/wp-codebox-runtime-selection.js" 2>&1)"
+selection_output="$(fixture_node - "${selection_module}" <<'NODE' 2>&1
+const selection = require(process.argv[2]);
+if (typeof selection.preflightWpCodeboxCommand !== 'function') process.exit(1);
+process.stdout.write(selection.REQUIRED_WP_CODEBOX_VERSION);
+NODE
+)"
+expected_version="$(fixture_node -p "require(process.argv[1]).minimum_version" "${HOMEBOY_ROOT}/agent-runtimes/wp-codebox/wp-codebox.json" 2>&1)"
+[ "${selection_output}" = "${expected_version}" ] || fail "Installed WP Codebox runtime-selection shim failed to load: ${selection_output}"
 
 # The opencode wrapper's only job is to resolve and require the shared runtime,
 # so assert that it gets past resolution. What the runtime then does with an
@@ -99,7 +114,7 @@ esac
 # WordPress-owned runtime selection remains available without the experimental
 # shared runtime. Wrappers that still consume shared runtimes must name what is
 # missing instead of emitting a bare MODULE_NOT_FOUND stack.
-rm "${HOMEBOY_ROOT}/agent-runtimes"
+rm -rf "${HOMEBOY_ROOT}/agent-runtimes"
 adapter_output="$(HOMEBOY_SETTINGS_JSON='{}' fixture_node "${EXTENSION_DIR}/scripts/test/wp-codebox-phpunit-adapter.mjs" 2>&1)"
 case "$adapter_output" in
     *HOMEBOY_COMPONENT_PATH*) ;;


### PR DESCRIPTION
## Summary

- resolve the WP Codebox compatibility shim against the canonical WordPress-owned helper in both checkout and installed sibling-extension layouts
- execute a copied runtime and extension tree in the installed-layout regression instead of resolving through a source-tree symlink
- teach the shared-asset contract that runtime dependencies may be separately installed extensions while preserving shared-package declarations

## Root Cause

The WordPress ownership refactor moved runtime selection into `wordpress/lib/wp-codebox-runtime-selection.js` and left a compatibility shim in `agent-runtimes/wp-codebox/lib`. That shim used the checkout-only relative require `../../../wordpress/lib/wp-codebox-runtime-selection`.

In a checkout, this resolves to `<repo>/wordpress/lib/...`. In an installed release, the runtime is at `<homeboy>/agent-runtimes/wp-codebox/lib` while WordPress is at `<homeboy>/extensions/wordpress`, so the same require incorrectly resolves to `<homeboy>/wordpress/lib/...` and fails before test inventory can run.

The existing installed-layout smoke only resolved the shim filename. Its runtime tree was symlinked back to the checkout, so Node never executed the shim from the copied installed path and the transitive failure remained hidden.

## Installed-Layout Reproduction

The regression now assembles the release shape under a temporary Homeboy root:

- `<homeboy>/extensions/wordpress/{scripts,lib,wordpress.json}`
- `<homeboy>/agent-runtimes`
- co-materialized `agent-task-contracts`, `dependency-adapters`, and `runtime-agent-ci`
- shared extension scripts at `<homeboy>/extensions/scripts/lib`

It resolves and requires `<homeboy>/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-selection.js`, then verifies the shim exports `preflightWpCodeboxCommand` and binds the runtime manifest's minimum version. This exact copied layout reproduced the missing `../../../wordpress/lib/...` dependency before the fix.

## Fix

The compatibility shim probes the two owned layouts explicitly:

1. installed: `<homeboy>/extensions/wordpress/lib/wp-codebox-runtime-selection.js`
2. checkout: `<repo>/wordpress/lib/wp-codebox-runtime-selection.js`

If neither exists, it reports every probed path and the extension-install remediation. The canonical implementation remains owned by the WordPress extension; no implementation is copied back into the runtime and no duplicate `wordpress` shared asset is introduced.

## Verification

Passed:

- `bash wordpress/tests/installed-agent-runtime-resolution-smoke.sh`
- `node tests/shared-assets-runtime-materialization-contract.mjs`
- `node wordpress/tests/agent-runtime-paths-smoke.js`
- `node --check agent-runtimes/wp-codebox/lib/wp-codebox-runtime-selection.js`
- `bash -n wordpress/tests/installed-agent-runtime-resolution-smoke.sh`
- `bash wordpress/tests/release-scripts-smoke.sh`
- `bash wordpress/tests/release-provenance-contract-smoke.sh`
- `bash tests/wordpress-release-package-cwd-smoke.sh`
- `node tests/agent-task-provider-contract-smoke.mjs`
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- declared WordPress lint/test sequence through `node tests/wp-codebox-phpunit-managed-selection-smoke.mjs`, including setup, cache, installed helper, installed runtime, Composer integrity, PHPUnit evidence, timeout, crash, and changed-scope gates

Umbrella limitations:

- `homeboy review ... --changed-only` completed audit, then refused tests because Homeboy requires a clean component checkout. The direct declared suite was used before commit instead.
- Direct execution of later Homeboy-injected lint smokes stopped at `autofixable-exit-smoke.sh` because `HOMEBOY_RUNTIME_RUNNER_PRELUDE` is supplied by the Homeboy runner rather than a plain shell.
- The root declared suite encountered an unrelated OpenCode 1.14.33 trailing-newline assertion. It is tracked separately as #2691; no OpenCode code is changed here.

Fixes #2690