### PR TITLE
fix(wordpress): bootstrap setup from extension source

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR}"' EXIT
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 NODE_BIN_DIR="$(dirname "$(command -v node)")"
 FAKE_BIN="${TMPDIR}/bin"
 HOME_DIR="${TMPDIR}/home"
 EXTENSION_DIR="${TMPDIR}/extension"
+GENERATION_ROOT="${TMPDIR}/runtime-generation"
+ROOT_DIR="${GENERATION_ROOT}/setup-source/wordpress"
 GITHUB_ENV_FILE="${TMPDIR}/github-env"
 SOURCE_GITHUB_ENV_FILE="${TMPDIR}/source-github-env"
 MISSING_RELEASE_GITHUB_ENV_FILE="${TMPDIR}/missing-release-github-env"
@@ -17,8 +19,34 @@ ARTIFACT_ROOT="${TMPDIR}/artifact-root"
 ARTIFACT_PATH="${TMPDIR}/wp-codebox-cli-linux-x64.tar.gz"
 REAL_GIT_BIN="${TMPDIR}/real-git-bin"
 
-mkdir -p "${FAKE_BIN}" "${REAL_GIT_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}/scripts/build" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/sharp"
+mkdir -p "${FAKE_BIN}" "${REAL_GIT_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}/scripts/build" "${ROOT_DIR}" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/sharp"
 ln -s "$(command -v git)" "${REAL_GIT_BIN}/git"
+
+# Reproduce Homeboy's setup generation: setup executes from a copied extension
+# source while shared runtimes are already materialized, but the final
+# extensions/wordpress sibling does not exist until setup completes.
+cp -R "${SOURCE_ROOT}/scripts" "${ROOT_DIR}/scripts"
+cp -R "${SOURCE_ROOT}/lib" "${ROOT_DIR}/lib"
+cp "${SOURCE_ROOT}/wordpress.json" "${ROOT_DIR}/wordpress.json"
+cp -R "${SOURCE_ROOT}/../agent-runtimes" "${GENERATION_ROOT}/agent-runtimes"
+
+for missing_sibling in "${GENERATION_ROOT}/extensions/wordpress" "${GENERATION_ROOT}/wordpress"; do
+    if [ -e "${missing_sibling}" ]; then
+        echo "Setup generation fixture must not contain preinstalled sibling: ${missing_sibling}" >&2
+        exit 1
+    fi
+done
+
+PREINSTALL_SHIM="${GENERATION_ROOT}/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-selection.js"
+if node -e 'require(process.argv[1])' "${PREINSTALL_SHIM}" 2> "${TMPDIR}/preinstall-shim.err"; then
+    echo "Pre-install runtime shim unexpectedly resolved without a WordPress sibling" >&2
+    exit 1
+fi
+if ! grep -q 'requires the installed WordPress extension' "${TMPDIR}/preinstall-shim.err"; then
+    echo "Expected pre-install runtime shim failure to name the missing WordPress sibling" >&2
+    cat "${TMPDIR}/preinstall-shim.err" >&2
+    exit 1
+fi
 
 cat > "${EXTENSION_DIR}/scripts/build/persist-wp-codebox-overrides.mjs" <<'NODE'
 #!/usr/bin/env node
@@ -173,6 +201,12 @@ chmod +x "${FAKE_BIN}/npm"
     HOMEBOY_WP_CODEBOX_DOWNLOAD_URL="https://example.test/wp-codebox-cli-linux-x64.tar.gz" \
     bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/setup.out"
 )
+
+if ! grep -q 'WordPress extension setup complete.' "${TMPDIR}/setup.out"; then
+    echo "Expected copied-generation setup to complete without a preinstalled WordPress sibling" >&2
+    cat "${TMPDIR}/setup.out" >&2
+    exit 1
+fi
 
 if ! grep -q '^HOMEBOY_WP_CODEBOX_BIN=' "${GITHUB_ENV_FILE}"; then
     echo "Expected setup to export HOMEBOY_WP_CODEBOX_BIN" >&2

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -64,15 +64,19 @@ install_wp_codebox() {
     preflight_wp_codebox_version() {
         local bin_path="$1"
         local script_dir
-        local resolver
         local selection_module
         local result
 
-        # Keep the setup gate bound to the same runtime manifest as the PHPUnit
-        # adapter. The resolver supports both installed and checkout layouts.
+        # Setup runs before Homeboy installs this extension beside the shared
+        # runtime shim. Validate through the canonical helper in the extension
+        # source currently being installed; runtime consumers use the shim once
+        # the installed sibling exists.
         script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        resolver="${script_dir}/../lib/agent-runtime-paths.cjs"
-        selection_module="$(node "${resolver}" "wp-codebox/lib/wp-codebox-runtime-selection.js")" || return 1
+        selection_module="${script_dir}/../../lib/wp-codebox-runtime-selection.js"
+        if [ ! -f "${selection_module}" ]; then
+            echo "WordPress setup runtime selection helper missing at ${selection_module}" >&2
+            return 1
+        fi
         result="$(node - "${selection_module}" "${bin_path}" <<'NODE'
 const { preflightWpCodeboxCommand } = require(process.argv[2]);
 const result = preflightWpCodeboxCommand([process.argv[3]]);

--- a/wordpress/tests/installed-agent-runtime-resolution-smoke.sh
+++ b/wordpress/tests/installed-agent-runtime-resolution-smoke.sh
@@ -57,8 +57,9 @@ for target in \
 done
 
 # Resolving a shim filename is insufficient: execute the copied runtime shim so
-# its dependency on the copied WordPress extension is proven in the installed
-# sibling layout that failed before test inventory started in #2690.
+# its dependency on the copied WordPress extension is proven after installation
+# in the sibling layout that failed before test inventory started in #2690 and
+# must remain the runtime path after the setup bootstrap fix in #2700.
 selection_module="$(fixture_node "${EXTENSION_DIR}/scripts/lib/agent-runtime-paths.cjs" "wp-codebox/lib/wp-codebox-runtime-selection.js" 2>&1)"
 selection_output="$(fixture_node - "${selection_module}" <<'NODE' 2>&1
 const selection = require(process.argv[2]);


### PR DESCRIPTION
## Summary
- bind setup-time WP Codebox validation to the canonical helper in the copied WordPress extension source being installed
- preserve the shared runtime compatibility shim for installed runtime execution
- reproduce Homeboy's copied generation with shared runtimes but no preinstalled WordPress sibling, then verify setup and post-install shim resolution

## Before

The copied-generation fixture confirms the compatibility shim cannot load before installation:

```text
node -e 'require(process.argv[1])' <generation>/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-selection.js
Error: WP Codebox runtime selection requires the installed WordPress extension.
```

That was the module setup previously resolved, so refresh stopped before the WordPress sibling could be installed.

## After

```text
bash wordpress/scripts/build/setup-wp-codebox-smoke.sh
WP Codebox setup smoke passed

bash wordpress/tests/installed-agent-runtime-resolution-smoke.sh
installed agent runtime resolution smoke passed

node wordpress/tests/agent-runtime-paths-smoke.js
agent runtime paths smoke passed

bash tests/wordpress-runtime-helper-resolver-smoke.sh
WordPress runtime helper resolver smoke passed

bash wordpress/tests/release-provenance-contract-smoke.sh
PASS: release provenance contract smoke
```

## Full Verification

```text
bash scripts/ci/run-self-checks.sh wordpress lint
wordpress lint self-checks: 4 passed, 0 failed, 0 skipped

bash scripts/ci/run-self-checks.sh wordpress test
wordpress test self-checks: 87 passed, 6 failed, 0 skipped
```

The six failures are the documented direct-run baseline from #2532: lint fixture checks require `HOMEBOY_RUNTIME_RUNNER_PRELUDE`, which Homeboy injects but the repository self-check wrapper does not. All other 87 checks passed, including setup, resolver, installed-layout, and release provenance coverage.

No provenance/version checks were weakened, no ambient CLI fallback was added, and no changelog or version files changed.

Fixes #2700