### PR TITLE
fix(rust): canonicalize failed test identities

### DIFF
--- a/rust/homeboy.json
+++ b/rust/homeboy.json
@@ -12,6 +12,7 @@
       "bash tests/env-provider-smoke.sh",
       "bash tests/fingerprint-policy-flow-smoke.sh",
       "bash tests/zero-test-scope-fallback-smoke.sh",
+      "bash scripts/parse-test-failures-smoke.sh",
       "bash tests/test-shard-inventory-smoke.sh",
       "bash tests/nextest-unsharded-counts-smoke.sh",
       "bash scripts/rust-nextest-runner-smoke.sh",

--- a/rust/scripts/parse-test-failures-smoke.sh
+++ b/rust/scripts/parse-test-failures-smoke.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT="$(mktemp "${TMPDIR:-/tmp}/rust-test-failures-output.XXXXXX")"
 RESULTS="$(mktemp "${TMPDIR:-/tmp}/rust-test-failures-json.XXXXXX")"
-trap 'rm -f "$OUTPUT" "$RESULTS"' EXIT
+IDENTITIES="$(mktemp "${TMPDIR:-/tmp}/rust-test-failure-identities.XXXXXX")"
+trap 'rm -f "$OUTPUT" "$RESULTS" "$IDENTITIES"' EXIT
 
 cat > "$OUTPUT" <<'EOF'
 running 2 tests
@@ -111,6 +112,43 @@ with open(sys.argv[1], encoding="utf-8") as handle:
 
 assert record["test_id"] == "cargo test", record
 assert record["failure_type"] == "infrastructure", record
+PY
+
+# Cargo's compiler-artifact map disambiguates identical names across packages
+# and targets. Sidecar IDs must be byte-for-byte inventory IDs.
+cat > "$IDENTITIES" <<'EOF'
+{"tests":[
+  {"id":"alpha::lib::alpha::tests::duplicate","package":"alpha","target":"alpha","target_kind":"lib","name":"tests::duplicate","executable":"/target/debug/deps/alpha-a1"},
+  {"id":"alpha::test::api::tests::duplicate","package":"alpha","target":"api","target_kind":"test","name":"tests::duplicate","executable":"/target/debug/deps/api-a2"},
+  {"id":"beta::test::api::tests::duplicate","package":"beta","target":"api","target_kind":"test","name":"tests::duplicate","executable":"/target/debug/deps/api-b1"}
+]}
+EOF
+cat > "$OUTPUT" <<'EOF'
+     Running unittests src/lib.rs (/target/debug/deps/alpha-a1)
+test tests::duplicate ... FAILED
+failures:
+    tests::duplicate
+test result: FAILED. 0 passed; 1 failed
+     Running tests/api.rs (/target/debug/deps/api-a2)
+test tests::duplicate ... FAILED
+failures:
+    tests::duplicate
+test result: FAILED. 0 passed; 1 failed
+     Running tests/api.rs (/target/debug/deps/api-b1)
+test tests::duplicate ... FAILED
+failures:
+    tests::duplicate
+test result: FAILED. 0 passed; 1 failed
+EOF
+python3 "$SCRIPT_DIR/parse-test-failures.py" /project "$OUTPUT" "$RESULTS" "$IDENTITIES"
+python3 - "$RESULTS" "$IDENTITIES" <<'PY'
+import json
+import sys
+
+records = json.load(open(sys.argv[1], encoding="utf-8"))
+inventory_ids = {item["id"] for item in json.load(open(sys.argv[2], encoding="utf-8"))["tests"]}
+assert {record["test_id"] for record in records} == inventory_ids, records
+assert all(record["test_id"] == record["test_name"] for record in records), records
 PY
 
 printf 'Rust test-failure parser smoke passed\n'

--- a/rust/scripts/parse-test-failures.py
+++ b/rust/scripts/parse-test-failures.py
@@ -7,6 +7,8 @@ import os
 import re
 import sys
 
+from rust_test_identity import canonical_test_id
+
 MAX_FAILURES = 100
 MAX_FIELD_BYTES = 1024
 MAX_EXCERPT_BYTES = 4000
@@ -34,14 +36,19 @@ def failure(test_id, output, project, location=None, message=None,
     return {
         # v1 fields remain authoritative for existing sidecar consumers.
         "test_id": identity,
+        "test_name": identity,
         "suite": None,
         "file": location.rsplit(":", 2)[0] if location else None,
+        "test_file": location.rsplit(":", 2)[0] if location else None,
         "line": int(location.rsplit(":", 2)[1]) if location and re.search(r":\d+:\d+$", location) else None,
         "message": message,
         "failure_type": failure_type,
         "fingerprint": fingerprint,
         "stdout_excerpt": bounded(output[-MAX_EXCERPT_BYTES:], MAX_EXCERPT_BYTES),
         "stderr_excerpt": "",
+        "source_file": location.rsplit(":", 2)[0] if location else None,
+        "source_line": int(location.rsplit(":", 2)[1]) if location and re.search(r":\d+:\d+$", location) else None,
+        "error_type": failure_type,
     }
 
 
@@ -74,30 +81,61 @@ def panic_message(lines, start):
     return None
 
 
-def parse(output, project):
+def parse(output, project, identity_map=None):
     records = []
     seen = set()
     lines = output.splitlines()
-    current = None
+    current_test = None
+    current_tests = []
+    executable_tests = {}
+    doc_tests = {}
+    if identity_map:
+        for item in identity_map.get("tests", []):
+            executable = item.get("executable")
+            if executable:
+                executable_tests.setdefault(os.path.realpath(executable), []).append(item)
+            if item.get("target_kind") == "doc":
+                doc_tests.setdefault(item.get("package"), []).append(item)
+
+    def resolve(name):
+        if not identity_map:
+            return name
+        matches = [item for item in current_tests if item.get("name") == name]
+        if len(matches) != 1:
+            return None
+        item = matches[0]
+        return canonical_test_id(
+            item.get("package"), item.get("target_kind"), item.get("target"), item.get("name")
+        )
 
     for index, raw in enumerate(lines):
+        running = re.match(r"^\s+Running .+ \((?P<executable>.+)\)$", raw)
+        if running:
+            current_tests = executable_tests.get(os.path.realpath(running.group("executable")), [])
+            current_test = None
+            continue
+        docs = re.match(r"^\s*Doc-tests (?P<package>\S+)\s*$", raw)
+        if docs:
+            current_tests = doc_tests.get(docs.group("package"), [])
+            current_test = None
+            continue
         section = re.match(r"^---- (?P<name>.+) stdout ----$", raw)
         if section:
-            current = section.group("name")
+            current_test = section.group("name")
             continue
         if raw.startswith("---- ") and raw.endswith(" ----"):
-            current = None
+            current_test = None
             continue
 
         failed = re.match(r"^test (?P<name>.+) \.\.\. FAILED$", raw)
         if failed:
-            add(records, seen, failed.group("name"), output, project)
+            add(records, seen, resolve(failed.group("name")), output, project)
 
         panic = re.match(r"^thread '(?P<name>.+)' panicked at (?P<location>.+):$", raw)
         if panic:
             # A libtest section names the failed test even when the panic came
             # from a worker thread instead of the test thread itself.
-            add(records, seen, current or panic.group("name"), output, project,
+            add(records, seen, resolve(current_test or panic.group("name")), output, project,
                 panic.group("location"), panic_message(lines, index + 1))
 
     failures_header = next((index for index, line in enumerate(lines) if line.strip() == "failures:"), None)
@@ -109,20 +147,28 @@ def parse(output, project):
                 break
             candidate = raw.strip()
             if candidate:
-                add(records, seen, candidate, output, project)
+                add(records, seen, resolve(candidate), output, project)
 
     return records
 
 
-if len(sys.argv) != 4:
-    raise SystemExit("usage: parse-test-failures.py PROJECT OUTPUT_FILE TARGET")
+if len(sys.argv) not in (4, 5):
+    raise SystemExit("usage: parse-test-failures.py PROJECT OUTPUT_FILE TARGET [IDENTITY_MAP]")
 
-PROJECT, OUTPUT_FILE, TARGET = sys.argv[1:]
+PROJECT, OUTPUT_FILE, TARGET = sys.argv[1:4]
 with open(OUTPUT_FILE, "rb") as handle:
     OUTPUT_BYTES = handle.read()
 OUTPUT = OUTPUT_BYTES.decode("utf-8", errors="replace")
 
-failures = parse(OUTPUT, PROJECT)
+IDENTITY_MAP = None
+if len(sys.argv) == 5:
+    try:
+        with open(sys.argv[4], encoding="utf-8") as handle:
+            IDENTITY_MAP = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        IDENTITY_MAP = {"tests": []}
+
+failures = parse(OUTPUT, PROJECT, IDENTITY_MAP)
 if not failures:
     fallback = failure(
         "cargo test", OUTPUT, PROJECT,

--- a/rust/scripts/rust_test_identity.py
+++ b/rust/scripts/rust_test_identity.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Canonical Rust test identities shared by inventory and result adapters."""
+
+
+def canonical_test_id(package, target_kind, target, name):
+    values = (package, target_kind, target, name)
+    if not all(isinstance(value, str) and value for value in values):
+        raise ValueError("Rust test identity fields must be non-empty strings")
+    return "::".join(values)
+
+
+def inventory_test(package, target_kind, target, name, expected_outcome="executed"):
+    return {
+        "id": canonical_test_id(package, target_kind, target, name),
+        "package": package,
+        "target": target,
+        "target_kind": target_kind,
+        "name": name,
+        "expected_outcome": expected_outcome,
+    }

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -496,6 +496,7 @@ from nextest_events_lib import (
     read_test_events,
     retry_base_identity,
 )
+from rust_test_identity import canonical_test_id
 
 expected = json.load(open(sys.argv[3], encoding="utf-8"))["selected"]
 failed_names_file = sys.argv[4]
@@ -563,8 +564,8 @@ if unexpected_missing:
 # Their listed disposition is canonical execution policy, not a relaxed match.
 passed = sum(status in PASSED_STATUSES for status in outcomes.values())
 failed_names = sorted(
-    f"{package}::{target}${test}"
-    for (package, _target_kind, target, test), status in outcomes.items()
+    canonical_test_id(package, target_kind, target, test)
+    for (package, target_kind, target, test), status in outcomes.items()
     if status in FAILED_STATUSES
 )
 failed = len(failed_names)
@@ -588,8 +589,9 @@ PY
 #
 # Prints "total\tpassed\tfailed\tskipped" -- the same tuple the cargo adapter
 # emits through parse-test-results.sh -- and writes failed identities one per
-# line to the second argument, in the same `package::target$test` form the shard
-# path writes, so `rust_nextest_merge_failure_evidence` consumes either.
+# line to the second argument. Runtime events omit target kind, so the caller
+# resolves these projections against nextest's structured inventory before
+# writing failure evidence.
 #
 # Returns 1 and prints nothing when the stream carried no terminal test event.
 # A compile failure, a crash before the first test, and a filter that matched
@@ -650,10 +652,45 @@ print(f"{passed + failed + skipped}\t{passed}\t{failed}\t{skipped}")
 PY
 }
 
-rust_nextest_merge_failure_evidence() {
-    local failed_names_file="$1" records_file failures_file name record
+rust_merge_failure_evidence() {
+    local failed_names_file="$1" inventory_file="${2:-}" records_file failures_file canonical_names name record
     homeboy_test_failures_enabled || return 0
     [ -s "$failed_names_file" ] || return 0
+
+    canonical_names="$failed_names_file"
+    if [ -n "$inventory_file" ]; then
+        canonical_names="$(mktemp)" || return 1
+        if ! python3 - "${EXTENSION_PATH}/scripts" "$failed_names_file" "$inventory_file" "$canonical_names" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, sys.argv[1])
+from nextest_events_lib import emitted_identity
+from rust_test_identity import canonical_test_id
+
+inventory = json.load(open(sys.argv[3], encoding="utf-8"))
+tests = inventory.get("inventory", inventory).get("tests", [])
+with open(sys.argv[4], "w", encoding="utf-8") as output:
+    for raw in open(sys.argv[2], encoding="utf-8"):
+        package, target, name = emitted_identity(raw.rstrip("\n"))
+        matches = [
+            item for item in tests
+            if item.get("package") == package
+            and item.get("target") == target
+            and item.get("name") == name
+        ]
+        if len(matches) != 1:
+            raise SystemExit(
+                f"Rust test failure identity is not uniquely present in inventory: {raw.rstrip()!r}"
+            )
+        item = matches[0]
+        output.write(canonical_test_id(package, item["target_kind"], target, name) + "\n")
+PY
+        then
+            rm -f "$canonical_names"
+            return 1
+        fi
+    fi
 
     records_file="$(mktemp)" || return 1
     failures_file="$(mktemp)" || {
@@ -662,11 +699,12 @@ rust_nextest_merge_failure_evidence() {
     }
     while IFS= read -r name; do
         [ -n "$name" ] || continue
-        record="$(homeboy_test_failure_record_json "rust-nextest" "$name" "${name%%\$*}" "" "" "nextest reported failed test: ${name}" "test_failure")"
+        record="$(homeboy_test_failure_record_json "rust-test" "$name" "" "" "" "Rust test runner reported failed test: ${name}" "test_failure")"
         printf '%s\n' "$record" >> "$records_file"
-    done < "$failed_names_file"
+    done < "$canonical_names"
     if ! jq -s '.' "$records_file" > "$failures_file"; then
         rm -f "$records_file" "$failures_file"
+        [ "$canonical_names" = "$failed_names_file" ] || rm -f "$canonical_names"
         return 1
     fi
     if homeboy_test_failures_merge_file "$failures_file"; then
@@ -674,9 +712,11 @@ rust_nextest_merge_failure_evidence() {
     else
         local merge_exit=$?
         rm -f "$records_file" "$failures_file"
+        [ "$canonical_names" = "$failed_names_file" ] || rm -f "$canonical_names"
         return "$merge_exit"
     fi
     rm -f "$records_file" "$failures_file"
+    [ "$canonical_names" = "$failed_names_file" ] || rm -f "$canonical_names"
 }
 
 rust_nextest_cleanup() {
@@ -1155,7 +1195,7 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
             rust_checkpoint_shard_progress "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED"
             echo "Rust shard progress: executed=${SHARD_EXECUTED}/${SHARD_TOTAL} passed=${SHARD_PASSED} failed=${SHARD_FAILED} skipped=${SHARD_SKIPPED}"
         done
-        if rust_nextest_merge_failure_evidence "$NEXTEST_FAILED_NAMES"; then
+        if rust_merge_failure_evidence "$NEXTEST_FAILED_NAMES"; then
             :
         else
             NEXTEST_MERGE_EXIT=$?
@@ -1167,7 +1207,11 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
         fi
         rust_nextest_cleanup 0
     else
-        while IFS=$'\t' read -r package target target_kind name; do
+        CARGO_FAILED_IDS=""
+        if homeboy_test_failures_enabled; then
+            CARGO_FAILED_IDS="$(mktemp)"
+        fi
+        while IFS=$'\t' read -r test_id package target target_kind name; do
             case "$target_kind" in
                 lib|rlib|proc-macro|cdylib|staticlib|dylib) TARGET_ARGS=(--lib) ;;
                 bin) TARGET_ARGS=(--bin "$target") ;;
@@ -1179,6 +1223,9 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
             echo "Replaying Rust shard test: ${package}::${target}::${name}"
             homeboy_run_step_capture SHARD_OUTPUT SHARD_EXIT "cargo test" -- cargo test --manifest-path "${PROJECT_PATH}/Cargo.toml" -p "$package" "${TARGET_ARGS[@]}" -- "$name" --exact --test-threads=1 || true
             IFS=$'\t' read -r PASSED FAILED SKIPPED < <(rust_shard_cargo_counts "$SHARD_OUTPUT")
+            if [ "$FAILED" -gt 0 ] && [ -n "$CARGO_FAILED_IDS" ]; then
+                printf '%s\n' "$test_id" >> "$CARGO_FAILED_IDS"
+            fi
             rm -f "$SHARD_OUTPUT"
             SHARD_PASSED=$((SHARD_PASSED + PASSED))
             SHARD_FAILED=$((SHARD_FAILED + FAILED))
@@ -1188,7 +1235,11 @@ if [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}${HOMEBOY_RUST_CHANGED_TEST_SELECTION_F
             # invocation per identity, so the checkpoint is negligible beside it.
             SHARD_EXECUTED=$((SHARD_PASSED + SHARD_FAILED + SHARD_SKIPPED))
             rust_checkpoint_shard_progress "$SHARD_EXECUTED" "$SHARD_PASSED" "$SHARD_FAILED" "$SHARD_SKIPPED"
-        done < <(jq -r '.selected[] | [.package, .target, .target_kind, .name] | @tsv' "$SHARD_DATA")
+        done < <(jq -r '.selected[] | [.id, .package, .target, .target_kind, .name] | @tsv' "$SHARD_DATA")
+        if [ -n "$CARGO_FAILED_IDS" ]; then
+            rust_merge_failure_evidence "$CARGO_FAILED_IDS" || true
+            rm -f "$CARGO_FAILED_IDS"
+        fi
     fi
     SHARD_ELAPSED=$(( $(date +%s) - SHARD_STARTED ))
     SHARD_EXECUTED=$((SHARD_PASSED + SHARD_FAILED + SHARD_SKIPPED))
@@ -1496,10 +1547,20 @@ else
         # The identities came out of the event stream, so reuse the shard path's
         # evidence writer rather than re-deriving them by scraping cargo-shaped
         # text that a libtest-json run never produced.
-        rust_nextest_merge_failure_evidence "${RUST_MEASURED_FAILED_NAMES:-}" || true
+        RUST_FAILURE_INVENTORY=""
+        if [ -n "${RUST_MEASURED_FAILED_NAMES:-}" ] && homeboy_runner_harness_temp RUST_FAILURE_INVENTORY "homeboy-rust-nextest-inventory.XXXXXX"; then
+            python3 "${EXTENSION_PATH}/scripts/test-shard-inventory.py" \
+                --project "$PROJECT_PATH" --runner nextest --output "$RUST_FAILURE_INVENTORY" || true
+        fi
+        rust_merge_failure_evidence "${RUST_MEASURED_FAILED_NAMES:-}" "$RUST_FAILURE_INVENTORY" || true
     elif homeboy_test_failures_enabled; then
         homeboy_runner_harness_temp TEST_FAILURES_TMP "homeboy-rust-test-failures.XXXXXX"
-        python3 "${EXTENSION_PATH}/scripts/parse-test-failures.py" "$PROJECT_PATH" "$TEST_TMPFILE" "$TEST_FAILURES_TMP"
+        homeboy_runner_harness_temp TEST_FAILURE_INVENTORY "homeboy-rust-cargo-inventory.XXXXXX"
+        homeboy_runner_harness_temp TEST_FAILURE_MAP "homeboy-rust-cargo-failure-map.XXXXXX"
+        python3 "${EXTENSION_PATH}/scripts/test-shard-inventory.py" \
+            --project "$PROJECT_PATH" --runner cargo --output "$TEST_FAILURE_INVENTORY" \
+            --failure-map-output "$TEST_FAILURE_MAP" || true
+        python3 "${EXTENSION_PATH}/scripts/parse-test-failures.py" "$PROJECT_PATH" "$TEST_TMPFILE" "$TEST_FAILURES_TMP" "$TEST_FAILURE_MAP"
         homeboy_test_failures_merge_file "$TEST_FAILURES_TMP"
     fi
 

--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -8,6 +8,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from rust_test_identity import inventory_test
+
 SCHEMA = "homeboy/test-inventory/v1"
 MANIFEST_SCHEMA = "homeboy/test-shard-manifest/v1"
 CHANGED_SELECTION_SCHEMA = "homeboy/rust-changed-test-selection/v2"
@@ -104,15 +106,12 @@ def cargo_inventory(workspace_root, packages):
         for test_line in listed.stdout.splitlines():
             name, separator, _kind = test_line.partition(": ")
             if separator and name:
-                test_id = f"{package}::{target_kind}::{target['name']}::{name}"
-                tests[test_id] = {
-                    "id": test_id,
-                    "package": package,
-                    "target": target["name"],
-                    "target_kind": target_kind,
-                    "name": name,
-                    "expected_outcome": "skipped" if name in ignored_names else "executed",
-                }
+                item = inventory_test(
+                    package, target_kind, target["name"], name,
+                    "skipped" if name in ignored_names else "executed",
+                )
+                item["executable"] = str(Path(message["executable"]).resolve())
+                tests[item["id"]] = item
     return list(tests.values())
 
 
@@ -172,20 +171,16 @@ def nextest_inventory(workspace_root):
                 fail("nextest emitted an invalid testcase identity")
             if testcase.get("filter-match", {}).get("status") != "matches":
                 continue
-            tests.append({
-                "id": f"{package}::{target_kind}::{target}::{name}",
-                "package": package,
-                "target": target,
-                "target_kind": target_kind,
-                "name": name,
+            tests.append(inventory_test(
+                package, target_kind, target, name,
                 # nextest list is the canonical source for tests that its
                 # default run policy intentionally skips without a terminal.
-                "expected_outcome": "skipped" if testcase.get("ignored") else "executed",
-            })
+                "skipped" if testcase.get("ignored") else "executed",
+            ))
     return tests
 
 
-def inventory(project, runner):
+def inventory(project, runner, failure_map_path=None):
     metadata, workspace_root, _component_root = cargo_metadata_roots(project, "while building inventory")
     packages = {package["id"]: package["name"] for package in metadata["packages"]}
     tests = nextest_inventory(workspace_root) if runner == "nextest" else cargo_inventory(workspace_root, packages)
@@ -208,14 +203,17 @@ def inventory(project, runner):
             name, separator, _kind = stripped.partition(": ")
             if not separator or not name or not doc_package:
                 continue
-            tests.append({
-                "id": f"{doc_package}::doc::doc::{name}",
-                "package": doc_package,
-                "target": "doc",
-                "target_kind": "doc",
-                "name": name,
-                "expected_outcome": "executed",
-            })
+            tests.append(inventory_test(doc_package, "doc", "doc", name))
+    if failure_map_path:
+        failure_map = {
+            "tests": [
+                {key: value for key, value in test.items() if key != "expected_outcome"}
+                for test in tests
+            ]
+        }
+        Path(failure_map_path).write_text(json.dumps(failure_map, indent=2) + "\n")
+    for test in tests:
+        test.pop("executable", None)
     tests.sort(key=lambda item: item["id"])
     if len({item["id"] for item in tests}) != len(tests):
         fail("cargo produced duplicate fully qualified test identities")
@@ -373,12 +371,13 @@ def main():
     parser.add_argument("--manifest")
     parser.add_argument("--changed-selection-file")
     parser.add_argument("--inventory-only", action="store_true")
+    parser.add_argument("--failure-map-output")
     args = parser.parse_args()
     if args.manifest and args.changed_selection_file:
         fail("shard manifest and changed test selection are mutually exclusive")
     if args.inventory_only and args.manifest:
         fail("inventory-only mode does not accept a shard manifest")
-    current = inventory(args.project, args.runner)
+    current = inventory(args.project, args.runner, args.failure_map_output)
     output = current
     if args.manifest:
         output = {"inventory": current, "selected": validate(args.manifest, current)}

--- a/rust/tests/test-shard-inventory-smoke.sh
+++ b/rust/tests/test-shard-inventory-smoke.sh
@@ -841,7 +841,7 @@ PATH="$BIN_DIR:$PATH" \
 bash "$EXTENSION_DIR/scripts/test-runner.sh" > "$WORK_DIR/batched-failure.out" 2>&1
 BATCH_FAILURE_EXIT=$?
 set -e
-python3 - "$WORK_DIR/batched-failure.log" "$WORK_DIR/batched-failure-results.json" "$WORK_DIR/batched-failure-evidence.json" "$BATCH_FAILURE_EXIT" <<'PY'
+python3 - "$WORK_DIR/batched-failure.log" "$WORK_DIR/batched-failure-results.json" "$WORK_DIR/batched-failure-evidence.json" "$BATCH_FAILURE_EXIT" "$INVENTORY_NEXTEST" <<'PY'
 import json
 import re
 import sys
@@ -853,7 +853,9 @@ assert selected == ["member::member_works", "unit::alpha", "unit::beta", "api::w
 assert len(selected) == len(set(selected)), selected
 assert json.load(open(sys.argv[2])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
 evidence = json.load(open(sys.argv[3]))
-assert [record["test_name"] for record in evidence] == ["pre-existing failure", "shard-smoke::shard_smoke$unit::beta"], evidence
+assert [record["test_name"] for record in evidence] == ["pre-existing failure", "shard-smoke::lib::shard_smoke::unit::beta"], evidence
+inventory_ids = {test["id"] for test in json.load(open(sys.argv[5]))["tests"]}
+assert evidence[-1]["test_id"] in inventory_ids, (evidence, inventory_ids)
 PY
 
 # A list validation failure is preflight-only: no batch run may have started.
@@ -1133,7 +1135,7 @@ import sys
 
 assert int(sys.argv[3]) != 0, sys.argv[3]
 assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
-assert [record["test_name"] for record in json.load(open(sys.argv[2]))] == ["shard-smoke::shard_smoke$unit::alpha"]
+assert [record["test_name"] for record in json.load(open(sys.argv[2]))] == ["shard-smoke::lib::shard_smoke::unit::alpha"]
 PY
 
 # A sidecar merge failure remains the runner's failure status while retaining
@@ -1190,7 +1192,7 @@ import sys
 
 assert int(sys.argv[3]) != 0, sys.argv[3]
 assert json.load(open(sys.argv[1])) == {"total": 5, "passed": 3, "failed": 1, "skipped": 1, "partial": "rust-shard"}
-assert [record["test_name"] for record in json.load(open(sys.argv[2]))] == ["shard-smoke::shard_smoke$unit::alpha"]
+assert [record["test_name"] for record in json.load(open(sys.argv[2]))] == ["shard-smoke::lib::shard_smoke::unit::alpha"]
 PY
 
 # A non-object JSON record is diagnostic-only. Planned terminal IDs remain the
@@ -1444,6 +1446,7 @@ HOMEBOY_FAKE_CARGO_LOG="$WORK_DIR/failing-cargo.log" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WORK_DIR/write-test-results.sh" \
 HOMEBOY_RUNTIME_SIDECAR_WRITER="$WORK_DIR/sidecar-writer.sh" \
 HOMEBOY_TEST_RESULTS_FILE="$WORK_DIR/failing-test-results.json" \
+HOMEBOY_TEST_FAILURES_FILE="$WORK_DIR/failing-test-failures.json" \
 HOMEBOY_ANNOTATIONS_DIR="$WORK_DIR/annotations" \
 HOMEBOY_RUNTIME_RUNNER_PRELUDE="$WORK_DIR/runner-prelude.sh" \
 HOMEBOY_RUNTIME_COMMAND_CAPTURE="$WORK_DIR/command-capture.sh" \
@@ -1456,7 +1459,7 @@ if [ "$FAIL_EXIT" -eq 0 ]; then
   exit 1
 fi
 
-python3 - "$WORK_DIR/failing-test-results.json" "$WORK_DIR/annotations/rust-test-shard.json" <<'PY'
+python3 - "$WORK_DIR/failing-test-results.json" "$WORK_DIR/annotations/rust-test-shard.json" "$WORK_DIR/failing-test-failures.json" "$INVENTORY_A" <<'PY'
 import json
 import sys
 
@@ -1466,6 +1469,10 @@ record = json.load(open(sys.argv[2]))[0]
 assert record["status"] == "failed", record
 assert (record["total"], record["executed"], record["passed"], record["failed"], record["skipped"]) == (7, 7, 5, 1, 1), record
 assert record["duration_ms"] >= 0, record
+failures = json.load(open(sys.argv[3]))
+inventory_ids = {test["id"] for test in json.load(open(sys.argv[4]))["tests"]}
+assert [failure["test_id"] for failure in failures] == ["shard-smoke::lib::shard_smoke::unit::beta"], failures
+assert {failure["test_id"] for failure in failures} <= inventory_ids, (failures, inventory_ids)
 PY
 
 for invalid in duplicate stale missing runner; do


### PR DESCRIPTION
## Summary
- use one canonical Rust test ID formatter across inventory and failure producers
- emit nextest failures with exact inventory IDs
- emit cargo shard and unsharded failures with package/target-qualified IDs, including duplicate test names across targets

## Context
Supports Extra-Chill/homeboy#13371 and follows up Extra-Chill/homeboy#11121 by making Rust failure evidence byte-compatible with the runtime inventory contract.

## Verification
- declared Rust extension test self-checks: 9 passed
- real nextest archive/shard fixture
- cargo failure parser fixture across packages/targets with duplicate names
- shell syntax and Python compilation
- `git diff --check`

## AI Assistance Disclosure
OpenAI GPT-5.6-sol via OpenCode inspected the Rust inventory and runner adapters; implemented and tested canonical failure identities; and prepared this pull request. Chris Huber directed the work and remains responsible for the change.