### PR TITLE
feat(nodejs): merge project release artifacts

### DIFF
--- a/nodejs/homeboy.json
+++ b/nodejs/homeboy.json
@@ -28,6 +28,7 @@
       "bash scripts/bench/nodejs-workload-progress-forwarding-smoke.sh",
       "bash scripts/bench/nodejs-workload-utils-smoke.sh",
       "bash scripts/build/build-runner-shell-smoke.sh",
+      "bash tests/release-package-manifest-smoke.sh",
       "bash scripts/runtime/nodejs-invocation-runtime-smoke.sh",
       "node scripts/trace/trace-helpers-smoke.mjs",
       "bash tests/local-workspace-deps-smoke.sh",

--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -130,6 +130,13 @@
       "description": "npm registry URL for publishing"
     },
     {
+      "id": "release_package_script",
+      "label": "Release Package Script",
+      "type": "string",
+      "default": "",
+      "description": "Optional package.json script that emits a terminal JSON artifact manifest. Its artifacts are merged with the canonical npm tarball."
+    },
+    {
       "id": "targeted_test_script",
       "label": "Targeted Test Script",
       "type": "string",

--- a/nodejs/scripts/release/build.sh
+++ b/nodejs/scripts/release/build.sh
@@ -17,23 +17,80 @@ fi
 
 PACKAGE_NAME=$(node -e "console.log(require('./package.json').name || '')" 2>/dev/null)
 PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version || '')" 2>/dev/null)
+RELEASE_PACKAGE_SCRIPT=""
+
+if [[ -n "${HOMEBOY_SETTINGS_JSON:-}" ]]; then
+  RELEASE_PACKAGE_SCRIPT=$(printf '%s' "${HOMEBOY_SETTINGS_JSON}" | jq -er '.config.release_package_script // "" | strings' 2>/dev/null) || {
+    echo "HOMEBOY_SETTINGS_JSON must contain a valid string config.release_package_script" >&2
+    exit 1
+  }
+fi
 
 if [[ -z "${PACKAGE_NAME}" || -z "${PACKAGE_VERSION}" ]]; then
   echo "Failed to read name/version from package.json" >&2
   exit 1
 fi
 
-# Check if a build script exists.
-has_build=$(node -e "
-  const pkg = require('./package.json');
-  console.log(pkg.scripts && pkg.scripts.build ? 'yes' : 'no');
-" 2>/dev/null || echo "no")
+PROJECT_ARTIFACTS='[]'
+if [[ -n "${RELEASE_PACKAGE_SCRIPT}" ]]; then
+  if ! jq -e --arg script "${RELEASE_PACKAGE_SCRIPT}" '.scripts[$script] | strings | select(length > 0)' package.json >/dev/null; then
+    echo "Configured release package script is missing from package.json: ${RELEASE_PACKAGE_SCRIPT}" >&2
+    exit 1
+  fi
 
-if [[ "${has_build}" == "yes" ]]; then
-  echo "Running npm run build for ${PACKAGE_NAME}@${PACKAGE_VERSION}..." >&2
-  npm run build >&2
+  package_output=$(mktemp)
+  trap 'rm -f "${package_output:-}"' EXIT
+  echo "Running npm run ${RELEASE_PACKAGE_SCRIPT} for ${PACKAGE_NAME}@${PACKAGE_VERSION}..." >&2
+  if ! npm run "${RELEASE_PACKAGE_SCRIPT}" >"${package_output}"; then
+    cat "${package_output}" >&2
+    echo "Configured release package script failed: ${RELEASE_PACKAGE_SCRIPT}" >&2
+    exit 1
+  fi
+  cat "${package_output}" >&2
+  PROJECT_ARTIFACTS=$(node - "${package_output}" <<'NODE'
+const fs = require("node:fs")
+const output = fs.readFileSync(process.argv[2], "utf8").trim()
+if (!output) {
+  console.error("Configured release package script produced empty stdout")
+  process.exit(1)
+}
+
+for (let index = output.length - 1; index >= 0; index--) {
+  if (output[index] !== "[" && output[index] !== "{") continue
+  try {
+    const parsed = JSON.parse(output.slice(index))
+    const artifacts = Array.isArray(parsed) ? parsed : [parsed]
+    if (artifacts.length === 0 || artifacts.some((artifact) => !artifact || typeof artifact !== "object" || Array.isArray(artifact) || typeof artifact.path !== "string" || artifact.path.length === 0)) continue
+    const unique = artifacts.filter((artifact, artifactIndex) => artifacts.findIndex((candidate) => candidate.path === artifact.path) === artifactIndex)
+    process.stdout.write(JSON.stringify(unique))
+    process.exit(0)
+  } catch {}
+}
+
+console.error("Configured release package script did not end with a valid artifact JSON object or array")
+process.exit(1)
+NODE
+  ) || exit 1
+
+  while IFS= read -r artifact_path; do
+    if [[ ! -f "${artifact_path}" ]]; then
+      echo "Configured release package script declared a missing artifact: ${artifact_path}" >&2
+      exit 1
+    fi
+  done < <(printf '%s' "${PROJECT_ARTIFACTS}" | jq -r '.[].path')
 else
-  echo "No build script defined in package.json, skipping build" >&2
+  # Check if a build script exists.
+  has_build=$(node -e "
+    const pkg = require('./package.json');
+    console.log(pkg.scripts && pkg.scripts.build ? 'yes' : 'no');
+  " 2>/dev/null || echo "no")
+
+  if [[ "${has_build}" == "yes" ]]; then
+    echo "Running npm run build for ${PACKAGE_NAME}@${PACKAGE_VERSION}..." >&2
+    npm run build >&2
+  else
+    echo "No build script defined in package.json, skipping build" >&2
+  fi
 fi
 
 # npm pack --json can emit lifecycle script output (prepack, prepare, etc.) to
@@ -56,4 +113,6 @@ if [[ -z "${PACK_TARBALL}" || ! -f "${PACK_TARBALL}" ]]; then
   exit 1
 fi
 
-jq -cn --arg path "${PACK_TARBALL}" '[{path: $path, type: "npm_tarball", platform: null}]'
+jq -cn --argjson project "${PROJECT_ARTIFACTS}" --arg path "${PACK_TARBALL}" '
+  $project + (if any($project[]; .path == $path) then [] else [{path: $path, type: "npm_tarball", platform: null}] end)
+'

--- a/nodejs/tests/release-package-manifest-smoke.sh
+++ b/nodejs/tests/release-package-manifest-smoke.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_SCRIPT="${EXTENSION_ROOT}/scripts/release/build.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+BIN_DIR="${TMP_DIR}/bin"
+mkdir -p "${BIN_DIR}"
+cat >"${BIN_DIR}/npm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  run)
+    script="${2:-}"
+    printf '%s\n' "${script}" >>"${NPM_CALLS_FILE}"
+    if [[ "${script}" == "release:package" ]]; then
+      case "${PACKAGE_FIXTURE_MODE:-valid}" in
+        valid)
+          touch plugin.zip cli.tar.gz
+          printf '%s\n' '> fixture@1.0.0 release:package' '> node package.js' '' '[{"path":"plugin.zip","type":"wordpress-plugin-zip"},{"path":"cli.tar.gz","type":"node-cli-tarball","platform":"linux-x64"}]'
+          ;;
+        duplicate)
+          touch fixture-1.0.0.tgz
+          printf '%s\n' '[{"path":"fixture-1.0.0.tgz","type":"npm_tarball","platform":null}]'
+          ;;
+        malformed)
+          printf '%s\n' 'not-json'
+          ;;
+        scalar)
+          printf '%s\n' '"artifact.zip"'
+          ;;
+        empty)
+          :
+          ;;
+        missing)
+          printf '%s\n' '[{"path":"missing.zip","type":"wordpress-plugin-zip"}]'
+          ;;
+        failure)
+          printf '%s\n' 'package failed'
+          exit 9
+          ;;
+      esac
+    fi
+    ;;
+  pack)
+    printf '%s\n' 'pack' >>"${NPM_CALLS_FILE}"
+    touch fixture-1.0.0.tgz
+    printf '%s\n' '> fixture@1.0.0 prepare' '[{"filename":"fixture-1.0.0.tgz"}]'
+    ;;
+  *)
+    echo "Unexpected npm invocation: $*" >&2
+    exit 64
+    ;;
+esac
+SH
+chmod +x "${BIN_DIR}/npm"
+
+write_package() {
+  local root="$1"
+  local scripts="$2"
+  mkdir -p "${root}"
+  jq -cn --argjson scripts "${scripts}" '{name:"fixture",version:"1.0.0",scripts:$scripts}' >"${root}/package.json"
+  : >"${root}/npm-calls.log"
+}
+
+run_build() {
+  local root="$1"
+  shift
+  (
+    cd "${root}"
+    env PATH="${BIN_DIR}:${PATH}" NPM_CALLS_FILE="${root}/npm-calls.log" "$@" bash "${BUILD_SCRIPT}"
+  )
+}
+
+configured="${TMP_DIR}/configured"
+write_package "${configured}" '{"build":"fixture-build","release:package":"fixture-package"}'
+configured_output=$(run_build "${configured}" HOMEBOY_SETTINGS_JSON='{"config":{"release_package_script":"release:package"}}')
+configured_expected='[{"path":"plugin.zip","type":"wordpress-plugin-zip"},{"path":"cli.tar.gz","type":"node-cli-tarball","platform":"linux-x64"},{"path":"fixture-1.0.0.tgz","type":"npm_tarball","platform":null}]'
+[[ "$(printf '%s' "${configured_output}" | jq -c .)" == "${configured_expected}" ]]
+[[ "$(cat "${configured}/npm-calls.log")" == $'release:package\npack' ]]
+
+default_root="${TMP_DIR}/default"
+write_package "${default_root}" '{"build":"fixture-build"}'
+default_output=$(run_build "${default_root}")
+[[ "$(printf '%s' "${default_output}" | jq -c .)" == '[{"path":"fixture-1.0.0.tgz","type":"npm_tarball","platform":null}]' ]]
+[[ "$(cat "${default_root}/npm-calls.log")" == $'build\npack' ]]
+
+duplicate_root="${TMP_DIR}/duplicate"
+write_package "${duplicate_root}" '{"release:package":"fixture-package"}'
+duplicate_output=$(run_build "${duplicate_root}" HOMEBOY_SETTINGS_JSON='{"config":{"release_package_script":"release:package"}}' PACKAGE_FIXTURE_MODE=duplicate)
+[[ "$(printf '%s' "${duplicate_output}" | jq 'length')" == "1" ]]
+
+for mode in malformed scalar empty missing failure; do
+  failure_root="${TMP_DIR}/${mode}"
+  write_package "${failure_root}" '{"release:package":"fixture-package"}'
+  if run_build "${failure_root}" HOMEBOY_SETTINGS_JSON='{"config":{"release_package_script":"release:package"}}' PACKAGE_FIXTURE_MODE="${mode}" >/dev/null 2>&1; then
+    echo "Configured package mode unexpectedly succeeded: ${mode}" >&2
+    exit 1
+  fi
+done
+
+absent_root="${TMP_DIR}/absent"
+write_package "${absent_root}" '{}'
+if run_build "${absent_root}" HOMEBOY_SETTINGS_JSON='{"config":{"release_package_script":"release:package"}}' >/dev/null 2>&1; then
+  echo "Missing configured package script unexpectedly succeeded" >&2
+  exit 1
+fi
+
+echo "Node.js release package manifest smoke passed"


### PR DESCRIPTION
## Summary
- add an explicit `release_package_script` setting to the generic Node.js extension
- validate and merge project-owned artifact manifests with the canonical npm tarball
- preserve existing build plus `npm pack` behavior when the setting is unset
- fail closed on missing scripts, failed commands, invalid JSON, scalar/empty output, and missing files

## Verification
- `bash nodejs/tests/release-package-manifest-smoke.sh`
- `bash -n nodejs/scripts/release/build.sh nodejs/tests/release-package-manifest-smoke.sh`
- `jq empty nodejs/nodejs.json nodejs/homeboy.json`

## Context
Homeboy core already accepts multi-artifact arrays from `release.package`; this keeps npm script selection and output normalization in the Node extension rather than parsing arbitrary component build logs in core. WP Codebox will opt in on a dependent PR and restore plugin-only `scripts.build` ownership.

Fixes #2712