### PR TITLE
fix(rust): resolve generic field types structurally

### DIFF
--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -739,6 +739,71 @@ def resolve_type(type_text, impl_type=None):
     return None
 
 
+# Generic constructors resolved by name rather than by declaration or import.
+# They are in the prelude or are ubiquitous std containers, so a field typed
+# `Option<T>` never carries an import that `imports_by_name` could resolve. The
+# constructor name alone is not an identity -- `Option<String>` and
+# `Option<u32>` are different field types -- so it is only ever emitted as the
+# head of a fully resolved application by `resolve_field_type`.
+std_generic_constructors = {
+    'Option', 'Result', 'Vec', 'VecDeque', 'Box', 'Arc', 'Rc', 'Cow',
+    'HashMap', 'BTreeMap', 'HashSet', 'BTreeSet', 'Mutex', 'RwLock',
+    'RefCell', 'Cell', 'OnceLock', 'OnceCell',
+}
+
+
+def resolve_field_type(type_text, impl_type=None):
+    """Resolve a declared field's type to a structural identity.
+
+    `resolve_type` deliberately drops generic arguments: its callers ask "which
+    declared aggregate is this value?", and for that `Vec<Foo>` and `Foo` are the
+    same answer. A field type is a different question. `Option<String>` and
+    `Option<u32>` are not the same field, so the arguments are part of the
+    identity and an application is resolved head-and-arguments rather than
+    stripped to its head.
+
+    Resolution is total or nothing. If any argument is unresolvable the whole
+    application is, because a partially resolved type compares equal to another
+    type that differs precisely where neither could be resolved -- which is a
+    false claim of sameness, and the thing consumers of `type_id` must never be
+    handed.
+    """
+    value = re.sub(r'\b(?:mut|const|dyn)\b', '', type_text).strip()
+    while value.startswith('&'):
+        value = re.sub(r"^&\s*(?:'[A-Za-z_]\w*\s+)?(?:mut\s+)?", '', value).strip()
+
+    application = re.fullmatch(
+        r'((?:crate|self|super|[A-Za-z_]\w*)(?:::(?:super|self|[A-Za-z_]\w*))*)(?:::)?\s*<(.*)>',
+        value,
+        re.S,
+    )
+    if not application:
+        return resolve_type(value, impl_type)
+
+    head, argument_text = application.group(1), application.group(2)
+    resolved_head = resolve_type(head, impl_type)
+    if resolved_head is None:
+        if head not in std_generic_constructors:
+            return None
+        resolved_head = head
+
+    arguments = []
+    for start, end in split_top_level_spans(argument_text):
+        argument = argument_text[start:end].strip()
+        if not argument:
+            continue
+        if re.fullmatch(r"'[A-Za-z_]\w*", argument):
+            continue
+        resolved_argument = resolve_field_type(argument, impl_type)
+        if resolved_argument is None:
+            return None
+        arguments.append(resolved_argument)
+
+    if not arguments:
+        return None
+    return '{}<{}>'.format(resolved_head, ', '.join(arguments))
+
+
 named_struct_pattern = re.compile(
     r'\b(?:pub(?:\([^)]*\))?\s+)?struct\s+([A-Z][A-Za-z0-9_]*)'
     r'(?:\s*<[^>{;]*>)?(?:\s+where\b[^{};]*)?\s*\{'
@@ -758,7 +823,7 @@ for struct_match in named_struct_pattern.finditer(aggregate_source):
         if not field_match:
             continue
         field = {'name': field_match.group(1)}
-        field_type = resolve_type(field_match.group(2).strip())
+        field_type = resolve_field_type(field_match.group(2).strip())
         if field_type:
             field['type_id'] = field_type
         fields.append(field)

--- a/rust/tests/fingerprint-policy-flow-smoke.sh
+++ b/rust/tests/fingerprint-policy-flow-smoke.sh
@@ -368,5 +368,67 @@ assert parent_owners == {
     ("allowed", "crate::domain::Policy"),
 }
 
+
+# --- structural field type resolution -------------------------------------
+#
+# A field type's generic arguments are part of its identity. Stripping them to
+# the constructor reports `Option<Inner>` and `Option<Other>` as the same field,
+# which is how a narrowing boundary reads as a duplicated type to any consumer
+# of `type_id`.
+
+field_result = fingerprint("src/domain/shapes.rs", '''
+pub struct Inner { pub a: u32 }
+pub struct Other { pub b: u32 }
+
+pub struct Wire {
+    pub id: String,
+    pub payload: Option<Inner>,
+    pub counts: Vec<u32>,
+}
+
+pub struct Narrowed {
+    pub id: String,
+    pub payload: Option<Other>,
+    pub counts: Vec<u32>,
+}
+''')
+shapes = {
+    definition["type_id"].split("::")[-1]: {
+        field["name"]: field.get("type_id")
+        for field in definition["fields"]
+    }
+    for definition in field_result["aggregate_definitions"]
+}
+
+# Applications resolve head-and-arguments rather than stripped to the head.
+assert shapes["Wire"]["counts"] == "Vec<u32>", shapes["Wire"]
+assert shapes["Wire"]["id"] == "String", shapes["Wire"]
+assert shapes["Wire"]["payload"] == "Option<crate::domain::shapes::Inner>", shapes["Wire"]
+
+# Two applications of one constructor over different arguments are different
+# field types. This is the whole point: without it these two structs have an
+# identical shape.
+assert shapes["Wire"]["payload"] != shapes["Narrowed"]["payload"], shapes
+assert shapes["Narrowed"]["payload"] == "Option<crate::domain::shapes::Other>", shapes["Narrowed"]
+
+# Resolution is total or nothing. A partially resolved application compares
+# equal to another type that differs exactly where neither side could be
+# resolved, which is a false claim of sameness.
+opaque_result = fingerprint("src/domain/opaque.rs", '''
+pub struct Holder {
+    pub handle: Option<NotDeclaredAnywhere>,
+    pub known: Option<String>,
+    pub nested: Vec<Option<String>>,
+}
+''')
+opaque = {
+    field["name"]: field.get("type_id")
+    for definition in opaque_result["aggregate_definitions"]
+    for field in definition["fields"]
+}
+assert opaque["handle"] is None, opaque
+assert opaque["known"] == "Option<String>", opaque
+assert opaque["nested"] == "Vec<Option<String>>", opaque
+
 print("Rust policy-flow fingerprint smoke passed")
 PY


### PR DESCRIPTION
Fixes Extra-Chill/homeboy#13359.

`resolve_type` strips generic arguments before resolving, so every field typed `Option<T>`, `Vec<T>`, `HashMap<K, V>` emitted **no `type_id` at all**. Measured across homeboy's 1,647 non-test sources: **10,897 of 22,440 declared fields — 48%.**

Field types now resolve head-and-arguments. Unresolved drops to **2,918 (13%)**.

## Why not just change `resolve_type`

It has six other callers, and for them dropping the arguments is *correct*: they ask "which declared aggregate is this value?" when typing a local, a parameter, or a literal target, and for that question `Vec<Foo>` and `Foo` are the same answer. Changing it in place would have altered variable typing and every projection edge built on top of it.

A field type is a different question — `Option<String>` and `Option<u32>` are not the same field — so `resolve_field_type` is a separate function used only at the struct-field call site.

## Resolution is total or nothing

An application with any unresolvable argument resolves to `None`, never to a partially resolved string. A partial resolution compares equal to another type that differs *precisely where neither side could be resolved* — a false claim of sameness, which is the one thing a `type_id` consumer must never be handed.

`std_generic_constructors` names the prelude and ubiquitous std containers, which never carry an import for `imports_by_name` to resolve. A constructor name is never emitted alone, only as the head of a fully resolved application.

## Measured effect on the consumer

homeboy's twin-type detector (Extra-Chill/homeboy#13358) skips any definition with an unresolved field — that's what bounded its recall. Against the same tree, **twin clusters go from 4 to 15**.

One correction worth stating plainly: `DomBoxElement`/`BrowserElement` stays excluded, but **by the conservative rule, not by discrimination**. Its `computed_style` fields are `serde_json` types that still don't resolve, so both sides are unresolved and skipped. `node_name` now resolves to `Option<String>` on both.

I mention it because the first draft of the test for this change asserted the resolver *distinguished* them, and the test failed and proved me wrong.

<callout accent="#f59e0b">
## Coordination required before release

homeboy resolves extensions at latest published release and is unpinned, so releasing this **propagates automatically** and takes homeboy's twin-type findings from 2 baselined to ~13.

That breaks homeboy's audit ratchet on arrival. The 11 newly-visible clusters need triage in homeboy **before or alongside** this release, not after.
</callout>

## Tests

`rust/tests/fingerprint-policy-flow-smoke.sh` now covers:
- applications resolve head-and-arguments — `Vec<u32>`, `Option<crate::..::Inner>`
- two applications of one constructor over different arguments are **different** field types (the whole point — without it those two structs have an identical shape)
- nesting resolves — `Vec<Option<String>>`
- an unresolvable argument yields `None`, not a partial

Passes, as does the pre-existing policy-flow coverage.

## Not fixed here

**28 of homeboy's sources fail this script entirely** with `Argument list too long` at the `INPUT_JSON=... python3` call — content is passed through the environment and large files exceed the limit. Confirmed pre-existing by stashing this change and re-running: identical `rc=126`. Those files contribute **no facts of any kind** today, silently. Reported separately.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
