### PR TITLE
fix(opencode): retry delayed session provenance

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -75,6 +75,7 @@ const MAX_STRUCTURED_OUTPUT_BYTES = 64 * 1024;
 const MAX_STRUCTURED_ANSWER_BYTES = MAX_STRUCTURED_OUTPUT_BYTES + 16 * 1024;
 const OPENCODE_SESSION_EXPORT_TIMEOUT_MS = 2_000;
 const OPENCODE_SESSION_EXPORT_MAX_BYTES = 1024 * 1024;
+const OPENCODE_SESSION_EXPORT_ATTEMPTS = 2;
 
 const OPENCODE_CAPABILITIES = [
 	'cli_runtime',
@@ -1072,30 +1073,31 @@ function sessionMetadata(context = {}) {
 		return context.sessionMetadata;
 	}
 	const [sessionId] = sessionIds;
-	const output = captureOpenCodeSessionExport(context, sessionId);
-	if (!output) {
-		context.sessionMetadata = {
-			status: 'unavailable',
-			session_id: sessionId,
-			reason: 'OpenCode did not return a readable completed-session export.',
-		};
-		return context.sessionMetadata;
-	}
-	const exported = parseOpenCodeExport(output);
-	const provider = stringValue(exported?.info?.model?.providerID);
-	const model = stringValue(exported?.info?.model?.id);
-	if (!provider || !model) {
-		context.sessionMetadata = {
-			status: 'unavailable',
-			session_id: sessionId,
-			reason: 'OpenCode session export did not contain a concrete provider and model.',
-		};
-		return context.sessionMetadata;
+	let readableExport = false;
+	for (let attempt = 0; attempt < OPENCODE_SESSION_EXPORT_ATTEMPTS; attempt += 1) {
+		const output = captureOpenCodeSessionExport(context, sessionId);
+		if (!output) {
+			continue;
+		}
+		readableExport = true;
+		const exported = parseOpenCodeExport(output);
+		const provider = stringValue(exported?.info?.model?.providerID);
+		const model = stringValue(exported?.info?.model?.id);
+		if (provider && model) {
+			context.sessionMetadata = {
+				status: 'captured',
+				session_id: sessionId,
+				model: `${provider}/${model}`,
+			};
+			return context.sessionMetadata;
+		}
 	}
 	context.sessionMetadata = {
-		status: 'captured',
+		status: 'unavailable',
 		session_id: sessionId,
-		model: `${provider}/${model}`,
+		reason: readableExport
+			? 'OpenCode session export did not contain a concrete provider and model.'
+			: 'OpenCode did not return a readable completed-session export.',
 	};
 	return context.sessionMetadata;
 }

--- a/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
+++ b/agent-runtimes/opencode/tests/opencode-agent-task-executor-boundary.test.js
@@ -678,6 +678,13 @@ if (process.argv[2] === 'export') {
   if (process.env.HOMEBOY_TEST_HANG_EXPORT === '1') {
     setInterval(() => {}, 1_000);
   } else {
+	if (process.env.HOMEBOY_TEST_DELAYED_EXPORT === '1') {
+	  const marker = ${JSON.stringify(path.join(root, 'delayed-session-export-marker'))};
+	  if (!fs.existsSync(marker)) {
+	    fs.writeFileSync(marker, 'first export unavailable');
+	    process.exit(1);
+	  }
+	}
     const exported = 'Exporting session\\n' + JSON.stringify({
       info: { model: { providerID: 'openai', id: 'gpt-5.6-sol' } },
       messages: [{ text: 'x'.repeat(70 * 1024) }],
@@ -720,6 +727,26 @@ if (process.argv[2] === 'export') {
 		status: 'captured', session_id: 'ses_default_model', model: 'openai/gpt-5.6-sol',
 	});
 	assert.deepEqual(fs.readdirSync(provenanceTempRoot).filter((name) => name.startsWith('opencode-session-export-')), []);
+	const delayedModelResult = await executeOpenCodeAgentTask({
+		...request,
+		task_id: 'opencode-delayed-session-model',
+		workspace_path: preflightWorkspace,
+		artifacts_path: path.join(root, 'delayed-model-artifacts'),
+		executor: {
+			...request.executor,
+			config: {
+				...request.executor.config,
+				runtime_bin: provenanceOpenCode,
+				command_args: [],
+				runtime_env: { HOMEBOY_TEST_DELAYED_EXPORT: '1' },
+			},
+		},
+	}, { env: fixtureEnv });
+	assert.equal(delayedModelResult.status, 'succeeded', JSON.stringify(delayedModelResult.diagnostics));
+	assert.equal(delayedModelResult.metadata.model, 'openai/gpt-5.6-sol');
+	assert.deepEqual(delayedModelResult.metadata.opencode_session, {
+		status: 'captured', session_id: 'ses_default_model', model: 'openai/gpt-5.6-sol',
+	});
 	const exportStarted = Date.now();
 	const unavailableModelResult = await executeOpenCodeAgentTask({
 		...request,
@@ -736,7 +763,7 @@ if (process.argv[2] === 'export') {
 			},
 		},
 	}, { env: fixtureEnv });
-	assert.ok(Date.now() - exportStarted < 4_000, 'session export must not block provider completion');
+	assert.ok(Date.now() - exportStarted < 5_000, 'session export retries must not block provider completion');
 	assert.equal(unavailableModelResult.status, 'succeeded', JSON.stringify(unavailableModelResult.diagnostics));
 	assert.deepEqual(unavailableModelResult.metadata.opencode_session, {
 		status: 'unavailable',


### PR DESCRIPTION
## Summary
- retry one bounded OpenCode session export when completion races session durability
- preserve concrete default-model provenance when the second export succeeds
- remain fail closed after two unreadable exports with a four-second maximum wait

## Root cause
The adapter attempted the completed-session export exactly once immediately after `opencode run` exited. The #1209 Cook recorded `provider_model: null` even though the same durable session subsequently exported `openai/gpt-5.6-sol` successfully. A transient first export therefore permanently blocked Homeboy promotion and finalization.

## Verification
- `npm run test:opencode-agent-task-executor-boundary`
- `npm run test:opencode-progress-events`
- `npm run test:opencode-progress-relay`
- `npm run check:runtime-manifest`
- `git diff --check origin/main...HEAD`

Fixes Extra-Chill/homeboy#13045

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** tracing the live Cook provenance failure, implementing the bounded retry, adding regression coverage, and running verification

Chris Huber remains responsible for the change.