### PR TITLE
test(wordpress): isolate WP Codebox resolver smokes

### DIFF
--- a/wordpress/scripts/test/wp-codebox-cli-resolution-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-cli-resolution-smoke.sh
@@ -20,6 +20,13 @@ SETUP="${EXTENSION_ROOT}/scripts/build/setup.sh"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "${TMP_ROOT}"' EXIT
 
+ISOLATED_BIN="${TMP_ROOT}/bin"
+mkdir -p "${ISOLATED_BIN}" "${TMP_ROOT}/home"
+for tool in bash dirname head jq node; do
+    tool_path="$(command -v "${tool}")"
+    ln -s "${tool_path}" "${ISOLATED_BIN}/${tool}"
+done
+
 failures=0
 
 fail() {
@@ -56,13 +63,32 @@ exec node "${INCOMPLETE_CACHE}/source/packages/cli/dist/index.js" "\$@"
 EOF
 chmod +x "${STALE_BIN_DIR}/wp-codebox"
 
-# --- 1. a stale PATH wrapper is never handed back as a usable CLI -----------
+# --- 1. no ambient candidate is inherited from the host --------------------
+
+set +e
+env -i \
+    PATH="${ISOLATED_BIN}" \
+    HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMP_ROOT}/empty-cache" \
+    bash -c 'source "$1" && homeboy_wp_codebox_resolve_bin ""' \
+    wp-codebox-no-candidate "${PATHS_LIB}" \
+    > "${TMP_ROOT}/no-candidate.out" 2> "${TMP_ROOT}/no-candidate.err"
+no_candidate_status=$?
+set -e
+
+if [ "${no_candidate_status}" -ne 0 ] && grep -q 'wp-codebox not found' "${TMP_ROOT}/no-candidate.err"; then
+    pass "resolver reports no candidate in an isolated environment"
+else
+    fail "resolver inherited an ambient candidate: $(cat "${TMP_ROOT}/no-candidate.out" "${TMP_ROOT}/no-candidate.err")"
+fi
+
+# --- 2. a stale PATH wrapper is never handed back as a usable CLI -----------
 
 resolution_stderr="${TMP_ROOT}/resolution.err"
 resolution_stdout="${TMP_ROOT}/resolution.out"
 set +e
 env -i \
-    PATH="${STALE_BIN_DIR}:/usr/bin:/bin" \
+    PATH="${STALE_BIN_DIR}:${ISOLATED_BIN}" \
     HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${INCOMPLETE_CACHE}" \
     bash -c 'source "$1" && homeboy_wp_codebox_resolve_bin ""' \
@@ -89,9 +115,9 @@ else
     pass "resolver does not leak a raw Node module error"
 fi
 
-# --- 2. an incomplete managed cache is reported as incomplete ---------------
+# --- 3. an incomplete managed cache is reported as incomplete ---------------
 
-if env -i PATH="/usr/bin:/bin" HOME="${TMP_ROOT}/home" \
+if env -i PATH="${ISOLATED_BIN}" HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${INCOMPLETE_CACHE}" \
     bash -c 'source "$1" && homeboy_wp_codebox_managed_cache_is_incomplete' \
     wp-codebox-cache "${PATHS_LIB}"; then
@@ -100,7 +126,7 @@ else
     fail "an unbuilt managed source cache was not classified incomplete"
 fi
 
-if env -i PATH="/usr/bin:/bin" HOME="${TMP_ROOT}/home" \
+if env -i PATH="${ISOLATED_BIN}" HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
     bash -c 'source "$1" && homeboy_wp_codebox_managed_cache_is_incomplete' \
     wp-codebox-cache "${PATHS_LIB}"; then
@@ -109,10 +135,10 @@ else
     pass "a built managed source cache is not classified incomplete"
 fi
 
-# --- 3. the exported argv prefixes node for a .js entrypoint ----------------
+# --- 4. managed selection and invocation are deterministic ------------------
 
 command_json="$(env -i \
-    PATH="/usr/bin:/bin" \
+    PATH="${ISOLATED_BIN}" \
     HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
     bash -c 'source "$1" && homeboy_wp_codebox_export_command "" && printf "%s" "$HOMEBOY_WP_CODEBOX_COMMAND_JSON"' \
@@ -125,7 +151,25 @@ else
     fail "exported argv is ${command_json}, expected ${expected_json}"
 fi
 
-# --- 4. a validated explicit override outranks the managed cache ------------
+MACHINE_CACHE="${TMP_ROOT}/machine-cache"
+MACHINE_BIN="${MACHINE_CACHE}/source/packages/cli/dist/index.js"
+mkdir -p "$(dirname "${MACHINE_BIN}")"
+cp "${COMPLETE_CACHE}/source/packages/cli/dist/index.js" "${MACHINE_BIN}"
+printf '{"wp_codebox_bin":"%s"}\n' "${MACHINE_BIN}" > "${MACHINE_CACHE}/wp-codebox-overrides.json"
+
+machine_selected_bin="$(env -i \
+    PATH="${ISOLATED_BIN}" \
+    HOME="${TMP_ROOT}/home" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${MACHINE_CACHE}" \
+    bash -c 'source "$1" && homeboy_wp_codebox_resolve_bin ""' \
+    wp-codebox-machine-selection "${PATHS_LIB}")"
+if [ "${machine_selected_bin}" = "${MACHINE_BIN}" ]; then
+    pass "machine-selected managed CLI outranks managed source fallback"
+else
+    fail "machine selection produced ${machine_selected_bin}, expected ${MACHINE_BIN}"
+fi
+
+# --- 5. a validated explicit override outranks the managed cache ------------
 
 OVERRIDE_BIN="${TMP_ROOT}/override-wp-codebox"
 cat > "${OVERRIDE_BIN}" <<'SH'
@@ -138,7 +182,7 @@ chmod +x "${OVERRIDE_BIN}"
 # not be masked by a lower-precedence valid pin.
 set +e
 env -i \
-    PATH="/usr/bin:/bin" \
+    PATH="${ISOLATED_BIN}" \
     HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_BIN="${TMP_ROOT}/does-not-exist/highest" \
     WP_CODEBOX_BIN="${OVERRIDE_BIN}" \
@@ -154,7 +198,7 @@ else
 fi
 
 override_json="$(env -i \
-    PATH="/usr/bin:/bin" \
+    PATH="${ISOLATED_BIN}" \
     HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
     HOMEBOY_WP_CODEBOX_BIN="${OVERRIDE_BIN}" \
@@ -171,7 +215,7 @@ fi
 # hand it to the runtime.
 set +e
 env -i \
-    PATH="/usr/bin:/bin" \
+    PATH="${ISOLATED_BIN}" \
     HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
     HOMEBOY_WP_CODEBOX_BIN="${TMP_ROOT}/does-not-exist/wp-codebox" \
@@ -197,7 +241,7 @@ SH
 chmod +x "${NONPROBING_OVERRIDE}"
 
 nonprobing_json="$(env -i \
-    PATH="/usr/bin:/bin" \
+    PATH="${ISOLATED_BIN}" \
     HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
     HOMEBOY_WP_CODEBOX_BIN="${NONPROBING_OVERRIDE}" \
@@ -214,7 +258,7 @@ fi
 # fail-closed behavior as HOMEBOY_WP_CODEBOX_BIN.
 set +e
 env -i \
-    PATH="${STALE_BIN_DIR}:/usr/bin:/bin" \
+    PATH="${STALE_BIN_DIR}:${ISOLATED_BIN}" \
     HOME="${TMP_ROOT}/home" \
     HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COMPLETE_CACHE}" \
     WP_CODEBOX_BIN="${TMP_ROOT}/does-not-exist/wp-codebox" \
@@ -229,7 +273,7 @@ else
     fail "dangling WP_CODEBOX_BIN did not fail closed: $(cat "${TMP_ROOT}/legacy-dangling-override.err")"
 fi
 
-# --- 5. the adapter consumes the resolved argv, never a bare CLI string -----
+# --- 6. the adapter consumes the resolved argv, never a bare CLI string -----
 
 if grep -q "HOMEBOY_WP_CODEBOX_BIN || process.env.WP_CODEBOX_BIN || 'wp-codebox'" "${ADAPTER}"; then
     fail "the adapter still resolves the CLI inline instead of using the shared seam"
@@ -262,7 +306,7 @@ else
     fail "the adapter does not preflight the exported argv directly"
 fi
 
-# --- 6. setup prunes a stale wrapper whose target is gone -------------------
+# --- 7. setup prunes a stale wrapper whose target is gone -------------------
 
 PRUNE_BIN_DIR="${TMP_ROOT}/prune-bin"
 mkdir -p "${PRUNE_BIN_DIR}"

--- a/wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh
@@ -10,6 +10,18 @@ source "$WP_CODEBOX_HELPER"
 fixture="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-recipe-helper.XXXXXX")"
 trap 'rm -rf "$fixture"' EXIT
 
+isolated_bin="${fixture}/bin"
+isolated_home="${fixture}/home"
+mkdir -p "$isolated_bin" "$isolated_home"
+for tool in bash cat chmod cp dirname git grep head jq mkdir node rm sh; do
+    tool_path="$(command -v "$tool")"
+    ln -s "$tool_path" "${isolated_bin}/${tool}"
+done
+export HOME="$isolated_home"
+export PATH="$isolated_bin"
+unset HOMEBOY_GLOBAL_NODE_MODULE_ROOT HOMEBOY_SETTINGS_JSON HOMEBOY_SETTINGS_WP_CODEBOX_BIN \
+    HOMEBOY_WP_CODEBOX_BIN HOMEBOY_WP_CODEBOX_INSTALL_DIR NODE_PATH WP_CODEBOX_BIN
+
 fake_wp_codebox="${fixture}/wp-codebox.cjs"
 managed_source="${fixture}/managed/source"
 managed_wp_codebox="${managed_source}/packages/cli/dist/index.js"
@@ -74,7 +86,7 @@ if ! homeboy_wp_codebox_bin_is_runnable "$js_bin"; then
     exit 1
 fi
 
-resolved_bin=$(HOMEBOY_WP_CODEBOX_INSTALL_DIR="${fixture}/empty-managed" PATH="${stale_path}:${valid_path}:${PATH}" homeboy_wp_codebox_resolve_bin '{}')
+resolved_bin=$(HOMEBOY_WP_CODEBOX_INSTALL_DIR="${fixture}/empty-managed" PATH="${stale_path}:${valid_path}:${isolated_bin}" homeboy_wp_codebox_resolve_bin '{}')
 if [ "$resolved_bin" != "${valid_path}/wp-codebox" ]; then
     echo "Expected resolver to skip stale wp-codebox wrapper and select working binary" >&2
     echo "Resolved: ${resolved_bin}" >&2

--- a/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
+++ b/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
@@ -12,6 +12,7 @@ const {
 } = require('../scripts/fuzz/fuzz-runner.cjs');
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-fuzz-runner-runtime-path-'));
+process.on('exit', () => fs.rmSync(root, { recursive: true, force: true }));
 const homeboyRoot = path.join(root, '.config', 'homeboy');
 const extensionPath = path.join(homeboyRoot, 'extensions', 'wordpress');
 const installedRuntimePath = path.join(homeboyRoot, 'agent-runtimes', 'wp-codebox');
@@ -20,6 +21,10 @@ const cachedCoreModule = path.join(root, 'wp-codebox-cache', 'source', 'node_mod
 const cachedCoreIndex = path.join(root, 'wp-codebox-cache', 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
 const manifestDefaultBin = path.join(root, 'wp-codebox-main-current', 'packages', 'cli', 'dist', 'index.js');
 const manifestDefaultCoreModule = path.join(root, 'wp-codebox-main-current', 'packages', 'runtime-core', 'dist', 'index.js');
+const isolatedRuntimeEnv = {
+	HOME: path.join(root, 'home'),
+	HOMEBOY_WP_CODEBOX_INSTALL_DIR: path.join(root, 'empty-wp-codebox-cache'),
+};
 
 fs.mkdirSync(extensionPath, { recursive: true });
 fs.mkdirSync(installedRuntimePath, { recursive: true });
@@ -46,18 +51,21 @@ assert.equal(resolveWpCodeboxRuntimePath({ env: {} }), sourceRuntimePath);
 
 assert.equal(
 	wpCodeboxRuntimeEnv({
+		...isolatedRuntimeEnv,
 		HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_core_module: '/tmp/wp-codebox-core.mjs' }),
 	}).HOMEBOY_WP_CODEBOX_CORE_MODULE,
 	'/tmp/wp-codebox-core.mjs'
 );
 assert.equal(
 	wpCodeboxRuntimeEnv({
+		...isolatedRuntimeEnv,
 		HOMEBOY_EXTENSION_PATH: extensionPath,
 	}).HOMEBOY_WP_CODEBOX_CORE_MODULE,
 	manifestDefaultCoreModule
 );
 assert.equal(
 	wpCodeboxRuntimeEnv({
+		...isolatedRuntimeEnv,
 		HOMEBOY_WP_CODEBOX_CORE_MODULE: '/existing/core.mjs',
 		HOMEBOY_EXTENSION_PATH: extensionPath,
 		HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_core_module: '/tmp/wp-codebox-core.mjs' }),

--- a/wordpress/tests/wp-codebox-recipe-helper-smoke.js
+++ b/wordpress/tests/wp-codebox-recipe-helper-smoke.js
@@ -23,6 +23,20 @@ const outputFile = path.join(root, 'output', 'wp-codebox-output.json');
 const managedInstall = path.join(root, 'managed');
 const managedSource = path.join(managedInstall, 'source');
 const managedBin = path.join(managedSource, 'packages', 'cli', 'dist', 'index.js');
+const isolatedBin = path.join(root, 'bin');
+const isolatedHome = path.join(root, 'home');
+const gitBin = require('node:child_process').spawnSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).stdout.trim();
+
+fs.mkdirSync(isolatedBin, { recursive: true });
+fs.mkdirSync(isolatedHome, { recursive: true });
+fs.symlinkSync(process.execPath, path.join(isolatedBin, 'node'));
+fs.symlinkSync(gitBin, path.join(isolatedBin, 'git'));
+process.env.HOME = isolatedHome;
+process.env.PATH = isolatedBin;
+for (const name of ['HOMEBOY_WP_CODEBOX_BIN', 'WP_CODEBOX_BIN', 'HOMEBOY_SETTINGS_WP_CODEBOX_BIN', 'HOMEBOY_SETTINGS_JSON', 'HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT', 'WP_CODEBOX_RUNTIME_COMPONENT', 'NODE_PATH']) {
+  delete process.env[name];
+}
+process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR = path.join(root, 'empty-managed');
 
 fs.writeFileSync(recipeFile, JSON.stringify({ schema: 'wp-codebox/workspace-recipe/v1' }));
 fs.writeFileSync(fixtureBin, `#!/usr/bin/env node
@@ -85,9 +99,7 @@ async function waitForReaped(pids, timeoutMs = 5000) {
   assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_BIN: '/env/wp-codebox', HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: fixtureBin }) } }), '/env/wp-codebox');
   assert.deepEqual(homeboySettings({ HOMEBOY_SETTINGS_JSON: '{"wp_codebox_bin":"/bin/wp-codebox"}' }), { wp_codebox_bin: '/bin/wp-codebox' });
   assert.deepEqual(homeboySettings({ HOMEBOY_SETTINGS_JSON: 'not json' }), {});
-  // Canonical selection may supply an installed runtime when no explicit pin is
-  // present; execution still performs the exact-command preflight below.
-  assert.equal(typeof wpCodeboxBin({ env: {} }), 'string');
+  assert.throws(() => wpCodeboxBin({ env: process.env }), /WP Codebox binary is not configured/);
   assert.deepEqual(wpCodeboxCommand('/tmp/wp-codebox.cjs'), { command: process.execPath, args: ['/tmp/wp-codebox.cjs'] });
   assert.deepEqual(wpCodeboxCommand('wp-codebox'), { command: 'wp-codebox', args: [] });
   assert.deepEqual(
@@ -258,5 +270,7 @@ async function waitForReaped(pids, timeoutMs = 5000) {
   console.log('wp-codebox recipe helper smoke passed');
 })().catch((error) => {
   console.error(error);
-  process.exit(1);
+  process.exitCode = 1;
+}).finally(() => {
+  fs.rmSync(root, { recursive: true, force: true });
 });

--- a/wordpress/tests/wp-codebox-resolver-smoke.js
+++ b/wordpress/tests/wp-codebox-resolver-smoke.js
@@ -7,148 +7,91 @@ const path = require('node:path');
 
 const {
 	resolveWpCodeboxIdentity,
-	wpCodeboxIdentityMismatchDiagnostics,
+	wpCodeboxCommand,
 } = require('../lib/wp-codebox-resolver');
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-resolver-'));
-
-function makeCodeboxRoot(name, version = '1.2.3') {
-	const sourceRoot = path.join(root, name);
-	const cliDist = path.join(sourceRoot, 'packages', 'cli', 'dist');
-	const coreDist = path.join(sourceRoot, 'packages', 'runtime-core', 'dist');
-	const runtimeDist = path.join(sourceRoot, 'packages', 'runtime-playground', 'dist');
-	fs.mkdirSync(cliDist, { recursive: true });
-	fs.mkdirSync(coreDist, { recursive: true });
-	fs.mkdirSync(runtimeDist, { recursive: true });
-	fs.writeFileSync(path.join(sourceRoot, 'package.json'), JSON.stringify({ version }));
-	fs.writeFileSync(path.join(cliDist, 'index.js'), '#!/usr/bin/env node\n');
-	fs.writeFileSync(path.join(coreDist, 'contracts.js'), 'export const contracts = true;\n');
-	fs.writeFileSync(path.join(coreDist, 'index.js'), 'export const ok = true;\n');
-	fs.writeFileSync(path.join(runtimeDist, 'index.js'), 'export const runtime = true;\n');
-	return sourceRoot;
-}
+const home = path.join(root, 'home');
+const emptyPath = path.join(root, 'bin');
+const manifestPath = path.join(root, 'wordpress.json');
+const emptyManifestPath = path.join(root, 'empty-wordpress.json');
+const envBin = path.join(root, 'env-wp-codebox.cjs');
+const settingsBin = path.join(root, 'settings-wp-codebox');
+const manifestBin = path.join(root, 'manifest-wp-codebox.mjs');
 
 try {
-	const envRoot = makeCodeboxRoot('wp-codebox@env', '1.0.0');
-	const settingsRoot = makeCodeboxRoot('wp-codebox@settings', '2.0.0');
-	const manifestDefaultRoot = makeCodeboxRoot('wp-codebox@manifest-default', '2.5.0');
-	const cacheRoot = path.join(root, 'cache', 'wp-codebox');
-	const cacheSourceRoot = makeCodeboxRoot(path.join('cache', 'wp-codebox', 'source'), '3.0.0');
-	const workspaceRoot = path.join(root, 'workspace');
-	const workspaceSourceRoot = makeCodeboxRoot(path.join('workspace', 'wp-codebox@feature'), '4.0.0');
-	const extensionPath = path.join(root, 'extensions', 'wordpress');
-	fs.mkdirSync(cacheRoot, { recursive: true });
-	fs.mkdirSync(workspaceRoot, { recursive: true });
-	fs.mkdirSync(extensionPath, { recursive: true });
-
-	const envBin = path.join(envRoot, 'packages', 'cli', 'dist', 'index.js');
-	const settingsBin = path.join(settingsRoot, 'packages', 'cli', 'dist', 'index.js');
-	const manifestDefaultBin = path.join(manifestDefaultRoot, 'packages', 'cli', 'dist', 'index.js');
-	const manifestDefaultCoreModule = path.join(manifestDefaultRoot, 'packages', 'runtime-core', 'dist', 'index.js');
-	fs.writeFileSync(path.join(extensionPath, 'wordpress.json'), JSON.stringify({
-		settings: [
-			{ id: 'wp_codebox_bin', default: manifestDefaultBin },
-			{ id: 'wp_codebox_core_module', default: manifestDefaultCoreModule },
-		],
+	fs.mkdirSync(home, { recursive: true });
+	fs.mkdirSync(emptyPath, { recursive: true });
+	fs.writeFileSync(envBin, '#!/usr/bin/env node\n');
+	fs.writeFileSync(settingsBin, '#!/bin/sh\n');
+	fs.writeFileSync(manifestBin, '#!/usr/bin/env node\n');
+	fs.writeFileSync(manifestPath, JSON.stringify({
+		settings: [{ id: 'wp_codebox_bin', default: manifestBin }],
 	}));
+	fs.writeFileSync(emptyManifestPath, JSON.stringify({ settings: [] }));
+
+	const isolatedEnv = {
+		HOME: home,
+		PATH: emptyPath,
+		HOMEBOY_EXTENSION_MANIFEST_PATH: '',
+		HOMEBOY_SETTINGS_JSON: '',
+		HOMEBOY_WP_CODEBOX_BIN: '',
+	};
 
 	const envIdentity = resolveWpCodeboxIdentity({
+		extension_manifest_path: manifestPath,
 		env: {
+			...isolatedEnv,
 			HOMEBOY_WP_CODEBOX_BIN: envBin,
 			HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: settingsBin }),
 		},
 	});
-	assert.equal(envIdentity.selectionSource, 'env');
-	assert.equal(envIdentity.bin, envBin);
-	assert.equal(envIdentity.sourceRoot, envRoot);
-	assert.equal(envIdentity.coreModulePath, path.join(envRoot, 'packages', 'runtime-core', 'dist', 'contracts.js'));
-	assert.equal(envIdentity.runtimePackagePath, path.join(envRoot, 'packages', 'runtime-playground', 'dist', 'index.js'));
-	assert.equal(envIdentity.fingerprint.version, '1.0.0');
-	assert.deepEqual(envIdentity.invocation, { command: process.execPath, args: [envBin] });
+	assert.deepEqual(envIdentity, {
+		bin: envBin,
+		invocation: { command: process.execPath, args: [envBin] },
+		selectionSource: 'env',
+	});
+
+	const explicitIdentity = resolveWpCodeboxIdentity({
+		wp_codebox_bin: settingsBin,
+		extension_manifest_path: manifestPath,
+		env: { ...isolatedEnv, HOMEBOY_WP_CODEBOX_BIN: envBin },
+	});
+	assert.deepEqual(explicitIdentity, {
+		bin: settingsBin,
+		invocation: { command: settingsBin, args: [] },
+		selectionSource: 'explicit',
+	});
 
 	const settingsIdentity = resolveWpCodeboxIdentity({
-		env: { HOMEBOY_SETTINGS_JSON: JSON.stringify({
-			wp_codebox_bin: settingsBin,
-			wp_codebox_core_module: path.join(settingsRoot, 'packages', 'runtime-core', 'dist', 'index.js'),
-		}) },
-	});
-	assert.equal(settingsIdentity.selectionSource, 'settings');
-	assert.equal(settingsIdentity.bin, settingsBin);
-	assert.equal(settingsIdentity.sourceRoot, settingsRoot);
-	assert.equal(settingsIdentity.coreModulePath, path.join(settingsRoot, 'packages', 'runtime-core', 'dist', 'index.js'));
-
-	const manifestDefaultIdentity = resolveWpCodeboxIdentity({
-		env: { HOMEBOY_EXTENSION_PATH: extensionPath },
-	});
-	assert.equal(manifestDefaultIdentity.selectionSource, 'manifest-default');
-	assert.equal(manifestDefaultIdentity.bin, manifestDefaultBin);
-	assert.equal(manifestDefaultIdentity.sourceRoot, manifestDefaultRoot);
-	assert.equal(manifestDefaultIdentity.coreModulePath, manifestDefaultCoreModule);
-
-	const manifestDefaultWithCacheIdentity = resolveWpCodeboxIdentity({
-		wpCodeboxInstallDir: cacheRoot,
-		env: { HOMEBOY_EXTENSION_PATH: extensionPath },
-	});
-	assert.equal(manifestDefaultWithCacheIdentity.selectionSource, 'manifest-default');
-	assert.equal(manifestDefaultWithCacheIdentity.bin, manifestDefaultBin);
-	assert.equal(manifestDefaultWithCacheIdentity.sourceRoot, manifestDefaultRoot);
-	assert.equal(manifestDefaultWithCacheIdentity.coreModulePath, manifestDefaultCoreModule);
-
-	const envOverManifestDefaultIdentity = resolveWpCodeboxIdentity({
+		extension_manifest_path: manifestPath,
 		env: {
-			HOMEBOY_EXTENSION_PATH: extensionPath,
-			HOMEBOY_WP_CODEBOX_BIN: envBin,
+			...isolatedEnv,
+			HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: settingsBin }),
 		},
 	});
-	assert.equal(envOverManifestDefaultIdentity.selectionSource, 'env');
-	assert.equal(envOverManifestDefaultIdentity.bin, envBin);
-
-	const cacheIdentity = resolveWpCodeboxIdentity({
-		wpCodeboxInstallDir: cacheRoot,
-		env: {},
+	assert.deepEqual(settingsIdentity, {
+		bin: settingsBin,
+		invocation: { command: settingsBin, args: [] },
+		selectionSource: 'settings',
 	});
-	assert.equal(cacheIdentity.selectionSource, 'cache');
-	assert.equal(cacheIdentity.installRoot, cacheRoot);
-	assert.equal(cacheIdentity.sourceRoot, cacheSourceRoot);
-	assert.equal(cacheIdentity.bin, path.join(cacheSourceRoot, 'packages', 'cli', 'dist', 'index.js'));
 
-	const staleEnvWithCacheIdentity = resolveWpCodeboxIdentity({
-		wpCodeboxInstallDir: cacheRoot,
-		env: {
-			HOMEBOY_WP_CODEBOX_BIN: envBin,
-			HOMEBOY_WP_CODEBOX_CORE_MODULE: path.join(envRoot, 'packages', 'runtime-core', 'dist', 'index.js'),
-		},
+	const manifestIdentity = resolveWpCodeboxIdentity({
+		extension_manifest_path: manifestPath,
+		env: isolatedEnv,
 	});
-	assert.equal(staleEnvWithCacheIdentity.selectionSource, 'env');
-	assert.equal(staleEnvWithCacheIdentity.bin, envBin);
-	assert.equal(staleEnvWithCacheIdentity.coreModulePath, path.join(envRoot, 'packages', 'runtime-core', 'dist', 'index.js'));
+	assert.deepEqual(manifestIdentity, {
+		bin: manifestBin,
+		invocation: { command: process.execPath, args: [manifestBin] },
+		selectionSource: 'manifest-default',
+	});
 
-	const explicitBinWithCacheIdentity = resolveWpCodeboxIdentity({
-		wpCodeboxBin: envBin,
-		wpCodeboxInstallDir: cacheRoot,
-		env: {},
-	});
-	assert.equal(explicitBinWithCacheIdentity.selectionSource, 'explicit');
-	assert.equal(explicitBinWithCacheIdentity.bin, envBin);
-
-	const workspaceIdentity = resolveWpCodeboxIdentity({
-		workspaceRoot,
-		wpCodeboxInstallDir: path.join(root, 'missing-cache'),
-		env: {},
-	});
-	assert.equal(workspaceIdentity.selectionSource, 'workspace');
-	assert.equal(workspaceIdentity.sourceRoot, workspaceSourceRoot);
-	assert.equal(workspaceIdentity.bin, path.join(workspaceSourceRoot, 'packages', 'cli', 'dist', 'index.js'));
-
-	const mismatchIdentity = resolveWpCodeboxIdentity({
-		env: { HOMEBOY_WP_CODEBOX_BIN: envBin },
-		coreModule: path.join(settingsRoot, 'packages', 'runtime-core', 'dist', 'index.js'),
-	});
-	const diagnostics = wpCodeboxIdentityMismatchDiagnostics(mismatchIdentity);
-	assert.equal(diagnostics.length, 1);
-	assert.equal(diagnostics[0].code, 'wp_codebox_identity_mismatch');
-	assert.match(diagnostics[0].message, /one checkout supplies all WP Codebox paths/);
-	assert.deepEqual(diagnostics[0].locations.map((entry) => entry.role).sort(), ['cli', 'core', 'runtime']);
+	assert.throws(
+		() => resolveWpCodeboxIdentity({ extension_manifest_path: emptyManifestPath, env: isolatedEnv }),
+		/WP Codebox binary is not configured/
+	);
+	assert.deepEqual(wpCodeboxCommand('wp-codebox'), { command: 'wp-codebox', args: [] });
+	assert.deepEqual(wpCodeboxCommand(envBin), { command: process.execPath, args: [envBin] });
 
 	console.log('wp-codebox resolver smoke passed');
 } finally {


### PR DESCRIPTION
## Summary

- align the JavaScript resolver smoke with the supported `bin`, `invocation`, and `selectionSource` identity contract
- isolate WP Codebox CLI, recipe-helper, and fuzz runtime-path fixtures from host `HOME`, `PATH`, managed caches, machine overrides, and global npm installs
- cover no candidate, explicit configuration precedence, machine-selected managed CLI, managed source fallback, stale ambient exclusion, and JavaScript invocation shape

Fixes #2679

## Root Cause

The resolver smoke still asserted checkout-derived internals removed from the public resolver contract, including source/core/runtime paths and fingerprint mismatch diagnostics. Shell and fuzz/recipe-helper smokes also inherited the host WP Codebox binary and `/home/opencode/.cache/homeboy/wp-codebox`, allowing deployed machine state to outrank test fixtures.

## Public Contract Decision

The public identity remains exactly `bin`, `invocation`, and `selectionSource`, matching `CodeboxClient.identity()`, `publicCliBin()`, and `publicCliInvocation()`. This PR removes stale assertions instead of restoring removed checkout internals. Production resolver and generic-layer code are unchanged.

## Isolation Model

Affected smokes now create temporary homes, managed install roots, and fixture-only executable paths. Required host tools are linked explicitly into those paths, but ambient `/usr/bin/wp-codebox`, global npm roots, deployed plugin binaries, machine override files, and real user caches cannot influence candidate selection. Fixtures are removed on success and failure.

## Regression Coverage

- no available candidate
- stale PATH wrapper exclusion
- explicit override and settings precedence
- machine-selected managed CLI precedence
- managed source fallback and Node-prefixed invocation
- global npm fallback only when explicitly fixture-configured
- recipe-helper resolution and managed identity preflight
- fuzz runner manifest/core-module resolution without ambient machine overrides

## Tests

Passed:

- `npm run test:wp-codebox-resolver`
- `bash scripts/test/wp-codebox-cli-resolution-smoke.sh`
- `bash scripts/test/wp-codebox-recipe-helper-smoke.sh`
- `npm run test:wp-codebox-recipe-helper`
- `npm run test:wp-codebox-setup-freshness`
- `bash scripts/ci/run-self-checks.sh wordpress lint` (4/4)
- `HOMEBOY_CORE_DIR=/var/lib/datamachine/workspace/homeboy bash scripts/ci/run-self-checks.sh wordpress test` (93/93)
- `git diff --check`

No secrets, production plugin/theme edits, generic-layer changes, version bumps, or changelog edits are included. No merge, release, or deploy occurred.