### PR TITLE
fix(inventory): order the workspace fingerprint by path components

### DIFF
--- a/rust/scripts/test-shard-inventory.py
+++ b/rust/scripts/test-shard-inventory.py
@@ -42,13 +42,24 @@ def run(command, cwd):
 
 
 def workspace_fingerprint(root):
+    # Ordered by path components, explicitly.
+    #
+    # Core hashes in `Ord for PathBuf` order, which is component-wise. A bare
+    # `sorted()` over `Path` objects happened to agree only because Python 3.12
+    # switched path comparison from the joined string to the components -- on
+    # 3.11 the same code ordered `src/auth-tokens/...` before `src/auth/...` and
+    # produced a fingerprint core would reject. Pin the order here rather than
+    # letting the runner's interpreter decide it. Extra-Chill/homeboy#13494.
     root = Path(root).resolve()
     files = sorted(
-        path for path in root.rglob("*")
-        if path.is_file()
-        and ".git" not in path.parts
-        and "target" not in path.parts
-        and (path.name in {"Cargo.toml", "Cargo.lock"} or path.suffix == ".rs")
+        (
+            path for path in root.rglob("*")
+            if path.is_file()
+            and ".git" not in path.parts
+            and "target" not in path.parts
+            and (path.name in {"Cargo.toml", "Cargo.lock"} or path.suffix == ".rs")
+        ),
+        key=lambda path: path.relative_to(root).parts,
     )
     content = "".join(f"{path.relative_to(root)}\0{path.read_text()}\0" for path in files)
     return digest(content)

--- a/wordpress/scripts/test/test-inventory-smoke.sh
+++ b/wordpress/scripts/test/test-inventory-smoke.sh
@@ -183,6 +183,49 @@ after_phpunit_config="$(python3 -c 'import json,sys; print(json.load(open(sys.ar
 [ "$after_php" != "$after_phpunit_config" ] || fail "a PHPUnit config edit did not move the workspace fingerprint"
 printf 'PASS: PHPUnit config edits move the workspace fingerprint\n'
 
+# Extra-Chill/homeboy#13494 — the concatenation order is core's, and core hashes
+# in `Ord for PathBuf` order, which compares path components. Sorting the joined
+# text instead disagrees whenever a directory name is a prefix of a sibling
+# followed by a byte below "/" (`inc/auth/` beside `inc/auth-tokens/`, which is
+# what `extrachill-users` has). Same files, different order, different digest —
+# and core then rejected every inventory this producer wrote, permanently.
+mkdir -p "${plugin}/inc/auth" "${plugin}/inc/auth-tokens"
+printf '<?php\n// auth\n' > "${plugin}/inc/auth/handler.php"
+printf '<?php\n// auth-tokens\n' > "${plugin}/inc/auth-tokens/token.php"
+run_producer "${WORKDIR}/ordered.json" > /dev/null || fail "producer failed with sibling-prefix directories"
+python3 - "${WORKDIR}/ordered.json" "$plugin" "$EXTENSION_PATH" <<'PY' || fail "workspace fingerprint ordering assertions failed"
+import hashlib, json, os, sys
+from pathlib import Path
+
+doc = json.load(open(sys.argv[1]))
+root = Path(sys.argv[2]).resolve()
+config = json.loads((Path(sys.argv[3]) / "wordpress.json").read_text())["test"]["inventory"]
+names = set(config["fingerprint_names"])
+extensions = set(config["fingerprint_extensions"])
+skip = set(config["fingerprint_skip_dirs"])
+
+selected = []
+for directory, subdirectories, files in os.walk(root):
+    subdirectories[:] = [name for name in subdirectories if name not in skip]
+    for name in files:
+        path = Path(directory) / name
+        if path.is_file() and (path.name in names or (path.suffix and path.suffix[1:] in extensions)):
+            selected.append(path.relative_to(root))
+
+def digest(order):
+    return hashlib.sha256(
+        "".join(f"{path}\0{(root / path).read_text()}\0" for path in order).encode()
+    ).hexdigest()
+
+by_components = sorted(selected, key=lambda path: path.parts)
+by_joined_text = sorted(selected, key=str)
+assert by_components != by_joined_text, "fixture no longer discriminates between the two orders"
+assert digest(by_components) != digest(by_joined_text), "fixture contents no longer discriminate"
+assert doc["workspace_fingerprint"] == digest(by_components), \
+    "producer must concatenate in path-component order, which is what core re-derives"
+print("PASS: workspace fingerprint orders by path components, not by the joined path text")
+PY
+
 # An empty enumeration is refused: it cannot be told apart from a broken
 # producer, and sharding nothing would report a green suite that ran no tests.
 empty="${WORKDIR}/empty"

--- a/wordpress/scripts/test/test-inventory.py
+++ b/wordpress/scripts/test/test-inventory.py
@@ -18,8 +18,9 @@ Two details are load-bearing and easy to get wrong:
   matching Python's `json.dumps` is the contract.
 
 * The workspace fingerprint concatenates `f"{relative_path}\\0{text}\\0"` over
-  the selected files in sorted order, where `text` has been read with universal
-  newlines. Core normalizes CRLF and lone CR to LF for the same reason.
+  the selected files ordered **by path components**, where `text` has been read
+  with universal newlines. Core normalizes CRLF and lone CR to LF for the same
+  reason, and orders by components because Rust's `Ord for PathBuf` does.
 
 The file selection, skip list, root markers and runner identity are read from
 the extension manifest's `test.inventory` block, so this script and the
@@ -93,8 +94,25 @@ def workspace_fingerprint(root, config):
             if path.is_file() and selected_for_fingerprint(path, config):
                 selected.append(path)
 
+    # Ordered by path components, never by the joined text.
+    #
+    # Core hashes in `Ord for PathBuf` order, which compares component by
+    # component. Sorting `str(relative)` instead disagrees with it whenever a
+    # directory name is a prefix of a sibling followed by a byte below "/":
+    #
+    #     inc/auth-tokens/browser-handoff-token.php   # first by joined text ("-" < "/")
+    #     inc/auth/browser-handoff-handler.php        # first by components ("auth" < "auth-tokens")
+    #
+    # Same files, different order, different digest -- so core rejected every
+    # inventory this producer wrote for `extrachill-users` (which has exactly
+    # that pair of directories) as a workspace-provenance mismatch, and no rerun
+    # could ever fix a sort order. Extra-Chill/homeboy#13494.
+    #
+    # `sorted()` over `Path` objects is not a substitute: it returned joined-text
+    # order before Python 3.12 and component order after it, which would make the
+    # fingerprint depend on the interpreter installed on the runner.
     content = []
-    for path in sorted(selected, key=lambda item: str(item.relative_to(root))):
+    for path in sorted(selected, key=lambda item: item.relative_to(root).parts):
         try:
             # `read_text` applies universal newlines, which is what core's
             # CRLF/CR normalization reproduces.


### PR DESCRIPTION
## Root cause of Extra-Chill/homeboy#13494

Core hashes the selected workspace files in `Ord for PathBuf` order, which compares **path components**. The WordPress producer sorted the **joined relative path text**. The two disagree whenever a directory name is a prefix of a sibling followed by a byte below `/`:

```
inc/auth-tokens/browser-handoff-token.php   # first by joined text ('-' < '/')
inc/auth/browser-handoff-handler.php        # first by components ("auth" < "auth-tokens")
```

Same files, different order, different digest. `extrachill-users` has exactly that pair of directories, so core rejected every inventory this producer wrote as `WorkspaceFingerprintMismatch` — permanently, because no rerun changes a sort order. That is why PR #377 there could not obtain differential test evidence and both reruns produced identical `invalid_evidence`.

Reproduced against the real checkout: 186 selected files, first divergence at `inc/auth-tokens/browser-handoff-token.php` vs `inc/auth/browser-handoff-handler.php`.

## Also fixed: a version-dependent fingerprint in the Rust producer

`test-shard-inventory.py` sorted `Path` objects. `sorted()` over `pathlib.Path` returned joined-text order before Python 3.12 and component order after it, so that fingerprint depended on the interpreter installed on the runner. Both producers now sort by `.parts` explicitly.

## Verification

- `wordpress/scripts/test/test-inventory-smoke.sh` — new sibling-prefix case asserts the producer's fingerprint equals the component-ordered digest, and asserts the fixture still discriminates between the two orders. Verified it **fails** with the old sort key.
- `wordpress/scripts/test/test-shard-replay-smoke.sh` — passes
- `rust/tests/test-shard-inventory-smoke.sh` — passes

Refs Extra-Chill/homeboy#13494