### PR TITLE
fix(opencode): capture large session exports safely

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -27,6 +27,7 @@ const { finalizeOwnershipMarker, writeOwnershipMarker } = require('./opencode-ex
 
 const { spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
@@ -73,6 +74,7 @@ const OPENCODE_GIT_CAPTURE_OPTIONS = {
 const MAX_STRUCTURED_OUTPUT_BYTES = 64 * 1024;
 const MAX_STRUCTURED_ANSWER_BYTES = MAX_STRUCTURED_OUTPUT_BYTES + 16 * 1024;
 const OPENCODE_SESSION_EXPORT_TIMEOUT_MS = 2_000;
+const OPENCODE_SESSION_EXPORT_MAX_BYTES = 1024 * 1024;
 
 const OPENCODE_CAPABILITIES = [
 	'cli_runtime',
@@ -1070,22 +1072,8 @@ function sessionMetadata(context = {}) {
 		return context.sessionMetadata;
 	}
 	const [sessionId] = sessionIds;
-	const result = spawnSync(context.commandSpec.command, [
-		...arrayValue(context.commandSpec.args),
-		'export',
-		sessionId,
-		'--sanitize',
-	], {
-		cwd: context.cwd,
-		env: context.spawnExtra?.env,
-		encoding: 'utf8',
-		maxBuffer: 1024 * 1024,
-		// Session provenance is supplementary to a completed provider run. Bound
-		// its follow-up process so a wedged export cannot hold Cook indefinitely.
-		timeout: OPENCODE_SESSION_EXPORT_TIMEOUT_MS,
-		killSignal: 'SIGKILL',
-	});
-	if (result.status !== 0 || result.error) {
+	const output = captureOpenCodeSessionExport(context, sessionId);
+	if (!output) {
 		context.sessionMetadata = {
 			status: 'unavailable',
 			session_id: sessionId,
@@ -1093,7 +1081,7 @@ function sessionMetadata(context = {}) {
 		};
 		return context.sessionMetadata;
 	}
-	const exported = parseOpenCodeExport(result.stdout);
+	const exported = parseOpenCodeExport(output);
 	const provider = stringValue(exported?.info?.model?.providerID);
 	const model = stringValue(exported?.info?.model?.id);
 	if (!provider || !model) {
@@ -1110,6 +1098,53 @@ function sessionMetadata(context = {}) {
 		model: `${provider}/${model}`,
 	};
 	return context.sessionMetadata;
+}
+
+function captureOpenCodeSessionExport(context, sessionId) {
+	const configuredTempRoot = context.spawnExtra?.env?.TMPDIR;
+	const tempRoot = isAbsolutePath(configuredTempRoot) ? configuredTempRoot : os.tmpdir();
+	let exportDirectory;
+	let outputFd;
+	try {
+		exportDirectory = fs.mkdtempSync(path.join(tempRoot, 'opencode-session-export-'));
+		const outputPath = path.join(exportDirectory, 'session.json');
+		outputFd = fs.openSync(outputPath, 'w', 0o600);
+		const result = spawnSync(context.commandSpec.command, [
+			...arrayValue(context.commandSpec.args),
+			'export',
+			sessionId,
+			'--sanitize',
+		], {
+			cwd: context.cwd,
+			env: context.spawnExtra?.env,
+			encoding: 'utf8',
+			stdio: ['ignore', outputFd, 'pipe'],
+			maxBuffer: OPENCODE_SESSION_EXPORT_MAX_BYTES,
+			// Session provenance is supplementary to a completed provider run. Bound
+			// its follow-up process so a wedged export cannot hold Cook indefinitely.
+			timeout: OPENCODE_SESSION_EXPORT_TIMEOUT_MS,
+			killSignal: 'SIGKILL',
+		});
+		fs.closeSync(outputFd);
+		outputFd = undefined;
+		if (result.status !== 0 || result.error) {
+			return '';
+		}
+		const bytes = fs.statSync(outputPath).size;
+		if (bytes === 0 || bytes > OPENCODE_SESSION_EXPORT_MAX_BYTES) {
+			return '';
+		}
+		return fs.readFileSync(outputPath, 'utf8');
+	} catch {
+		return '';
+	} finally {
+		if (outputFd !== undefined) {
+			try { fs.closeSync(outputFd); } catch { /* Cleanup is best-effort after capture failure. */ }
+		}
+		if (exportDirectory) {
+			try { fs.rmSync(exportDirectory, { recursive: true, force: true }); } catch { /* Temporary sanitized data cleanup is best-effort. */ }
+		}
+	}
 }
 
 function openCodeSessionIds(stdout = '') {

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -666,6 +666,7 @@ process.exit(0);
 
 	const provenanceOpenCode = path.join(root, 'opencode');
 	fs.writeFileSync(provenanceOpenCode, `#!/usr/bin/env node
+const fs = require('node:fs');
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT || '{}');
 if (process.argv[2] === 'debug') {
   const permission = Object.entries(config.agent.build.permission)
@@ -677,7 +678,11 @@ if (process.argv[2] === 'export') {
   if (process.env.HOMEBOY_TEST_HANG_EXPORT === '1') {
     setInterval(() => {}, 1_000);
   } else {
-    process.stdout.write('Exporting session\\n' + JSON.stringify({ info: { model: { providerID: 'openai', id: 'gpt-5.6-sol' } } }));
+    const exported = 'Exporting session\\n' + JSON.stringify({
+      info: { model: { providerID: 'openai', id: 'gpt-5.6-sol' } },
+      messages: [{ text: 'x'.repeat(70 * 1024) }],
+    });
+    process.stdout.write(fs.fstatSync(1).isFile() ? exported : exported.slice(0, 64 * 1024));
     process.exit(0);
   }
 } else {
@@ -689,6 +694,8 @@ if (process.argv[2] === 'export') {
 }
 `);
 	fs.chmodSync(provenanceOpenCode, 0o755);
+	const provenanceTempRoot = path.join(root, 'provenance-temp');
+	fs.mkdirSync(provenanceTempRoot);
 	const defaultModelRun = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
 		env: fixtureEnv,
@@ -699,7 +706,7 @@ if (process.argv[2] === 'export') {
 			artifacts_path: path.join(root, 'default-model-artifacts'),
 			executor: {
 				...request.executor,
-				config: { ...request.executor.config, runtime_bin: provenanceOpenCode, command_args: [] },
+				config: { ...request.executor.config, runtime_bin: provenanceOpenCode, command_args: [], runtime_env: { TMPDIR: provenanceTempRoot } },
 			},
 		}),
 	});
@@ -712,6 +719,7 @@ if (process.argv[2] === 'export') {
 	assert.deepEqual(defaultModelResult.metadata.opencode_session, {
 		status: 'captured', session_id: 'ses_default_model', model: 'openai/gpt-5.6-sol',
 	});
+	assert.deepEqual(fs.readdirSync(provenanceTempRoot).filter((name) => name.startsWith('opencode-session-export-')), []);
 	const exportStarted = Date.now();
 	const unavailableModelResult = await executeOpenCodeAgentTask({
 		...request,


### PR DESCRIPTION
## Summary
- capture sanitized OpenCode session exports through a mode-0600 temporary regular file instead of a pipe
- preserve the two-second provenance timeout and one-MiB size bound, with unconditional temporary-data cleanup
- cover exports larger than 64 KiB and verify concrete default-model provenance survives the known OpenCode truncation defect

## Root cause
OpenCode truncates large piped exports at exactly 65,536 bytes, as tracked in anomalyco/opencode#29330. The adapter used `spawnSync` with captured stdout, received invalid JSON, and therefore persisted no concrete model for otherwise successful Cook runs. Regular-file redirection is the verified provider workaround and keeps the compatibility repair inside our runtime adapter.

## Verification
- `npm run test:opencode-agent-task-executor-boundary`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `npm run test:opencode-external-storage-retention`
- `npm run check:runtime-manifest`
- `git diff --check origin/main...HEAD`

Fixes Extra-Chill/homeboy#13045

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** reproducing the provider pipe truncation, tracing model-provenance loss, implementing the bounded adapter capture, and verifying the regression coverage

Chris Huber reviewed the result and remains responsible for every line.