### PR TITLE
Fix WP Codebox candidate SHA build provenance

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TMPDIR="$(mktemp -d)"
+TMPDIR="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "${TMPDIR}"' EXIT
 
 SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -63,6 +63,10 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 [ -n "$prefix" ] || { echo "missing --prefix" >&2; exit 2; }
+if [ -n "${EXPECTED_WP_CODEBOX_SOURCE_SHA:-}" ]; then
+    [ "${WP_CODEBOX_SOURCE_SHA:-}" = "$EXPECTED_WP_CODEBOX_SOURCE_SHA" ] || { echo "npm inherited stale WP_CODEBOX_SOURCE_SHA: ${WP_CODEBOX_SOURCE_SHA:-}" >&2; exit 2; }
+    [ "${WP_CODEBOX_SOURCE_REF:-}" = "$EXPECTED_WP_CODEBOX_SOURCE_REF" ] || { echo "npm did not receive requested WP_CODEBOX_SOURCE_REF: ${WP_CODEBOX_SOURCE_REF:-}" >&2; exit 2; }
+fi
 case "${args[*]}" in
     ci*)
         case " ${args[*]} " in
@@ -146,7 +150,7 @@ git -C "$SOURCE_WORK" commit --quiet -m 'final wp-codebox fixture'
 FINAL_SHA="$(git -C "$SOURCE_WORK" rev-parse HEAD)"
 git -C "$SOURCE_WORK" push --quiet origin HEAD:main
 
-OUTPUT="$(PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --source "$REMOTE_REPO" --ref "$INITIAL_SHA" --cache-dir "$CACHE_DIR" --npm "${FAKE_BIN}/npm")"
+OUTPUT="$(WP_CODEBOX_SOURCE_SHA=stale-inherited-sha EXPECTED_WP_CODEBOX_SOURCE_SHA="$INITIAL_SHA" EXPECTED_WP_CODEBOX_SOURCE_REF="$INITIAL_SHA" PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --source "$REMOTE_REPO" --ref "$INITIAL_SHA" --cache-dir "$CACHE_DIR" --npm "${FAKE_BIN}/npm")"
 case "$OUTPUT" in
     *"WP Codebox cache SHA: ${INITIAL_SHA}"*) ;;
     *)

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -144,6 +144,8 @@ fi
 echo "Fetching WP Codebox ref: $REQUESTED_REF"
 git -C "$CANDIDATE_DIR" fetch --quiet --tags origin "$REQUESTED_REF" || fail "failed to fetch ref '$REQUESTED_REF' from $SOURCE"
 git -C "$CANDIDATE_DIR" reset --hard --quiet FETCH_HEAD || fail "failed to reset staged cache checkout to FETCH_HEAD"
+SHA="$(git -C "$CANDIDATE_DIR" rev-parse HEAD)" || fail "failed to read staged WP Codebox SHA"
+export WP_CODEBOX_SOURCE_REF="$REQUESTED_REF" WP_CODEBOX_SOURCE_SHA="$SHA"
 git -C "$CANDIDATE_DIR" clean -ffdx --quiet || fail "failed to clean untracked build residue from staged WP Codebox cache checkout"
 
 [ -f "$CANDIDATE_DIR/package-lock.json" ] || [ -f "$CANDIDATE_DIR/npm-shrinkwrap.json" ] || fail "WP Codebox source cache requires an npm lockfile (package-lock.json or npm-shrinkwrap.json) for deterministic npm ci: $SOURCE"
@@ -154,7 +156,6 @@ echo "Installing WP Codebox dependencies..."
 echo "Building WP Codebox packages..."
 "$NPM_BIN" --prefix "$CANDIDATE_DIR" run build || fail "npm run build failed in $CANDIDATE_DIR"
 
-SHA="$(git -C "$CANDIDATE_DIR" rev-parse HEAD)" || fail "failed to read resulting WP Codebox SHA"
 CLI="$CANDIDATE_DIR/packages/cli/dist/index.js"
 [ -x "$CLI" ] || fail "WP Codebox build did not produce executable CLI: $CLI"
 VERSION="$($CLI --version 2>&1)" || fail "built WP Codebox CLI version probe failed: $CLI. Rebuild the requested ref with a compatible WP Codebox CLI."


### PR DESCRIPTION
Closes #2715.

## Summary
- resolve and export the staged WP Codebox checkout SHA immediately after fetch/reset
- pass the requested source ref and fetched SHA into `npm ci` and `npm run build`
- prove an inherited stale SHA is replaced before package scripts run
- normalize the aggregate smoke temp path for macOS path identity

## Verification
- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash -n wordpress/scripts/build/setup-wp-codebox-smoke.sh wordpress/scripts/build/update-wp-codebox-cache-smoke.sh wordpress/scripts/build/update-wp-codebox-cache.sh`
- `git diff --check`

## AI Assistance
Implemented with OpenCode using OpenAI gpt-5.6-sol. The assistant traced the CI provenance race, dispatched a durable Homeboy agent-task plan, reviewed and applied its patch artifact, and independently reran the deterministic gates.